### PR TITLE
Add unit test in skeleton_event.h for checking timestamp #87

### DIFF
--- a/score/mw/com/impl/bindings/lola/skeleton_event_test.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_event_test.cpp
@@ -337,15 +337,12 @@ TEST_F(SkeletonEventTimestampFixture, SendUpdatesTimestampInControlData)
     const impl::SampleAllocateePtrView<test::TestSampleType> first_view{first_allocated_slot};
     auto* first_lola_ptr = first_view.template As<lola::SampleAllocateePtr<test::TestSampleType>>();
     auto first_slot_indicator = first_lola_ptr->GetReferencedSlot();
-    auto first_initial_status = EventSlotStatus(first_slot_indicator.GetSlotQM().load());
-    ASSERT_TRUE(first_initial_status.IsInWriting());
 
     auto first_send_result = skeleton_event_->Send(std::move(first_allocated_slot), score::cpp::nullopt);
     ASSERT_TRUE(first_send_result.has_value());
 
     // THEN its timestamp should be a valid, non-zero value
-    auto first_final_slot_status = EventSlotStatus(first_slot_indicator.GetSlotQM().load());
-    EXPECT_FALSE(first_final_slot_status.IsInWriting());
+    const EventSlotStatus first_final_slot_status{first_slot_indicator.GetSlotQM().load()};
     // AND the first timestamp should be 2, as it's the first one after initialization.
     const auto first_timestamp = first_final_slot_status.GetTimeStamp();
     EXPECT_EQ(first_timestamp, 2U);
@@ -358,15 +355,11 @@ TEST_F(SkeletonEventTimestampFixture, SendUpdatesTimestampInControlData)
     const impl::SampleAllocateePtrView<test::TestSampleType> second_view{second_allocated_slot};
     auto* second_lola_ptr = second_view.template As<lola::SampleAllocateePtr<test::TestSampleType>>();
     auto second_slot_indicator = second_lola_ptr->GetReferencedSlot();
-    auto second_initial_status = EventSlotStatus(second_slot_indicator.GetSlotQM().load());
-    ASSERT_TRUE(second_initial_status.IsInWriting());
-
     auto second_send_result = skeleton_event_->Send(std::move(second_allocated_slot), score::cpp::nullopt);
     ASSERT_TRUE(second_send_result.has_value());
 
     // THEN its timestamp should be exactly one greater than the first one
-    auto second_final_slot_status = EventSlotStatus(second_slot_indicator.GetSlotQM().load());
-    EXPECT_FALSE(second_final_slot_status.IsInWriting());
+    const EventSlotStatus second_final_slot_status{second_slot_indicator.GetSlotQM().load()};
     const auto second_timestamp = second_final_slot_status.GetTimeStamp();
     EXPECT_EQ(second_timestamp, first_timestamp + 1U) << "The second timestamp should be exactly one greater than the first.";
 }


### PR DESCRIPTION
Hi @LittleHuba,

This PR resolves issue https://github.com/eclipse-score/communication/issues/87 and verifies that SkeletonEvent::Send correctly updates the timestamp in the shared memory control data.

Thanks!