### PR TITLE
Use ResultBlank consistently

### DIFF
--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance_methods_test.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance_methods_test.cpp
@@ -100,7 +100,7 @@ class MessagePassingServiceInstanceMethodsFixture : public ::testing::Test
             .WillByDefault(Return(ByMove(std::move(client_connection_mock_facade))));
 
         ON_CALL(client_connection_mock_, SendWaitReply(_, _))
-            .WillByDefault(Return(CreateSerializedMethodReply(score::cpp::blank{}, method_reply_buffer_)));
+            .WillByDefault(Return(CreateSerializedMethodReply(score::ResultBlank{}, method_reply_buffer_)));
         ON_CALL(client_connection_mock_, GetState()).WillByDefault(testing::Return(IClientConnection::State::kReady));
 
         ON_CALL(*unistd_mock_, getpid()).WillByDefault(Return(kLocalPid));
@@ -110,7 +110,7 @@ class MessagePassingServiceInstanceMethodsFixture : public ::testing::Test
             executor_task_ = std::forward<decltype(task)>(task);
         });
 
-        ON_CALL(mock_subscribe_method_handler_, Call(_, _, _)).WillByDefault(Return(score::cpp::blank{}));
+        ON_CALL(mock_subscribe_method_handler_, Call(_, _, _)).WillByDefault(Return(score::ResultBlank{}));
     }
 
     MessagePassingServiceInstanceMethodsFixture& GivenAMessagePassingServiceInstance(
@@ -352,7 +352,7 @@ TEST_F(MessagePassingServiceInstanceRemoteCallMethodTest, CallingWithOtherProces
         EXPECT_EQ(actual_payload.queue_position, kQueuePosition);
         EXPECT_EQ(actual_payload.proxy_method_instance_identifier, kProxyMethodInstanceIdentifier);
 
-        return CreateSerializedMethodReply(score::cpp::blank{}, method_reply_buffer_);
+        return CreateSerializedMethodReply(score::ResultBlank{}, method_reply_buffer_);
     })));
 
     // and expecting that the registered method call handler will NOT be called (which would happen when the client is
@@ -574,7 +574,7 @@ TEST_F(MessagePassingServiceInstanceRemoteSubscribeMethodTest, CallingWithOtherP
         EXPECT_EQ(actual_payload.skeleton_instance_identifier, kSkeletonInstanceIdentifier);
         EXPECT_EQ(actual_payload.proxy_instance_identifier, kProxyInstanceIdentifier);
 
-        return CreateSerializedMethodReply(score::cpp::blank{}, method_reply_buffer_);
+        return CreateSerializedMethodReply(score::ResultBlank{}, method_reply_buffer_);
     })));
 
     // and expecting that the registered method subscribe handler will NOT be called (which would happen when the client

--- a/score/mw/com/impl/bindings/lola/proxy_method_handling_test.cpp
+++ b/score/mw/com/impl/bindings/lola/proxy_method_handling_test.cpp
@@ -490,7 +490,7 @@ TEST_F(ProxySetupMethodsProxyAutoReconnectFixture,
     // handler when the service has been reoffered which succeeds
     EXPECT_CALL(*mock_service_, SubscribeServiceMethod(_, _, _, _))
         .Times(2)
-        .WillRepeatedly(Return(score::cpp::blank{}));
+        .WillRepeatedly(Return(score::ResultBlank{}));
 
     // Given that SetupMethods was called
     score::cpp::ignore = proxy_->SetupMethods({kDummyMethodName0});
@@ -636,7 +636,7 @@ TEST_F(ProxySetupMethodsMessagePassingFixture, ProxyMethodsMarkedAsSubscribedWhe
               kValidInArgsTypeErasedDataInfo, kValidReturnTypeTypeErasedDataInfo, kDummyQueueSize1}}});
 
     // Expecting that SubscribeServiceMethod will be called and returns a valid result
-    EXPECT_CALL(*mock_service_, SubscribeServiceMethod(_, _, _, _)).WillOnce(Return(score::cpp::blank{}));
+    EXPECT_CALL(*mock_service_, SubscribeServiceMethod(_, _, _, _)).WillOnce(Return(score::ResultBlank{}));
 
     // When calling SetupMethods with the name of the registered ProxyMethods
     score::cpp::ignore = proxy_->SetupMethods({kDummyMethodName0, kDummyMethodName1});


### PR DESCRIPTION
Avoid the direct usage of `score::Blank` or value type of `score::ResultBlank`. This ensures that potential change in the underlying type of `ResultBlank` won't affect the codebase.