### PR TITLE
mw com migrate to result nodiscard.

### DIFF
--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.cpp
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.cpp
@@ -430,7 +430,7 @@ void mw_com_proxy_clear_event_receive_handler(ProxyEventBase* event_ptr)
     {
         return;
     }
-    event_ptr->UnsetReceiveHandler();
+    score::cpp::ignore = event_ptr->UnsetReceiveHandler();
 }
 
 /// \brief Start asynchronous service discovery with a callback

--- a/score/mw/com/test/common_test_resources/proxy_observer.h
+++ b/score/mw/com/test/common_test_resources/proxy_observer.h
@@ -72,7 +72,7 @@ class ProxyObserver
             {
                 std::cout << "Requested number of proxies created" << std::endl;
                 promise_.SetValue();
-                Proxy::StopFindService(find_service_handle);
+                score::cpp::ignore = Proxy::StopFindService(find_service_handle);
             }
         };
 

--- a/score/mw/com/test/field_initial_value/client.cpp
+++ b/score/mw/com/test/field_initial_value/client.cpp
@@ -48,7 +48,7 @@ int run_client(const std::size_t num_retries, const std::chrono::milliseconds re
     auto lola_proxy_handles_result = TestDataProxy::StartFindService(
         [moved_service_discovery_promise = std::move(service_discovery_promise)](auto handles, auto handle) mutable {
             moved_service_discovery_promise.set_value(handles);
-            TestDataProxy::StopFindService(handle);
+            score::cpp::ignore = TestDataProxy::StopFindService(handle);
         },
         std::move(instance_specifier));
 

--- a/score/mw/com/test/methods/methods_test_resources/proxy_container.h
+++ b/score/mw/com/test/methods/methods_test_resources/proxy_container.h
@@ -72,7 +72,7 @@ bool ProxyContainer<Proxy>::CreateProxy(InstanceSpecifier instance_specifier,
             return;
         }
         handle_ = std::make_unique<typename Proxy::HandleType>(service_handle_container[0]);
-        Proxy::StopFindService(find_service_handle);
+        score::cpp::ignore = Proxy::StopFindService(find_service_handle);
         callback_called = true;
         proxy_creation_condition_variable_.notify_all();
     };

--- a/score/mw/com/test/receive_handler_usage/receive_handler_usage_application.cpp
+++ b/score/mw/com/test/receive_handler_usage/receive_handler_usage_application.cpp
@@ -74,7 +74,7 @@ score::Result<score::mw::com::test::BigDataProxy> CreateProxy(
     auto handles_result = score::mw::com::test::BigDataProxy::StartFindService(
         [moved_service_discovery_promise = std::move(service_discovery_promise)](auto handles, auto handle) mutable {
             moved_service_discovery_promise.set_value(handles);
-            score::mw::com::test::BigDataProxy::StopFindService(handle);
+            score::cpp::ignore = score::mw::com::test::BigDataProxy::StopFindService(handle);
         },
         std::move(instance_specifier));
     if (!handles_result.has_value())

--- a/score/mw/com/test/smokeyeyes/smokeyeyes.cpp
+++ b/score/mw/com/test/smokeyeyes/smokeyeyes.cpp
@@ -245,7 +245,7 @@ int run_receiver(SharedState& shared_state,
             [moved_service_discovery_promise = std::move(service_discovery_promise)](auto found_handles,
                                                                                      auto handle) mutable {
                 moved_service_discovery_promise.set_value(found_handles);
-                DataProxy::StopFindService(handle);
+                score::cpp::ignore = DataProxy::StopFindService(handle);
             },
             std::move(instance_specifier_result).value());
         if (!handles_result.has_value())

--- a/score/mw/com/test/unsubscribe_deadlock/unsubscribe_deadlock_application.cpp
+++ b/score/mw/com/test/unsubscribe_deadlock/unsubscribe_deadlock_application.cpp
@@ -62,7 +62,7 @@ score::Result<score::mw::com::test::BigDataProxy> CreateProxy(
     auto handles_result = score::mw::com::test::BigDataProxy::StartFindService(
         [moved_service_discovery_promise = std::move(service_discovery_promise)](auto handles, auto handle) mutable {
             moved_service_discovery_promise.set_value(handles);
-            score::mw::com::test::BigDataProxy::StopFindService(handle);
+            score::cpp::ignore = score::mw::com::test::BigDataProxy::StopFindService(handle);
         },
         std::move(instance_specifier));
     if (!handles_result.has_value())


### PR DESCRIPTION
Baselibs result migrated to nodiscard. Updated mw/com to properly use or explicitly discard these return values.