### PR TITLE
Coverage Report is a required check in the merge queue

### DIFF
--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -15,6 +15,8 @@ name: Coverage Report
 on:
   pull_request:
     types: [ opened, reopened, synchronize ]
+  merge_group:
+    types: [checks_requested]
   workflow_call:
     outputs:
       artifact-name:


### PR DESCRIPTION
Run it as part of the merge queue.