### PR TITLE
build: Add missing header

### DIFF
--- a/score/mw/com/impl/bindings/lola/subscription_state_machine_states.h
+++ b/score/mw/com/impl/bindings/lola/subscription_state_machine_states.h
@@ -13,6 +13,7 @@
 #ifndef SCORE_MW_COM_IMPL_BINDINGS_LOLA_SUBSCRIPTION_STATE_MACHINE_STATES_H
 #define SCORE_MW_COM_IMPL_BINDINGS_LOLA_SUBSCRIPTION_STATE_MACHINE_STATES_H
 
+#include <cstdint>
 #include <string>
 
 namespace score::mw::com::impl::lola


### PR DESCRIPTION
Those were discovered when trying to build the project using AutoSD GCC toolchain.

Similar to https://github.com/eclipse-score/baselibs/pull/19