### PR TITLE
fix "No module named 'get_git_info'" from parse_source_files.py

### DIFF
--- a/third_party/traceability/tools/source_code_linker/BUILD
+++ b/third_party/traceability/tools/source_code_linker/BUILD
@@ -21,5 +21,6 @@ py_binary(
         "parse_source_files.py",
     ],
     main = "parse_source_files.py",
+    imports = ["."],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
fixes #73 

The `imports = ["."]` attribute tells Bazel to add the current directory (where the BUILD file is located) to the Python import path when running the binary. This allows parse_source_files.py to import get_git_info.py directly without any path manipulation.