### PR TITLE
Add copt to toolchain to always use coloring in build output

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -19,6 +19,9 @@ bazel_dep(name = "gcc_toolchain", version = "0.9.0", dev_dependency = True)
 gcc_toolchains = use_extension("@gcc_toolchain//toolchain:module_extensions.bzl", "gcc_toolchains", dev_dependency = True)
 gcc_toolchains.toolchain(
     name = "gcc_toolchain_x86_64",
+    extra_cxxflags = [
+        "-fdiagnostics-color=always",  # Adds copt to always use coloring in build output
+    ],
     extra_ldflags = [
         "-lstdc++",
         "-lrt",


### PR DESCRIPTION
Adds coloring in build output.

Old:
<img width="2581" height="1298" alt="Screenshot from 2026-03-16 12-13-20" src="https://github.com/user-attachments/assets/1a3a2c30-7041-4fe9-92e7-f59d68e1fb46" />


New:
<img width="2581" height="1298" alt="Screenshot from 2026-03-16 12-12-37" src="https://github.com/user-attachments/assets/a2f9bcc1-da2a-4521-8fe3-021344a02e99" />
