### PR TITLE
qnx_unit_tests: Skip inotify event tests on QNX 8 x86_64

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -291,7 +291,7 @@ pip.parse(
 )
 use_repo(pip, "lobster_dependencies")
 
-bazel_dep(name = "score_bazel_platforms", version = "0.1.1")
+bazel_dep(name = "score_bazel_platforms", version = "0.1.2")
 
 bazel_dep(name = "rules_oci", version = "1.8.0", dev_dependency = True)
 

--- a/score/mw/com/impl/bindings/lola/service_discovery/client/BUILD
+++ b/score/mw/com/impl/bindings/lola/service_discovery/client/BUILD
@@ -49,6 +49,13 @@ cc_gtest_unit_test(
         "service_discovery_client_worker_thread_test.cpp",
     ],
     features = COMPILER_WARNING_FEATURES,
+    # TODO: Ticket-253098
+    target_compatible_with = select({
+        "@score_bazel_platforms//settings:x86_64-qnx": [
+            "@score_bazel_platforms//version:sdp_7.1.0",
+        ],
+        "//conditions:default": [],
+    }),
     visibility = [
         "//score/mw/com/impl/bindings/lola/service_discovery/client:__pkg__",
     ],

--- a/score/mw/com/impl/bindings/lola/test/proxy_component_test.cpp
+++ b/score/mw/com/impl/bindings/lola/test/proxy_component_test.cpp
@@ -272,6 +272,9 @@ class ProxyServiceDiscoveryFixture : public ProxyWithRealMemFixture
 // Test to check that race condition in Ticket-169333 does not occur.
 TEST_F(ProxyServiceDiscoveryFixture, CallingStartFindServiceInHandlerAndStartFindServiceInMainThreadDoesNotDeadLock)
 {
+#if defined(__QNX__) && __QNX__ >= 800 && defined(__x86_64__)
+    GTEST_SKIP() << "TODO: Ticket-253098 Inotify not supported on QNX 8 x86_64 filesystem";
+#else
     MockFunction<void(ServiceHandleContainer<HandleType>, FindServiceHandle)> find_service_handler_2{};
 
     // Given a real ServiceDiscovery and a configuration that contains no events
@@ -300,11 +303,15 @@ TEST_F(ProxyServiceDiscoveryFixture, CallingStartFindServiceInHandlerAndStartFin
 
     // Then we expect that both calls to StartFindService are called without a dead lock and both handlers are called
     handler_done_notifier_.waitWithAbort(stop_token_);
+#endif
 }
 
 // Test to check that race condition in Ticket-169333 does not occur.
 TEST_F(ProxyServiceDiscoveryFixture, CallingStartFindServiceInHandlerAndStopFindServiceInMainThreadDoesNotDeadLock)
 {
+#if defined(__QNX__) && __QNX__ >= 800 && defined(__x86_64__)
+    GTEST_SKIP() << "TODO: Ticket-253098 Inotify not supported on QNX 8 x86_64 filesystem";
+#else
     // Given a real ServiceDiscovery and a configuration that contains no events
     WithARealServiceDiscovery().WithAConfigurationContainingNoEvents();
     const InstanceIdentifier instance_identifier{config_store_->GetInstanceIdentifier()};
@@ -328,11 +335,15 @@ TEST_F(ProxyServiceDiscoveryFixture, CallingStartFindServiceInHandlerAndStopFind
     // Then we expect that both the call to StartFindService in the handler and the call to StopFindService are called
     // without a dead lock and that the handler are finishes
     handler_done_notifier_.waitWithAbort(stop_token_);
+#endif
 }
 
 // Test to check that race condition in Ticket-169333 does not occur.
 TEST_F(ProxyServiceDiscoveryFixture, CallingStopFindServiceInHandlerAndStartFindServiceInMainThreadDoesNotDeadLock)
 {
+#if defined(__QNX__) && __QNX__ >= 800 && defined(__x86_64__)
+    GTEST_SKIP() << "TODO: Ticket-253098 Inotify not supported on QNX 8 x86_64 filesystem";
+#else
     MockFunction<void(ServiceHandleContainer<HandleType>, FindServiceHandle)> find_service_handler_2{};
 
     // Given a real ServiceDiscovery and a configuration that contains no events
@@ -361,11 +372,15 @@ TEST_F(ProxyServiceDiscoveryFixture, CallingStopFindServiceInHandlerAndStartFind
 
     // Then we expect that both calls to StartFindService are called without a dead lock and both handlers are called
     handler_done_notifier_.waitWithAbort(stop_token_);
+#endif
 }
 
 // Test to check that race condition in Ticket-169333 does not occur.
 TEST_F(ProxyServiceDiscoveryFixture, CallingStopFindServiceInHandlerAndStopFindServiceInMainThreadDoesNotDeadLock)
 {
+#if defined(__QNX__) && __QNX__ >= 800 && defined(__x86_64__)
+    GTEST_SKIP() << "TODO: Ticket-253098 Inotify not supported on QNX 8 x86_64 filesystem";
+#else
     // Given a real ServiceDiscovery and a configuration that contains no events
     WithARealServiceDiscovery().WithAConfigurationContainingNoEvents();
     const InstanceIdentifier instance_identifier{config_store_->GetInstanceIdentifier()};
@@ -389,6 +404,7 @@ TEST_F(ProxyServiceDiscoveryFixture, CallingStopFindServiceInHandlerAndStopFindS
     // Then we expect that both the call to StartFindService in the handler and the call to StopFindService are called
     // without a dead lock and that the handler are finishes
     handler_done_notifier_.waitWithAbort(stop_token_);
+#endif
 }
 
 }  // namespace


### PR DESCRIPTION
QNX 8 x86_64 does not deliver inotify events on the ramdisk-backed /persistent filesystem, causing real-inotify tests to hang on poll(). Skip the affected tests on that platform. Mock-based tests are unaffected.

Issue: Ticket-253098