### PR TITLE
Replaced score::cpp with std

### DIFF
--- a/score/mw/com/impl/bindings/lola/skeleton_event.h
+++ b/score/mw/com/impl/bindings/lola/skeleton_event.h
@@ -33,7 +33,6 @@
 #include "score/mw/log/logging.h"
 
 #include <score/assert.hpp>
-#include <score/optional.hpp>
 #include <score/utility.hpp>
 
 #include <atomic>
@@ -85,11 +84,11 @@ class SkeletonEvent final : public SkeletonEventBinding<SampleType>
     /// \brief Sends a value by _copy_ towards a consumer. It will allocate the necessary space and then copy the value
     /// into Shared Memory.
     Result<void> Send(const SampleType& value,
-                      score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>
+                      std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>
                           send_trace_callback) noexcept override;
 
     Result<void> Send(impl::SampleAllocateePtr<SampleType> sample,
-                      score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>
+                      std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>
                           send_trace_callback) noexcept override;
 
     Result<impl::SampleAllocateePtr<SampleType>> Allocate() noexcept override;
@@ -134,7 +133,7 @@ template <typename SampleType>
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
 Result<void> SkeletonEvent<SampleType>::Send(
     const SampleType& value,
-    score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> send_trace_callback) noexcept
+    std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> send_trace_callback) noexcept
 {
     auto allocated_slot_result = Allocate();
     if (!(allocated_slot_result.has_value()))
@@ -150,7 +149,7 @@ Result<void> SkeletonEvent<SampleType>::Send(
 template <typename SampleType>
 Result<void> SkeletonEvent<SampleType>::Send(
     impl::SampleAllocateePtr<SampleType> sample,
-    score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> send_trace_callback) noexcept
+    std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> send_trace_callback) noexcept
 {
     const auto send_result = skeleton_event_common_.Send(sample);
     if (!send_result.has_value())

--- a/score/mw/com/impl/bindings/lola/skeleton_event_test.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_event_test.cpp
@@ -416,7 +416,7 @@ TEST_F(SkeletonEventTimestampFixture, SendUpdatesTimestampInControlData)
     auto* first_lola_ptr = first_view.template As<lola::SampleAllocateePtr<test::TestSampleType>>();
     auto first_slot_index = first_lola_ptr->GetReferencedSlot();
 
-    auto first_send_result = skeleton_event_->Send(std::move(first_allocated_slot), score::cpp::nullopt);
+    auto first_send_result = skeleton_event_->Send(std::move(first_allocated_slot), std::nullopt);
     ASSERT_TRUE(first_send_result.has_value());
 
     // THEN its timestamp should be a valid, non-zero value
@@ -435,7 +435,7 @@ TEST_F(SkeletonEventTimestampFixture, SendUpdatesTimestampInControlData)
     const impl::SampleAllocateePtrView<test::TestSampleType> second_view{second_allocated_slot};
     auto* second_lola_ptr = second_view.template As<lola::SampleAllocateePtr<test::TestSampleType>>();
     auto second_slot_index = second_lola_ptr->GetReferencedSlot();
-    auto second_send_result = skeleton_event_->Send(std::move(second_allocated_slot), score::cpp::nullopt);
+    auto second_send_result = skeleton_event_->Send(std::move(second_allocated_slot), std::nullopt);
     ASSERT_TRUE(second_send_result.has_value());
 
     // THEN its timestamp should be exactly one greater than the first one

--- a/score/mw/com/impl/bindings/lola/tracing/tracing_runtime.cpp
+++ b/score/mw/com/impl/bindings/lola/tracing/tracing_runtime.cpp
@@ -282,20 +282,22 @@ analysis::tracing::ServiceInstanceElement TracingRuntime::ConvertToTracingServic
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(lola_service_type_deployment != nullptr);
 
     using ServiceInstanceElement = analysis::tracing::ServiceInstanceElement;
-    ServiceInstanceElement output_service_instance_element{};
     const auto service_element_type =
         service_element_instance_identifier_view.service_element_identifier_view.service_element_type;
     const auto service_element_name =
         service_element_instance_identifier_view.service_element_identifier_view.service_element_name;
+
+    // Compute element variant using the new type-safe StdVariantType interface
+    ServiceInstanceElement::StdVariantType element_variant;
     if (service_element_type == impl::ServiceElementType::EVENT)
     {
         const auto lola_event_id = lola_service_type_deployment->events_.at(std::string{service_element_name});
-        output_service_instance_element.element_id = static_cast<ServiceInstanceElement::EventIdType>(lola_event_id);
+        element_variant = ServiceInstanceElement::EventId{lola_event_id};
     }
     else if (service_element_type == impl::ServiceElementType::FIELD)
     {
         const auto lola_field_id = lola_service_type_deployment->fields_.at(std::string{service_element_name});
-        output_service_instance_element.element_id = static_cast<ServiceInstanceElement::FieldIdType>(lola_field_id);
+        element_variant = ServiceInstanceElement::FieldId{lola_field_id};
     }
     else
     {
@@ -304,7 +306,8 @@ analysis::tracing::ServiceInstanceElement TracingRuntime::ConvertToTracingServic
         std::terminate();
     }
 
-    output_service_instance_element.service_id =
+    // Compute other fields
+    const auto service_id =
         static_cast<ServiceInstanceElement::ServiceIdType>(lola_service_type_deployment->service_id_);
 
     if (!lola_service_instance_deployment->instance_id_.has_value())
@@ -313,13 +316,15 @@ analysis::tracing::ServiceInstanceElement TracingRuntime::ConvertToTracingServic
             << "Tracing should not be done on service element without configured instance ID. Terminating.";
         std::terminate();
     }
-    output_service_instance_element.instance_id = static_cast<ServiceInstanceElement::InstanceIdType>(
+    const auto instance_id = static_cast<ServiceInstanceElement::InstanceIdType>(
         lola_service_instance_deployment->instance_id_.value().GetId());
 
     const auto version = ServiceIdentifierTypeView{service_identifier}.GetVersion();
-    output_service_instance_element.major_version = ServiceVersionTypeView{version}.getMajor();
-    output_service_instance_element.minor_version = ServiceVersionTypeView{version}.getMinor();
-    return output_service_instance_element;
+    const auto major_version = ServiceVersionTypeView{version}.getMajor();
+    const auto minor_version = ServiceVersionTypeView{version}.getMinor();
+
+    // Construct using the new StdVariantType constructor
+    return ServiceInstanceElement{service_id, major_version, minor_version, instance_id, element_variant};
 }
 
 std::optional<analysis::tracing::ShmObjectHandle> TracingRuntime::GetShmObjectHandle(

--- a/score/mw/com/impl/bindings/lola/tracing/tracing_runtime.cpp
+++ b/score/mw/com/impl/bindings/lola/tracing/tracing_runtime.cpp
@@ -226,7 +226,7 @@ void TracingRuntime::CacheFileDescriptorForReregisteringShmObject(
     }
 }
 
-score::cpp::optional<std::pair<memory::shared::ISharedMemoryResource::FileDescriptor, void*>>
+std::optional<std::pair<memory::shared::ISharedMemoryResource::FileDescriptor, void*>>
 TracingRuntime::GetCachedFileDescriptorForReregisteringShmObject(
     const impl::tracing::ServiceElementInstanceIdentifierView& service_element_instance_identifier_view) const noexcept
 {
@@ -322,7 +322,7 @@ analysis::tracing::ServiceInstanceElement TracingRuntime::ConvertToTracingServic
     return output_service_instance_element;
 }
 
-score::cpp::optional<analysis::tracing::ShmObjectHandle> TracingRuntime::GetShmObjectHandle(
+std::optional<analysis::tracing::ShmObjectHandle> TracingRuntime::GetShmObjectHandle(
     const impl::tracing::ServiceElementInstanceIdentifierView& service_element_instance_identifier_view) const noexcept
 {
     impl::tracing::ServiceElementInstanceIdentifierView lolaBindingSpecificIdentifier =
@@ -336,7 +336,7 @@ score::cpp::optional<analysis::tracing::ShmObjectHandle> TracingRuntime::GetShmO
     return find_result->second.first;
 }
 
-score::cpp::optional<void*> TracingRuntime::GetShmRegionStartAddress(
+std::optional<void*> TracingRuntime::GetShmRegionStartAddress(
     const impl::tracing::ServiceElementInstanceIdentifierView& service_element_instance_identifier_view) const noexcept
 {
     impl::tracing::ServiceElementInstanceIdentifierView simplifiedIdentifier =

--- a/score/mw/com/impl/bindings/lola/tracing/tracing_runtime.h
+++ b/score/mw/com/impl/bindings/lola/tracing/tracing_runtime.h
@@ -23,8 +23,6 @@
 #include "score/language/safecpp/scoped_function/scope.h"
 #include "score/memory/shared/i_shared_memory_resource.h"
 
-#include <score/optional.hpp>
-
 #include <cstddef>
 #include <mutex>
 #include <optional>
@@ -102,20 +100,19 @@ class TracingRuntime : public impl::tracing::IBindingTracingRuntime
     void UnregisterShmObject(const impl::tracing::ServiceElementInstanceIdentifierView&
                                  service_element_instance_identifier_view) noexcept override;
 
-    score::cpp::optional<analysis::tracing::ShmObjectHandle> GetShmObjectHandle(
+    std::optional<analysis::tracing::ShmObjectHandle> GetShmObjectHandle(
         const impl::tracing::ServiceElementInstanceIdentifierView& service_element_instance_identifier_view)
         const noexcept override;
 
-    score::cpp::optional<void*> GetShmRegionStartAddress(
-        const impl::tracing::ServiceElementInstanceIdentifierView& service_element_instance_identifier_view)
-        const noexcept override;
+    std::optional<void*> GetShmRegionStartAddress(const impl::tracing::ServiceElementInstanceIdentifierView&
+                                                      service_element_instance_identifier_view) const noexcept override;
 
     void CacheFileDescriptorForReregisteringShmObject(
         const impl::tracing::ServiceElementInstanceIdentifierView& service_element_instance_identifier_view,
         const memory::shared::ISharedMemoryResource::FileDescriptor shm_file_descriptor,
         void* const shm_memory_start_address) noexcept override;
 
-    score::cpp::optional<std::pair<memory::shared::ISharedMemoryResource::FileDescriptor, void*>>
+    std::optional<std::pair<memory::shared::ISharedMemoryResource::FileDescriptor, void*>>
     GetCachedFileDescriptorForReregisteringShmObject(
         const impl::tracing::ServiceElementInstanceIdentifierView& service_element_instance_identifier_view)
         const noexcept override;
@@ -151,7 +148,7 @@ class TracingRuntime : public impl::tracing::IBindingTracingRuntime
         // Suppress "AUTOSAR C++14 M11-0-1" rule findings. This rule states: "Member data in non-POD class types shall
         // be private.". We need these data elements to be organized into a coherent organized data structure.
         // coverity[autosar_cpp14_m11_0_1_violation]
-        score::cpp::optional<impl::tracing::TypeErasedSamplePtr> sample_ptr;
+        std::optional<impl::tracing::TypeErasedSamplePtr> sample_ptr;
         // coverity[autosar_cpp14_m11_0_1_violation]
         std::mutex mutex;
     };
@@ -170,7 +167,7 @@ class TracingRuntime : public impl::tracing::IBindingTracingRuntime
         -> std::optional<TraceContextId>;
 
     const Configuration& configuration_;
-    score::cpp::optional<analysis::tracing::TraceClientId> trace_client_id_;
+    std::optional<analysis::tracing::TraceClientId> trace_client_id_;
     bool data_loss_flag_;
 
     /// \brief Array of type erased sample pointers containing one element per service element that registers itself via

--- a/score/mw/com/impl/bindings/lola/tracing/tracing_runtime_test.cpp
+++ b/score/mw/com/impl/bindings/lola/tracing/tracing_runtime_test.cpp
@@ -1035,13 +1035,13 @@ TEST_F(TracingRuntimeConvertToTracingServiceInstanceElementFixture,
         major_version_number_,
         minor_version_number_,
         static_cast<ServiceInstanceElement::InstanceIdType>(instance_id_),
-        static_cast<ServiceInstanceElement::EventIdType>(event_id_)};
+        ServiceInstanceElement::StdVariantType{ServiceInstanceElement::EventId{event_id_}}};
     const ServiceInstanceElement expected_service_instance_element_field{
         static_cast<ServiceInstanceElement::ServiceIdType>(service_id_),
         major_version_number_,
         minor_version_number_,
         static_cast<ServiceInstanceElement::InstanceIdType>(instance_id_),
-        static_cast<ServiceInstanceElement::FieldIdType>(field_id_)};
+        ServiceInstanceElement::StdVariantType{ServiceInstanceElement::FieldId{field_id_}}};
 
     // Given a TracingRuntimeObject with a provided configuration object
     TracingRuntime tracing_runtime{kNumberOfTotalConfiguredTracingSlots, configuration};

--- a/score/mw/com/impl/bindings/mock_binding/skeleton_event.h
+++ b/score/mw/com/impl/bindings/mock_binding/skeleton_event.h
@@ -39,13 +39,12 @@ class SkeletonEvent : public SkeletonEventBinding<SampleType>
   public:
     MOCK_METHOD(Result<void>,
                 Send,
-                (const SampleType& value,
-                 score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>),
+                (const SampleType& value, std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>),
                 (noexcept, override));
     MOCK_METHOD(Result<void>,
                 Send,
                 (score::mw::com::impl::SampleAllocateePtr<SampleType> sample,
-                 score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>),
+                 std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>),
                 (noexcept, override));
     MOCK_METHOD(Result<score::mw::com::impl::SampleAllocateePtr<SampleType>>, Allocate, (), (noexcept, override));
     MOCK_METHOD(Result<void>, PrepareOffer, (), (noexcept, override));
@@ -69,13 +68,13 @@ class SkeletonEventFacade : public SkeletonEventBinding<SampleType>
     ~SkeletonEventFacade() override = default;
     Result<void> Send(
         const SampleType& value,
-        score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> callback) noexcept override
+        std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> callback) noexcept override
     {
         return skeleton_event_.Send(value, std::move(callback));
     };
     Result<void> Send(
         score::mw::com::impl::SampleAllocateePtr<SampleType> sample,
-        score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> callback) noexcept override
+        std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> callback) noexcept override
     {
         return skeleton_event_.Send(std::move(sample), std::move(callback));
     }

--- a/score/mw/com/impl/bindings/mock_binding/tracing/tracing_runtime.h
+++ b/score/mw/com/impl/bindings/mock_binding/tracing/tracing_runtime.h
@@ -36,11 +36,11 @@ class TracingRuntime : public IBindingTracingRuntime
                 UnregisterShmObject,
                 (const impl::tracing::ServiceElementInstanceIdentifierView&),
                 (noexcept, override));
-    MOCK_METHOD(score::cpp::optional<analysis::tracing::ShmObjectHandle>,
+    MOCK_METHOD(std::optional<analysis::tracing::ShmObjectHandle>,
                 GetShmObjectHandle,
                 (const impl::tracing::ServiceElementInstanceIdentifierView&),
                 (const, noexcept, override));
-    MOCK_METHOD(score::cpp::optional<void*>,
+    MOCK_METHOD(std::optional<void*>,
                 GetShmRegionStartAddress,
                 (const impl::tracing::ServiceElementInstanceIdentifierView&),
                 (const, noexcept, override));
@@ -50,7 +50,7 @@ class TracingRuntime : public IBindingTracingRuntime
                  memory::shared::ISharedMemoryResource::FileDescriptor,
                  void*),
                 (noexcept, override));
-    MOCK_METHOD((score::cpp::optional<std::pair<memory::shared::ISharedMemoryResource::FileDescriptor, void*>>),
+    MOCK_METHOD((std::optional<std::pair<memory::shared::ISharedMemoryResource::FileDescriptor, void*>>),
                 GetCachedFileDescriptorForReregisteringShmObject,
                 (const impl::tracing::ServiceElementInstanceIdentifierView&),
                 (const, noexcept, override));

--- a/score/mw/com/impl/skeleton_event_binding.h
+++ b/score/mw/com/impl/skeleton_event_binding.h
@@ -20,10 +20,10 @@
 #include "score/result/result.h"
 
 #include <score/callback.hpp>
-#include <score/optional.hpp>
 
 #include <cstddef>
 #include <cstdint>
+#include <optional>
 
 namespace score::mw::com::impl
 {
@@ -78,12 +78,12 @@ class SkeletonEventBinding : public SkeletonEventBindingBase
 
     /// \brief SampleType is allocated by the user and provided to the middleware to send
     /// \return On failure, returns an error code.
-    virtual Result<void> Send(const SampleType&, score::cpp::optional<SendTraceCallback>) noexcept = 0;
+    virtual Result<void> Send(const SampleType&, std::optional<SendTraceCallback>) noexcept = 0;
 
     /// \brief SampleType is previously allocated by middleware and provided by the user to indicate that he is finished
     /// filling the provided pointer with live.
     /// \return On failure, returns an error code.
-    virtual Result<void> Send(SampleAllocateePtr<SampleType>, score::cpp::optional<SendTraceCallback>) noexcept = 0;
+    virtual Result<void> Send(SampleAllocateePtr<SampleType>, std::optional<SendTraceCallback>) noexcept = 0;
 
     /// \brief Allocates memory for SampleType for the user to fill it. This is especially necessary for Zero-Copy
     /// implementations.

--- a/score/mw/com/impl/skeleton_event_binding_test.cpp
+++ b/score/mw/com/impl/skeleton_event_binding_test.cpp
@@ -32,15 +32,13 @@ class MyEvent final : public SkeletonEventBinding<SampleType>
         return {};
     }
     void PrepareStopOffer() noexcept override {}
-    Result<void> Send(
-        const SampleType&,
-        score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>) noexcept override
+    Result<void> Send(const SampleType&,
+                      std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>) noexcept override
     {
         return {};
     }
-    Result<void> Send(
-        SampleAllocateePtr<SampleType>,
-        score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>) noexcept override
+    Result<void> Send(SampleAllocateePtr<SampleType>,
+                      std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>) noexcept override
     {
         return {};
     }

--- a/score/mw/com/impl/tracing/common_event_tracing.cpp
+++ b/score/mw/com/impl/tracing/common_event_tracing.cpp
@@ -46,7 +46,7 @@ Result<void> TraceData(const ServiceElementInstanceIdentifierView service_elemen
                        const TracingRuntime::TracePointType trace_point,
                        const BindingType binding_type,
                        const std::pair<const void*, std::size_t>& local_data_chunk,
-                       const score::cpp::optional<TracingRuntime::TracePointDataId> trace_point_data_id) noexcept
+                       const std::optional<TracingRuntime::TracePointDataId> trace_point_data_id) noexcept
 {
     auto* const tracing_runtime = impl::Runtime::getInstance().GetTracingRuntime();
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(tracing_runtime != nullptr);

--- a/score/mw/com/impl/tracing/common_event_tracing.h
+++ b/score/mw/com/impl/tracing/common_event_tracing.h
@@ -18,9 +18,8 @@
 #include "score/mw/com/impl/tracing/configuration/service_element_instance_identifier_view.h"
 #include "score/mw/com/impl/tracing/tracing_runtime.h"
 
-#include <score/optional.hpp>
-
 #include <cstdint>
+#include <optional>
 #include <string_view>
 #include <utility>
 
@@ -39,7 +38,7 @@ Result<void> TraceData(const ServiceElementInstanceIdentifierView service_elemen
                        const TracingRuntime::TracePointType trace_point,
                        const BindingType binding_type,
                        const std::pair<const void*, std::size_t>& local_data_chunk = {nullptr, 0U},
-                       const score::cpp::optional<TracingRuntime::TracePointDataId> trace_point_data_id = {}) noexcept;
+                       const std::optional<TracingRuntime::TracePointDataId> trace_point_data_id = {}) noexcept;
 
 Result<void> TraceShmData(const BindingType binding_type,
                           const ServiceElementTracingData service_element_tracing_data,

--- a/score/mw/com/impl/tracing/common_event_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/common_event_tracing_test.cpp
@@ -22,13 +22,13 @@
 
 #include "score/result/result.h"
 
-#include <score/optional.hpp>
 #include <score/utility.hpp>
 
 #include <gtest/gtest.h>
 #include <cstddef>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string_view>
 #include <utility>
 
@@ -119,7 +119,7 @@ TEST_F(CommonEventTracingLocalTraceDataFixture, CallingTraceDataWillDispatchToBi
                 Trace(binding_type_,
                       service_element_instance_identifier_view_,
                       trace_point_,
-                      score::cpp::optional<TracingRuntime::TracePointDataId>{trace_point_data_id_},
+                      std::optional<TracingRuntime::TracePointDataId>{trace_point_data_id_},
                       local_data_chunk_.first,
                       local_data_chunk_.second));
 

--- a/score/mw/com/impl/tracing/configuration/tracing_filter_config_test.cpp
+++ b/score/mw/com/impl/tracing/configuration/tracing_filter_config_test.cpp
@@ -18,6 +18,7 @@
 #include <cstddef>
 #include <cstdint>
 #include <limits>
+#include <optional>
 #include <string>
 #include <string_view>
 
@@ -704,7 +705,7 @@ class ConfigurationFixture : public ::testing::Test
         PrepareMinimalConfiguration(valid_instance_specifier, service_type_, events, fields);
     }
 
-    score::cpp::optional<Configuration> configuration_{};
+    std::optional<Configuration> configuration_{};
     TracingFilterConfig tracing_filter_config_{};
     const std::string_view service_type_ = "/score/ncar/services/TirePressureService";
     const std::string event_name_ = "CurrentPressureFrontLeft";

--- a/score/mw/com/impl/tracing/i_binding_tracing_runtime.h
+++ b/score/mw/com/impl/tracing/i_binding_tracing_runtime.h
@@ -21,9 +21,9 @@
 #include "score/mw/com/impl/tracing/type_erased_sample_ptr.h"
 
 #include <score/callback.hpp>
-#include <score/optional.hpp>
 
 #include <cstdint>
+#include <optional>
 
 namespace score::mw::com::impl::tracing
 {
@@ -84,10 +84,10 @@ class IBindingTracingRuntime
     virtual void UnregisterShmObject(const impl::tracing::ServiceElementInstanceIdentifierView&
                                          service_element_instance_identifier_view) noexcept = 0;
 
-    virtual score::cpp::optional<analysis::tracing::ShmObjectHandle> GetShmObjectHandle(
+    virtual std::optional<analysis::tracing::ShmObjectHandle> GetShmObjectHandle(
         const impl::tracing::ServiceElementInstanceIdentifierView& service_element_instance_identifier_view)
         const noexcept = 0;
-    virtual score::cpp::optional<void*> GetShmRegionStartAddress(
+    virtual std::optional<void*> GetShmRegionStartAddress(
         const impl::tracing::ServiceElementInstanceIdentifierView& service_element_instance_identifier_view)
         const noexcept = 0;
 
@@ -95,7 +95,7 @@ class IBindingTracingRuntime
         const impl::tracing::ServiceElementInstanceIdentifierView& service_element_instance_identifier_view,
         const memory::shared::ISharedMemoryResource::FileDescriptor shm_file_descriptor,
         void* const shm_memory_start_address) noexcept = 0;
-    virtual score::cpp::optional<std::pair<memory::shared::ISharedMemoryResource::FileDescriptor, void*>>
+    virtual std::optional<std::pair<memory::shared::ISharedMemoryResource::FileDescriptor, void*>>
     GetCachedFileDescriptorForReregisteringShmObject(const impl::tracing::ServiceElementInstanceIdentifierView&
                                                          service_element_instance_identifier_view) const noexcept = 0;
     virtual void ClearCachedFileDescriptorForReregisteringShmObject(

--- a/score/mw/com/impl/tracing/i_tracing_runtime.h
+++ b/score/mw/com/impl/tracing/i_tracing_runtime.h
@@ -26,6 +26,7 @@
 #include "score/result/result.h"
 
 #include <cstdint>
+#include <optional>
 #include <variant>
 
 namespace score::mw::com::impl::tracing
@@ -72,7 +73,7 @@ class ITracingRuntime
     virtual Result<void> Trace(const BindingType binding_type,
                                const ServiceElementInstanceIdentifierView service_element_instance_identifier,
                                const TracePointType trace_point_type,
-                               const score::cpp::optional<TracePointDataId> trace_point_data_id,
+                               const std::optional<TracePointDataId> trace_point_data_id,
                                const void* const local_data_ptr,
                                const std::size_t local_data_size) noexcept = 0;
 

--- a/score/mw/com/impl/tracing/skeleton_event_tracing.h
+++ b/score/mw/com/impl/tracing/skeleton_event_tracing.h
@@ -27,9 +27,8 @@
 #include "score/mw/com/impl/tracing/configuration/service_element_instance_identifier_view.h"
 #include "score/mw/com/impl/tracing/skeleton_event_tracing_data.h"
 
-#include <score/optional.hpp>
-
 #include <cstdint>
+#include <optional>
 #include <string_view>
 
 namespace score::mw::com::impl::tracing
@@ -249,9 +248,9 @@ void TraceSendWithAllocate(SkeletonEventTracingData& skeleton_event_tracing_data
 template <typename SampleType>
 auto CreateTracingSendCallback(SkeletonEventTracingData& skeleton_event_tracing_data,
                                const SkeletonEventBindingBase& skeleton_event_binding_base) noexcept
-    -> score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>
+    -> std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>
 {
-    score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> tracing_handler{};
+    std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> tracing_handler{};
     if (skeleton_event_tracing_data.enable_send)
     {
         tracing_handler = [&skeleton_event_tracing_data, &skeleton_event_binding_base](
@@ -265,9 +264,9 @@ auto CreateTracingSendCallback(SkeletonEventTracingData& skeleton_event_tracing_
 template <typename SampleType>
 auto CreateTracingSendWithAllocateCallback(SkeletonEventTracingData& skeleton_event_tracing_data,
                                            const SkeletonEventBindingBase& skeleton_event_binding_base) noexcept
-    -> score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>
+    -> std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>
 {
-    score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> tracing_handler{};
+    std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> tracing_handler{};
     if (skeleton_event_tracing_data.enable_send_with_allocate)
     {
         tracing_handler = [&skeleton_event_tracing_data, &skeleton_event_binding_base](

--- a/score/mw/com/impl/tracing/test/proxy_event_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/test/proxy_event_tracing_test.cpp
@@ -469,7 +469,7 @@ TYPED_TEST(ProxyEventTracingSubscribeFixture, SubscribeCallsAreTracedWhenEnabled
                 Trace(BindingType::kLoLa,
                       expected_service_element_instance_identifier_view,
                       trace_point_type,
-                      score::cpp::optional<tracing::ITracingRuntime::TracePointDataId>{},
+                      std::optional<tracing::ITracingRuntime::TracePointDataId>{},
                       _,
                       _))
         .WillOnce(WithArgs<4, 5>(
@@ -539,7 +539,7 @@ TYPED_TEST(ProxyEventTracingSubscribeFixture,
                 Trace(BindingType::kLoLa,
                       expected_service_element_instance_identifier_view,
                       trace_point_type,
-                      score::cpp::optional<tracing::ITracingRuntime::TracePointDataId>{},
+                      std::optional<tracing::ITracingRuntime::TracePointDataId>{},
                       _,
                       _))
         .WillOnce(WithArgs<4, 5>(
@@ -617,7 +617,7 @@ TYPED_TEST(ProxyEventTracingSubscribeFixture,
                 Trace(BindingType::kLoLa,
                       expected_service_element_instance_identifier_view,
                       trace_point_type,
-                      score::cpp::optional<tracing::ITracingRuntime::TracePointDataId>{},
+                      std::optional<tracing::ITracingRuntime::TracePointDataId>{},
                       _,
                       _))
         .WillOnce(WithArgs<4, 5>(
@@ -733,7 +733,7 @@ TYPED_TEST(ProxyEventTracingUnsubscribeFixture, UnsubscribeCallsAreTracedWhenEna
                 Trace(BindingType::kLoLa,
                       expected_service_element_instance_identifier_view,
                       trace_point_type,
-                      score::cpp::optional<tracing::ITracingRuntime::TracePointDataId>{},
+                      std::optional<tracing::ITracingRuntime::TracePointDataId>{},
                       nullptr,
                       0U))
         .WillOnce(Return(Result<void>{}));
@@ -794,7 +794,7 @@ TYPED_TEST(ProxyEventTracingUnsubscribeFixture,
                 Trace(BindingType::kLoLa,
                       expected_service_element_instance_identifier_view,
                       trace_point_type,
-                      score::cpp::optional<tracing::ITracingRuntime::TracePointDataId>{},
+                      std::optional<tracing::ITracingRuntime::TracePointDataId>{},
                       nullptr,
                       0U))
         .WillOnce(Return(MakeUnexpected(tracing::TraceErrorCode::TraceErrorDisableTracePointInstance)));
@@ -863,7 +863,7 @@ TYPED_TEST(ProxyEventTracingUnsubscribeFixture,
                 Trace(BindingType::kLoLa,
                       expected_service_element_instance_identifier_view,
                       trace_point_type,
-                      score::cpp::optional<tracing::ITracingRuntime::TracePointDataId>{},
+                      std::optional<tracing::ITracingRuntime::TracePointDataId>{},
                       nullptr,
                       0U))
         .WillOnce(Return(MakeUnexpected(tracing::TraceErrorCode::TraceErrorDisableAllTracePoints)));
@@ -969,7 +969,7 @@ TYPED_TEST(ProxyEventTracingSetReceiveHandlerFixture, SetReceiveHandlerCallsAreT
                 Trace(BindingType::kLoLa,
                       expected_service_element_instance_identifier_view,
                       trace_point_type,
-                      score::cpp::optional<tracing::ITracingRuntime::TracePointDataId>{},
+                      std::optional<tracing::ITracingRuntime::TracePointDataId>{},
                       nullptr,
                       0U))
         .WillOnce(Return(Result<void>{}));
@@ -1026,7 +1026,7 @@ TYPED_TEST(ProxyEventTracingSetReceiveHandlerFixture,
                 Trace(BindingType::kLoLa,
                       expected_service_element_instance_identifier_view,
                       trace_point_type,
-                      score::cpp::optional<tracing::ITracingRuntime::TracePointDataId>{},
+                      std::optional<tracing::ITracingRuntime::TracePointDataId>{},
                       nullptr,
                       0U))
         .WillOnce(Return(MakeUnexpected(tracing::TraceErrorCode::TraceErrorDisableTracePointInstance)));
@@ -1090,7 +1090,7 @@ TYPED_TEST(ProxyEventTracingSetReceiveHandlerFixture,
                 Trace(BindingType::kLoLa,
                       expected_service_element_instance_identifier_view,
                       trace_point_type,
-                      score::cpp::optional<tracing::ITracingRuntime::TracePointDataId>{},
+                      std::optional<tracing::ITracingRuntime::TracePointDataId>{},
                       nullptr,
                       0U))
         .WillOnce(Return(MakeUnexpected(tracing::TraceErrorCode::TraceErrorDisableAllTracePoints)));
@@ -1198,7 +1198,7 @@ TYPED_TEST(ProxyEventTracingReceiveHandlerCallbackFixture, ReceiveHandlerCallbac
                 Trace(BindingType::kLoLa,
                       expected_service_element_instance_identifier_view,
                       trace_point_type,
-                      score::cpp::optional<tracing::ITracingRuntime::TracePointDataId>{},
+                      std::optional<tracing::ITracingRuntime::TracePointDataId>{},
                       nullptr,
                       0U));
 
@@ -1266,7 +1266,7 @@ TYPED_TEST(ProxyEventTracingReceiveHandlerCallbackFixture,
                 Trace(BindingType::kLoLa,
                       expected_service_element_instance_identifier_view,
                       trace_point_type,
-                      score::cpp::optional<tracing::ITracingRuntime::TracePointDataId>{},
+                      std::optional<tracing::ITracingRuntime::TracePointDataId>{},
                       nullptr,
                       0U))
         .WillOnce(Return(MakeUnexpected(tracing::TraceErrorCode::TraceErrorDisableTracePointInstance)));
@@ -1342,7 +1342,7 @@ TYPED_TEST(ProxyEventTracingReceiveHandlerCallbackFixture,
                 Trace(BindingType::kLoLa,
                       expected_service_element_instance_identifier_view,
                       trace_point_type,
-                      score::cpp::optional<tracing::ITracingRuntime::TracePointDataId>{},
+                      std::optional<tracing::ITracingRuntime::TracePointDataId>{},
                       nullptr,
                       0U))
         .WillOnce(Return(MakeUnexpected(tracing::TraceErrorCode::TraceErrorDisableAllTracePoints)));
@@ -1456,7 +1456,7 @@ TYPED_TEST(ProxyEventTracingUnsetReceiveHandlerFixture, UnsetReceiveHandlerCalls
                 Trace(BindingType::kLoLa,
                       expected_service_element_instance_identifier_view,
                       trace_point_type,
-                      score::cpp::optional<tracing::ITracingRuntime::TracePointDataId>{},
+                      std::optional<tracing::ITracingRuntime::TracePointDataId>{},
                       nullptr,
                       0U));
 
@@ -1515,7 +1515,7 @@ TYPED_TEST(ProxyEventTracingUnsetReceiveHandlerFixture,
                 Trace(BindingType::kLoLa,
                       expected_service_element_instance_identifier_view,
                       trace_point_type,
-                      score::cpp::optional<tracing::ITracingRuntime::TracePointDataId>{},
+                      std::optional<tracing::ITracingRuntime::TracePointDataId>{},
                       nullptr,
                       0U))
         .WillOnce(Return(MakeUnexpected(tracing::TraceErrorCode::TraceErrorDisableTracePointInstance)));
@@ -1582,7 +1582,7 @@ TYPED_TEST(ProxyEventTracingUnsetReceiveHandlerFixture,
                 Trace(BindingType::kLoLa,
                       expected_service_element_instance_identifier_view,
                       trace_point_type,
-                      score::cpp::optional<tracing::ITracingRuntime::TracePointDataId>{},
+                      std::optional<tracing::ITracingRuntime::TracePointDataId>{},
                       nullptr,
                       0U))
         .WillOnce(Return(MakeUnexpected(tracing::TraceErrorCode::TraceErrorDisableAllTracePoints)));
@@ -1689,7 +1689,7 @@ TYPED_TEST(ProxyEventTracingGetNewSamplesFixture, GetNewSamplesCallsAreTracedWhe
                 Trace(BindingType::kLoLa,
                       expected_service_element_instance_identifier_view,
                       trace_point_type,
-                      score::cpp::optional<tracing::ITracingRuntime::TracePointDataId>{},
+                      std::optional<tracing::ITracingRuntime::TracePointDataId>{},
                       nullptr,
                       0U));
 
@@ -1743,7 +1743,7 @@ TYPED_TEST(ProxyEventTracingGetNewSamplesFixture,
                 Trace(BindingType::kLoLa,
                       expected_service_element_instance_identifier_view,
                       trace_point_type,
-                      score::cpp::optional<tracing::ITracingRuntime::TracePointDataId>{},
+                      std::optional<tracing::ITracingRuntime::TracePointDataId>{},
                       nullptr,
                       0U))
         .WillOnce(Return(MakeUnexpected(tracing::TraceErrorCode::TraceErrorDisableTracePointInstance)));
@@ -1806,7 +1806,7 @@ TYPED_TEST(ProxyEventTracingGetNewSamplesFixture,
                 Trace(BindingType::kLoLa,
                       expected_service_element_instance_identifier_view,
                       trace_point_type,
-                      score::cpp::optional<tracing::ITracingRuntime::TracePointDataId>{},
+                      std::optional<tracing::ITracingRuntime::TracePointDataId>{},
                       nullptr,
                       0U))
         .WillOnce(Return(MakeUnexpected(tracing::TraceErrorCode::TraceErrorDisableAllTracePoints)));

--- a/score/mw/com/impl/tracing/test/skeleton_event_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/test/skeleton_event_tracing_test.cpp
@@ -280,11 +280,11 @@ TEST_F(SkeletonEventTracingSendFixture, SendCallsAreTracedWhenEnabled)
     EXPECT_CALL(tracing_runtime_mock, RegisterServiceElement(BindingType::kLoLa));
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(sample_data, _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -367,11 +367,11 @@ TEST_F(SkeletonEventTracingSendFixture, SendTracePointShouldBeDisabledAfterTrace
     EXPECT_CALL(tracing_runtime_mock, RegisterServiceElement(BindingType::kLoLa));
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(sample_data, _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -457,11 +457,11 @@ TEST_F(SkeletonEventTracingSendFixture, SendTracePointShouldBeDisabledAfterTrace
     EXPECT_CALL(tracing_runtime_mock, RegisterServiceElement(BindingType::kLoLa));
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(sample_data, _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -542,11 +542,11 @@ TEST_F(SkeletonEventTracingSendFixture, SendCallsAreNotTracedWhenDisabled)
     EXPECT_CALL(*mock_skeleton_event_binding_, GetBindingType()).WillOnce(Return(BindingType::kLoLa));
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(sample_data, _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -591,11 +591,11 @@ TEST_F(SkeletonEventTracingSendFixture, SendCallsAreNotTracedWhenTracingFilterCo
     // and that the SkeletonEvent binding never checks which trace points are enabled
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(sample_data, _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -643,11 +643,11 @@ TEST_F(SkeletonEventTracingSendFixture, SendCallsAreNotTracedWhenTracingRuntimeC
     // and that the SkeletonEvent binding never checks which trace points are enabled
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(sample_data, _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -715,11 +715,11 @@ TEST_F(SkeletonEventTracingSendWithAllocateFixture, SendCallsAreTracedWhenEnable
         .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>()))));
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -813,11 +813,11 @@ TEST_F(SkeletonEventTracingSendWithAllocateFixture,
         .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>()))));
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -914,11 +914,11 @@ TEST_F(SkeletonEventTracingSendWithAllocateFixture,
         .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>()))));
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -1009,11 +1009,11 @@ TEST_F(SkeletonEventTracingSendWithAllocateFixture, SendCallsAreNotTracedWhenDis
         .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>()))));
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -1068,11 +1068,11 @@ TEST_F(SkeletonEventTracingSendWithAllocateFixture, SendCallsAreNotTracedWhenTra
         .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>()))));
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -1130,11 +1130,11 @@ TEST_F(SkeletonEventTracingSendWithAllocateFixture, SendCallsAreNotTracedWhenTra
         .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>()))));
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));

--- a/score/mw/com/impl/tracing/test/skeleton_field_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/test/skeleton_field_tracing_test.cpp
@@ -287,11 +287,11 @@ TEST_F(SkeletonFieldTracingSendFixture, SendCallsAreTracedWhenEnabled)
     EXPECT_CALL(tracing_runtime_mock, RegisterServiceElement(BindingType::kLoLa));
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(sample_data, _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -377,11 +377,11 @@ TEST_F(SkeletonFieldTracingSendFixture, SendTracePointShouldBeDisabledAfterTrace
     EXPECT_CALL(tracing_runtime_mock, RegisterServiceElement(BindingType::kLoLa));
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(sample_data, _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -470,11 +470,11 @@ TEST_F(SkeletonFieldTracingSendFixture, SendTracePointShouldBeDisabledAfterTrace
     EXPECT_CALL(tracing_runtime_mock, RegisterServiceElement(BindingType::kLoLa));
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(sample_data, _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -558,11 +558,11 @@ TEST_F(SkeletonFieldTracingSendFixture, SendCallsAreNotTracedWhenDisabled)
     EXPECT_CALL(*mock_skeleton_field_binding_, GetBindingType()).WillOnce(Return(BindingType::kLoLa));
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(sample_data, _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -610,11 +610,11 @@ TEST_F(SkeletonFieldTracingSendFixture, SendCallsAreNotTracedWhenTracingFilterCo
     // and that the SkeletonEvent binding never checks which trace points are enabled
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(sample_data, _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -665,11 +665,11 @@ TEST_F(SkeletonFieldTracingSendFixture, SendCallsAreNotTracedWhenTracingRuntimeC
     // and that the SkeletonEvent binding never checks which trace points are enabled
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(sample_data, _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -740,11 +740,11 @@ TEST_F(SkeletonFieldTracingSendWithAllocateFixture, SendCallsAreTracedWhenEnable
         .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>()))));
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -849,11 +849,11 @@ TEST_F(SkeletonFieldTracingSendWithAllocateFixture,
         .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>()))));
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -961,11 +961,11 @@ TEST_F(SkeletonFieldTracingSendWithAllocateFixture,
         .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>()))));
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -1067,11 +1067,11 @@ TEST_F(SkeletonFieldTracingSendWithAllocateFixture, SendCallsAreNotTracedWhenDis
         .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>()))));
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -1136,11 +1136,11 @@ TEST_F(SkeletonFieldTracingSendWithAllocateFixture, SendCallsAreNotTracedWhenTra
         .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>()))));
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -1208,11 +1208,11 @@ TEST_F(SkeletonFieldTracingSendWithAllocateFixture, SendCallsAreNotTracedWhenTra
         .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>()))));
 
     // and that Send will be called on the binding with the wrapped handler containing the trace call
-    score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
+    std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback> send_trace_callback_result{};
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
-        .WillOnce(WithArgs<1>(Invoke(
-            [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> Result<void> {
+        .WillOnce(WithArgs<1>(
+            Invoke([&send_trace_callback_result](std::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
+                                                     provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));

--- a/score/mw/com/impl/tracing/test/skeleton_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/test/skeleton_tracing_test.cpp
@@ -322,11 +322,10 @@ TEST_F(SkeletonBaseUnregisterShmTracingFixture, UnregisterShmObjectIsTracedIfTra
 
     // and that PrepareStopOffer will be called on the binding with the wrapped handler containing the unregister shm
     // object trace call
-    score::cpp::optional<SkeletonBinding::UnregisterShmObjectTraceCallback>
-        unregister_shm_object_trace_callback_result{};
+    std::optional<SkeletonBinding::UnregisterShmObjectTraceCallback> unregister_shm_object_trace_callback_result{};
     EXPECT_CALL(*binding_mock_, PrepareStopOffer(_))
         .WillOnce(Invoke([&unregister_shm_object_trace_callback_result](
-                             score::cpp::optional<SkeletonBinding::UnregisterShmObjectTraceCallback>
+                             std::optional<SkeletonBinding::UnregisterShmObjectTraceCallback>
                                  provided_unregister_shm_object_trace_callback_result) -> Result<void> {
             unregister_shm_object_trace_callback_result =
                 std::move(provided_unregister_shm_object_trace_callback_result);
@@ -382,11 +381,10 @@ TEST_F(SkeletonBaseUnregisterShmTracingFixture, UnregisterShmObjectIsNotTracedIf
 
     // and that PrepareStopOffer will be called on the binding with the wrapped handler containing the unregister shm
     // object trace call
-    score::cpp::optional<SkeletonBinding::UnregisterShmObjectTraceCallback>
-        unregister_shm_object_trace_callback_result{};
+    std::optional<SkeletonBinding::UnregisterShmObjectTraceCallback> unregister_shm_object_trace_callback_result{};
     EXPECT_CALL(*binding_mock_, PrepareStopOffer(_))
         .WillOnce(Invoke([&unregister_shm_object_trace_callback_result](
-                             score::cpp::optional<SkeletonBinding::UnregisterShmObjectTraceCallback>
+                             std::optional<SkeletonBinding::UnregisterShmObjectTraceCallback>
                                  provided_unregister_shm_object_trace_callback_result) -> Result<void> {
             unregister_shm_object_trace_callback_result =
                 std::move(provided_unregister_shm_object_trace_callback_result);
@@ -447,7 +445,7 @@ TEST_F(SkeletonBaseUnregisterShmTracingFixture, UnregisterShmObjectIsTracedOnDes
     // and that PrepareStopOffer will be called on the binding with the wrapped handler containing the unregister shm
     // object trace call
     EXPECT_CALL(*binding_mock_, PrepareStopOffer(_))
-        .WillOnce(Invoke([](score::cpp::optional<SkeletonBinding::UnregisterShmObjectTraceCallback>
+        .WillOnce(Invoke([](std::optional<SkeletonBinding::UnregisterShmObjectTraceCallback>
                                 provided_unregister_shm_object_trace_callback_result) -> Result<void> {
             // Expect that the unregister shm object tracing callback is not empty
             EXPECT_TRUE(provided_unregister_shm_object_trace_callback_result.has_value());
@@ -504,7 +502,7 @@ TEST_F(SkeletonBaseUnregisterShmTracingFixture,
     // and that PrepareStopOffer will be called on the binding with the wrapped handler containing the unregister shm
     // object trace call
     EXPECT_CALL(*binding_mock_, PrepareStopOffer(_))
-        .WillOnce(Invoke([](score::cpp::optional<SkeletonBinding::UnregisterShmObjectTraceCallback>
+        .WillOnce(Invoke([](std::optional<SkeletonBinding::UnregisterShmObjectTraceCallback>
                                 provided_unregister_shm_object_trace_callback_result) -> Result<void> {
             // Expect that the unregister shm object tracing callback is empty
             EXPECT_FALSE(provided_unregister_shm_object_trace_callback_result.has_value());

--- a/score/mw/com/impl/tracing/tracing_runtime.cpp
+++ b/score/mw/com/impl/tracing/tracing_runtime.cpp
@@ -20,6 +20,7 @@
 #include "score/mw/com/impl/tracing/trace_error.h"
 
 #include <score/assert.hpp>
+#include <score/optional.hpp>
 #include <score/overload.hpp>
 
 #include <utility>
@@ -172,14 +173,17 @@ analysis::tracing::TracePointType InternalToExternalTracePointType(
 analysis::tracing::AraComMetaInfo CreateMetaInfo(
     const ServiceElementInstanceIdentifierView& service_element_instance_identifier,
     const TracingRuntime::TracePointType& trace_point_type,
-    const score::cpp::optional<TracingRuntime::TracePointDataId> trace_point_data_id,
+    const std::optional<TracingRuntime::TracePointDataId> trace_point_data_id,
     const IBindingTracingRuntime& binding_runtime) noexcept
 {
     const analysis::tracing::TracePointType ext_trace_point_type = InternalToExternalTracePointType(trace_point_type);
+    // Convert std::optional to score::cpp::optional for baselibs API compatibility
+    const score::cpp::optional<TracingRuntime::TracePointDataId> converted_trace_point_data_id =
+        trace_point_data_id.has_value() ? score::cpp::make_optional(*trace_point_data_id) : score::cpp::nullopt;
     analysis::tracing::AraComMetaInfo result{analysis::tracing::AraComProperties(
         ext_trace_point_type,
         binding_runtime.ConvertToTracingServiceInstanceElement(service_element_instance_identifier),
-        trace_point_data_id)};
+        converted_trace_point_data_id)};
     if (binding_runtime.GetDataLossFlag())
     {
         result.SetDataLossBit();
@@ -602,7 +606,7 @@ Result<void> TracingRuntime::Trace(const BindingType binding_type,
 Result<void> TracingRuntime::Trace(const BindingType binding_type,
                                    const ServiceElementInstanceIdentifierView service_element_instance_identifier,
                                    const TracePointType trace_point_type,
-                                   const score::cpp::optional<TracePointDataId> trace_point_data_id,
+                                   const std::optional<TracePointDataId> trace_point_data_id,
                                    const void* const local_data_ptr,
                                    const std::size_t local_data_size) noexcept
 {

--- a/score/mw/com/impl/tracing/tracing_runtime.h
+++ b/score/mw/com/impl/tracing/tracing_runtime.h
@@ -154,7 +154,7 @@ class TracingRuntime : public ITracingRuntime
     Result<void> Trace(const BindingType binding_type,
                        const ServiceElementInstanceIdentifierView service_element_instance_identifier,
                        const TracePointType trace_point_type,
-                       const score::cpp::optional<TracePointDataId> trace_point_data_id,
+                       const std::optional<TracePointDataId> trace_point_data_id,
                        const void* const local_data_ptr,
                        const std::size_t local_data_size) noexcept override;
 

--- a/score/mw/com/impl/tracing/tracing_runtime_mock.h
+++ b/score/mw/com/impl/tracing/tracing_runtime_mock.h
@@ -49,7 +49,7 @@ class TracingRuntimeMock : public ITracingRuntime
                 (BindingType,
                  ServiceElementInstanceIdentifierView,
                  TracePointType,
-                 score::cpp::optional<TracePointDataId>,
+                 std::optional<TracePointDataId>,
                  const void*,
                  std::size_t),
                 (noexcept, override));

--- a/score/mw/com/impl/tracing/tracing_runtime_test.cpp
+++ b/score/mw/com/impl/tracing/tracing_runtime_test.cpp
@@ -163,7 +163,7 @@ TEST(TracingRuntime, TracingRuntimeTraceWillReceivePointerToConstShmData)
         score::mw::com::impl::tracing::TracingRuntime::*)(BindingType,
                                                           ServiceElementInstanceIdentifierView,
                                                           ITracingRuntime::TracePointType,
-                                                          score::cpp::optional<ITracingRuntime::TracePointDataId>,
+                                                          std::optional<ITracingRuntime::TracePointDataId>,
                                                           ShmPointerType,
                                                           std::size_t)>(&TracingRuntime::Trace);
     static_assert(std::is_member_function_pointer_v<decltype(trace_shm_signature)>,
@@ -449,7 +449,7 @@ TEST_F(TracingRuntimeUnregisterShmObjectFixture,
 
     // and that UuT calls GetShmObjectHandle on the binding specific tracing runtime, which returns an empty optional
     ON_CALL(binding_tracing_runtime_mock_, GetShmObjectHandle(dummy_service_element_instance_identifier_view_))
-        .WillByDefault(Return(score::cpp::optional<analysis::tracing::ShmObjectHandle>{}));
+        .WillByDefault(Return(std::optional<analysis::tracing::ShmObjectHandle>{}));
 
     // Expecting that UuT calls ClearCachedFileDescriptorForReregisteringShmObject on the binding specific tracing
     // runtime
@@ -467,7 +467,7 @@ TEST_F(TracingRuntimeUnregisterShmObjectFixture,
 
     // and that UuT calls GetShmObjectHandle on the binding specific tracing runtime, which returns an empty optional
     ON_CALL(binding_tracing_runtime_mock_, GetShmObjectHandle(dummy_service_element_instance_identifier_view_))
-        .WillByDefault(Return(score::cpp::optional<analysis::tracing::ShmObjectHandle>{}));
+        .WillByDefault(Return(std::optional<analysis::tracing::ShmObjectHandle>{}));
 
     // when calling UnregisterShmObject on the UuT.
     unit_under_test_->UnregisterShmObject(BindingType::kLoLa, dummy_service_element_instance_identifier_view_);

--- a/score/mw/com/impl/tracing/tracing_runtime_trace_test.cpp
+++ b/score/mw/com/impl/tracing/tracing_runtime_trace_test.cpp
@@ -52,7 +52,7 @@ constexpr std::string_view kInstanceSpecifier{"/my_service_type_port"};
 
 const void* const kLocalDataPtr{reinterpret_cast<void*>(static_cast<intptr_t>(500))};
 constexpr std::size_t kLocalDataSize{8};
-const score::cpp::optional<TracingRuntime::TracePointDataId> kEmptyDataId{};
+const std::optional<TracingRuntime::TracePointDataId> kEmptyDataId{};
 
 const analysis::tracing::ServiceInstanceElement::EventIdType kServiceInstanceElementEventId = 42U;
 const analysis::tracing::ServiceInstanceElement::VariantType kServiceInstanceElementVariant{
@@ -338,12 +338,12 @@ TEST_P(TracingRuntimeTraceShmParamaterisedFixture, TraceShmDataOK_RetryShmObject
         .WillOnce(Return(trace_context_id_));
     // expect, that the binding specific tracing runtime doesn't have a ShmObjectHandle for the given identifier
     EXPECT_CALL(binding_tracing_runtime_mock_, GetShmObjectHandle(dummy_service_element_instance_identifier_view_))
-        .WillOnce(Return(score::cpp::optional<analysis::tracing::ShmObjectHandle>{}));
+        .WillOnce(Return(std::optional<analysis::tracing::ShmObjectHandle>{}));
     // then expect, that UuT calls GetCachedFileDescriptorForReregisteringShmObject() on binding specific tracing
     // runtime
     EXPECT_CALL(binding_tracing_runtime_mock_,
                 GetCachedFileDescriptorForReregisteringShmObject(dummy_service_element_instance_identifier_view_))
-        .WillOnce(Return(score::cpp::optional<std::pair<memory::shared::ISharedMemoryResource::FileDescriptor, void*>>{
+        .WillOnce(Return(std::optional<std::pair<memory::shared::ISharedMemoryResource::FileDescriptor, void*>>{
             {shm_file_descriptor, dummy_shm_object_start_address_}}));
     // and expect, that it then retries the RegisterShmObject() call on the GenericTraceAPI, which is successful and
     // returns a ShmObjectHandle
@@ -401,12 +401,12 @@ TEST_P(TracingRuntimeTraceShmParamaterisedFixture, TraceShmDataNOK_RetryShmObjec
 
     // expect, that the binding specific tracing runtime doesn't have a ShmObjectHandle for the given identifier
     EXPECT_CALL(binding_tracing_runtime_mock_, GetShmObjectHandle(dummy_service_element_instance_identifier_view_))
-        .WillOnce(Return(score::cpp::optional<analysis::tracing::ShmObjectHandle>{}));
+        .WillOnce(Return(std::optional<analysis::tracing::ShmObjectHandle>{}));
     // then expect, that UuT calls GetCachedFileDescriptorForReregisteringShmObject() on binding specific tracing
     // runtime
     EXPECT_CALL(binding_tracing_runtime_mock_,
                 GetCachedFileDescriptorForReregisteringShmObject(dummy_service_element_instance_identifier_view_))
-        .WillOnce(Return(score::cpp::optional<std::pair<memory::shared::ISharedMemoryResource::FileDescriptor, void*>>{
+        .WillOnce(Return(std::optional<std::pair<memory::shared::ISharedMemoryResource::FileDescriptor, void*>>{
             {shm_file_descriptor, dummy_shm_object_start_address_}}));
     // expect, that UuT calls GetTraceClientId() on the binding specific tracing runtime
     EXPECT_CALL(binding_tracing_runtime_mock_, GetTraceClientId()).WillOnce(Return(trace_client_id_));
@@ -450,12 +450,12 @@ TEST_P(TracingRuntimeTraceShmParamaterisedFixture, TraceShmDataNOK_RetryShmObjec
 
     // expect, that the binding specific tracing runtime doesn't have a ShmObjectHandle for the given identifier
     EXPECT_CALL(binding_tracing_runtime_mock_, GetShmObjectHandle(dummy_service_element_instance_identifier_view_))
-        .WillOnce(Return(score::cpp::optional<analysis::tracing::ShmObjectHandle>{}));
+        .WillOnce(Return(std::optional<analysis::tracing::ShmObjectHandle>{}));
     // then expect, that UuT calls GetCachedFileDescriptorForReregisteringShmObject() on binding specific tracing
     // runtime
     EXPECT_CALL(binding_tracing_runtime_mock_,
                 GetCachedFileDescriptorForReregisteringShmObject(dummy_service_element_instance_identifier_view_))
-        .WillOnce(Return(score::cpp::optional<std::pair<memory::shared::ISharedMemoryResource::FileDescriptor, void*>>{
+        .WillOnce(Return(std::optional<std::pair<memory::shared::ISharedMemoryResource::FileDescriptor, void*>>{
             {shm_file_descriptor, dummy_shm_object_start_address_}}));
     // expect, that UuT calls GetTraceClientId() on the binding specific tracing runtime
     EXPECT_CALL(binding_tracing_runtime_mock_, GetTraceClientId()).WillOnce(Return(trace_client_id_));
@@ -494,13 +494,13 @@ TEST_P(TracingRuntimeTraceShmParamaterisedFixture, TraceShmDataNOK_NoCachedFiled
 
     // expect, that the binding specific tracing runtime doesn't have a ShmObjectHandle for the given identifier
     EXPECT_CALL(binding_tracing_runtime_mock_, GetShmObjectHandle(dummy_service_element_instance_identifier_view_))
-        .WillOnce(Return(score::cpp::optional<analysis::tracing::ShmObjectHandle>{}));
+        .WillOnce(Return(std::optional<analysis::tracing::ShmObjectHandle>{}));
     // then expect, that UuT calls GetCachedFileDescriptorForReregisteringShmObject() on binding specific tracing
     // runtime, which doesn't return any
     EXPECT_CALL(binding_tracing_runtime_mock_,
                 GetCachedFileDescriptorForReregisteringShmObject(dummy_service_element_instance_identifier_view_))
         .WillOnce(
-            Return(score::cpp::optional<std::pair<memory::shared::ISharedMemoryResource::FileDescriptor, void*>>{}));
+            Return(std::optional<std::pair<memory::shared::ISharedMemoryResource::FileDescriptor, void*>>{}));
 
     // when we call Trace on the UuT
     auto result = unit_under_test_->Trace(BindingType::kLoLa,

--- a/score/mw/com/impl/tracing/tracing_runtime_trace_test.cpp
+++ b/score/mw/com/impl/tracing/tracing_runtime_trace_test.cpp
@@ -54,9 +54,9 @@ const void* const kLocalDataPtr{reinterpret_cast<void*>(static_cast<intptr_t>(50
 constexpr std::size_t kLocalDataSize{8};
 const std::optional<TracingRuntime::TracePointDataId> kEmptyDataId{};
 
-const analysis::tracing::ServiceInstanceElement::EventIdType kServiceInstanceElementEventId = 42U;
-const analysis::tracing::ServiceInstanceElement::VariantType kServiceInstanceElementVariant{
-    kServiceInstanceElementEventId};
+const analysis::tracing::ServiceInstanceElement::EventIdType kServiceInstanceElementEventId{42U};
+const analysis::tracing::ServiceInstanceElement::StdVariantType kServiceInstanceElementVariant{
+    analysis::tracing::ServiceInstanceElement::EventId{kServiceInstanceElementEventId}};
 const analysis::tracing::ServiceInstanceElement kServiceInstanceElement{25, 1, 0, 1, kServiceInstanceElementVariant};
 
 // Debouncing test constants
@@ -361,7 +361,7 @@ TEST_P(TracingRuntimeTraceShmParamaterisedFixture, TraceShmDataOK_RetryShmObject
     EXPECT_CALL(binding_tracing_runtime_mock_, SetDataLossFlag(false)).Times(1);
     EXPECT_CALL(binding_tracing_runtime_mock_, GetTraceClientId()).WillRepeatedly(Return(trace_client_id_));
 
-    analysis::tracing::ServiceInstanceElement::VariantType variant{};
+    analysis::tracing::ServiceInstanceElement::StdVariantType variant{};
     analysis::tracing::ServiceInstanceElement service_instance_element{25, 1, 0, 1, variant};
     EXPECT_CALL(binding_tracing_runtime_mock_,
                 ConvertToTracingServiceInstanceElement(dummy_service_element_instance_identifier_view_))
@@ -499,8 +499,7 @@ TEST_P(TracingRuntimeTraceShmParamaterisedFixture, TraceShmDataNOK_NoCachedFiled
     // runtime, which doesn't return any
     EXPECT_CALL(binding_tracing_runtime_mock_,
                 GetCachedFileDescriptorForReregisteringShmObject(dummy_service_element_instance_identifier_view_))
-        .WillOnce(
-            Return(std::optional<std::pair<memory::shared::ISharedMemoryResource::FileDescriptor, void*>>{}));
+        .WillOnce(Return(std::optional<std::pair<memory::shared::ISharedMemoryResource::FileDescriptor, void*>>{}));
 
     // when we call Trace on the UuT
     auto result = unit_under_test_->Trace(BindingType::kLoLa,
@@ -543,7 +542,7 @@ TEST_P(TracingRuntimeTraceShmParamaterisedDeathTest, TraceShmDataNOK_GetShmRegio
         // address
         EXPECT_CALL(binding_tracing_runtime_mock_,
                     GetShmRegionStartAddress(dummy_service_element_instance_identifier_view_))
-            .WillOnce(Return(score::cpp::optional<void*>{}));
+            .WillOnce(Return(std::optional<void*>{}));
         // when we call Trace on the UuT
         std::ignore = unit_under_test_->Trace(BindingType::kLoLa,
                                               service_element_tracing_data_,
@@ -902,8 +901,9 @@ TEST_P(TracingRuntimeTraceLocalParamaterisedFixture, TraceLocalData_NonRecoverab
     analysis::tracing::LocalDataChunk root_chunk{kLocalDataPtr, kLocalDataSize};
     analysis::tracing::LocalDataChunkList expected_chunk_list{root_chunk};
 
-    analysis::tracing::ServiceInstanceElement::EventIdType event_id = 42U;
-    analysis::tracing::ServiceInstanceElement::VariantType variant{event_id};
+    analysis::tracing::ServiceInstanceElement::EventIdType event_id{42U};
+    analysis::tracing::ServiceInstanceElement::StdVariantType variant{
+        analysis::tracing::ServiceInstanceElement::EventId{event_id}};
     analysis::tracing::ServiceInstanceElement service_instance_element{25, 1, 0, 1, variant};
 
     // expect, that UuT calls GetDataLossFlag() on the binding specific tracing runtime to setup meta-info property
@@ -958,7 +958,7 @@ TEST_P(TracingRuntimeTraceLocalParamaterisedFixture, DisabledTracing_EarlyReturn
     auto result1 = unit_under_test_->Trace(BindingType::kLoLa,
                                            dummy_service_element_instance_identifier_view_,
                                            trace_point_type_,
-                                           score::cpp::optional<TracingRuntime::TracePointDataId>{},
+                                           std::optional<TracingRuntime::TracePointDataId>{},
                                            reinterpret_cast<void*>(static_cast<intptr_t>(500)),
                                            std::size_t{0});
     EXPECT_FALSE(result1.has_value());
@@ -999,8 +999,9 @@ TEST_P(TracingRuntimeTraceLocalParamaterisedFixture, TraceLocalData_FatalError)
     analysis::tracing::LocalDataChunk root_chunk{kLocalDataPtr, kLocalDataSize};
     analysis::tracing::LocalDataChunkList expected_chunk_list{root_chunk};
 
-    analysis::tracing::ServiceInstanceElement::EventIdType event_id = 42U;
-    analysis::tracing::ServiceInstanceElement::VariantType variant{event_id};
+    analysis::tracing::ServiceInstanceElement::EventIdType event_id{42U};
+    analysis::tracing::ServiceInstanceElement::StdVariantType variant{
+        analysis::tracing::ServiceInstanceElement::EventId{event_id}};
     analysis::tracing::ServiceInstanceElement service_instance_element{25, 1, 0, 1, variant};
 
     // expect, that UuT calls GetDataLossFlag() on the binding specific tracing runtime to setup meta-info property


### PR DESCRIPTION
## Summary

Migrates `mw/com` tracing and skeleton event code from `score::cpp` types to their `std` equivalents, and adopts the new type-safe `ServiceInstanceElement` interface from baselibs.

## Motivation

As part of the ongoing migration from `score::cpp` wrappers to standard C++ types, this PR replaces deprecated types with their `std` counterparts and leverages the new type-safe `ServiceInstanceElement` variant interface introduced in [eclipse-score/baselibs@be21786](https://github.com/eclipse-score/baselibs/commit/be21786bab8f7a6c0df71a92c4a653bf421ab87d). Using `std::variant` with distinct wrapper structs (`EventId`, `FieldId`, `MethodId`) instead of `score::cpp::variant<uint32_t, uint32_t, uint32_t>` eliminates reliance on index-based access and makes the variant type-safe.

## Changes

### Commit 1: Replace score::cpp::optional with std::optional in tracing

| Before | After |
|---|---|
| `score::cpp::optional<T>` | `std::optional<T>` |
| `score::cpp::nullopt` | `std::nullopt` |
| `#include <score/optional.hpp>` | `#include <optional>` |

- **`skeleton_event_binding.h`:** `Send()` signature changed from `score::cpp::optional<SendTraceCallback>` to `std::optional<SendTraceCallback>`, propagated through all implementations (lola, mock_binding) and tests.
- **`common_event_tracing.h/cpp`:** `TraceData()` parameter migrated to `std::optional`.
- **`i_binding_tracing_runtime.h` / `i_tracing_runtime.h`:** Interface methods migrated to return `std::optional`.
- **`skeleton_event_tracing.h`:** Callbacks use `std::optional`.
- **tracing_runtime.cpp:** Bridge conversion added (`std::optional` → `score::cpp::optional`) for baselibs `AraComProperties` API compatibility.

### Commit 2: Adopt type-safe StdVariantType for ServiceInstanceElement

| Before | After |
|---|---|
| `score::cpp::variant` (index-based) | `std::variant` (type-safe) |
| `ServiceInstanceElement::EventIdType` (`uint32_t` alias) | `ServiceInstanceElement::EventId` (struct wrapper) |
| `ServiceInstanceElement::FieldIdType` (`uint32_t` alias) | `ServiceInstanceElement::FieldId` (struct wrapper) |
| `ServiceInstanceElement::VariantType` | `ServiceInstanceElement::StdVariantType` |

- **tracing_runtime.cpp (lola):** Constructs `ServiceInstanceElement` using the new `StdVariantType` constructor with `EventId{}`/`FieldId{}` struct wrappers instead of assigning raw `uint32_t` to aggregate members.
- **`tracing_runtime_test.cpp` (lola) / `tracing_runtime_trace_test.cpp`:** Test expectations updated to use `StdVariantType{EventId{...}}`.

## Testing

All existing unit tests updated to use the new interface. No behavioral changes — this is a pure type migration.

