### PR TITLE
Enable QNX builds for forks

### DIFF
--- a/.github/workflows/build_and_test_qnx.yml
+++ b/.github/workflows/build_and_test_qnx.yml
@@ -1,87 +1,28 @@
-# *******************************************************************************
-# Copyright (c) 2024 Contributors to the Eclipse Foundation
-#
-# See the NOTICE file(s) distributed with this work for additional
-# information regarding copyright ownership.
-#
-# This program and the accompanying materials are made available under the
-# terms of the Apache License Version 2.0 which is available at
-# https://www.apache.org/licenses/LICENSE-2.0
-#
-# SPDX-License-Identifier: Apache-2.0
-# *******************************************************************************
-
-# Workflow configuration for S-CORE CI - Bazel Build & Test communication module for target platforms
-# This workflow runs Bazel build and test for QNX when triggered by specific pull request events.
-
-name: Bazel Build & Test communication module (target-platforms)
 on:
-  pull_request:
+  pull_request_target:
     types: [opened, reopened, synchronize]
+  push:
+    branches:
+      - main
   merge_group:
     types: [checks_requested]
   workflow_call:
-    secrets:
-      SCORE_QNX_LICENSE:
-        required: true
-      SCORE_QNX_USER:
-        required: true
-      SCORE_QNX_PASSWORD:
-        required: true
-env:
-  LICENSE_DIR: "/opt/score_qnx/license"
 jobs:
-    build_and_test_qnx:
-      strategy:
-        fail-fast: false
-        matrix:
-          bazel-config: ["qnx_x86_64", "qnx_arm64"]
-          include:
-            - bazel-config: "qnx_x86_64"
-              incompatible_targets:
-                - "-//score/mw/com/requirements/..." # Uninvestigated problem
-                - "-//score/mw/com/performance_benchmarks/..." # Uninvestigated problem
-                - "-//score/mw/com/doc/..." # Uninvestigated problem
-                - "-//score/mw/com/design/..." # Uninvestigated problem
-            - bazel-config: "qnx_arm64"
-              incompatible_targets:
-                - "-//score/mw/com/requirements/..." # Uninvestigated problem
-                - "-//score/mw/com/performance_benchmarks/..." # Uninvestigated problem
-                - "-//score/mw/com/doc/..." # Uninvestigated problem
-                - "-//score/mw/com/design/..." # Uninvestigated problem
-      runs-on: ubuntu-24.04
-      permissions:
-        contents: read
-      environment: "workflow-approval"
-      steps:
-        - name: Checkout repository
-          uses: actions/checkout@v4.2.2
-        - name: Free Disk Space (Ubuntu)
-          uses: ./actions/free_disk_space
-        - name: Setup Bazel
-          uses: bazel-contrib/setup-bazel@0.15.0
-          with:
-            bazelisk-cache: true
-            disk-cache: ${{ github.workflow }}-${{ matrix.bazel-config }}
-            repository-cache: true
-        - name: Allow linux-sandbox
-          uses: ./actions/unblock_user_namespace_for_linux_sandbox
-        - name: Setup QNX License
-          if: ${{ contains(matrix.bazel-config, 'qnx') }}
-          env:
-            SCORE_QNX_LICENSE: ${{ secrets.SCORE_QNX_LICENSE }}
-          run: |
-            set -euo pipefail
-
-            sudo mkdir -p "${{ env.LICENSE_DIR }}"
-            echo "${SCORE_QNX_LICENSE}" | base64 --decode | sudo tee "${{ env.LICENSE_DIR }}/licenses" >/dev/null
-        - name: Build targets
-          env:
-            SCORE_QNX_USER: ${{ secrets.SCORE_QNX_USER }}
-            SCORE_QNX_PASSWORD: ${{ secrets.SCORE_QNX_PASSWORD }}
-          run: |
-            bazel build --config ${{ matrix.bazel-config }} -- //score/... ${{ join(matrix.incompatible_targets, ' ') }}
-        - name: Cleanup QNX License
-          if: ${{ contains(matrix.bazel-config, 'qnx') && !cancelled() }}
-          run: sudo rm -rf ${{ env.LICENSE_DIR }}
-          # TODO Run tests on QNX QEMU
+  qnx-build:
+    strategy:
+      fail-fast: false
+      matrix:
+        bazel-config: [qnx_x86_64, qnx_arm64]
+    uses: eclipse-score/cicd-workflows/.github/workflows/qnx-build.yml@c1c90b1a82a1fab0fc202979dde6686b2162d5a8 # v0.0.0
+    permissions:
+      contents: read
+      pull-requests: read
+    with:
+      bazel-target: "//score/..."
+      bazel-config: ${{ matrix.bazel-config }}
+      credential-helper: ".github/tools/qnx_credential_helper.py"
+      bazel-disk-cache: ${{ matrix.bazel-config }}
+    secrets:
+      score-qnx-license: ${{ secrets.SCORE_QNX_LICENSE }}
+      score-qnx-user: ${{ secrets.SCORE_QNX_USER }}
+      score-qnx-password: ${{ secrets.SCORE_QNX_PASSWORD }}


### PR DESCRIPTION
With this commit, we are not following best practices of GitHub, but have no better alternative to handle the secrets for the build.

We enusure that only trusted code is used, via a custom envorionment, that is only approved by people with write access.

While we are not confineced of this approach, we follow here th reference integration for now.