### PR TITLE
Reduce host configurations tested in CI

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -57,6 +57,8 @@ jobs:
   run-build-and-test-host:
     needs: create-draft-release
     uses: ./.github/workflows/build_and_test_host.yml
+    with:
+      run_all_configurations: true
     permissions:
       contents: read
 

--- a/.github/workflows/build_and_test_host.yml
+++ b/.github/workflows/build_and_test_host.yml
@@ -21,19 +21,66 @@ on:
   merge_group:
     types: [checks_requested]
   workflow_call:
+    inputs:
+      run_all_configurations:
+        description: Run all host build configurations instead of only the default one.
+        required: false
+        type: boolean
+        default: true
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   cancel-in-progress: ${{ github.event_name == 'pull_request'}}
 jobs:
+    prepare_build_and_test_host_matrix:
+      runs-on: ubuntu-24.04
+      outputs:
+        matrix: ${{ steps.set-matrix.outputs.matrix }}
+      steps:
+        - name: Select host build configurations
+          id: set-matrix
+          env:
+            EVENT_NAME: ${{ github.event_name }}
+            RUN_ALL_CONFIGURATIONS: ${{ inputs.run_all_configurations }}
+          run: |
+            python3 - <<'PY'
+            import json
+            import os
+
+            default_configurations = [
+                {"identifier": "", "config": ""},
+            ]
+            extended_configurations = [
+                {
+                    "identifier": "_llvm",
+                    "config": "--extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux",
+                },
+                {
+                    "identifier": "_score_gcc12",
+                    "config": "--config=linux_x86_64_score_gcc_12_2_0_posix",
+                },
+            ]
+
+            event_name = os.environ.get("EVENT_NAME", "")
+            run_all_configurations = os.environ.get("RUN_ALL_CONFIGURATIONS", "false").lower() == "true"
+
+            matrix = list(default_configurations)
+            if event_name == "workflow_call" and run_all_configurations:
+                matrix.extend(extended_configurations)
+
+            matrix_json = json.dumps(matrix)
+            with open(os.environ["GITHUB_OUTPUT"], "a", encoding="utf-8") as output_file:
+                output_file.write("matrix<<EOF\n")
+                output_file.write(f"{matrix_json}\n")
+                output_file.write("EOF\n")
+            PY
+
     build_and_test_host:
-      name: build_and_test_host${{ matrix.param.identifier }}
+      needs: prepare_build_and_test_host_matrix
+      name: build_and_test_host${{ matrix.identifier }}
       strategy:
         fail-fast: false
         matrix:
-          param:
-            - { identifier: "", config: "" } # The default configuration
-            - { identifier: "_llvm", config: "--extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux" }
-            - { identifier: "_score_gcc12", config: "--config=linux_x86_64_score_gcc_12_2_0_posix" }
+          include: ${{ fromJSON(needs.prepare_build_and_test_host_matrix.outputs.matrix) }}
       runs-on: ubuntu-24.04
       permissions:
         contents: read
@@ -45,14 +92,14 @@ jobs:
         - uses: bazel-contrib/setup-bazel@0.18.0
           with:
             bazelisk-cache: true
-            disk-cache: build_and_test_host${{ matrix.param.identifier }}
+            disk-cache: build_and_test_host${{ matrix.identifier }}
             repository-cache: true
             cache-save: ${{ github.event_name == 'merge_group' }}
         - name: Allow linux-sandbox
           uses: ./actions/unblock_user_namespace_for_linux_sandbox
         - name: Bazel build communication targets
           run: |
-            bazel build ${{ matrix.param.config }} //...
+            bazel build ${{ matrix.config }} //...
         - name: Bazel test communication targets
           run: |
-            bazel test ${{ matrix.param.config }} //... --build_tests_only
+            bazel test ${{ matrix.config }} //... --build_tests_only


### PR DESCRIPTION
To reduce our cache consumption, we only run a limited set of configurations in the CI.

On release we still run the full set.