### PR TITLE
Disable coverage report generation in PRs

### DIFF
--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -13,10 +13,6 @@
 name: Coverage Report
 
 on:
-  pull_request:
-    types: [ opened, reopened, synchronize ]
-  merge_group:
-    types: [checks_requested]
   workflow_call:
     outputs:
       artifact-name:


### PR DESCRIPTION
Coverage report generation is severely broken currently and adds no benefit to PR runs.

We retain it for release builds but disable all other triggers.