### PR TITLE
rust example app: use default config file in score

### DIFF
--- a/score/mw/com/example/ipc_bridge/ipc_bridge.rs
+++ b/score/mw/com/example/ipc_bridge/ipc_bridge.rs
@@ -40,7 +40,7 @@ fn run<F: std::future::Future<Output=()> + Send>(future: F) {
 fn main() {
     println!("[Rust] Size of MapApiLanesStamped: {}", std::mem::size_of::<lib_gen_rs::MapApiLanesStamped>());
     println!("[Rust] Size of MapApiLanesStamped::lane_boundaries: {}", std::mem::size_of_val(&lib_gen_rs::MapApiLanesStamped::default().lane_boundaries));
-    proxy_bridge_rs::initialize(Some(Path::new("./platform/aas/mw/com/example/ipc_bridge/etc/mw_com_config.json")));
+    proxy_bridge_rs::initialize(Some(Path::new("./score/mw/com/example/ipc_bridge/etc/mw_com_config.json")));
 
     let instance_specifier = proxy_bridge_rs::InstanceSpecifier::try_from("xpad/cp60/MapApiLanesStamped")
         .expect("Instance specifier creation failed");


### PR DESCRIPTION
 - replaced path to mw_com_config.json in platform/aas instead use score

The ipc_bridge_rs was still pointing to the old platform/aas config file. I didn't want to modify the sample so it can accept parameters like the C++ app as this would take a bit more time than I can spend right away, hope this is useful on its own.

In the project root, to run the sampel app launch the cpp ipc_bridge first...
```sh
bazel run //score/mw/com/example/ipc_bridge:ipc_bridge_cpp  --   --mode=send   --num-cycles=100   --cycle-time=1000   --service_instance_manifest=score/mw/com/example/ipc_bridge/etc/mw_com_config.json
```

and then the rust receiver like so:
```sh
bazel run //score/mw/com/example/ipc_bridge:ipc_bridge_rs
```
(or more C++ receivers like so:)
```sh
bazel run //score/mw/com/example/ipc_bridge:ipc_bridge_cpp  --   --mode=recv   --num-cycles=100   --cycle-time=1000   --service_instance_manifest=score/mw/com/example/ipc_bridge/etc/mw_com_config.json
```

Mark Schmitt, Mercedes-Benz Tech Innovation GmbH
[Provider Information](https://github.com/mercedes-benz/foss/blob/master/PROVIDER_INFORMATION.md)