### PR TITLE
Fix download_utils dependency for json_schema_validator_test

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -184,7 +184,8 @@ bazel_dep(name = "score_crates", version = "0.0.7", repo_name = "score_communica
 bazel_dep(name = "boost.program_options", version = "1.87.0")
 bazel_dep(name = "boost.interprocess", version = "1.87.0")
 
-bazel_dep(name = "download_utils", version = "1.2.2", dev_dependency = True)
+bazel_dep(name = "download_utils", version = "1.2.2")
+
 bazel_dep(name = "hedron_compile_commands", dev_dependency = True)
 git_override(
     module_name = "hedron_compile_commands",

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -183,7 +183,6 @@ bazel_dep(name = "buildifier_prebuilt", version = "8.2.1.2", dev_dependency = Tr
 bazel_dep(name = "score_crates", version = "0.0.7", repo_name = "score_communication_crate_index")
 bazel_dep(name = "boost.program_options", version = "1.87.0")
 bazel_dep(name = "boost.interprocess", version = "1.87.0")
-
 bazel_dep(name = "download_utils", version = "1.2.2")
 
 bazel_dep(name = "hedron_compile_commands", dev_dependency = True)


### PR DESCRIPTION
When score_communication is used in another module, the `download_utils` dependency is stripped away, as it is declared as a `dev_dependency` within score_communication. There are `use_repo_rule` calls upon this `dev_dependency` to get repo_rule_proxy(s) `download_archive` and `download_file` which are then used to create among others the `@json_schema_validator` repo. 

<img width="984" height="248" alt="grafik" src="https://github.com/user-attachments/assets/9ec5a156-7f31-436a-a93a-4c7d1f00e614" />


When using the `validate_json_schema_test` macro outside of score_communication, like in the score_someip_gateway for example, this fails during BUILD file loading, as the macro references the `@json_schema_validator` repo. When trying to create that repo, using the repo_rule, this fails in the score_someip_gateway context, as the necessary `download_utils` is marked as `dev_dependency` and therefore not available outside of score_communication.

Usage of the macro in score_someip_gateway:
<img width="1195" height="600" alt="grafik" src="https://github.com/user-attachments/assets/24bf0d14-a54b-428b-93a1-5b97918c202f" />


Build error in score_someip_gateway:
<img width="1242" height="227" alt="grafik" src="https://github.com/user-attachments/assets/79a800dd-06f2-487b-beab-bc431b1b72f1" />


Scope of the PR is to make this a "normal" dependency.

