### PR TITLE
third_party: Explicitly load rules_cc and rules_python load

### DIFF
--- a/third_party/traceability/doc/sample_library/BUILD
+++ b/third_party/traceability/doc/sample_library/BUILD
@@ -11,6 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
+load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//third_party/traceability/bazel:traceability.bzl", "safety_software_seooc", "safety_software_unit")
 
 cc_library(

--- a/third_party/traceability/doc/sample_library/unit_1/BUILD
+++ b/third_party/traceability/doc/sample_library/unit_1/BUILD
@@ -11,6 +11,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
 cc_library(
     name = "unit_1",
     srcs = ["foo.cpp"],

--- a/third_party/traceability/doc/sample_library/unit_2/BUILD
+++ b/third_party/traceability/doc/sample_library/unit_2/BUILD
@@ -11,6 +11,8 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
+load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
+
 cc_library(
     name = "unit_2",
     srcs = ["bar.cpp"],

--- a/third_party/traceability/tools/source_code_linker/BUILD
+++ b/third_party/traceability/tools/source_code_linker/BUILD
@@ -14,6 +14,8 @@
 # Carry over from Eclipse S-Core including slight modifications:
 # https://github.com/eclipse-score/docs-as-code/tree/v0.4.0/src/extensions/score_source_code_linker
 
+load("@rules_python//python:defs.bzl", "py_binary", "py_library")
+
 # Python library for the source code linker package
 py_library(
     name = "source_code_linker_lib",

--- a/third_party/traceability/tools/trlc_renderer/BUILD
+++ b/third_party/traceability/tools/trlc_renderer/BUILD
@@ -11,6 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
+load("@rules_python//python:defs.bzl", "py_binary")
 load("@score_communication_pip//:requirements.bzl", "requirement")
 
 py_binary(


### PR DESCRIPTION
If we want to make sure that the rules C++ and Python loaded are the version we defined and not the one in Bazel, we need to explicitly add the load statement.
This also becomes mandatory in Bazel 9.