### PR TITLE
Add devcontainer

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,5 @@
+{
+    "name": "eclipse-s-core",
+    "image": "ghcr.io/eclipse-score/devcontainer:latest",
+    "initializeCommand": "mkdir -p ${localEnv:HOME}/.cache/bazel"
+}

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,8 @@
 bazel-*
 MODULE.bazel.lock
 user.bazelrc
+
+# Compilation databases for code completion in IDEs
+.cache/*
+compile_commands.json
+rust-project.json

--- a/README.md
+++ b/README.md
@@ -1,2 +1,4 @@
 # communication
 Repository for the communication module LoLa
+
+For setting up the devcontainer and enabling code completion read [eclipse-score/devcontainer/README.md#inside-the-container](https://github.com/eclipse-score/devcontainer/blob/main/README.md#inside-the-container).

--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
 # communication
 Repository for the communication module LoLa
 
-For setting up the devcontainer and enabling code completion read [eclipse-score/devcontainer/README.md#inside-the-container](https://github.com/eclipse-score/devcontainer/blob/main/README.md#inside-the-container).
+> [!NOTE]
+> This repository offers a [DevContainer](https://containers.dev/).
+> For setting this up and enabling code completion read [eclipse-score/devcontainer/README.md#inside-the-container](https://github.com/eclipse-score/devcontainer/blob/main/README.md#inside-the-container).


### PR DESCRIPTION
This makes it way easier to compile, run and debug code without huge setup efforts.

depends on https://gitlab.eclipse.org/eclipsefdn/helpdesk/-/issues/6389 to publish images via https://github.com/eclipse-score/devcontainer

Is in relation to https://github.com/eclipse-score/score/issues/1256