### PR TITLE
Exit gracefully when help is requested

### DIFF
--- a/score/mw/com/example/ipc_bridge/main.cpp
+++ b/score/mw/com/example/ipc_bridge/main.cpp
@@ -11,7 +11,6 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 #include "assert_handler.h"
-#include "score/mw/com/impl/instance_specifier.h"
 #include "sample_sender_receiver.h"
 
 #include <boost/program_options.hpp>
@@ -72,7 +71,7 @@ Params ParseCommandLineArguments(const int argc, const char** argv)
     if (args.count("help") > 0U)
     {
         std::cerr << options << std::endl;
-        throw std::runtime_error("Could not parse command line arguments");
+        std::exit(EXIT_SUCCESS);
     }
 
     return {GetValueIfProvided<std::string>(args, "mode"),


### PR DESCRIPTION
Using --help should not be an exceptional case. Instead it is always valid to use.