### PR TITLE
Test require workflow approval for QNX workflow

### DIFF
--- a/.github/workflows/build_and_test_qnx.yml
+++ b/.github/workflows/build_and_test_qnx.yml
@@ -49,6 +49,7 @@ jobs:
       permissions:
         contents: read
         pull-requests: read
+      environment: "workflow-approval"
       steps:
         - name: Checkout repository
           uses: actions/checkout@v4.2.2


### PR DESCRIPTION
Secrets can only be used in PRs from forks once the PR is approved.

closes #144