### PR TITLE
Service Discovery, Traits: Add information in log

### DIFF
--- a/score/mw/com/impl/service_discovery.cpp
+++ b/score/mw/com/impl/service_discovery.cpp
@@ -350,7 +350,8 @@ Result<ServiceHandleContainer<HandleType>> ServiceDiscovery::FindService(Instanc
     const auto instance_identifiers = runtime_.resolve(instance_specifier);
     if (instance_identifiers.size() == static_cast<std::size_t>(0U))
     {
-        score::mw::log::LogError("lola") << "Failed to resolve instance identifier from instance specifier";
+        score::mw::log::LogError("lola") << "Failed to resolve instance identifier from instance specifier:"
+                                         << instance_specifier.ToString();
         return MakeUnexpected(ComErrc::kInvalidInstanceIdentifierString);
     }
 

--- a/score/mw/com/impl/traits.h
+++ b/score/mw/com/impl/traits.h
@@ -189,7 +189,8 @@ class SkeletonWrapperClass : public Interface<Trait>
         const auto instance_identifier_result = GetInstanceIdentifier(specifier);
         if (!instance_identifier_result.has_value())
         {
-            score::mw::log::LogError("lola") << "Failed to resolve instance identifier from instance specifier";
+            score::mw::log::LogError("lola")
+                << "Failed to resolve instance identifier from instance specifier:" << specifier.ToString();
             return MakeUnexpected(ComErrc::kInvalidInstanceIdentifierString);
         }
         return Create(instance_identifier_result.value());


### PR DESCRIPTION
Adds specifier information to error logs if respective instance specifier could not be resolved.