### PR TITLE
actions: Fix job-names to match otterdog configuration

### DIFF
--- a/.github/workflows/build_and_test_host.yml
+++ b/.github/workflows/build_and_test_host.yml
@@ -22,14 +22,15 @@ on:
     types: [checks_requested]
   workflow_call:
 jobs:
-    build_and_test:
+    build_and_test_host:
+      name: build_and_test_host${{ matrix.param.identifier }}
       strategy:
         fail-fast: false
         matrix:
           param:
-            - "" # The default configuration
-            - "--extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux"
-            - "--config=linux_x86_64_score_gcc_12_2_0_posix"
+            - { identifier: "", config: "" } # The default configuration
+            - { identifier: "_llvm", config: "--extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux" }
+            - { identifier: "_score_gcc12", config: "--config=linux_x86_64_score_gcc_12_2_0_posix" }
       runs-on: ubuntu-24.04
       permissions:
         contents: read
@@ -41,13 +42,13 @@ jobs:
         - uses: bazel-contrib/setup-bazel@0.15.0
           with:
             bazelisk-cache: true
-            disk-cache: ${{ github.workflow }}-${{ matrix.toolchain }}
+            disk-cache: build_and_test_host${{ matrix.param.identifier }}
             repository-cache: true
         - name: Allow linux-sandbox
           uses: ./actions/unblock_user_namespace_for_linux_sandbox
         - name: Bazel build communication targets
           run: |
-            bazel build ${{ matrix.param }} //...
+            bazel build ${{ matrix.param.config }} //...
         - name: Bazel test communication targets
           run: |
-            bazel test ${{ matrix.param }} //... --build_tests_only
+            bazel test ${{ matrix.param.config }} //... --build_tests_only

--- a/.github/workflows/build_and_test_qnx.yml
+++ b/.github/workflows/build_and_test_qnx.yml
@@ -33,18 +33,21 @@ env:
   LICENSE_DIR: "/opt/score_qnx/license"
 jobs:
     build_and_test_qnx:
+      name: build_and_test_qnx{{ matrix.identifier }}
       strategy:
         fail-fast: false
         matrix:
           bazel-config: ["qnx_x86_64", "qnx_arm64"]
           include:
             - bazel-config: "qnx_x86_64"
+              identifier: ""
               incompatible_targets:
                 - "-//score/mw/com/requirements/..." # Uninvestigated problem
                 - "-//score/mw/com/performance_benchmarks/..." # Uninvestigated problem
                 - "-//score/mw/com/doc/..." # Uninvestigated problem
                 - "-//score/mw/com/design/..." # Uninvestigated problem
-            - bazel-config: "qnx_arm64"
+            - bazel-config: "_arm64"
+              identifier: "arm64"
               incompatible_targets:
                 - "-//score/mw/com/requirements/..." # Uninvestigated problem
                 - "-//score/mw/com/performance_benchmarks/..." # Uninvestigated problem

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -25,7 +25,7 @@ permissions:
   contents: read
 
 jobs:
-  coverage-report:
+  coverage_report:
     runs-on: ubuntu-24.04
     outputs:
       artifact-name: ${{ steps.set-artifact-name.outputs.artifact-name }}


### PR DESCRIPTION
The job-names did not match the otterdog configuration, due to typos are matrix based names.