### PR TITLE
actions: Store bazel cache only in merge_queue

### DIFF
--- a/.github/workflows/address_undefined_behavior_leak_sanitizer.yml
+++ b/.github/workflows/address_undefined_behavior_leak_sanitizer.yml
@@ -32,11 +32,12 @@ jobs:
           uses: actions/checkout@v4.2.2
         - name: Free Disk Space (Ubuntu)
           uses: ./actions/free_disk_space
-        - uses: bazel-contrib/setup-bazel@0.15.0
+        - uses: bazel-contrib/setup-bazel@0.18.0
           with:
             bazelisk-cache: true
-            disk-cache: ${{ github.workflow }}
+            disk-cache: "build_and_test_asan_ubsan_lsan"
             repository-cache: true
+            cache-save: ${{ github.event_name == 'merge_group' }}
         - name: Allow linux-sandbox
           uses: ./actions/unblock_user_namespace_for_linux_sandbox
         - name: Bazel test communication targets with address and UB and leak sanitizer

--- a/.github/workflows/build_and_test_host.yml
+++ b/.github/workflows/build_and_test_host.yml
@@ -39,11 +39,12 @@ jobs:
           uses: actions/checkout@v4.2.2
         - name: Free Disk Space (Ubuntu)
           uses: ./actions/free_disk_space
-        - uses: bazel-contrib/setup-bazel@0.15.0
+        - uses: bazel-contrib/setup-bazel@0.18.0
           with:
             bazelisk-cache: true
             disk-cache: build_and_test_host${{ matrix.param.identifier }}
             repository-cache: true
+            cache-save: ${{ github.event_name == 'merge_group' }}
         - name: Allow linux-sandbox
           uses: ./actions/unblock_user_namespace_for_linux_sandbox
         - name: Bazel build communication targets

--- a/.github/workflows/build_and_test_qnx.yml
+++ b/.github/workflows/build_and_test_qnx.yml
@@ -67,11 +67,12 @@ jobs:
         - name: Free Disk Space (Ubuntu)
           uses: ./actions/free_disk_space
         - name: Setup Bazel
-          uses: bazel-contrib/setup-bazel@0.15.0
+          uses: bazel-contrib/setup-bazel@0.18.0
           with:
             bazelisk-cache: true
-            disk-cache: ${{ github.workflow }}-${{ matrix.bazel-config }}
+            disk-cache: build_and_test_qnx${{ matrix.identifier }}
             repository-cache: true
+            cache-save: ${{ github.event_name == 'merge_group' }}
         - name: Allow linux-sandbox
           uses: ./actions/unblock_user_namespace_for_linux_sandbox
         - name: Setup QNX License

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -45,11 +45,12 @@ jobs:
           sudo apt-get install -y lcov
 
       - name: Setup Bazel with shared caching
-        uses: bazel-contrib/setup-bazel@0.15.0
+        uses: bazel-contrib/setup-bazel@0.18.0
         with:
           bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}
+          disk-cache: "coverage_report"
           repository-cache: true
+          cache-save: ${{ github.event_name == 'merge_group' }}
 
       - name: Allow linux-sandbox
         uses: ./actions/unblock_user_namespace_for_linux_sandbox

--- a/.github/workflows/thread_sanitizer.yml
+++ b/.github/workflows/thread_sanitizer.yml
@@ -31,11 +31,12 @@ jobs:
           uses: actions/checkout@v4.2.2
         - name: Free Disk Space (Ubuntu)
           uses: ./actions/free_disk_space
-        - uses: bazel-contrib/setup-bazel@0.15.0
+        - uses: bazel-contrib/setup-bazel@0.18.0
           with:
             bazelisk-cache: true
-            disk-cache: ${{ github.workflow }}
+            disk-cache: "build_and_test_tsan"
             repository-cache: true
+            cache-save: ${{ github.event_name == 'merge_group' }}
         - name: Allow linux-sandbox
           uses: ./actions/unblock_user_namespace_for_linux_sandbox
         - name: Bazel test communication targets with thread sanitizer


### PR DESCRIPTION
In order to avoid cache poisining and overrunning our limits, we update the bazel cache only in the merge queue. This way, we ensure an always hot cache.