### PR TITLE
Use devcontainer 1.0.0 release

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,6 +1,6 @@
 {
     "name": "eclipse-s-core",
-    "image": "ghcr.io/eclipse-score/devcontainer:latest",
+    "image": "ghcr.io/eclipse-score/devcontainer:1.0.0",
     "runArgs": [
         "--privileged"
     ]


### PR DESCRIPTION
Use a fixed version of the devcontainer instead of "latest" to avoid unexpected changes.