### PR TITLE
Make message_passing public

### DIFF
--- a/score/message_passing/BUILD
+++ b/score/message_passing/BUILD
@@ -199,7 +199,7 @@ cc_library(
         "additional_warnings",
     ],
     tags = ["FFI"],
-    visibility = ["//visibility:public"],
+    visibility = ["//score/mw/com/impl:__subpackages__"],
     deps = [
         ":message_passing_common",
         ":qnx_resource_path",

--- a/score/message_passing/BUILD
+++ b/score/message_passing/BUILD
@@ -57,11 +57,7 @@ cc_library(
         "additional_warnings",
     ],
     tags = ["FFI"],
-    visibility = [
-        "//score/mw/com/impl:__subpackages__",
-        "@score_logging//score/datarouter:__subpackages__",
-        "@score_logging//score/mw/log/detail/data_router:__subpackages__",
-    ],
+    visibility = ["//visibility:public"],
     deps = select({
         "@platforms//os:qnx": [":message_passing_qnx_dispatch"],
         "//conditions:default": [":message_passing_unix_domain"],
@@ -203,11 +199,7 @@ cc_library(
         "additional_warnings",
     ],
     tags = ["FFI"],
-    visibility = [
-        "//score/mw/com/impl:__subpackages__",
-        "@score_logging//score/datarouter:__subpackages__",
-        "@score_logging//score/mw/log/detail/data_router:__subpackages__",
-    ],
+    visibility = ["//visibility:public"],
     deps = [
         ":message_passing_common",
         ":qnx_resource_path",


### PR DESCRIPTION
Other infrastructure components (also external to S-CORE) such as the SOME/IP Gateway or the diagnostics stack may re-use it for their internal communication needs.

Apart from the reduced implementation and resource overhead for infrastructure components, it is also beneficial to use message_passing instead of trying to build on top of mw::com to lessen the amount of configuration the integrators have to write in order to make those infrastructure components work. Otherwise they have to configure the infrastructure component and in addition also provide an mw::com configuration for the service instances used internally in the infrastructure component. This is error prone and provides negligible additional value.