### PR TITLE
mw/com/impl: migrate score::cpp::optional to std::optional 

### DIFF
--- a/score/mw/com/impl/configuration/config_parser.cpp
+++ b/score/mw/com/impl/configuration/config_parser.cpp
@@ -1068,7 +1068,7 @@ auto ParseServiceTypes(const score::json::Object& json_map) -> Configuration::Se
 }
 
 auto ParseReceiverQueueSize(const score::json::Object& global_config_map, const QualityType quality_type)
-    -> score::cpp::optional<std::int32_t>
+    -> std::optional<std::int32_t>
 {
     const auto& queue_size = global_config_map.find(kQueueSizeKey.data());
     if (queue_size != global_config_map.cend())
@@ -1096,23 +1096,23 @@ auto ParseReceiverQueueSize(const score::json::Object& global_config_map, const 
         const auto& asil_queue_size = queue_size_map.find(queue_type_str.data());
         if (asil_queue_size != queue_size_map.cend())
         {
-            return score::ResultToAmpOptionalOrElse(asil_queue_size->second.As<std::int32_t>(), [](const auto&) {
+            return score::ResultToOptionalOrElse(asil_queue_size->second.As<std::int32_t>(), [](const auto&) {
                 score::mw::log::LogFatal("lola") << "Invalid value for ReceiverQueueSize";
                 SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(false);
             });
         }
         else
         {
-            return score::cpp::nullopt;
+            return std::nullopt;
         }
     }
     else
     {
-        return score::cpp::nullopt;
+        return std::nullopt;
     }
 }
 
-auto ParseSenderQueueSize(const score::json::Object& global_config_map) -> score::cpp::optional<std::int32_t>
+auto ParseSenderQueueSize(const score::json::Object& global_config_map) -> std::optional<std::int32_t>
 {
     const auto& queue_size = global_config_map.find(kQueueSizeKey.data());
     if (queue_size != global_config_map.cend())
@@ -1124,19 +1124,19 @@ auto ParseSenderQueueSize(const score::json::Object& global_config_map) -> score
         const auto& asil_tx_queue_size = queue_size_map.find("B-sender");
         if (asil_tx_queue_size != queue_size_map.cend())
         {
-            return score::ResultToAmpOptionalOrElse(asil_tx_queue_size->second.As<std::int32_t>(), [](const auto&) {
+            return score::ResultToOptionalOrElse(asil_tx_queue_size->second.As<std::int32_t>(), [](const auto&) {
                 score::mw::log::LogFatal("lola") << "Invalid value for SenderQueueSize";
                 SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(false);
             });
         }
         else
         {
-            return score::cpp::nullopt;
+            return std::nullopt;
         }
     }
     else
     {
-        return score::cpp::nullopt;
+        return std::nullopt;
     }
 }
 
@@ -1181,21 +1181,21 @@ auto ParseGlobalProperties(const score::json::Object& top_level_object) -> Globa
             }
         }
 
-        const score::cpp::optional<std::int32_t> qm_rx_message_size{
+        const std::optional<std::int32_t> qm_rx_message_size{
             ParseReceiverQueueSize(process_properties_map, QualityType::kASIL_QM)};
         if (qm_rx_message_size.has_value())
         {
             global_configuration.SetReceiverMessageQueueSize(QualityType::kASIL_QM, qm_rx_message_size.value());
         }
 
-        const score::cpp::optional<std::int32_t> b_rx_message_size{
+        const std::optional<std::int32_t> b_rx_message_size{
             ParseReceiverQueueSize(process_properties_map, QualityType::kASIL_B)};
         if (b_rx_message_size.has_value())
         {
             global_configuration.SetReceiverMessageQueueSize(QualityType::kASIL_B, b_rx_message_size.value());
         }
 
-        const score::cpp::optional<std::int32_t> b_tx_message_size{ParseSenderQueueSize(process_properties_map)};
+        const std::optional<std::int32_t> b_tx_message_size{ParseSenderQueueSize(process_properties_map)};
         if (b_tx_message_size.has_value())
         {
             global_configuration.SetSenderMessageQueueSize(b_tx_message_size.value());


### PR DESCRIPTION
- baselibs/result reducing the dependency of score::cpp::optional
- mw/com/ currently uses ResultToAmpOptionalOrElse public API
- Migrate to std::optional and uses ResultToOptionalOrElse API
