### PR TITLE
use clang_tidy from aspect_rules_lint

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -22,4 +22,5 @@ test --test_tag_filters=-manual
 common --registry=https://raw.githubusercontent.com/eclipse-score/bazel_registry/refs/heads/main/
 common --registry=https://bcr.bazel.build
 
-build:clang_tidy --aspects=//tools/lint:linters.bzl%clang_tidy --output_groups=rules_lint_human --keep_going
+build:clang --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux
+build:clang_tidy --config=clang --aspects=//tools/lint:linters.bzl%clang_tidy --output_groups=rules_lint_human --keep_going

--- a/.bazelrc
+++ b/.bazelrc
@@ -21,3 +21,5 @@ test --test_tag_filters=-manual
 
 common --registry=https://raw.githubusercontent.com/eclipse-score/bazel_registry/refs/heads/main/
 common --registry=https://bcr.bazel.build
+
+build:clang_tidy --aspects=//tools/lint:linters.bzl%clang_tidy --output_groups=rules_lint_human --keep_going

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -80,7 +80,7 @@ bazel_dep(name = "score-baselibs", version = "0.0.0")
 git_override(
     module_name = "score-baselibs",
     commit = "fc8930c739fae07a75ea2e280756cf3498bdeeef",
-    remote = "git@github.com:eclipse-score/baselibs.git",
+    remote = "https://github.com/eclipse-score/baselibs",
 )
 
 ###############################################################################

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -16,9 +16,9 @@ bazel_dep(name = "score_toolchains_gcc", version = "0.4")
 
 gcc = use_extension("@score_toolchains_gcc//extentions:gcc.bzl", "gcc")
 gcc.toolchain(
-    url = "https://github.com/eclipse-score/toolchains_gcc_packages/releases/download/0.0.1/x86_64-unknown-linux-gnu_gcc12.tar.gz",
     sha256 = "457f5f20f57528033cb840d708b507050d711ae93e009388847e113b11bf3600",
     strip_prefix = "x86_64-unknown-linux-gnu",
+    url = "https://github.com/eclipse-score/toolchains_gcc_packages/releases/download/0.0.1/x86_64-unknown-linux-gnu_gcc12.tar.gz",
 )
 
 # TODO to be moved to toolchain. https://github.com/eclipse-score/toolchains_gcc/issues/11
@@ -29,47 +29,74 @@ gcc.extra_features(
     ],
 )
 gcc.warning_flags(
-    minimal_warnings = ["-Wall", "-Wno-error=deprecated-declarations"],
-    strict_warnings = ["-Wextra", "-Wpedantic"],
+    minimal_warnings = [
+        "-Wall",
+        "-Wno-error=deprecated-declarations",
+    ],
+    strict_warnings = [
+        "-Wextra",
+        "-Wpedantic",
+    ],
     treat_warnings_as_errors = ["-Werror"],
 )
-
 use_repo(gcc, "gcc_toolchain", "gcc_toolchain_gcc")
 
 bazel_dep(name = "googletest", version = "1.15.0")
 bazel_dep(name = "google_benchmark", version = "1.9.1")
-
 bazel_dep(name = "rules_rust", version = "0.61.0")
 
 crate = use_extension("@rules_rust//crate_universe:extensions.bzl", "crate")
-
-crate.spec(package = "futures", version = "0.3.31")
-crate.spec(package = "libc", version = "0.2.155")
-
+crate.spec(
+    package = "futures",
+    version = "0.3.31",
+)
+crate.spec(
+    package = "libc",
+    version = "0.2.155",
+)
 crate.from_specs(name = "crate_index")
 use_repo(crate, "crate_index")
 
 archive_override(
     module_name = "rules_boost",
-    urls = "https://github.com/nelhage/rules_boost/archive/refs/heads/master.tar.gz",
     strip_prefix = "rules_boost-master",
+    urls = "https://github.com/nelhage/rules_boost/archive/refs/heads/master.tar.gz",
 )
 
 bazel_dep(name = "download_utils", version = "1.0.1")
+
 download_archive = use_repo_rule("@download_utils//download/archive:defs.bzl", "download_archive")
+
 download_archive(
     name = "json_schema_validator",
-    urls = ["https://github.com/pboettch/json-schema-validator/archive/refs/tags/2.1.0.tar.gz"],
     build = "//third_party/json_schema_validator:json_schema_validator.BUILD",
     strip_prefix = "json-schema-validator-2.1.0",
+    urls = ["https://github.com/pboettch/json-schema-validator/archive/refs/tags/2.1.0.tar.gz"],
 )
 
 bazel_dep(name = "nlohmann_json", version = "3.11.3")
 bazel_dep(name = "bazel_skylib", version = "1.7.1")
-
 bazel_dep(name = "score-baselibs", version = "0.0.0")
 git_override(
     module_name = "score-baselibs",
-    remote = "git@github.com:eclipse-score/baselibs.git",
     commit = "fc8930c739fae07a75ea2e280756cf3498bdeeef",
+    remote = "git@github.com:eclipse-score/baselibs.git",
 )
+
+###############################################################################
+#
+# Generic linting and formatting rules
+#
+###############################################################################
+bazel_dep(name = "aspect_rules_lint", version = "1.4.2")
+
+# LLVM Toolchains Rules - host configuration
+bazel_dep(name = "toolchains_llvm", version = "1.2.0")
+
+llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
+llvm.toolchain(
+    cxx_standard = {"": "c++17"},
+    llvm_version = "19.1.0",
+)
+use_repo(llvm, "llvm_toolchain")
+use_repo(llvm, "llvm_toolchain_llvm")

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -97,6 +97,24 @@ llvm = use_extension("@toolchains_llvm//toolchain/extensions:llvm.bzl", "llvm")
 llvm.toolchain(
     cxx_standard = {"": "c++17"},
     llvm_version = "19.1.0",
+    compile_flags = {"": [
+        "-march=nehalem",
+        "-ffp-model=strict",
+        # Security
+        "-U_FORTIFY_SOURCE",  # https://github.com/google/sanitizers/issues/247
+        "-fstack-protector",
+        "-fno-omit-frame-pointer",
+        # Diagnostics
+        "-fcolor-diagnostics",
+        "-Wno-deprecated-declarations",
+        "-Wno-error=self-assign-overloaded",
+        "-Wthread-safety",
+    ]},
+    link_libs ={"":[
+        "-lrt",
+    ]},
 )
 use_repo(llvm, "llvm_toolchain")
 use_repo(llvm, "llvm_toolchain_llvm")
+
+register_toolchains("@llvm_toolchain//:all")

--- a/score/mw/com/BUILD
+++ b/score/mw/com/BUILD
@@ -12,7 +12,6 @@
 # *******************************************************************************
 load("@score-baselibs//bazel:unit_tests.bzl", "cc_gtest_unit_test")
 load("//score/mw:common_features.bzl", "COMPILER_WARNING_FEATURES")
-load("//platform/aas/quality/clang_tidy:extra_checks.bzl", "clang_tidy_extra_checks")
 
 cc_library(
     name = "com_error_domain",
@@ -110,7 +109,7 @@ test_suite(
     visibility = ["//platform/aas/mw:__pkg__"],
 )
 
-clang_tidy_extra_checks(
-    name = "clang_tidy_extra_checks",
-    tidy_config_file = ".clang-tidy-extra",
+exports_files(
+    [".clang-tidy-extra"],
+    visibility = ["//visibility:public"],
 )

--- a/tools/lint/BUILD.bazel
+++ b/tools/lint/BUILD.bazel
@@ -1,0 +1,9 @@
+load("@bazel_skylib//rules:native_binary.bzl", "native_binary")
+
+package(default_visibility = ["//:__subpackages__"])
+
+native_binary(
+    name = "clang_tidy",
+    src = "@llvm_toolchain_llvm//:bin/clang-tidy",
+    out = "clang_tidy",
+)

--- a/tools/lint/linters.bzl
+++ b/tools/lint/linters.bzl
@@ -1,0 +1,16 @@
+"Define linter aspects"
+
+load("@aspect_rules_lint//lint:clang_tidy.bzl", "lint_clang_tidy_aspect")
+load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
+
+clang_tidy = lint_clang_tidy_aspect(
+    binary = "@@//tools/lint:clang_tidy",
+    configs = [
+        "@@//score/mw/com:.clang-tidy-extra",
+    ],
+    lint_target_headers = True,
+    angle_includes_are_system = False,
+    verbose = False,
+)
+
+clang_tidy_test = lint_test(aspect = clang_tidy)


### PR DESCRIPTION

There is a problem of https://github.com/eclipse-score/communication/commit/7bd54283130f633242bf3ff4bea50b79a58eb09e using the bazel rules from internal `//platform/aas/quality/clang_tidy:extra_checks.bzl`

Propose using the open source solution from https://github.com/aspect-build/rules_lint for clang-tidy.

Run clang-tidy with bazel command eg:

```
bazel build --config=clang_tidy //...
```