### PR TITLE
rust: add placement default API

### DIFF
--- a/score/mw/com/impl/rust/com-api/com-api-concept/com_api_concept.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-concept/com_api_concept.rs
@@ -352,6 +352,19 @@ where
     ///
     /// A `SampleMut` instance providing mutable access to the initialized data.
     fn write(self, value: T) -> Self::SampleMut;
+
+    /// Writes in place (skipping intermediate moves) the default value directly into the buffer and renders it initialized.
+    /// This requires that T implements `PlacementDefault`.
+    fn write_default(mut self) -> Self::SampleMut
+    where
+        Self: Sized,
+        T: PlacementDefault,
+    {
+        T::placement_default(self.as_mut().as_mut_ptr());
+
+        // Safety: `placement_default` initialized the data
+        unsafe { self.assume_init() }
+    }
 }
 
 /// Service interface contract definition.
@@ -747,6 +760,23 @@ pub trait Subscription<T: Reloc + Send + Debug, R: Runtime + ?Sized> {
         new_samples: usize,
         max_samples: usize,
     ) -> impl Future<Output = Result<usize>> + Send;
+}
+
+/// A trait for types that can be default-constructed in place, skipping intermediate moves.
+///
+/// # Safety
+/// The implementer must ensure that the `placement_default` method correctly initializes the
+/// memory at the given pointer to a valid instance of the type, without creating temporary
+/// references that would lead to undefined behavior. The `value` under pointer after call to
+/// `placement_default` is considered initialized.
+pub unsafe trait PlacementDefault: Default {
+    /// Writes in place (skipping intermediate moves) the default value directly into the buffer.
+    ///
+    /// # Safety
+    ///  - `ptr` shall be assumed the pointer to uninitialized memory
+    ///  - implementer shall use `&raw FIELD` access to write data into fields and not producing
+    ///    temporary references that would cause undefined behavior
+    fn placement_default(ptr: *mut Self);
 }
 
 ///Test module for InstanceSpecifier validation

--- a/score/mw/com/impl/rust/com-api/com-api/com_api.rs
+++ b/score/mw/com/impl/rust/com-api/com-api/com_api.rs
@@ -18,7 +18,7 @@ pub use com_api_runtime_mock::RuntimeBuilderImpl as MockRuntimeBuilderImpl;
 
 pub use com_api_concept::{
     Builder, Consumer, ConsumerBuilder, ConsumerDescriptor, Error, FindServiceSpecifier,
-    InstanceSpecifier, Interface, OfferedProducer, Producer, ProducerBuilder, Publisher, Reloc,
-    Result, Runtime, SampleContainer, SampleMaybeUninit, SampleMut, ServiceDiscovery, Subscriber,
-    Subscription,
+    InstanceSpecifier, Interface, OfferedProducer, PlacementDefault, Producer, ProducerBuilder,
+    Publisher, Reloc, Result, Runtime, SampleContainer, SampleMaybeUninit, SampleMut,
+    ServiceDiscovery, Subscriber, Subscription,
 };


### PR DESCRIPTION
Intoroduce default way of implementing
initilization of data in place (in previously
allocated memory)