### PR TITLE
Fix Google Benchmark main function scope

### DIFF
--- a/score/mw/com/performance_benchmarks/api_microbenchmarks/lola_public_api_benchmarks.cpp
+++ b/score/mw/com/performance_benchmarks/api_microbenchmarks/lola_public_api_benchmarks.cpp
@@ -83,7 +83,7 @@ BENCHMARK_F(LolaBenchmarkFixture, LoLaInstanceSpecifierCreatePartialLoopBenchmar
     }
 }
 
-// // Run the benchmark
-BENCHMARK_MAIN();
-
 }  // namespace score::mw::com::test
+
+// Run the benchmark (must be at global scope)
+BENCHMARK_MAIN();


### PR DESCRIPTION
Move BENCHMARK_MAIN() from inside namespace to global scope. When BENCHMARK_MAIN() is inside a namespace, it generates a namespaced main function that the linker cannot find, causing 'undefined reference to main' errors.