### PR TITLE
Use devcontainer image in Github Actions

### DIFF
--- a/.github/workflows/build_and_test_host_gcc.yml
+++ b/.github/workflows/build_and_test_host_gcc.yml
@@ -22,7 +22,9 @@ on:
     types: [checks_requested]
 jobs:
     build_and_test_gcc_host_gcc12:
-      runs-on: ghcr.io/eclipse-score/devcontainer:latest
+      runs-on: ubuntu-latest
+      container:
+        image: ghcr.io/eclipse-score/devcontainer:latest
       steps:
         - name: Checkout repository
           uses: actions/checkout@v4.2.2

--- a/.github/workflows/build_and_test_host_gcc.yml
+++ b/.github/workflows/build_and_test_host_gcc.yml
@@ -22,12 +22,10 @@ on:
     types: [checks_requested]
 jobs:
     build_and_test_gcc_host_gcc12:
-      runs-on: ubuntu-latest
+      runs-on: ghcr.io/eclipse-score/devcontainer:latest
       steps:
         - name: Checkout repository
           uses: actions/checkout@v4.2.2
-        - name: Setup Bazel
-          uses: bazel-contrib/setup-bazel@0.9.1
         - name: Bazel build communication targets
           run: |
             bazel build //...


### PR DESCRIPTION
With the devcontainer image the same tools and versions are used for CI and developers. This makes it way easier to reproduce CI findings or even prevent them from occuring.