### PR TITLE
mw/com: migrate_umlet_to_plantuml__design_docs

### DIFF
--- a/score/mw/com/design/README.md
+++ b/score/mw/com/design/README.md
@@ -150,7 +150,7 @@ design
 are adjusted if source code is changed in the future.
 
 This comes with the drawback that we shall try to not place binary blobs into the repository.
-Thus, we decided to use [UMLet](https://www.umlet.com) for drawing any UML-related diagrams (it can be used on any OS).
+Thus, we decided to use [PlantUML](https://www.plantuml.com) for drawing any UML-related diagrams (it can be used on any OS).
 
 For graphics, we decided to only use SVGs.
 
@@ -182,13 +182,13 @@ visibility, i.e. an API that should be visible to the entire implementation name
 we use a pattern involving a friend class. In these cases, an `Example` class has a public API exposed to the end user,
 and one or both friend classes, named `ExampleView` and `ExampleMutableView`, will provide view or modification access,
 respectively, to the private members of the `ExampleClass`. We then restrict the visibility of these friend classes to
-the implementation namespace through an [AoU](broken_link_c/issue/5835119), which effectively
+the implementation namespace through an [AoU](#assumptions-of-use-aous), which effectively
 provides us with module-level encapsulation.
 Since this use of the `friend` keyword does not break encapsulation but provides us with a new kind of encapsulation
 that we need, we find that in spirit it does not contradict the guideline, and we deem such use as acceptable in
 `com::impl` namespace.
 
-## Assumptions of Use(AoUs)
+## Assumptions of Use (AoUs)
 
 A full list of AoUs can be seen [here](broken_link_c/issue/6221478). The following presents only a
 small selection.

--- a/score/mw/com/design/TODO.md
+++ b/score/mw/com/design/TODO.md
@@ -1,0 +1,7 @@
+TODOs:
+- [ ] Broken Links need to be cleaned up
+- [ ] AoU refers to a small selection in the design readme. But there is no content afterwards.
+- [ ] Configuration: Symphony (a BMW internal tool) is mentioned
+- [ ] ARXML is mentioned, will S-CORE depend on ARXML? I hope not.
+- [ ] Configuration: sequence_startup_view.puml is not referred to in the README.md
+- [ ] ipc_tracing: some links are not working to analysis api


### PR DESCRIPTION
Closes original [PR #20 ](https://github.com/eclipse-score/communication/pull/24) by creating smaller size pull requests on per directory within `/score/mw/com/design` directory 

Covered parts:
- [x] top level design docs
- [ ] configuration
- [ ] events_fields
- [ ] extensions
- [ ] ipc_tracing
- [ ] partial restart
- [ ] runtime
- [ ] service_discovery
- [ ] shared_mem_layout
- [ ] skeleton_proxy