### PR TITLE
bazel: fix MODULE in CICD

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -81,6 +81,6 @@ bazel_dep(name = "bazel_skylib", version = "1.7.1")
 bazel_dep(name = "score-baselibs", version = "0.0.0")
 git_override(
     module_name = "score-baselibs",
-    remote = "git@github.com:eclipse-score/baselibs.git",
+    remote = "https://github.com/eclipse-score/baselibs.git",
     commit = "ae349b99cafc1e79d98c0391a851fc5664c04ebc",
 )


### PR DESCRIPTION
Replace ssh repo link with https - GH runner does not have ssh configured, so it fails when trying to fetch the changes.

Closes: https://github.com/eclipse-score/score/issues/1318