### PR TITLE
lola: Extract skeleton shared memory functionality

### DIFF
--- a/score/mw/com/impl/bindings/lola/BUILD
+++ b/score/mw/com/impl/bindings/lola/BUILD
@@ -271,6 +271,7 @@ cc_library(
         "skeleton_event.cpp",
         "skeleton_event_common.cpp",
         "skeleton_event_properties.cpp",
+        "skeleton_memory_manager.cpp",
         "skeleton_method.cpp",
     ],
     hdrs = [
@@ -278,6 +279,7 @@ cc_library(
         "skeleton_event.h",
         "skeleton_event_common.h",
         "skeleton_event_properties.h",
+        "skeleton_memory_manager.h",
         "skeleton_method.h",
     ],
     features = COMPILER_WARNING_FEATURES,

--- a/score/mw/com/impl/bindings/lola/skeleton.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton.cpp
@@ -435,15 +435,6 @@ auto Skeleton::PrepareStopOffer(std::optional<UnregisterShmObjectTraceCallback> 
     memory_manager_.Reset();
 }
 
-// Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
-// implicitly". This is a false positive, std::less which is used by std::map::find could throw an exception if the
-// key value is not comparable and in our case the key is comparable. so no way for 'event_controls_.find()' to
-// throw an exception. coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-score::cpp::optional<EventMetaInfo> Skeleton::GetEventMetaInfo(const ElementFqId element_fq_id) const
-{
-    return memory_manager_.GetEventMetaInfo(element_fq_id);
-}
-
 QualityType Skeleton::GetInstanceQualityType() const
 {
     return quality_type_;

--- a/score/mw/com/impl/bindings/lola/skeleton.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton.cpp
@@ -198,16 +198,6 @@ std::string GetDataChannelShmPath(const LolaServiceInstanceDeployment& lola_serv
 
 }  // namespace
 
-namespace detail_skeleton
-{
-
-bool HasAsilBSupport(const InstanceIdentifier& identifier)
-{
-    return (InstanceIdentifierView{identifier}.GetServiceInstanceDeployment().asilLevel_ == QualityType::kASIL_B);
-}
-
-}  // namespace detail_skeleton
-
 // Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
 // implicitly". std::terminate() is implicitly called from 'service_instance_existence_marker_file.value()' in case the
 // 'service_instance_existence_marker_file' doesn't have value but as we check before with 'has_value()' so no way for
@@ -273,6 +263,7 @@ Skeleton::Skeleton(const InstanceIdentifier& identifier,
                        service_instance_existence_flock_mutex_and_lock)
     : SkeletonBinding{},
       identifier_{identifier},
+      quality_type_{InstanceIdentifierView{identifier_}.GetServiceInstanceDeployment().asilLevel_},
       lola_service_instance_deployment_{lola_service_instance_deployment},
       lola_service_type_deployment_{lola_service_type_deployment},
       lola_instance_id_{lola_service_instance_deployment_.instance_id_.value().GetId()},
@@ -395,7 +386,7 @@ auto Skeleton::PrepareOffer(SkeletonEventBindings& events,
     }
     method_subscription_registration_guard_qm_ = std::move(qm_registration_result).value();
 
-    if (detail_skeleton::HasAsilBSupport(identifier_))
+    if (quality_type_ == QualityType::kASIL_B)
     {
         auto allowed_consumers_asil_b = GetAllowedConsumers(QualityType::kASIL_B);
         auto asil_b_registration_result = lola_message_passing.RegisterOnServiceMethodSubscribedHandler(
@@ -518,7 +509,7 @@ auto Skeleton::CreateSharedMemory(SkeletonEventBindings& events,
         return MakeUnexpected(ComErrc::kErroneousFileHandle, "Could not create shared memory object for control QM");
     }
 
-    if (detail_skeleton::HasAsilBSupport(identifier_) &&
+    if ((quality_type_ == QualityType::kASIL_B) &&
         (!CreateSharedMemoryForControl(lola_service_instance_deployment_,
                                        QualityType::kASIL_B,
                                        storage_size_calc_result.control_asil_b_size.value())))
@@ -544,7 +535,7 @@ auto Skeleton::OpenExistingSharedMemory(
         return MakeUnexpected(ComErrc::kErroneousFileHandle, "Could not open shared memory object for control QM");
     }
 
-    if (detail_skeleton::HasAsilBSupport(identifier_) && (!OpenSharedMemoryForControl(QualityType::kASIL_B)))
+    if ((quality_type_ == QualityType::kASIL_B) && (!OpenSharedMemoryForControl(QualityType::kASIL_B)))
     {
         return MakeUnexpected(ComErrc::kErroneousFileHandle, "Could not open shared memory object for control ASIL-B");
     }
@@ -795,7 +786,7 @@ Skeleton::ShmResourceStorageSizes Skeleton::CalculateShmResourceStorageSizesBySi
     // (lola::Skeleton::Register()), which leads to updates/allocation within ctrl AND data resources!
     InitializeSharedMemoryForControl(QualityType::kASIL_QM, control_qm_resource_);
 
-    if (detail_skeleton::HasAsilBSupport(identifier_))
+    if (quality_type_ == QualityType::kASIL_B)
     {
         control_asil_resource_ = std::make_shared<NewDeleteDelegateMemoryResource>(
             CalculateMemoryResourceId(lola_service_id_, lola_instance_id_, ShmObjectType::kControl_ASIL_B));
@@ -827,7 +818,7 @@ Skeleton::ShmResourceStorageSizes Skeleton::CalculateShmResourceStorageSizesBySi
     }
 
     const auto control_asil_b_size =
-        detail_skeleton::HasAsilBSupport(identifier_)
+        quality_type_ == QualityType::kASIL_B
             ? score::cpp::optional<std::size_t>{control_asil_resource_->GetUserAllocatedBytes()}
             : score::cpp::optional<std::size_t>{};
 
@@ -942,7 +933,7 @@ score::cpp::optional<EventMetaInfo> Skeleton::GetEventMetaInfo(const ElementFqId
 
 QualityType Skeleton::GetInstanceQualityType() const
 {
-    return InstanceIdentifierView{identifier_}.GetServiceInstanceDeployment().asilLevel_;
+    return quality_type_;
 }
 
 // Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called

--- a/score/mw/com/impl/bindings/lola/skeleton.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton.cpp
@@ -18,39 +18,28 @@
 #include "score/mw/com/impl/bindings/lola/methods/proxy_method_instance_identifier.h"
 #include "score/mw/com/impl/bindings/lola/methods/type_erased_call_queue.h"
 #include "score/mw/com/impl/bindings/lola/proxy_instance_identifier.h"
-#include "score/mw/com/impl/bindings/lola/service_data_control.h"
-#include "score/mw/com/impl/bindings/lola/service_data_storage.h"
-#include "score/mw/com/impl/bindings/lola/shm_path_builder.h"
 #include "score/mw/com/impl/bindings/lola/skeleton_instance_identifier.h"
 #include "score/mw/com/impl/bindings/lola/skeleton_method.h"
 #include "score/mw/com/impl/bindings/lola/tracing/tracing_runtime.h"
 #include "score/mw/com/impl/com_error.h"
-#include "score/mw/com/impl/configuration/lola_event_instance_deployment.h"
 #include "score/mw/com/impl/configuration/lola_method_id.h"
 #include "score/mw/com/impl/configuration/lola_service_instance_deployment.h"
 #include "score/mw/com/impl/configuration/lola_service_type_deployment.h"
 #include "score/mw/com/impl/configuration/quality_type.h"
 #include "score/mw/com/impl/runtime.h"
-#include "score/mw/com/impl/skeleton_event_binding.h"
-#include "score/mw/com/impl/util/arithmetic_utils.h"
 #include "score/result/result.h"
 
 #include "score/memory/shared/flock/flock_mutex_and_lock.h"
-#include "score/memory/shared/new_delete_delegate_resource.h"
 #include "score/memory/shared/shared_memory_factory.h"
-#include "score/memory/shared/shared_memory_resource.h"
 #include "score/mw/log/logging.h"
-#include "score/os/acl.h"
 #include "score/os/stat.h"
 
 #include <score/assert.hpp>
 #include <score/span.hpp>
 #include <sys/types.h>
 
-#include <algorithm>
 #include <cstddef>
 #include <exception>
-#include <limits>
 #include <mutex>
 #include <string>
 #include <unordered_map>
@@ -90,45 +79,6 @@ const LolaServiceInstanceDeployment& GetLolaServiceInstanceDeployment(const Inst
         std::terminate();
     }
     return *lola_service_instance_deployment_ptr;
-}
-
-ServiceDataControl* GetServiceDataControlSkeletonSide(const memory::shared::ManagedMemoryResource& control)
-{
-    // Suppress "AUTOSAR C++14 M5-2-8" rule. The rule declares:
-    // An object with integer type or pointer to void type shall not be converted to an object with pointer type.
-    // The "ServiceDataStorage" type is strongly defined as shared IPC data between Proxy and Skeleton.
-    // coverity[autosar_cpp14_m5_2_8_violation]
-    auto* const service_data_control = static_cast<ServiceDataControl*>(control.getUsableBaseAddress());
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(service_data_control != nullptr,
-                                                "Could not retrieve service data control.");
-    return service_data_control;
-}
-
-ServiceDataStorage* GetServiceDataStorageSkeletonSide(const memory::shared::ManagedMemoryResource& data)
-{
-    // Suppress "AUTOSAR C++14 M5-2-8" rule. The rule declares:
-    // An object with integer type or pointer to void type shall not be converted to an object with pointer type.
-    // The "ServiceDataStorage" type is strongly defined as shared IPC data between Proxy and Skeleton.
-    // coverity[autosar_cpp14_m5_2_8_violation]
-    auto* const service_data_storage = static_cast<ServiceDataStorage*>(data.getUsableBaseAddress());
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(service_data_storage != nullptr,
-                                                "Could not retrieve service data storage within shared-memory.");
-    return service_data_storage;
-}
-
-enum class ShmObjectType : std::uint8_t
-{
-    kControl_QM = 0x00,
-    kControl_ASIL_B = 0x01,
-    kData = 0x02,
-};
-
-std::uint64_t CalculateMemoryResourceId(const LolaServiceTypeDeployment::ServiceId lola_service_id,
-                                        const LolaServiceInstanceId::InstanceId lola_instance_id,
-                                        const ShmObjectType object_type)
-{
-    return ((static_cast<std::uint64_t>(lola_service_id) << 24U) +
-            (static_cast<std::uint64_t>(lola_instance_id) << 8U) + static_cast<std::uint8_t>(object_type));
 }
 
 bool CreatePartialRestartDirectory(const score::filesystem::Filesystem& filesystem,
@@ -181,19 +131,11 @@ std::optional<memory::shared::LockFile> CreateOrOpenServiceInstanceUsageMarkerFi
     return memory::shared::LockFile::CreateOrOpen(service_instance_usage_marker_file_path, take_ownership);
 }
 
-std::string GetControlChannelShmPath(const LolaServiceInstanceDeployment& lola_service_instance_deployment,
-                                     const QualityType quality_type,
-                                     const IShmPathBuilder& shm_path_builder)
+template <typename T>
+T& DereferenceWithNullCheck(std::unique_ptr<T>& ptr)
 {
-    const auto instance_id = lola_service_instance_deployment.instance_id_.value().GetId();
-    return shm_path_builder.GetControlChannelShmName(instance_id, quality_type);
-}
-
-std::string GetDataChannelShmPath(const LolaServiceInstanceDeployment& lola_service_instance_deployment,
-                                  const IShmPathBuilder& shm_path_builder)
-{
-    const auto instance_id = lola_service_instance_deployment.instance_id_.value().GetId();
-    return shm_path_builder.GetDataChannelShmName(instance_id);
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(ptr != nullptr, "Cannot dereference pointer as it is Null");
+    return *ptr;
 }
 
 }  // namespace
@@ -264,20 +206,15 @@ Skeleton::Skeleton(const InstanceIdentifier& identifier,
     : SkeletonBinding{},
       identifier_{identifier},
       quality_type_{InstanceIdentifierView{identifier_}.GetServiceInstanceDeployment().asilLevel_},
-      lola_service_instance_deployment_{lola_service_instance_deployment},
-      lola_service_type_deployment_{lola_service_type_deployment},
-      lola_instance_id_{lola_service_instance_deployment_.instance_id_.value().GetId()},
+      lola_instance_id_{lola_service_instance_deployment.instance_id_.value().GetId()},
       lola_service_id_{lola_service_type_deployment.service_id_},
-      data_storage_path_{},
-      data_control_qm_path_{},
-      data_control_asil_path_{},
-      storage_{nullptr},
-      control_qm_{nullptr},
-      control_asil_b_{nullptr},
-      storage_resource_{},
-      control_qm_resource_{},
-      control_asil_resource_{},
       shm_path_builder_{std::move(shm_path_builder)},
+      memory_manager_{GetInstanceQualityType(),
+                      DereferenceWithNullCheck(shm_path_builder_),
+                      lola_service_instance_deployment,
+                      lola_service_type_deployment,
+                      lola_instance_id_,
+                      lola_service_id_},
       partial_restart_path_builder_{std::move(partial_restart_path_builder)},
       service_instance_existence_marker_file_{std::move(service_instance_existence_marker_file)},
       service_instance_usage_marker_file_{},
@@ -292,6 +229,8 @@ Skeleton::Skeleton(const InstanceIdentifier& identifier,
       method_call_handler_scope_{},
       on_service_method_subscribed_handler_scope_{}
 {
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(shm_path_builder_ != nullptr,
+                                                      "Shared memory path builder pointer is Null");
 }
 
 auto Skeleton::PrepareOffer(SkeletonEventBindings& events,
@@ -327,9 +266,10 @@ auto Skeleton::PrepareOffer(SkeletonEventBindings& events,
         // all since unsubscribed. Or, (2), the previous Skeleton crashed while setting up the shared memory. Since we
         // don't differentiate between the 2 cases and because it's unused anyway, we simply remove the old memory
         // region and re-create it.
-        RemoveStaleSharedMemoryArtefacts();
+        memory_manager_.RemoveStaleSharedMemoryArtefacts();
 
-        const auto create_result = CreateSharedMemory(events, fields, std::move(register_shm_object_trace_callback));
+        const auto create_result =
+            memory_manager_.CreateSharedMemory(events, fields, std::move(register_shm_object_trace_callback));
         if (!(create_result.has_value()))
         {
             score::mw::log::LogError("lola") << "Could not create shared memory region for Skeleton.";
@@ -343,13 +283,14 @@ auto Skeleton::PrepareOffer(SkeletonEventBindings& events,
         // Since the previous shared memory region is being currently used by proxies, it must have been properly
         // created and OfferService finished. Therefore, we can simply re-open it and cleanup any previous in-writing
         // transactions by the previous skeleton.
-        const auto open_result = OpenExistingSharedMemory(std::move(register_shm_object_trace_callback));
+        const auto open_result =
+            memory_manager_.OpenExistingSharedMemory(std::move(register_shm_object_trace_callback));
         if (!open_result.has_value())
         {
             score::mw::log::LogError("lola") << "Could not open existing shared memory region for Skeleton.";
             return open_result;
         }
-        CleanupSharedMemoryAfterCrash();
+        memory_manager_.CleanupSharedMemoryAfterCrash();
     }
 
     // If there are no registered SkeletonMethods, then we don't need to register a method subscribed handler and can
@@ -481,7 +422,7 @@ auto Skeleton::PrepareStopOffer(std::optional<UnregisterShmObjectTraceCallback> 
     {
         // Since we were able to exclusively lock the usage marker file, it means that no proxies are currently using
         // the shared memory region.
-        RemoveSharedMemory();
+        memory_manager_.RemoveSharedMemory();
         // We take ownership of the usage marker file so that it gets unlinked from the fs, when we destroy it.
         service_instance_usage_marker_file_.value().TakeOwnership();
         // Unlock the usage marker file before destroying it so that the destructor doesn't try to unlock an already
@@ -491,444 +432,16 @@ auto Skeleton::PrepareStopOffer(std::optional<UnregisterShmObjectTraceCallback> 
         service_instance_usage_marker_file_.reset();
     }
 
-    storage_ = nullptr;
-    control_qm_ = nullptr;
-    control_asil_b_ = nullptr;
-}
-
-auto Skeleton::CreateSharedMemory(SkeletonEventBindings& events,
-                                  SkeletonFieldBindings& fields,
-                                  std::optional<RegisterShmObjectTraceCallback> register_shm_object_trace_callback)
-    -> ResultBlank
-{
-    const auto storage_size_calc_result = CalculateShmResourceStorageSizes(events, fields);
-
-    if (!CreateSharedMemoryForControl(
-            lola_service_instance_deployment_, QualityType::kASIL_QM, storage_size_calc_result.control_qm_size))
-    {
-        return MakeUnexpected(ComErrc::kErroneousFileHandle, "Could not create shared memory object for control QM");
-    }
-
-    if ((quality_type_ == QualityType::kASIL_B) &&
-        (!CreateSharedMemoryForControl(lola_service_instance_deployment_,
-                                       QualityType::kASIL_B,
-                                       storage_size_calc_result.control_asil_b_size.value())))
-    {
-        return MakeUnexpected(ComErrc::kErroneousFileHandle,
-                              "Could not create shared memory object for control ASIL-B");
-    }
-
-    if (!CreateSharedMemoryForData(lola_service_instance_deployment_,
-                                   storage_size_calc_result.data_size,
-                                   std::move(register_shm_object_trace_callback)))
-    {
-        return MakeUnexpected(ComErrc::kErroneousFileHandle, "Could not create shared memory object for data");
-    }
-    return {};
-}
-
-auto Skeleton::OpenExistingSharedMemory(
-    std::optional<RegisterShmObjectTraceCallback> register_shm_object_trace_callback) -> ResultBlank
-{
-    if (!OpenSharedMemoryForControl(QualityType::kASIL_QM))
-    {
-        return MakeUnexpected(ComErrc::kErroneousFileHandle, "Could not open shared memory object for control QM");
-    }
-
-    if ((quality_type_ == QualityType::kASIL_B) && (!OpenSharedMemoryForControl(QualityType::kASIL_B)))
-    {
-        return MakeUnexpected(ComErrc::kErroneousFileHandle, "Could not open shared memory object for control ASIL-B");
-    }
-
-    if (!OpenSharedMemoryForData(std::move(register_shm_object_trace_callback)))
-    {
-        return MakeUnexpected(ComErrc::kErroneousFileHandle, "Could not open shared memory object for data");
-    }
-    return {};
-}
-
-// Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
-// implicitly". This is a false positive, all results which are accessed with '.value()' that could implicitly call
-// 'std::terminate()' (in case it doesn't have value) has a check in advance using '.has_value()', so no way for
-// throwing std::bad_optional_access which leds to std::terminate(). This suppression should be removed after fixing
-// [Ticket-173043](broken_link_j/Ticket-173043)
-// coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-bool Skeleton::CreateSharedMemoryForData(
-    const LolaServiceInstanceDeployment& instance,
-    const std::size_t shm_size,
-    std::optional<RegisterShmObjectTraceCallback> register_shm_object_trace_callback)
-{
-    memory::shared::SharedMemoryFactory::UserPermissionsMap permissions{};
-    for (const auto& allowed_consumer : instance.allowed_consumer_)
-    {
-        for (const auto& user_identifier : allowed_consumer.second)
-        {
-            permissions[score::os::Acl::Permission::kRead].push_back(user_identifier);
-        }
-    }
-
-    const auto path = shm_path_builder_->GetDataChannelShmName(lola_instance_id_);
-    const bool use_typed_memory = register_shm_object_trace_callback.has_value();
-    const memory::shared::SharedMemoryFactory::UserPermissions user_permissions =
-        (permissions.empty()) && (instance.strict_permissions_ == false)
-            ? memory::shared::SharedMemoryFactory::WorldReadable{}
-            : memory::shared::SharedMemoryFactory::UserPermissions{permissions};
-    const auto memory_resource = score::memory::shared::SharedMemoryFactory::Create(
-        path,
-        [this](std::shared_ptr<score::memory::shared::ISharedMemoryResource> memory) {
-            this->InitializeSharedMemoryForData(memory);
-        },
-        shm_size,
-        user_permissions,
-        use_typed_memory);
-    if (memory_resource == nullptr)
-    {
-        return false;
-    }
-    data_storage_path_ = path;
-    if (register_shm_object_trace_callback.has_value() && memory_resource->IsShmInTypedMemory())
-    {
-        // only if the memory_resource could be successfully allocated in typed-memory, we call back the
-        // register_shm_object_trace_callback, because only then the shm-object can be accessed by tracing
-        // subsystem.
-        // Since LoLa creates shm-objects on the granularity of whole service-instances (including ALL its service
-        // elements), we call register_shm_object_trace_callback once and hand over a dummy element name/type!
-        // Other bindings, which might create shm-objects per service-element would call
-        // register_shm_object_trace_callback for each service-element and then use their "real" name and type ...
-        // Suppress "AUTOSAR C++14 A15-4-2" rule finding. This rule states: "I a function is declared to be
-        // , (true) or (<true condition>), then it shall not exit with an exception"
-        // we can't add  to score::cpp::callback signature.
-        // coverity[autosar_cpp14_a15_4_2_violation]
-        register_shm_object_trace_callback.value()(
-            tracing::TracingRuntime::kDummyElementNameForShmRegisterCallback,
-            // Suppress "AUTOSAR C++14 A4-5-1" rule findings. This rule states: "Expressions with type enum or enum
-            // class shall not be used as operands to built-in and overloaded operators other than the subscript
-            // operator [ ], the assignment operator =, the equality operators == and ! =, the unary & operator, and the
-            // relational operators <,
-            // <=, >, >=.". The enum is not an operand, its a function parameter.
-            // coverity[autosar_cpp14_a4_5_1_violation : FALSE]
-            tracing::TracingRuntime::kDummyElementTypeForShmRegisterCallback,
-            memory_resource->GetFileDescriptor(),
-            memory_resource->getBaseAddress());
-    }
-
-    score::mw::log::LogDebug("lola") << "Created shared-memory-object for DATA (S: " << lola_service_id_
-                                     << " I:" << lola_instance_id_ << ")";
-    return true;
-}
-
-bool Skeleton::CreateSharedMemoryForControl(const LolaServiceInstanceDeployment& instance,
-                                            const QualityType asil_level,
-                                            const std::size_t shm_size)
-{
-    const auto path = shm_path_builder_->GetControlChannelShmName(lola_instance_id_, asil_level);
-
-    const auto consumer = instance.allowed_consumer_.find(asil_level);
-    auto& control_resource = (asil_level == QualityType::kASIL_QM) ? control_qm_resource_ : control_asil_resource_;
-    auto& data_control_path = (asil_level == QualityType::kASIL_QM) ? data_control_qm_path_ : data_control_asil_path_;
-
-    memory::shared::SharedMemoryFactory::UserPermissionsMap permissions{};
-    if (consumer != instance.allowed_consumer_.cend())
-    {
-        for (const auto& user_identifier : consumer->second)
-        {
-            permissions[score::os::Acl::Permission::kRead].push_back(user_identifier);
-            permissions[score::os::Acl::Permission::kWrite].push_back(user_identifier);
-        }
-    }
-
-    const memory::shared::SharedMemoryFactory::UserPermissions user_permissions =
-        (permissions.empty()) && (instance.strict_permissions_ == false)
-            ? memory::shared::SharedMemoryFactory::WorldWritable{}
-            : memory::shared::SharedMemoryFactory::UserPermissions{permissions};
-    control_resource = score::memory::shared::SharedMemoryFactory::Create(
-        path,
-        [this, asil_level](std::shared_ptr<score::memory::shared::ManagedMemoryResource> memory) {
-            this->InitializeSharedMemoryForControl(asil_level, memory);
-        },
-        shm_size,
-        user_permissions);
-    if (control_resource == nullptr)
-    {
-        return false;
-    }
-    data_control_path = path;
-    return true;
-}
-
-// Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
-// implicitly". This is a false positive, all results which are accessed with '.value()' that could implicitly call
-// 'std::terminate()' (in case it doesn't have value) has a check in advance using '.has_value()', so no way for
-// throwing std::bad_optional_access which leds to std::terminate(). This suppression should be removed after fixing
-// [Ticket-173043](broken_link_j/Ticket-173043)
-// coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-bool Skeleton::OpenSharedMemoryForData(
-    const std::optional<RegisterShmObjectTraceCallback> register_shm_object_trace_callback)
-{
-    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(
-        shm_path_builder_ != nullptr, "Skeleton::OpenSharedMemoryForData: shared memory path builder pointer is Null");
-    const auto path = GetDataChannelShmPath(lola_service_instance_deployment_, *shm_path_builder_);
-
-    const auto memory_resource = score::memory::shared::SharedMemoryFactory::Open(path, true);
-    if (memory_resource == nullptr)
-    {
-        return false;
-    }
-    data_storage_path_ = path;
-    storage_resource_ = memory_resource;
-
-    const auto& memory_resource_ref = *memory_resource.get();
-    storage_ = GetServiceDataStorageSkeletonSide(memory_resource_ref);
-
-    // Our pid will have changed after re-start and we now have to update it in the re-opened DATA section.
-    const auto pid = GetBindingRuntime<lola::IRuntime>(BindingType::kLoLa).GetPid();
-    score::mw::log::LogDebug("lola") << "Updating PID of Skeleton (S: " << lola_service_id_
-                                     << " I:" << lola_instance_id_ << ") with:" << pid;
-    storage_->skeleton_pid_ = pid;
-
-    if (register_shm_object_trace_callback.has_value() && memory_resource->IsShmInTypedMemory())
-    {
-        // only if the memory_resource could be successfully allocated in typed-memory, we call back the
-        // register_shm_object_trace_callback, because only then the shm-object can be accessed by tracing
-        // subsystem.
-        // Suppress "AUTOSAR C++14 A15-4-2" rule finding. This rule states: "I a function is declared to be
-        // , (true) or (<true condition>), then it shall not exit with an exception"
-        // we can't add  to score::cpp::callback signature.
-        // coverity[autosar_cpp14_a15_4_2_violation]
-        register_shm_object_trace_callback.value()(
-            tracing::TracingRuntime::kDummyElementNameForShmRegisterCallback,
-            // Suppress "AUTOSAR C++14 A4-5-1" rule findings. This rule states: "Expressions with type enum or enum
-            // class shall not be used as operands to built-in and overloaded operators other than the subscript
-            // operator [ ], the assignment operator =, the equality operators == and ! =, the unary & operator, and the
-            // relational operators <,
-            // <=, >, >=.". The enum is not an operand, its a function parameter.
-            // coverity[autosar_cpp14_a4_5_1_violation : FALSE]
-            tracing::TracingRuntime::kDummyElementTypeForShmRegisterCallback,
-            memory_resource->GetFileDescriptor(),
-            memory_resource->getBaseAddress());
-    }
-    return true;
-}
-
-bool Skeleton::OpenSharedMemoryForControl(const QualityType asil_level)
-{
-    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(
-        shm_path_builder_ != nullptr,
-        "Skeleton::OpenSharedMemoryForControl: shared memory path builder pointer is Null");
-    const auto path = GetControlChannelShmPath(lola_service_instance_deployment_, asil_level, *shm_path_builder_);
-
-    auto& control_resource = (asil_level == QualityType::kASIL_QM) ? control_qm_resource_ : control_asil_resource_;
-    auto& data_control_path = (asil_level == QualityType::kASIL_QM) ? data_control_qm_path_ : data_control_asil_path_;
-
-    control_resource = score::memory::shared::SharedMemoryFactory::Open(path, true);
-    if (control_resource == nullptr)
-    {
-        return false;
-    }
-    data_control_path = path;
-
-    auto& control = (asil_level == QualityType::kASIL_QM) ? control_qm_ : control_asil_b_;
-
-    const auto& control_resource_ref = *control_resource.get();
-    control = GetServiceDataControlSkeletonSide(control_resource_ref);
-
-    return true;
-}
-
-void Skeleton::RemoveSharedMemory()
-{
-    constexpr auto RemoveMemoryIfExists = [](const score::cpp::optional<std::string>& path) -> void {
-        if (path.has_value())
-        {
-            score::memory::shared::SharedMemoryFactory::Remove(path.value());
-        }
-    };
-    RemoveMemoryIfExists(data_control_qm_path_);
-    RemoveMemoryIfExists(data_control_asil_path_);
-    RemoveMemoryIfExists(data_storage_path_);
-
-    storage_resource_.reset();
-    control_qm_resource_.reset();
-    control_asil_resource_.reset();
-}
-
-void Skeleton::RemoveStaleSharedMemoryArtefacts() const
-{
-    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(
-        shm_path_builder_ != nullptr,
-        "Skeleton::RemoveStaleSharedMemoryArtefacts: shared memory path builder pointer is Null");
-    const auto control_qm_path =
-        GetControlChannelShmPath(lola_service_instance_deployment_, QualityType::kASIL_QM, *shm_path_builder_);
-    const auto control_asil_b_path =
-        GetControlChannelShmPath(lola_service_instance_deployment_, QualityType::kASIL_B, *shm_path_builder_);
-    const auto data_path = GetDataChannelShmPath(lola_service_instance_deployment_, *shm_path_builder_);
-
-    memory::shared::SharedMemoryFactory::RemoveStaleArtefacts(control_qm_path);
-    memory::shared::SharedMemoryFactory::RemoveStaleArtefacts(control_asil_b_path);
-    memory::shared::SharedMemoryFactory::RemoveStaleArtefacts(data_path);
-}
-
-Skeleton::ShmResourceStorageSizes Skeleton::CalculateShmResourceStorageSizesBySimulation(SkeletonEventBindings& events,
-                                                                                         SkeletonFieldBindings& fields)
-{
-    using NewDeleteDelegateMemoryResource = memory::shared::NewDeleteDelegateMemoryResource;
-
-    // we create up to 3 DryRun Memory Resources and then do the "normal" initialization of control and data
-    // shm-objects on it
-    control_qm_resource_ = std::make_shared<NewDeleteDelegateMemoryResource>(
-        CalculateMemoryResourceId(lola_service_id_, lola_instance_id_, ShmObjectType::kControl_QM));
-
-    storage_resource_ = std::make_shared<NewDeleteDelegateMemoryResource>(
-        CalculateMemoryResourceId(lola_service_id_, lola_instance_id_, ShmObjectType::kData));
-
-    // Note, that it is important to have all DryRun Memory Resources "active" in parallel as the upcoming calls to
-    // PrepareOffer() for the events triggers all SkeletonEvents to register themselves at their parent Skeleton
-    // (lola::Skeleton::Register()), which leads to updates/allocation within ctrl AND data resources!
-    InitializeSharedMemoryForControl(QualityType::kASIL_QM, control_qm_resource_);
-
-    if (quality_type_ == QualityType::kASIL_B)
-    {
-        control_asil_resource_ = std::make_shared<NewDeleteDelegateMemoryResource>(
-            CalculateMemoryResourceId(lola_service_id_, lola_instance_id_, ShmObjectType::kControl_ASIL_B));
-        InitializeSharedMemoryForControl(QualityType::kASIL_B, control_asil_resource_);
-    }
-    InitializeSharedMemoryForData(storage_resource_);
-
-    // Offer events to calculate the shared memory allocated for the control and data segments for each event
-    for (auto& event : events)
-    {
-        score::cpp::ignore = event.second.get().PrepareOffer();
-    }
-    for (auto& field : fields)
-    {
-        score::cpp::ignore = field.second.get().PrepareOffer();
-    }
-
-    const auto control_qm_size = control_qm_resource_->GetUserAllocatedBytes();
-    const auto control_data_size = storage_resource_->GetUserAllocatedBytes();
-
-    // PrepareStopOffer events to clean up the events/fields again for the real/next offer done after simulation.
-    for (auto& event : events)
-    {
-        event.second.get().PrepareStopOffer();
-    }
-    for (auto& field : fields)
-    {
-        field.second.get().PrepareStopOffer();
-    }
-
-    const auto control_asil_b_size =
-        quality_type_ == QualityType::kASIL_B
-            ? score::cpp::optional<std::size_t>{control_asil_resource_->GetUserAllocatedBytes()}
-            : score::cpp::optional<std::size_t>{};
-
-    return ShmResourceStorageSizes{control_data_size, control_qm_size, control_asil_b_size};
-}
-
-Skeleton::ShmResourceStorageSizes Skeleton::CalculateShmResourceStorageSizes(SkeletonEventBindings& events,
-                                                                             SkeletonFieldBindings& fields)
-{
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
-        GetBindingRuntime<lola::IRuntime>(BindingType::kLoLa).GetShmSizeCalculationMode() ==
-            ShmSizeCalculationMode::kSimulation,
-        "No other shm size calculation mode is currently suppored");
-    if ((lola_service_instance_deployment_.shared_memory_size_.has_value()) &&
-        (lola_service_instance_deployment_.control_asil_b_memory_size_.has_value()) &&
-        (lola_service_instance_deployment_.control_qm_memory_size_.has_value()))
-    {
-        score::mw::log::LogInfo("lola")
-            << "shm-size, control-asil-b-shm-size and control-qm-shm-size manually specified "
-               "for service_id:instance_id "
-            << lola_service_id_
-            << ":"
-            // coverity[autosar_cpp14_a18_9_2_violation]
-            << lola_instance_id_
-            << "- Make sure that this value is sufficiently big to"
-               "avoid aborts at runtime.";
-        return {lola_service_instance_deployment_.shared_memory_size_.value(),
-                lola_service_instance_deployment_.control_qm_memory_size_.value(),
-                lola_service_instance_deployment_.control_asil_b_memory_size_.value()};
-    }
-
-    auto required_shm_storage_size = CalculateShmResourceStorageSizesBySimulation(events, fields);
-
-    const std::size_t control_asil_b_size_result = required_shm_storage_size.control_asil_b_size.has_value()
-                                                       ? required_shm_storage_size.control_asil_b_size.value()
-                                                       : 0U;
-
-    // Suppress "AUTOSAR C++14 A18-9-2" rule finding: "Forwarding values to other functions shall be done via:
-    // (1) std::move if the value is an rvalue reference, (2) std::forward if the value is forwarding
-    // reference".
-    // Passing result of std::move() as a const reference argument, no move will actually happen.
-    // coverity[autosar_cpp14_a18_9_2_violation]
-    score::mw::log::LogInfo("lola") << "Calculated sizes of shm-objects for service_id:instance_id " << lola_service_id_
-                                    << ":"
-                                    // coverity[autosar_cpp14_a18_9_2_violation]
-                                    << lola_instance_id_
-                                    << " are as follows:\nQM-Ctrl: " << required_shm_storage_size.control_qm_size
-                                    << ", ASIL_B-Ctrl: " << control_asil_b_size_result
-                                    << ", Data: " << required_shm_storage_size.data_size;
-
-    if (lola_service_instance_deployment_.shared_memory_size_.has_value())
-    {
-        score::mw::log::LogInfo("lola") << "shm-size manually specified for service_id:instance_id " << lola_service_id_
-                                        << ":"
-                                        // coverity[autosar_cpp14_a18_9_2_violation]
-                                        << lola_instance_id_
-                                        << "- Make sure that this value is sufficiently big to"
-                                           "avoid aborts at runtime.";
-        required_shm_storage_size.data_size = lola_service_instance_deployment_.shared_memory_size_.value();
-    }
-
-    if (lola_service_instance_deployment_.control_asil_b_memory_size_.has_value())
-    {
-        score::mw::log::LogInfo("lola") << "control-asil-b-shm-size manually specified for service_id:instance_id "
-                                        << lola_service_id_
-                                        << ":"
-                                        // coverity[autosar_cpp14_a18_9_2_violation]
-                                        << lola_instance_id_
-                                        << "- Make sure that this value is sufficiently big to"
-                                           "avoid aborts at runtime.";
-        required_shm_storage_size.control_asil_b_size =
-            lola_service_instance_deployment_.control_asil_b_memory_size_.value();
-    }
-
-    if (lola_service_instance_deployment_.control_qm_memory_size_.has_value())
-    {
-        score::mw::log::LogInfo("lola") << "control-qm-shm-size manually specified for service_id:instance_id "
-                                        << lola_service_id_
-                                        << ":"
-                                        // coverity[autosar_cpp14_a18_9_2_violation]
-                                        << lola_instance_id_
-                                        << "- Make sure that this value is sufficiently big to"
-                                           "avoid aborts at runtime.";
-        required_shm_storage_size.control_qm_size = lola_service_instance_deployment_.control_qm_memory_size_.value();
-    }
-
-    return required_shm_storage_size;
+    memory_manager_.Reset();
 }
 
 // Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
 // implicitly". This is a false positive, std::less which is used by std::map::find could throw an exception if the
-// key value is not comparable and in our case the key is comparable. so no way for 'event_controls_.find()' to throw
-// an exception.
-// coverity[autosar_cpp14_a15_5_3_violation : FALSE]
+// key value is not comparable and in our case the key is comparable. so no way for 'event_controls_.find()' to
+// throw an exception. coverity[autosar_cpp14_a15_5_3_violation : FALSE]
 score::cpp::optional<EventMetaInfo> Skeleton::GetEventMetaInfo(const ElementFqId element_fq_id) const
 {
-    auto search = storage_->events_metainfo_.find(element_fq_id);
-    if (search == storage_->events_metainfo_.cend())
-    {
-        return score::cpp::nullopt;
-    }
-    else
-    {
-        // Suppress "AUTOSAR C++14 A5-3-2" rule finding. This rule declares: "Null pointers shall not be dereferenced.".
-        // The "search" variable is an iterator of interprocess map returned by "find" method.
-        // Performed the check, that iterator is not equal to map.end(). A check is made that the iterator is not equal
-        // to map.end(). Therefore, the call to "search->" does not return nullptr.
-        // coverity[autosar_cpp14_a5_3_2_violation]
-        return search->second;
-    }
+    return memory_manager_.GetEventMetaInfo(element_fq_id);
 }
 
 QualityType Skeleton::GetInstanceQualityType() const
@@ -941,18 +454,7 @@ QualityType Skeleton::GetInstanceQualityType() const
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
 void Skeleton::CleanupSharedMemoryAfterCrash()
 {
-    for (auto& event : control_qm_->event_controls_)
-    {
-        event.second.data_control.RemoveAllocationsForWriting();
-    }
-
-    if (control_asil_b_ != nullptr)
-    {
-        for (auto& event : control_asil_b_->event_controls_)
-        {
-            event.second.data_control.RemoveAllocationsForWriting();
-        }
-    }
+    memory_manager_.CleanupSharedMemoryAfterCrash();
 }
 
 void Skeleton::DisconnectQmConsumers()
@@ -990,123 +492,6 @@ bool Skeleton::VerifyAllMethodsRegistered() const
     return true;
 }
 
-// Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
-// implicitly". This is a false positive, there is no way for calling std::terminate().
-// coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-void Skeleton::InitializeSharedMemoryForData(
-    const std::shared_ptr<score::memory::shared::ManagedMemoryResource>& memory)
-{
-    storage_ = memory->construct<ServiceDataStorage>(*memory);
-    storage_resource_ = memory;
-    // Suppress "AUTOSAR C++14 A0-1-1", The rule states: "A project shall not contain instances of non-volatile
-    // variables being given values that are not subsequently used"
-    // There is no variable instantiation.
-    // coverity[autosar_cpp14_a0_1_1_violation : FALSE]
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
-        storage_resource_ != nullptr,
-        "storage_resource_ must be no nullptr, otherwise the callback would not be invoked.");
-}
-
-// Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
-// implicitly". This is a false positive, there is no way for calling std::terminate().
-// coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-void Skeleton::InitializeSharedMemoryForControl(
-    const QualityType asil_level,
-    const std::shared_ptr<score::memory::shared::ManagedMemoryResource>& memory)
-{
-    auto& control = (asil_level == QualityType::kASIL_QM) ? control_qm_ : control_asil_b_;
-    control = memory->construct<ServiceDataControl>(*memory);
-}
-
-EventDataControlComposite<> Skeleton::CreateEventControlComposite(
-    const ElementFqId element_fq_id,
-    const SkeletonEventProperties& element_properties) noexcept
-{
-    auto control_qm = control_qm_->event_controls_.emplace(std::piecewise_construct,
-                                                           std::forward_as_tuple(element_fq_id),
-                                                           std::forward_as_tuple(element_properties.number_of_slots,
-                                                                                 element_properties.max_subscribers,
-                                                                                 element_properties.enforce_max_samples,
-                                                                                 *control_qm_resource_));
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(control_qm.second,
-                                                "Couldn't register/emplace event-meta-info in data-section.");
-
-    EventDataControl* control_asil_result{nullptr};
-    if (control_asil_resource_ != nullptr)
-    {
-        auto iterator =
-            control_asil_b_->event_controls_.emplace(std::piecewise_construct,
-                                                     std::forward_as_tuple(element_fq_id),
-                                                     std::forward_as_tuple(element_properties.number_of_slots,
-                                                                           element_properties.max_subscribers,
-                                                                           element_properties.enforce_max_samples,
-                                                                           *control_asil_resource_));
-
-        // Suppress "AUTOSAR C++14 M7-5-1" rule. This rule declares:
-        // A function shall not return a reference or a pointer to an automatic variable (including parameters), defined
-        // within the function.
-        // Suppress "AUTOSAR C++14 M7-5-2": The address of an object with automatic storage shall not be assigned to
-        // another object that may persist after the first object has ceased to exist.
-        // The result pointer is still valid outside this method until Skeleton object (as a holder) is alive.
-        // coverity[autosar_cpp14_m7_5_1_violation]
-        // coverity[autosar_cpp14_m7_5_2_violation]
-        // coverity[autosar_cpp14_a3_8_1_violation]
-        control_asil_result = &iterator.first->second.data_control;
-    }
-    // The lifetime of the "control_asil_result" object lasts as long as the Skeleton is alive.
-    // coverity[autosar_cpp14_m7_5_1_violation]
-    // coverity[autosar_cpp14_m7_5_2_violation]
-    // coverity[autosar_cpp14_a3_8_1_violation]
-    return EventDataControlComposite{&control_qm.first->second.data_control, control_asil_result};
-}
-
-std::pair<void*, EventDataControlComposite<>> Skeleton::CreateEventDataFromOpenedSharedMemory(
-    const ElementFqId element_fq_id,
-    const SkeletonEventProperties& element_properties,
-    size_t sample_size,
-    size_t sample_alignment) noexcept
-{
-
-    // Guard against over-aligned types (Short-term solution protection)
-    if (sample_alignment > alignof(std::max_align_t))
-    {
-        score::mw::log::LogFatal("Skeleton")
-            << "Requested sample alignment (" << sample_alignment << ") exceeds max_align_t ("
-            << alignof(std::max_align_t) << "). Safe shared memory layout cannot be guaranteed.";
-
-        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(sample_alignment <= alignof(std::max_align_t),
-                                                    "Requested sample alignment exceeds maximum supported alignment.");
-    }
-
-    // Calculate the aligned size for a single sample to ensure proper padding between slots
-    const auto aligned_sample_size = memory::shared::CalculateAlignedSize(sample_size, sample_alignment);
-    const auto total_data_size_bytes = aligned_sample_size * element_properties.number_of_slots;
-
-    // Convert total bytes to the number of std::max_align_t elements needed (round up)
-    const size_t num_max_align_elements =
-        (total_data_size_bytes + sizeof(std::max_align_t) - 1) / sizeof(std::max_align_t);
-
-    auto* const data_storage = storage_resource_->construct<EventDataStorage<std::max_align_t>>(
-        num_max_align_elements, memory::shared::PolymorphicOffsetPtrAllocator<std::max_align_t>(*storage_resource_));
-
-    auto inserted_data_slots = storage_->events_.emplace(
-        std::piecewise_construct, std::forward_as_tuple(element_fq_id), std::forward_as_tuple(data_storage));
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(inserted_data_slots.second,
-                                                "Couldn't register/emplace event-storage in data-section.");
-
-    const DataTypeMetaInfo sample_meta_info{sample_size, static_cast<std::uint8_t>(sample_alignment)};
-    void* const event_data_raw_array = data_storage->data();
-
-    auto inserted_meta_info =
-        storage_->events_metainfo_.emplace(std::piecewise_construct,
-                                           std::forward_as_tuple(element_fq_id),
-                                           std::forward_as_tuple(sample_meta_info, event_data_raw_array));
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(inserted_meta_info.second,
-                                                "Couldn't register/emplace event-meta-info in data-section.");
-
-    return {data_storage, CreateEventControlComposite(element_fq_id, element_properties)};
-}
-
 std::pair<void*, EventDataControlComposite<>> Skeleton::RegisterGeneric(
     const ElementFqId element_fq_id,
     const SkeletonEventProperties& element_properties,
@@ -1115,7 +500,8 @@ std::pair<void*, EventDataControlComposite<>> Skeleton::RegisterGeneric(
 {
     if (was_old_shm_region_reopened_)
     {
-        auto [data_storage, control_composite] = OpenEventDataFromOpenedSharedMemory<std::uint8_t>(element_fq_id);
+        auto [data_storage, control_composite] =
+            memory_manager_.OpenEventDataFromOpenedSharedMemory<std::uint8_t>(element_fq_id);
 
         auto& event_data_control_qm = control_composite.GetQmEventDataControl();
         auto rollback_result = event_data_control_qm.GetTransactionLogSet().RollbackSkeletonTracingTransactions(
@@ -1133,7 +519,8 @@ std::pair<void*, EventDataControlComposite<>> Skeleton::RegisterGeneric(
         return {data_storage, control_composite};
     }
 
-    return CreateEventDataFromOpenedSharedMemory(element_fq_id, element_properties, sample_size, sample_alignment);
+    return memory_manager_.CreateEventDataFromOpenedSharedMemory(
+        element_fq_id, element_properties, sample_size, sample_alignment);
 }
 
 ResultBlank Skeleton::OnServiceMethodsSubscribed(const ProxyInstanceIdentifier& proxy_instance_identifier,

--- a/score/mw/com/impl/bindings/lola/skeleton.h
+++ b/score/mw/com/impl/bindings/lola/skeleton.h
@@ -268,6 +268,7 @@ class Skeleton final : public SkeletonBinding
     IMessagePassingService::AllowedConsumerUids GetAllowedConsumers(const QualityType asil_level) const;
 
     InstanceIdentifier identifier_;
+    QualityType quality_type_;
     const LolaServiceInstanceDeployment& lola_service_instance_deployment_;
     const LolaServiceTypeDeployment& lola_service_type_deployment_;
     LolaServiceInstanceId::InstanceId lola_instance_id_;
@@ -325,13 +326,6 @@ class Skeleton final : public SkeletonBinding
     /// method.
     safecpp::Scope<> on_service_method_subscribed_handler_scope_;
 };
-
-namespace detail_skeleton
-{
-
-bool HasAsilBSupport(const InstanceIdentifier& identifier);
-
-}  // namespace detail_skeleton
 
 template <typename SampleType>
 auto Skeleton::Register(const ElementFqId element_fq_id, SkeletonEventProperties element_properties)
@@ -392,7 +386,7 @@ auto Skeleton::OpenEventDataFromOpenedSharedMemory(const ElementFqId element_fq_
     const auto event_control_qm_it = find_element(control_qm_->event_controls_, element_fq_id);
 
     EventDataControl* event_data_control_asil_b{nullptr};
-    if (detail_skeleton::HasAsilBSupport(identifier_))
+    if (quality_type_ == QualityType::kASIL_B)
     {
         const auto event_control_asil_b_it = find_element(control_asil_b_->event_controls_, element_fq_id);
         // Suppress "AUTOSAR C++14 M7-5-1" rule. This rule declares:

--- a/score/mw/com/impl/bindings/lola/skeleton.h
+++ b/score/mw/com/impl/bindings/lola/skeleton.h
@@ -22,30 +22,20 @@
 #include "score/mw/com/impl/bindings/lola/messaging/method_subscription_registration_guard.h"
 #include "score/mw/com/impl/bindings/lola/methods/method_data.h"
 #include "score/mw/com/impl/bindings/lola/methods/method_resource_map.h"
-#include "score/mw/com/impl/bindings/lola/methods/type_erased_call_queue.h"
 #include "score/mw/com/impl/bindings/lola/proxy_instance_identifier.h"
-#include "score/mw/com/impl/bindings/lola/runtime.h"
-#include "score/mw/com/impl/bindings/lola/service_data_control.h"
-#include "score/mw/com/impl/bindings/lola/service_data_storage.h"
 #include "score/mw/com/impl/bindings/lola/skeleton_event_properties.h"
-#include "score/mw/com/impl/bindings/lola/skeleton_instance_identifier.h"
+#include "score/mw/com/impl/bindings/lola/skeleton_memory_manager.h"
 #include "score/mw/com/impl/bindings/lola/skeleton_method.h"
-#include "score/mw/com/impl/configuration/global_configuration.h"
-#include "score/mw/com/impl/configuration/lola_event_id.h"
 #include "score/mw/com/impl/configuration/lola_method_id.h"
 #include "score/mw/com/impl/configuration/lola_service_instance_deployment.h"
 #include "score/mw/com/impl/instance_identifier.h"
 #include "score/mw/com/impl/runtime.h"
 #include "score/mw/com/impl/skeleton_binding.h"
-#include "score/mw/com/impl/tracing/skeleton_event_tracing.h"
-#include "score/mw/com/impl/tracing/skeleton_event_tracing_data.h"
 
 #include "score/filesystem/filesystem.h"
 #include "score/memory/shared/flock/exclusive_flock_mutex.h"
 #include "score/memory/shared/flock/flock_mutex_and_lock.h"
-#include "score/memory/shared/i_shared_memory_resource.h"
 #include "score/memory/shared/lock_file.h"
-#include "score/memory/shared/polymorphic_offset_ptr_allocator.h"
 
 #include <score/assert.hpp>
 #include <score/optional.hpp>
@@ -54,8 +44,6 @@
 #include <functional>
 #include <memory>
 #include <mutex>
-#include <string>
-#include <tuple>
 #include <unordered_map>
 #include <utility>
 
@@ -167,81 +155,6 @@ class Skeleton final : public SkeletonBinding
     bool VerifyAllMethodsRegistered() const override;
 
   private:
-    ResultBlank OpenExistingSharedMemory(
-        std::optional<RegisterShmObjectTraceCallback> register_shm_object_trace_callback);
-    ResultBlank CreateSharedMemory(SkeletonEventBindings& events,
-                                   SkeletonFieldBindings& fields,
-                                   std::optional<RegisterShmObjectTraceCallback> register_shm_object_trace_callback);
-
-    bool CreateSharedMemoryForData(const LolaServiceInstanceDeployment&,
-                                   const std::size_t shm_size,
-                                   std::optional<RegisterShmObjectTraceCallback> register_shm_object_trace_callback);
-    bool CreateSharedMemoryForControl(const LolaServiceInstanceDeployment& instance,
-                                      const QualityType asil_level,
-                                      const std::size_t shm_size);
-    bool OpenSharedMemoryForData(
-        const std::optional<RegisterShmObjectTraceCallback> register_shm_object_trace_callback);
-    bool OpenSharedMemoryForControl(const QualityType asil_level);
-    void InitializeSharedMemoryForData(const std::shared_ptr<score::memory::shared::ManagedMemoryResource>& memory);
-    void InitializeSharedMemoryForControl(const QualityType asil_level,
-                                          const std::shared_ptr<score::memory::shared::ManagedMemoryResource>& memory);
-
-    template <typename SampleType>
-    std::pair<EventDataStorage<SampleType>*, EventDataControlComposite<>> OpenEventDataFromOpenedSharedMemory(
-        const ElementFqId element_fq_id);
-
-    template <typename SampleType>
-    std::pair<EventDataStorage<SampleType>*, EventDataControlComposite<>> CreateEventDataFromOpenedSharedMemory(
-        const ElementFqId element_fq_id,
-        const SkeletonEventProperties& element_properties);
-
-    /// \brief Creates the control structures (QM and optional ASIL-B) for an event.
-    /// \param element_fq_id The full qualified ID of the element.
-    /// \param element_properties Properties of the event.
-    /// \return The EventDataControlComposite containing pointers to the control structures.
-    EventDataControlComposite<> CreateEventControlComposite(const ElementFqId element_fq_id,
-                                                            const SkeletonEventProperties& element_properties) noexcept;
-
-    /// \brief Creates shared memory storage for a generic (type-erased) event.
-    /// \param element_fq_id The full qualified ID of the element.
-    /// \param element_properties Properties of the event.
-    /// \param sample_size The size of a single data sample.
-    /// \param sample_alignment The alignment of the data sample.
-    /// \return A pair containing the data storage pointer (void*) and the control composite.
-    std::pair<void*, EventDataControlComposite<>> CreateEventDataFromOpenedSharedMemory(
-        const ElementFqId element_fq_id,
-        const SkeletonEventProperties& element_properties,
-        size_t sample_size,
-        size_t sample_alignment) noexcept;
-
-    class ShmResourceStorageSizes
-    {
-      public:
-        // Suppress "AUTOSAR C++14 M11-0-1" rule findings. This rule states: "Member data in non-POD class types shall
-        // be private.". There are no class invariants to maintain which could be violated by directly accessing member
-        // variables.
-        // coverity[autosar_cpp14_m11_0_1_violation]
-        std::size_t data_size;
-        // coverity[autosar_cpp14_m11_0_1_violation]
-        std::size_t control_qm_size;
-        // coverity[autosar_cpp14_m11_0_1_violation]
-        score::cpp::optional<std::size_t> control_asil_b_size;
-    };
-
-    /// \brief Calculates needed sizes for shm-objects for data and ctrl either via simulation or a rough estimation
-    /// depending on config.
-    /// \return storage sizes for the different shm-objects
-    ShmResourceStorageSizes CalculateShmResourceStorageSizes(SkeletonEventBindings& events,
-                                                             SkeletonFieldBindings& fields);
-    /// \brief Calculates needed sizes for shm-objects for data and ctrl via simulation of allocations against a heap
-    /// backed memory resource.
-    /// \return storage sizes for the different shm-objects
-    ShmResourceStorageSizes CalculateShmResourceStorageSizesBySimulation(SkeletonEventBindings& events,
-                                                                         SkeletonFieldBindings& fields);
-
-    void RemoveSharedMemory();
-    void RemoveStaleSharedMemoryArtefacts() const;
-
     ResultBlank OnServiceMethodsSubscribed(const ProxyInstanceIdentifier& proxy_instance_identifier,
                                            const uid_t proxy_uid,
                                            const QualityType asil_level,
@@ -264,22 +177,13 @@ class Skeleton final : public SkeletonBinding
 
     InstanceIdentifier identifier_;
     QualityType quality_type_;
-    const LolaServiceInstanceDeployment& lola_service_instance_deployment_;
-    const LolaServiceTypeDeployment& lola_service_type_deployment_;
     LolaServiceInstanceId::InstanceId lola_instance_id_;
     LolaServiceTypeDeployment::ServiceId lola_service_id_;
 
-    score::cpp::optional<std::string> data_storage_path_;
-    score::cpp::optional<std::string> data_control_qm_path_;
-    score::cpp::optional<std::string> data_control_asil_path_;
-    ServiceDataStorage* storage_;
-    ServiceDataControl* control_qm_;
-    ServiceDataControl* control_asil_b_;
-    std::shared_ptr<score::memory::shared::ManagedMemoryResource> storage_resource_;
-    std::shared_ptr<score::memory::shared::ManagedMemoryResource> control_qm_resource_;
-    std::shared_ptr<score::memory::shared::ManagedMemoryResource> control_asil_resource_;
-
     std::unique_ptr<IShmPathBuilder> shm_path_builder_;
+
+    SkeletonMemoryManager memory_manager_;
+
     std::unique_ptr<IPartialRestartPathBuilder> partial_restart_path_builder_;
     std::optional<memory::shared::LockFile> service_instance_existence_marker_file_;
     std::optional<memory::shared::LockFile> service_instance_usage_marker_file_;
@@ -332,7 +236,7 @@ auto Skeleton::Register(const ElementFqId element_fq_id, SkeletonEventProperties
     if (was_old_shm_region_reopened_)
     {
         auto [typed_event_data_storage_ptr, event_data_control_composite] =
-            OpenEventDataFromOpenedSharedMemory<SampleType>(element_fq_id);
+            memory_manager_.OpenEventDataFromOpenedSharedMemory<SampleType>(element_fq_id);
 
         auto& event_data_control_qm = event_data_control_composite.GetQmEventDataControl();
         auto rollback_result = event_data_control_qm.GetTransactionLogSet().RollbackSkeletonTracingTransactions(
@@ -349,109 +253,7 @@ auto Skeleton::Register(const ElementFqId element_fq_id, SkeletonEventProperties
         return {typed_event_data_storage_ptr, event_data_control_composite};
     }
 
-    return CreateEventDataFromOpenedSharedMemory<SampleType>(element_fq_id, element_properties);
-}
-
-template <typename SampleType>
-// Suppress "AUTOSAR C++14 M3-2-2" rule finding. This rule declares: "The One Definition Rule shall not be
-// violated.".
-// The "Skeleton" is a template class with its declaration and definition in different places within the same header
-// file, it does not violate the One Definition Rule
-// Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
-// implicitly". No way for 'OffsetPtr::get()' which called from 'event_data_storage_it->second.template' to throw an
-// exception but we can't mark 'OffsetPtr::get()' as ''.
-// coverity[autosar_cpp14_m3_2_2_violation]
-// coverity[autosar_cpp14_a15_5_3_violation]
-auto Skeleton::OpenEventDataFromOpenedSharedMemory(const ElementFqId element_fq_id)
-    -> std::pair<EventDataStorage<SampleType>*, EventDataControlComposite<>>
-{
-    // Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be
-    // called implicitly". This is a false positive, std::less which is used by std::map::find could throw an exception
-    // if the key value is not comparable and in our case the key is comparable. so no way for 'event_controls_.find()'
-    // to throw an exception.
-    // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-    auto find_element = [](auto& map, const ElementFqId& target_element_fq_id) -> auto {
-        const auto it = map.find(target_element_fq_id);
-        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(it != map.cend(), "Could not find element fq id in map");
-        return it;
-    };
-
-    score::cpp::ignore = find_element(storage_->events_metainfo_, element_fq_id);
-    const auto event_data_storage_it = find_element(storage_->events_, element_fq_id);
-    const auto event_control_qm_it = find_element(control_qm_->event_controls_, element_fq_id);
-
-    EventDataControl* event_data_control_asil_b{nullptr};
-    if (quality_type_ == QualityType::kASIL_B)
-    {
-        const auto event_control_asil_b_it = find_element(control_asil_b_->event_controls_, element_fq_id);
-        // Suppress "AUTOSAR C++14 M7-5-1" rule. This rule declares:
-        // A function shall not return a reference or a pointer to an automatic variable (including parameters), defined
-        // within the function.
-        // Suppress "AUTOSAR C++14 M7-5-2": The address of an object with automatic storage shall not be assigned to
-        // another object that may persist after the first object has ceased to exist.
-        // The result pointer is still valid outside this method until Skeleton object (as a holder) is alive.
-        // coverity[autosar_cpp14_m7_5_1_violation]
-        // coverity[autosar_cpp14_m7_5_2_violation]
-        // coverity[autosar_cpp14_a3_8_1_violation]
-        event_data_control_asil_b = &(event_control_asil_b_it->second.data_control);
-    }
-
-    // Suppress "AUTOSAR C++14 A5-3-2" rule finding. This rule declares: "Null pointers shall not be dereferenced.".
-    // The "event_data_storage_it" variable is an iterator of interprocess map returned by the "find_element" method.
-    // A check is made that the iterator is not equal to map.cend(). Therefore, the call to "event_data_storage_it->"
-    // does not return nullptr.
-    // coverity[autosar_cpp14_a5_3_2_violation]
-    auto* const typed_event_data_storage_ptr =
-        event_data_storage_it->second.template get<EventDataStorage<SampleType>>();
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(typed_event_data_storage_ptr != nullptr,
-                                                "Could not get EventDataStorage*");
-
-    // Suppress "AUTOSAR C++14 A3-8-1" rule findings. This rule declares:
-    // "An object shall not be accessed outside of its lifetime"
-    // The "event_data_control_asil_b" and "typed_event_data_storage_ptr" are still valid lifetime even returned pointer
-    // to internal state until Skeleton object is alive.
-    // coverity[autosar_cpp14_a3_8_1_violation]
-    return {typed_event_data_storage_ptr,
-            // The lifetime of the "event_data_control_asil_b" object lasts as long as the Skeleton is alive.
-            // coverity[autosar_cpp14_m7_5_1_violation]
-            // coverity[autosar_cpp14_m7_5_2_violation]
-            // coverity[autosar_cpp14_a3_8_1_violation]
-            EventDataControlComposite{&event_control_qm_it->second.data_control, event_data_control_asil_b}};
-}
-
-template <typename SampleType>
-// Suppress "AUTOSAR C++14 M3-2-2" rule finding. This rule declares: "The One Definition Rule shall not be
-// violated.".
-// The "Skeleton" is a template class with its declaration and definition in different places within the same header
-// file, it does not violate the One Definition Rule
-// Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
-// implicitly". This is a false positive, no way to throw std::bad_variant_access.
-// coverity[autosar_cpp14_m3_2_2_violation]
-// coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-auto Skeleton::CreateEventDataFromOpenedSharedMemory(const ElementFqId element_fq_id,
-                                                     const SkeletonEventProperties& element_properties)
-    -> std::pair<EventDataStorage<SampleType>*, EventDataControlComposite<>>
-{
-    auto* typed_event_data_storage_ptr = storage_resource_->construct<EventDataStorage<SampleType>>(
-        element_properties.number_of_slots,
-        memory::shared::PolymorphicOffsetPtrAllocator<SampleType>(*storage_resource_));
-
-    auto inserted_data_slots = storage_->events_.emplace(std::piecewise_construct,
-                                                         std::forward_as_tuple(element_fq_id),
-                                                         std::forward_as_tuple(typed_event_data_storage_ptr));
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(inserted_data_slots.second,
-                                                "Couldn't register/emplace event-storage in data-section.");
-
-    constexpr DataTypeMetaInfo sample_meta_info{sizeof(SampleType), static_cast<std::uint8_t>(alignof(SampleType))};
-    auto* event_data_raw_array = typed_event_data_storage_ptr->data();
-    auto inserted_meta_info =
-        storage_->events_metainfo_.emplace(std::piecewise_construct,
-                                           std::forward_as_tuple(element_fq_id),
-                                           std::forward_as_tuple(sample_meta_info, event_data_raw_array));
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(inserted_meta_info.second,
-                                                "Couldn't register/emplace event-meta-info in data-section.");
-
-    return {typed_event_data_storage_ptr, CreateEventControlComposite(element_fq_id, element_properties)};
+    return memory_manager_.CreateEventDataFromOpenedSharedMemory<SampleType>(element_fq_id, element_properties);
 }
 
 }  // namespace score::mw::com::impl::lola

--- a/score/mw/com/impl/bindings/lola/skeleton.h
+++ b/score/mw/com/impl/bindings/lola/skeleton.h
@@ -238,11 +238,6 @@ class Skeleton final : public SkeletonBinding
     /// \return storage sizes for the different shm-objects
     ShmResourceStorageSizes CalculateShmResourceStorageSizesBySimulation(SkeletonEventBindings& events,
                                                                          SkeletonFieldBindings& fields);
-    /// \brief Calculates needed sizes for shm-objects for data and ctrl via estimation based on sizeof info of related
-    /// data types.
-    /// \return storage sizes for the different shm-objects
-    ShmResourceStorageSizes CalculateShmResourceStorageSizesByEstimation(SkeletonEventBindings& events,
-                                                                         SkeletonFieldBindings& fields) const;
 
     void RemoveSharedMemory();
     void RemoveStaleSharedMemoryArtefacts() const;

--- a/score/mw/com/impl/bindings/lola/skeleton.h
+++ b/score/mw/com/impl/bindings/lola/skeleton.h
@@ -125,11 +125,6 @@ class Skeleton final : public SkeletonBinding
         const ElementFqId element_fq_id,
         SkeletonEventProperties element_properties);
 
-    /// \brief Returns the meta-info for the given registered event.
-    /// \param element_fq_id identification of the event.
-    /// \return Events meta-info, if it has been registered, null else.
-    score::cpp::optional<EventMetaInfo> GetEventMetaInfo(const ElementFqId element_fq_id) const;
-
     QualityType GetInstanceQualityType() const;
 
     /// \brief Cleans up all allocated slots for this SkeletonEvent of any previous running instance

--- a/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
@@ -316,28 +316,6 @@ void SkeletonMemoryManager::Reset()
     control_asil_b_ = nullptr;
 }
 
-// Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
-// implicitly". This is a false positive, std::less which is used by std::map::find could throw an exception if the
-// key value is not comparable and in our case the key is comparable. so no way for 'event_controls_.find()' to
-// throw an exception. coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-score::cpp::optional<EventMetaInfo> SkeletonMemoryManager::GetEventMetaInfo(const ElementFqId element_fq_id) const
-{
-    auto search = storage_->events_metainfo_.find(element_fq_id);
-    if (search == storage_->events_metainfo_.cend())
-    {
-        return score::cpp::nullopt;
-    }
-    else
-    {
-        // Suppress "AUTOSAR C++14 A5-3-2" rule finding. This rule declares: "Null pointers shall not be dereferenced
-        // .". The "search" variable is an iterator of interprocess map returned by "find" method. Performed the check,
-        // that iterator is not equal to map.end(). A check is made that the iterator is not equal
-        // to map.end(). Therefore, the call to "search->" does not return nullptr.
-        // coverity[autosar_cpp14_a5_3_2_violation]
-        return search->second;
-    }
-}
-
 SkeletonMemoryManager::ShmResourceStorageSizes SkeletonMemoryManager::CalculateShmResourceStorageSizes(
     SkeletonBinding::SkeletonEventBindings& events,
     SkeletonBinding::SkeletonFieldBindings& fields)

--- a/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
@@ -291,8 +291,8 @@ void SkeletonMemoryManager::RemoveStaleSharedMemoryArtefacts() const
     memory::shared::SharedMemoryFactory::RemoveStaleArtefacts(data_path);
 }
 
-// Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
-// implicitly". This is a false positive, there is no way for calling std::terminate().
+// Suppress "AUTOSAR C++14 A15-5-3": std::terminate() should not be called implicitly.
+// This is a false positive, there is no way for calling std::terminate().
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
 void SkeletonMemoryManager::CleanupSharedMemoryAfterCrash()
 {
@@ -458,8 +458,8 @@ SkeletonMemoryManager::ShmResourceStorageSizes SkeletonMemoryManager::CalculateS
     return ShmResourceStorageSizes{control_data_size, control_qm_size, control_asil_b_size};
 }
 
-// Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
-// implicitly". This is a false positive, all results which are accessed with '.value()' that could implicitly call
+// Suppress "AUTOSAR C++14 A15-5-3":
+// This is a false positive, all results which are accessed with '.value()' that could implicitly call
 // 'std::terminate()' (in case it doesn't have value) has a check in advance using '.has_value()', so no way for
 // throwing std::bad_optional_access which leds to std::terminate(). This suppression should be removed after fixing
 // [Ticket-173043](broken_link_j/Ticket-173043)
@@ -512,11 +512,9 @@ bool SkeletonMemoryManager::CreateSharedMemoryForData(
         // coverity[autosar_cpp14_a15_4_2_violation]
         register_shm_object_trace_callback.value()(
             tracing::TracingRuntime::kDummyElementNameForShmRegisterCallback,
-            // Suppress "AUTOSAR C++14 A4-5-1" rule findings. This rule states: "Expressions with type enum or enum
-            // class shall not be used as operands to built-in and overloaded operators other than the subscript
-            // operator [ ], the assignment operator =, the equality operators == and ! =, the unary & operator, and the
-            // relational operators <,
-            // <=, >, >=.". The enum is not an operand, its a function parameter.
+            // Suppress "AUTOSAR C++14 A4-5-1": Enums should not be used as operands to operators (other than
+            // operator[], operator=, operator==, operator!=, * and relational operators).
+            // Justification: The enum is not an operator, it's a function parameter.
             // coverity[autosar_cpp14_a4_5_1_violation : FALSE]
             tracing::TracingRuntime::kDummyElementTypeForShmRegisterCallback,
             memory_resource->GetFileDescriptor(),

--- a/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
@@ -1,0 +1,694 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/impl/bindings/lola/skeleton_memory_manager.h"
+#include "score/memory/shared/managed_memory_resource.h"
+#include "score/mw/com/impl/bindings/lola/i_shm_path_builder.h"
+#include "score/mw/com/impl/bindings/lola/service_data_control.h"
+#include "score/mw/com/impl/bindings/lola/service_data_storage.h"
+#include "score/mw/com/impl/bindings/lola/tracing/tracing_runtime.h"
+#include "score/mw/com/impl/com_error.h"
+#include "score/mw/com/impl/configuration/lola_service_instance_deployment.h"
+#include "score/mw/com/impl/configuration/lola_service_type_deployment.h"
+#include "score/mw/com/impl/configuration/quality_type.h"
+#include "score/mw/com/impl/runtime.h"
+#include "score/mw/com/impl/skeleton_event_binding.h"
+#include "score/result/result.h"
+
+#include "score/memory/shared/new_delete_delegate_resource.h"
+#include "score/memory/shared/shared_memory_factory.h"
+#include "score/mw/log/logging.h"
+#include "score/os/acl.h"
+
+#include <score/assert.hpp>
+#include <score/span.hpp>
+#include <sys/types.h>
+
+#include <cstddef>
+#include <string>
+#include <unordered_map>
+
+namespace score::mw::com::impl::lola
+{
+namespace
+{
+
+ServiceDataControl* GetServiceDataControlSkeletonSide(const memory::shared::ManagedMemoryResource& control)
+{
+    // Suppress "AUTOSAR C++14 M5-2-8" rule. The rule declares:
+    // An object with integer type or pointer to void type shall not be converted to an object with pointer type.
+    // The "ServiceDataStorage" type is strongly defined as shared IPC data between Proxy and Skeleton.
+    // coverity[autosar_cpp14_m5_2_8_violation]
+    auto* const service_data_control = static_cast<ServiceDataControl*>(control.getUsableBaseAddress());
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(service_data_control != nullptr,
+                                                "Could not retrieve service data control.");
+    return service_data_control;
+}
+
+ServiceDataStorage* GetServiceDataStorageSkeletonSide(const memory::shared::ManagedMemoryResource& data)
+{
+    // Suppress "AUTOSAR C++14 M5-2-8" rule. The rule declares:
+    // An object with integer type or pointer to void type shall not be converted to an object with pointer type.
+    // The "ServiceDataStorage" type is strongly defined as shared IPC data between Proxy and Skeleton.
+    // coverity[autosar_cpp14_m5_2_8_violation]
+    auto* const service_data_storage = static_cast<ServiceDataStorage*>(data.getUsableBaseAddress());
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(service_data_storage != nullptr,
+                                                "Could not retrieve service data storage within shared-memory.");
+    return service_data_storage;
+}
+
+std::string GetControlChannelShmPath(const LolaServiceInstanceDeployment& lola_service_instance_deployment,
+                                     const QualityType quality_type,
+                                     const IShmPathBuilder& shm_path_builder)
+{
+    const auto instance_id = lola_service_instance_deployment.instance_id_.value().GetId();
+    return shm_path_builder.GetControlChannelShmName(instance_id, quality_type);
+}
+
+std::string GetDataChannelShmPath(const LolaServiceInstanceDeployment& lola_service_instance_deployment,
+                                  const IShmPathBuilder& shm_path_builder)
+{
+    const auto instance_id = lola_service_instance_deployment.instance_id_.value().GetId();
+    return shm_path_builder.GetDataChannelShmName(instance_id);
+}
+
+enum class ShmObjectType : std::uint8_t
+{
+    kControl_QM = 0x00,
+    kControl_ASIL_B = 0x01,
+    kData = 0x02,
+};
+
+std::uint64_t CalculateMemoryResourceId(const LolaServiceTypeDeployment::ServiceId lola_service_id,
+                                        const LolaServiceInstanceId::InstanceId lola_instance_id,
+                                        const ShmObjectType object_type)
+{
+    return ((static_cast<std::uint64_t>(lola_service_id) << 24U) +
+            (static_cast<std::uint64_t>(lola_instance_id) << 8U) + static_cast<std::uint8_t>(object_type));
+}
+
+}  // namespace
+
+SkeletonMemoryManager::SkeletonMemoryManager(QualityType quality_type,
+                                             const IShmPathBuilder& shm_path_builder,
+                                             const LolaServiceInstanceDeployment& lola_service_instance_deployment,
+                                             const LolaServiceTypeDeployment& lola_service_type_deployment,
+                                             const LolaServiceInstanceId::InstanceId lola_instance_id,
+                                             const LolaServiceTypeDeployment::ServiceId lola_service_id)
+    : quality_type_{quality_type},
+      shm_path_builder_{shm_path_builder},
+      lola_service_instance_deployment_{lola_service_instance_deployment},
+      lola_service_type_deployment_{lola_service_type_deployment},
+      lola_instance_id_{lola_instance_id},
+      lola_service_id_{lola_service_id},
+      data_storage_path_{},
+      data_control_qm_path_{},
+      data_control_asil_path_{},
+      storage_{nullptr},
+      control_qm_{nullptr},
+      control_asil_b_{nullptr},
+      storage_resource_{},
+      control_qm_resource_{},
+      control_asil_resource_{}
+{
+}
+
+auto SkeletonMemoryManager::OpenExistingSharedMemory(
+    std::optional<SkeletonBinding::RegisterShmObjectTraceCallback> register_shm_object_trace_callback) -> ResultBlank
+{
+    if (!OpenSharedMemoryForControl(QualityType::kASIL_QM))
+    {
+        return MakeUnexpected(ComErrc::kErroneousFileHandle, "Could not open shared memory object for control QM");
+    }
+
+    if ((quality_type_ == QualityType::kASIL_B) && (!OpenSharedMemoryForControl(QualityType::kASIL_B)))
+    {
+        return MakeUnexpected(ComErrc::kErroneousFileHandle, "Could not open shared memory object for control ASIL-B");
+    }
+
+    if (!OpenSharedMemoryForData(std::move(register_shm_object_trace_callback)))
+    {
+        return MakeUnexpected(ComErrc::kErroneousFileHandle, "Could not open shared memory object for data");
+    }
+    return {};
+}
+
+auto SkeletonMemoryManager::CreateSharedMemory(
+    SkeletonBinding::SkeletonEventBindings& events,
+    SkeletonBinding::SkeletonFieldBindings& fields,
+    std::optional<SkeletonBinding::RegisterShmObjectTraceCallback> register_shm_object_trace_callback) -> ResultBlank
+{
+    const auto storage_size_calc_result = CalculateShmResourceStorageSizes(events, fields);
+
+    if (!CreateSharedMemoryForControl(
+            lola_service_instance_deployment_, QualityType::kASIL_QM, storage_size_calc_result.control_qm_size))
+    {
+        return MakeUnexpected(ComErrc::kErroneousFileHandle, "Could not create shared memory object for control QM");
+    }
+
+    if ((quality_type_ == QualityType::kASIL_B) &&
+        (!CreateSharedMemoryForControl(lola_service_instance_deployment_,
+                                       QualityType::kASIL_B,
+                                       storage_size_calc_result.control_asil_b_size.value())))
+    {
+        return MakeUnexpected(ComErrc::kErroneousFileHandle,
+                              "Could not create shared memory object for control ASIL-B");
+    }
+
+    if (!CreateSharedMemoryForData(lola_service_instance_deployment_,
+                                   storage_size_calc_result.data_size,
+                                   std::move(register_shm_object_trace_callback)))
+    {
+        return MakeUnexpected(ComErrc::kErroneousFileHandle, "Could not create shared memory object for data");
+    }
+    return {};
+}
+
+EventDataControlComposite<> SkeletonMemoryManager::CreateEventControlComposite(
+    const ElementFqId element_fq_id,
+    const SkeletonEventProperties& element_properties) noexcept
+{
+    auto control_qm = control_qm_->event_controls_.emplace(std::piecewise_construct,
+                                                           std::forward_as_tuple(element_fq_id),
+                                                           std::forward_as_tuple(element_properties.number_of_slots,
+                                                                                 element_properties.max_subscribers,
+                                                                                 element_properties.enforce_max_samples,
+                                                                                 *control_qm_resource_));
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(control_qm.second,
+                                                "Couldn't register/emplace event-meta-info in data-section.");
+
+    EventDataControl* control_asil_result{nullptr};
+    if (control_asil_resource_ != nullptr)
+    {
+        auto iterator =
+            control_asil_b_->event_controls_.emplace(std::piecewise_construct,
+                                                     std::forward_as_tuple(element_fq_id),
+                                                     std::forward_as_tuple(element_properties.number_of_slots,
+                                                                           element_properties.max_subscribers,
+                                                                           element_properties.enforce_max_samples,
+                                                                           *control_asil_resource_));
+
+        // Suppress "AUTOSAR C++14 M7-5-1" rule. This rule declares:
+        // A function shall not return a reference or a pointer to an automatic variable (including parameters), defined
+        // within the function.
+        // Suppress "AUTOSAR C++14 M7-5-2": The address of an object with automatic storage shall not be assigned to
+        // another object that may persist after the first object has ceased to exist.
+        // The result pointer is still valid outside this method until Skeleton object (as a holder) is alive.
+        // coverity[autosar_cpp14_m7_5_1_violation]
+        // coverity[autosar_cpp14_m7_5_2_violation]
+        // coverity[autosar_cpp14_a3_8_1_violation]
+        control_asil_result = &iterator.first->second.data_control;
+    }
+    // The lifetime of the "control_asil_result" object lasts as long as the Skeleton is alive.
+    // coverity[autosar_cpp14_m7_5_1_violation]
+    // coverity[autosar_cpp14_m7_5_2_violation]
+    // coverity[autosar_cpp14_a3_8_1_violation]
+    return EventDataControlComposite{&control_qm.first->second.data_control, control_asil_result};
+}
+
+std::pair<void*, EventDataControlComposite<>> SkeletonMemoryManager::CreateEventDataFromOpenedSharedMemory(
+    const ElementFqId element_fq_id,
+    const SkeletonEventProperties& element_properties,
+    size_t sample_size,
+    size_t sample_alignment) noexcept
+{
+    // Guard against over-aligned types (Short-term solution protection)
+    if (sample_alignment > alignof(std::max_align_t))
+    {
+        score::mw::log::LogFatal("Skeleton")
+            << "Requested sample alignment (" << sample_alignment << ") exceeds max_align_t ("
+            << alignof(std::max_align_t) << "). Safe shared memory layout cannot be guaranteed.";
+
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(sample_alignment <= alignof(std::max_align_t),
+                                                    "Requested sample alignment exceeds maximum supported alignment.");
+    }
+
+    // Calculate the aligned size for a single sample to ensure proper padding between slots
+    const auto aligned_sample_size = memory::shared::CalculateAlignedSize(sample_size, sample_alignment);
+    const auto total_data_size_bytes = aligned_sample_size * element_properties.number_of_slots;
+
+    // Convert total bytes to the number of std::max_align_t elements needed (round up)
+    const size_t num_max_align_elements =
+        (total_data_size_bytes + sizeof(std::max_align_t) - 1) / sizeof(std::max_align_t);
+
+    auto* data_storage = storage_resource_->construct<EventDataStorage<std::max_align_t>>(
+        num_max_align_elements, memory::shared::PolymorphicOffsetPtrAllocator<std::max_align_t>(*storage_resource_));
+
+    auto inserted_data_slots = storage_->events_.emplace(
+        std::piecewise_construct, std::forward_as_tuple(element_fq_id), std::forward_as_tuple(data_storage));
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(inserted_data_slots.second,
+                                                "Couldn't register/emplace event-storage in data-section.");
+
+    const DataTypeMetaInfo sample_meta_info{sample_size, static_cast<std::uint8_t>(sample_alignment)};
+    void* const event_data_raw_array = data_storage->data();
+
+    auto inserted_meta_info =
+        storage_->events_metainfo_.emplace(std::piecewise_construct,
+                                           std::forward_as_tuple(element_fq_id),
+                                           std::forward_as_tuple(sample_meta_info, event_data_raw_array));
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(inserted_meta_info.second,
+                                                "Couldn't register/emplace event-meta-info in data-section.");
+
+    return {data_storage, CreateEventControlComposite(element_fq_id, element_properties)};
+}
+
+void SkeletonMemoryManager::RemoveSharedMemory()
+{
+    constexpr auto RemoveMemoryIfExists = [](const score::cpp::optional<std::string>& path) -> void {
+        if (path.has_value())
+        {
+            score::memory::shared::SharedMemoryFactory::Remove(path.value());
+        }
+    };
+    RemoveMemoryIfExists(data_control_qm_path_);
+    RemoveMemoryIfExists(data_control_asil_path_);
+    RemoveMemoryIfExists(data_storage_path_);
+
+    storage_resource_.reset();
+    control_qm_resource_.reset();
+    control_asil_resource_.reset();
+}
+
+void SkeletonMemoryManager::RemoveStaleSharedMemoryArtefacts() const
+{
+    const auto control_qm_path =
+        GetControlChannelShmPath(lola_service_instance_deployment_, QualityType::kASIL_QM, shm_path_builder_);
+    const auto control_asil_b_path =
+        GetControlChannelShmPath(lola_service_instance_deployment_, QualityType::kASIL_B, shm_path_builder_);
+    const auto data_path = GetDataChannelShmPath(lola_service_instance_deployment_, shm_path_builder_);
+
+    memory::shared::SharedMemoryFactory::RemoveStaleArtefacts(control_qm_path);
+    memory::shared::SharedMemoryFactory::RemoveStaleArtefacts(control_asil_b_path);
+    memory::shared::SharedMemoryFactory::RemoveStaleArtefacts(data_path);
+}
+
+// Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
+// implicitly". This is a false positive, there is no way for calling std::terminate().
+// coverity[autosar_cpp14_a15_5_3_violation : FALSE]
+void SkeletonMemoryManager::CleanupSharedMemoryAfterCrash()
+{
+    for (auto& event : control_qm_->event_controls_)
+    {
+        event.second.data_control.RemoveAllocationsForWriting();
+    }
+
+    if (control_asil_b_ != nullptr)
+    {
+        for (auto& event : control_asil_b_->event_controls_)
+        {
+            event.second.data_control.RemoveAllocationsForWriting();
+        }
+    }
+}
+void SkeletonMemoryManager::Reset()
+{
+    storage_ = nullptr;
+    control_qm_ = nullptr;
+    control_asil_b_ = nullptr;
+}
+
+// Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
+// implicitly". This is a false positive, std::less which is used by std::map::find could throw an exception if the
+// key value is not comparable and in our case the key is comparable. so no way for 'event_controls_.find()' to
+// throw an exception. coverity[autosar_cpp14_a15_5_3_violation : FALSE]
+score::cpp::optional<EventMetaInfo> SkeletonMemoryManager::GetEventMetaInfo(const ElementFqId element_fq_id) const
+{
+    auto search = storage_->events_metainfo_.find(element_fq_id);
+    if (search == storage_->events_metainfo_.cend())
+    {
+        return score::cpp::nullopt;
+    }
+    else
+    {
+        // Suppress "AUTOSAR C++14 A5-3-2" rule finding. This rule declares: "Null pointers shall not be dereferenced
+        // .". The "search" variable is an iterator of interprocess map returned by "find" method. Performed the check,
+        // that iterator is not equal to map.end(). A check is made that the iterator is not equal
+        // to map.end(). Therefore, the call to "search->" does not return nullptr.
+        // coverity[autosar_cpp14_a5_3_2_violation]
+        return search->second;
+    }
+}
+
+SkeletonMemoryManager::ShmResourceStorageSizes SkeletonMemoryManager::CalculateShmResourceStorageSizes(
+    SkeletonBinding::SkeletonEventBindings& events,
+    SkeletonBinding::SkeletonFieldBindings& fields)
+{
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+        GetBindingRuntime<lola::IRuntime>(BindingType::kLoLa).GetShmSizeCalculationMode() ==
+            ShmSizeCalculationMode::kSimulation,
+        "No other shm size calculation mode is currently suppored");
+    if ((lola_service_instance_deployment_.shared_memory_size_.has_value()) &&
+        (lola_service_instance_deployment_.control_asil_b_memory_size_.has_value()) &&
+        (lola_service_instance_deployment_.control_qm_memory_size_.has_value()))
+    {
+        score::mw::log::LogInfo("lola")
+            << "shm-size, control-asil-b-shm-size and control-qm-shm-size manually specified "
+               "for service_id:instance_id "
+            << lola_service_id_
+            << ":"
+            // coverity[autosar_cpp14_a18_9_2_violation]
+            << lola_instance_id_
+            << "- Make sure that this value is sufficiently big to"
+               "avoid aborts at runtime.";
+        return {lola_service_instance_deployment_.shared_memory_size_.value(),
+                lola_service_instance_deployment_.control_qm_memory_size_.value(),
+                lola_service_instance_deployment_.control_asil_b_memory_size_.value()};
+    }
+
+    auto required_shm_storage_size = CalculateShmResourceStorageSizesBySimulation(events, fields);
+
+    const std::size_t control_asil_b_size_result = required_shm_storage_size.control_asil_b_size.has_value()
+                                                       ? required_shm_storage_size.control_asil_b_size.value()
+                                                       : 0U;
+
+    // Suppress "AUTOSAR C++14 A18-9-2" rule finding: "Forwarding values to other functions shall be done via:
+    // (1) std::move if the value is an rvalue reference, (2) std::forward if the value is forwarding
+    // reference".
+    // Passing result of std::move() as a const reference argument, no move will actually happen.
+    // coverity[autosar_cpp14_a18_9_2_violation]
+    score::mw::log::LogInfo("lola") << "Calculated sizes of shm-objects for service_id:instance_id " << lola_service_id_
+                                    << ":"
+                                    // coverity[autosar_cpp14_a18_9_2_violation]
+                                    << lola_instance_id_
+                                    << " are as follows:\nQM-Ctrl: " << required_shm_storage_size.control_qm_size
+                                    << ", ASIL_B-Ctrl: " << control_asil_b_size_result
+                                    << ", Data: " << required_shm_storage_size.data_size;
+
+    if (lola_service_instance_deployment_.shared_memory_size_.has_value())
+    {
+        score::mw::log::LogInfo("lola") << "shm-size manually specified for service_id:instance_id " << lola_service_id_
+                                        << ":"
+                                        // coverity[autosar_cpp14_a18_9_2_violation]
+                                        << lola_instance_id_
+                                        << "- Make sure that this value is sufficiently big to"
+                                           "avoid aborts at runtime.";
+        required_shm_storage_size.data_size = lola_service_instance_deployment_.shared_memory_size_.value();
+    }
+
+    if (lola_service_instance_deployment_.control_asil_b_memory_size_.has_value())
+    {
+        score::mw::log::LogInfo("lola") << "control-asil-b-shm-size manually specified for service_id:instance_id "
+                                        << lola_service_id_
+                                        << ":"
+                                        // coverity[autosar_cpp14_a18_9_2_violation]
+                                        << lola_instance_id_
+                                        << "- Make sure that this value is sufficiently big to"
+                                           "avoid aborts at runtime.";
+        required_shm_storage_size.control_asil_b_size =
+            lola_service_instance_deployment_.control_asil_b_memory_size_.value();
+    }
+
+    if (lola_service_instance_deployment_.control_qm_memory_size_.has_value())
+    {
+        score::mw::log::LogInfo("lola") << "control-qm-shm-size manually specified for service_id:instance_id "
+                                        << lola_service_id_
+                                        << ":"
+                                        // coverity[autosar_cpp14_a18_9_2_violation]
+                                        << lola_instance_id_
+                                        << "- Make sure that this value is sufficiently big to"
+                                           "avoid aborts at runtime.";
+        required_shm_storage_size.control_qm_size = lola_service_instance_deployment_.control_qm_memory_size_.value();
+    }
+
+    return required_shm_storage_size;
+}
+
+SkeletonMemoryManager::ShmResourceStorageSizes SkeletonMemoryManager::CalculateShmResourceStorageSizesBySimulation(
+    SkeletonBinding::SkeletonEventBindings& events,
+    SkeletonBinding::SkeletonFieldBindings& fields)
+{
+    using NewDeleteDelegateMemoryResource = memory::shared::NewDeleteDelegateMemoryResource;
+
+    // we create up to 3 DryRun Memory Resources and then do the "normal" initialization of control and data
+    // shm-objects on it
+    control_qm_resource_ = std::make_shared<NewDeleteDelegateMemoryResource>(
+        CalculateMemoryResourceId(lola_service_id_, lola_instance_id_, ShmObjectType::kControl_QM));
+
+    storage_resource_ = std::make_shared<NewDeleteDelegateMemoryResource>(
+        CalculateMemoryResourceId(lola_service_id_, lola_instance_id_, ShmObjectType::kData));
+
+    // Note, that it is important to have all DryRun Memory Resources "active" in parallel as the upcoming calls to
+    // PrepareOffer() for the events triggers all SkeletonEvents to register themselves at their parent Skeleton
+    // (lola::SkeletonMemoryManager::Register()), which leads to updates/allocation within ctrl AND data resources!
+    InitializeSharedMemoryForControl(QualityType::kASIL_QM, control_qm_resource_);
+
+    if (quality_type_ == QualityType::kASIL_B)
+    {
+        control_asil_resource_ = std::make_shared<NewDeleteDelegateMemoryResource>(
+            CalculateMemoryResourceId(lola_service_id_, lola_instance_id_, ShmObjectType::kControl_ASIL_B));
+        InitializeSharedMemoryForControl(QualityType::kASIL_B, control_asil_resource_);
+    }
+    InitializeSharedMemoryForData(storage_resource_);
+
+    // Offer events to calculate the shared memory allocated for the control and data segments for each event
+    for (auto& event : events)
+    {
+        score::cpp::ignore = event.second.get().PrepareOffer();
+    }
+    for (auto& field : fields)
+    {
+        score::cpp::ignore = field.second.get().PrepareOffer();
+    }
+
+    const auto control_qm_size = control_qm_resource_->GetUserAllocatedBytes();
+    const auto control_data_size = storage_resource_->GetUserAllocatedBytes();
+
+    // PrepareStopOffer events to clean up the events/fields again for the real/next offer done after simulation.
+    for (auto& event : events)
+    {
+        event.second.get().PrepareStopOffer();
+    }
+    for (auto& field : fields)
+    {
+        field.second.get().PrepareStopOffer();
+    }
+
+    const auto control_asil_b_size =
+        quality_type_ == QualityType::kASIL_B
+            ? score::cpp::optional<std::size_t>{control_asil_resource_->GetUserAllocatedBytes()}
+            : score::cpp::optional<std::size_t>{};
+
+    return ShmResourceStorageSizes{control_data_size, control_qm_size, control_asil_b_size};
+}
+
+// Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
+// implicitly". This is a false positive, all results which are accessed with '.value()' that could implicitly call
+// 'std::terminate()' (in case it doesn't have value) has a check in advance using '.has_value()', so no way for
+// throwing std::bad_optional_access which leds to std::terminate(). This suppression should be removed after fixing
+// [Ticket-173043](broken_link_j/Ticket-173043)
+// coverity[autosar_cpp14_a15_5_3_violation : FALSE]
+bool SkeletonMemoryManager::CreateSharedMemoryForData(
+    const LolaServiceInstanceDeployment& instance,
+    const std::size_t shm_size,
+    std::optional<SkeletonBinding::RegisterShmObjectTraceCallback> register_shm_object_trace_callback)
+{
+    memory::shared::SharedMemoryFactory::UserPermissionsMap permissions{};
+    for (const auto& allowed_consumer : instance.allowed_consumer_)
+    {
+        for (const auto& user_identifier : allowed_consumer.second)
+        {
+            permissions[score::os::Acl::Permission::kRead].push_back(user_identifier);
+        }
+    }
+
+    const auto path = shm_path_builder_.GetDataChannelShmName(lola_instance_id_);
+    const bool use_typed_memory = register_shm_object_trace_callback.has_value();
+    const memory::shared::SharedMemoryFactory::UserPermissions user_permissions =
+        (permissions.empty()) && (instance.strict_permissions_ == false)
+            ? memory::shared::SharedMemoryFactory::WorldReadable{}
+            : memory::shared::SharedMemoryFactory::UserPermissions{permissions};
+    const auto memory_resource = score::memory::shared::SharedMemoryFactory::Create(
+        path,
+        [this](std::shared_ptr<score::memory::shared::ISharedMemoryResource> memory) {
+            this->InitializeSharedMemoryForData(memory);
+        },
+        shm_size,
+        user_permissions,
+        use_typed_memory);
+    if (memory_resource == nullptr)
+    {
+        return false;
+    }
+    data_storage_path_ = path;
+    if (register_shm_object_trace_callback.has_value() && memory_resource->IsShmInTypedMemory())
+    {
+        // only if the memory_resource could be successfully allocated in typed-memory, we call back the
+        // register_shm_object_trace_callback, because only then the shm-object can be accessed by tracing
+        // subsystem.
+        // Since LoLa creates shm-objects on the granularity of whole service-instances (including ALL its service
+        // elements), we call register_shm_object_trace_callback once and hand over a dummy element name/type!
+        // Other bindings, which might create shm-objects per service-element would call
+        // register_shm_object_trace_callback for each service-element and then use their "real" name and type ...
+        // Suppress "AUTOSAR C++14 A15-4-2" rule finding. This rule states: "I a function is declared to be
+        // , (true) or (<true condition>), then it shall not exit with an exception"
+        // we can't add  to score::cpp::callback signature.
+        // coverity[autosar_cpp14_a15_4_2_violation]
+        register_shm_object_trace_callback.value()(
+            tracing::TracingRuntime::kDummyElementNameForShmRegisterCallback,
+            // Suppress "AUTOSAR C++14 A4-5-1" rule findings. This rule states: "Expressions with type enum or enum
+            // class shall not be used as operands to built-in and overloaded operators other than the subscript
+            // operator [ ], the assignment operator =, the equality operators == and ! =, the unary & operator, and the
+            // relational operators <,
+            // <=, >, >=.". The enum is not an operand, its a function parameter.
+            // coverity[autosar_cpp14_a4_5_1_violation : FALSE]
+            tracing::TracingRuntime::kDummyElementTypeForShmRegisterCallback,
+            memory_resource->GetFileDescriptor(),
+            memory_resource->getBaseAddress());
+    }
+
+    score::mw::log::LogDebug("lola") << "Created shared-memory-object for DATA (S: " << lola_service_id_
+                                     << " I:" << lola_instance_id_ << ")";
+    return true;
+}
+
+bool SkeletonMemoryManager::CreateSharedMemoryForControl(const LolaServiceInstanceDeployment& instance,
+                                                         const QualityType asil_level,
+                                                         const std::size_t shm_size)
+{
+    const auto path = shm_path_builder_.GetControlChannelShmName(lola_instance_id_, asil_level);
+
+    const auto consumer = instance.allowed_consumer_.find(asil_level);
+    auto& control_resource = (asil_level == QualityType::kASIL_QM) ? control_qm_resource_ : control_asil_resource_;
+    auto& data_control_path = (asil_level == QualityType::kASIL_QM) ? data_control_qm_path_ : data_control_asil_path_;
+
+    memory::shared::SharedMemoryFactory::UserPermissionsMap permissions{};
+    if (consumer != instance.allowed_consumer_.cend())
+    {
+        for (const auto& user_identifier : consumer->second)
+        {
+            permissions[score::os::Acl::Permission::kRead].push_back(user_identifier);
+            permissions[score::os::Acl::Permission::kWrite].push_back(user_identifier);
+        }
+    }
+
+    const memory::shared::SharedMemoryFactory::UserPermissions user_permissions =
+        (permissions.empty()) && (instance.strict_permissions_ == false)
+            ? memory::shared::SharedMemoryFactory::WorldWritable{}
+            : memory::shared::SharedMemoryFactory::UserPermissions{permissions};
+    control_resource = score::memory::shared::SharedMemoryFactory::Create(
+        path,
+        [this, asil_level](std::shared_ptr<score::memory::shared::ManagedMemoryResource> memory) {
+            this->InitializeSharedMemoryForControl(asil_level, memory);
+        },
+        shm_size,
+        user_permissions);
+    if (control_resource == nullptr)
+    {
+        return false;
+    }
+    data_control_path = path;
+    return true;
+}
+
+// Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
+// implicitly". This is a false positive, all results which are accessed with '.value()' that could implicitly call
+// 'std::terminate()' (in case it doesn't have value) has a check in advance using '.has_value()', so no way for
+// throwing std::bad_optional_access which leds to std::terminate(). This suppression should be removed after fixing
+// [Ticket-173043](broken_link_j/Ticket-173043)
+// coverity[autosar_cpp14_a15_5_3_violation : FALSE]
+bool SkeletonMemoryManager::OpenSharedMemoryForData(
+    const std::optional<SkeletonBinding::RegisterShmObjectTraceCallback> register_shm_object_trace_callback)
+{
+    const auto path = GetDataChannelShmPath(lola_service_instance_deployment_, shm_path_builder_);
+
+    const auto memory_resource = score::memory::shared::SharedMemoryFactory::Open(path, true);
+    if (memory_resource == nullptr)
+    {
+        return false;
+    }
+    data_storage_path_ = path;
+    storage_resource_ = memory_resource;
+
+    const auto& memory_resource_ref = *memory_resource.get();
+    storage_ = GetServiceDataStorageSkeletonSide(memory_resource_ref);
+
+    // Our pid will have changed after re-start and we now have to update it in the re-opened DATA section.
+    const auto pid = GetBindingRuntime<lola::IRuntime>(BindingType::kLoLa).GetPid();
+    score::mw::log::LogDebug("lola") << "Updating PID of Skeleton (S: " << lola_service_id_
+                                     << " I:" << lola_instance_id_ << ") with:" << pid;
+    storage_->skeleton_pid_ = pid;
+
+    if (register_shm_object_trace_callback.has_value() && memory_resource->IsShmInTypedMemory())
+    {
+        // only if the memory_resource could be successfully allocated in typed-memory, we call back the
+        // register_shm_object_trace_callback, because only then the shm-object can be accessed by tracing
+        // subsystem.
+        // Suppress "AUTOSAR C++14 A15-4-2" rule finding. This rule states: "I a function is declared to be
+        // , (true) or (<true condition>), then it shall not exit with an exception"
+        // we can't add  to score::cpp::callback signature.
+        // coverity[autosar_cpp14_a15_4_2_violation]
+        register_shm_object_trace_callback.value()(
+            tracing::TracingRuntime::kDummyElementNameForShmRegisterCallback,
+            // Suppress "AUTOSAR C++14 A4-5-1" rule findings. This rule states: "Expressions with type enum or enum
+            // class shall not be used as operands to built-in and overloaded operators other than the subscript
+            // operator [ ], the assignment operator =, the equality operators == and ! =, the unary & operator, and the
+            // relational operators <,
+            // <=, >, >=.". The enum is not an operand, its a function parameter.
+            // coverity[autosar_cpp14_a4_5_1_violation : FALSE]
+            tracing::TracingRuntime::kDummyElementTypeForShmRegisterCallback,
+            memory_resource->GetFileDescriptor(),
+            memory_resource->getBaseAddress());
+    }
+    return true;
+}
+
+bool SkeletonMemoryManager::OpenSharedMemoryForControl(const QualityType asil_level)
+{
+    const auto path = GetControlChannelShmPath(lola_service_instance_deployment_, asil_level, shm_path_builder_);
+
+    auto& control_resource = (asil_level == QualityType::kASIL_QM) ? control_qm_resource_ : control_asil_resource_;
+    auto& data_control_path = (asil_level == QualityType::kASIL_QM) ? data_control_qm_path_ : data_control_asil_path_;
+
+    control_resource = score::memory::shared::SharedMemoryFactory::Open(path, true);
+    if (control_resource == nullptr)
+    {
+        return false;
+    }
+    data_control_path = path;
+
+    auto& control = (asil_level == QualityType::kASIL_QM) ? control_qm_ : control_asil_b_;
+
+    const auto& control_resource_ref = *control_resource.get();
+    control = GetServiceDataControlSkeletonSide(control_resource_ref);
+
+    return true;
+}
+
+// Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
+// implicitly". This is a false positive, there is no way for calling std::terminate().
+// coverity[autosar_cpp14_a15_5_3_violation : FALSE]
+void SkeletonMemoryManager::InitializeSharedMemoryForData(
+    const std::shared_ptr<score::memory::shared::ManagedMemoryResource>& memory)
+{
+    storage_ = memory->construct<ServiceDataStorage>(*memory);
+    storage_resource_ = memory;
+    // Suppress "AUTOSAR C++14 A0-1-1", The rule states: "A project shall not contain instances of non-volatile
+    // variables being given values that are not subsequently used"
+    // There is no variable instantiation.
+    // coverity[autosar_cpp14_a0_1_1_violation : FALSE]
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+        storage_resource_ != nullptr,
+        "storage_resource_ must be no nullptr, otherwise the callback would not be invoked.");
+}
+
+// Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
+// implicitly". This is a false positive, there is no way for calling std::terminate().
+// coverity[autosar_cpp14_a15_5_3_violation : FALSE]
+void SkeletonMemoryManager::InitializeSharedMemoryForControl(
+    const QualityType asil_level,
+    const std::shared_ptr<score::memory::shared::ManagedMemoryResource>& memory)
+{
+    auto& control = (asil_level == QualityType::kASIL_QM) ? control_qm_ : control_asil_b_;
+    control = memory->construct<ServiceDataControl>(*memory);
+}
+
+}  // namespace score::mw::com::impl::lola

--- a/score/mw/com/impl/bindings/lola/skeleton_memory_manager.h
+++ b/score/mw/com/impl/bindings/lola/skeleton_memory_manager.h
@@ -38,14 +38,14 @@
 namespace score::mw::com::impl::lola
 {
 
-/// \brief SkeletonMemoryManager manages are shared memory related functionality of a Skeleton.
+/// \brief SkeletonMemoryManager manages shared memory related functionality of a Skeleton.
 ///
 /// A SkeletonMemoryManager is owned and dispatched to by a Skeleton.
 class SkeletonMemoryManager final
 {
-    // Suppress "AUTOSAR C++14 A11-3-1", The rule declares: "Friend declarations shall not be used".
-    // The "SkeletonAttorney" class is a helper, which sets the internal state of "Skeleton" accessing
-    // private members and used for testing purposes only.
+    // Suppress "AUTOSAR C++14 A11-3-1": Forbids the use of friend declarations.
+    // Justification: The "SkeletonMemoryManagerTestAttorney" class is a helper, which sets the internal state of
+    // "Skeleton" accessing private members and used for testing purposes only.
     // coverity[autosar_cpp14_a11_3_1_violation]
     friend class SkeletonMemoryManagerTestAttorney;
 
@@ -112,8 +112,8 @@ class SkeletonMemoryManager final
     class ShmResourceStorageSizes
     {
       public:
-        // Suppress "AUTOSAR C++14 M11-0-1" rule findings. This rule states: "Member data in non-POD class types shall
-        // be private.". There are no class invariants to maintain which could be violated by directly accessing member
+        // Suppress "AUTOSAR C++14 M11-0-1": All non-POD class types should only have private member data.
+        // Justification: There are no class invariants to maintain which could be violated by directly accessing member
         // variables.
         // coverity[autosar_cpp14_m11_0_1_violation]
         std::size_t data_size;
@@ -169,12 +169,11 @@ class SkeletonMemoryManager final
 };
 
 template <typename SampleType>
-// Suppress "AUTOSAR C++14 M3-2-2" rule finding. This rule declares: "The One Definition Rule shall not be
-// violated.".
-// The "Skeleton" is a template class with its declaration and definition in different places within the same header
-// file, it does not violate the One Definition Rule
-// Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
-// implicitly". This is a false positive, no way to throw std::bad_variant_access.
+// Suppress "AUTOSAR C++14 M3-2-2": ODR (One Definition Rule) must not be violated.
+// Justification: The "Skeleton" is a template class with its declaration and definition in different places within the
+// same header file, it does not violate the One Definition Rule.
+// Suppress "AUTOSAR C++14 A15-5-3": std::terminate() should not be called implicitly.
+// Justification: This is a false positive, no way to throw std::bad_variant_access.
 // coverity[autosar_cpp14_m3_2_2_violation]
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
 auto SkeletonMemoryManager::CreateEventDataFromOpenedSharedMemory(const ElementFqId element_fq_id,
@@ -204,22 +203,20 @@ auto SkeletonMemoryManager::CreateEventDataFromOpenedSharedMemory(const ElementF
 }
 
 template <typename SampleType>
-// Suppress "AUTOSAR C++14 M3-2-2" rule finding. This rule declares: "The One Definition Rule shall not be
-// violated.".
-// The "Skeleton" is a template class with its declaration and definition in different places within the same header
-// file, it does not violate the One Definition Rule
-// Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
-// implicitly". No way for 'OffsetPtr::get()' which called from 'event_data_storage_it->second.template' to throw an
+// Suppress "AUTOSAR C++14 M3-2-2":
+// Justification: Same justification as above.
+// Suppress "AUTOSAR C++14 A15-5-3":
+// Justification: No way for 'OffsetPtr::get()' which called from 'event_data_storage_it->second.template' to throw an
 // exception but we can't mark 'OffsetPtr::get()' as ''.
 // coverity[autosar_cpp14_m3_2_2_violation]
 // coverity[autosar_cpp14_a15_5_3_violation]
 auto SkeletonMemoryManager::OpenEventDataFromOpenedSharedMemory(const ElementFqId element_fq_id)
     -> std::pair<EventDataStorage<SampleType>*, EventDataControlComposite<>>
 {
-    // Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be
-    // called implicitly". This is a false positive, std::less which is used by std::map::find could throw an exception
-    // if the key value is not comparable and in our case the key is comparable. so no way for 'event_controls_.find()'
-    // to throw an exception.
+    // Suppress "AUTOSAR C++14 A15-5-3":
+    // Justification: This is a false positive, std::less which is used by std::map::find could throw an exception if
+    // the key value is not comparable and in our case the key is comparable. so no way for 'event_controls_.find()' to
+    // throw an exception.
     // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
     auto find_element = [](auto& map, const ElementFqId& target_element_fq_id) -> auto {
         const auto it = map.find(target_element_fq_id);
@@ -235,32 +232,34 @@ auto SkeletonMemoryManager::OpenEventDataFromOpenedSharedMemory(const ElementFqI
     if (quality_type_ == QualityType::kASIL_B)
     {
         const auto event_control_asil_b_it = find_element(control_asil_b_->event_controls_, element_fq_id);
-        // Suppress "AUTOSAR C++14 M7-5-1" rule. This rule declares:
-        // A function shall not return a reference or a pointer to an automatic variable (including parameters), defined
-        // within the function.
-        // Suppress "AUTOSAR C++14 M7-5-2": The address of an object with automatic storage shall not be assigned to
-        // another object that may persist after the first object has ceased to exist.
-        // The result pointer is still valid outside this method until Skeleton object (as a holder) is alive.
+        // Suppress "AUTOSAR C++14 M7-5-1": Functions should not return references or pointers to automatic variables
+        // defined in the function.
+        // Suppress "AUTOSAR C++14 M7-5-2": Should not assign an object with automatic storage to another which could
+        // persist after the first objects has been destroyed.
+        // Suppress "AUTOSAR C++14 A3-8-1": Don't access an object before construction or after destruction.
+        // Jutification: The lifetime of the object whose address is assigned to "event_data_control_asil_b" is owned by
+        // the Skeleton itself. The pointer is passed to EventDataControlComposite which is then owned by a
+        // SkeletonEvent which is guaranteed to be destroyed before the Skeleton is destroyed (since it's a member of
+        // the parent Skeleton).
         // coverity[autosar_cpp14_m7_5_1_violation]
         // coverity[autosar_cpp14_m7_5_2_violation]
         // coverity[autosar_cpp14_a3_8_1_violation]
         event_data_control_asil_b = &(event_control_asil_b_it->second.data_control);
     }
 
-    // Suppress "AUTOSAR C++14 A5-3-2" rule finding. This rule declares: "Null pointers shall not be dereferenced.".
-    // The "event_data_storage_it" variable is an iterator of interprocess map returned by the "find_element" method.
-    // A check is made that the iterator is not equal to map.cend(). Therefore, the call to "event_data_storage_it->"
-    // does not return nullptr.
+    // Suppress "AUTOSAR C++14 A5-3-2": Don't dereference null pointers.
+    // Justification: The "event_data_storage_it" variable is an iterator of interprocess map returned by the
+    // "find_element" method. A check is made that the iterator is not equal to map.cend(). Therefore, the call to
+    // "event_data_storage_it->" does not return nullptr.
     // coverity[autosar_cpp14_a5_3_2_violation]
     auto* const typed_event_data_storage_ptr =
         event_data_storage_it->second.template get<EventDataStorage<SampleType>>();
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(typed_event_data_storage_ptr != nullptr,
                                                 "Could not get EventDataStorage*");
 
-    // Suppress "AUTOSAR C++14 A3-8-1" rule findings. This rule declares:
-    // "An object shall not be accessed outside of its lifetime"
-    // The "event_data_control_asil_b" and "typed_event_data_storage_ptr" are still valid lifetime even returned pointer
-    // to internal state until Skeleton object is alive.
+    // Suppress "AUTOSAR C++14 A3-8-1":
+    // Justification: The "event_data_control_asil_b" and "typed_event_data_storage_ptr" are still valid lifetime even
+    // returned pointer to internal state until Skeleton object is alive.
     // coverity[autosar_cpp14_a3_8_1_violation]
     return {typed_event_data_storage_ptr,
             // The lifetime of the "event_data_control_asil_b" object lasts as long as the Skeleton is alive.

--- a/score/mw/com/impl/bindings/lola/skeleton_memory_manager.h
+++ b/score/mw/com/impl/bindings/lola/skeleton_memory_manager.h
@@ -106,8 +106,6 @@ class SkeletonMemoryManager final
     /// \details Note: Only invoke _after_ a crash was detected!
     void CleanupSharedMemoryAfterCrash();
 
-    score::cpp::optional<EventMetaInfo> GetEventMetaInfo(const ElementFqId element_fq_id) const;
-
     void Reset();
 
   private:

--- a/score/mw/com/impl/bindings/lola/skeleton_memory_manager.h
+++ b/score/mw/com/impl/bindings/lola/skeleton_memory_manager.h
@@ -1,0 +1,277 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_IMPL_BINDINGS_LOLA_SKELETON_MEMORY_MANAGER_H
+#define SCORE_MW_COM_IMPL_BINDINGS_LOLA_SKELETON_MEMORY_MANAGER_H
+
+#include "score/mw/com/impl/bindings/lola/element_fq_id.h"
+#include "score/mw/com/impl/bindings/lola/event_data_control_composite.h"
+#include "score/mw/com/impl/bindings/lola/event_data_storage.h"
+#include "score/mw/com/impl/bindings/lola/i_shm_path_builder.h"
+#include "score/mw/com/impl/bindings/lola/service_data_control.h"
+#include "score/mw/com/impl/bindings/lola/service_data_storage.h"
+#include "score/mw/com/impl/bindings/lola/skeleton_event_properties.h"
+#include "score/mw/com/impl/configuration/lola_service_instance_deployment.h"
+#include "score/mw/com/impl/configuration/quality_type.h"
+#include "score/mw/com/impl/skeleton_binding.h"
+
+#include "score/memory/shared/polymorphic_offset_ptr_allocator.h"
+
+#include <score/assert.hpp>
+#include <score/optional.hpp>
+
+#include <sys/types.h>
+#include <memory>
+#include <string>
+#include <tuple>
+#include <utility>
+
+namespace score::mw::com::impl::lola
+{
+
+/// \brief SkeletonMemoryManager manages are shared memory related functionality of a Skeleton.
+///
+/// A SkeletonMemoryManager is owned and dispatched to by a Skeleton.
+class SkeletonMemoryManager final
+{
+    // Suppress "AUTOSAR C++14 A11-3-1", The rule declares: "Friend declarations shall not be used".
+    // The "SkeletonAttorney" class is a helper, which sets the internal state of "Skeleton" accessing
+    // private members and used for testing purposes only.
+    // coverity[autosar_cpp14_a11_3_1_violation]
+    friend class SkeletonMemoryManagerTestAttorney;
+
+  public:
+    SkeletonMemoryManager(QualityType quality_type,
+                          const IShmPathBuilder& shm_path_builder,
+                          const LolaServiceInstanceDeployment& lola_service_instance_deployment,
+                          const LolaServiceTypeDeployment& lola_service_type_deployment,
+                          const LolaServiceInstanceId::InstanceId lola_instance_id,
+                          const LolaServiceTypeDeployment::ServiceId lola_service_id);
+
+    ~SkeletonMemoryManager() noexcept = default;
+
+    SkeletonMemoryManager(const SkeletonMemoryManager&) = delete;
+    SkeletonMemoryManager& operator=(const SkeletonMemoryManager&) = delete;
+    SkeletonMemoryManager(SkeletonMemoryManager&& other) = delete;
+    SkeletonMemoryManager& operator=(SkeletonMemoryManager&& other) = delete;
+
+    ResultBlank OpenExistingSharedMemory(
+        std::optional<SkeletonBinding::RegisterShmObjectTraceCallback> register_shm_object_trace_callback);
+    ResultBlank CreateSharedMemory(
+        SkeletonBinding::SkeletonEventBindings& events,
+        SkeletonBinding::SkeletonFieldBindings& fields,
+        std::optional<SkeletonBinding::RegisterShmObjectTraceCallback> register_shm_object_trace_callback);
+
+    template <typename SampleType>
+    std::pair<EventDataStorage<SampleType>*, EventDataControlComposite<>> CreateEventDataFromOpenedSharedMemory(
+        const ElementFqId element_fq_id,
+        const SkeletonEventProperties& element_properties);
+
+    /// \brief Creates the control structures (QM and optional ASIL-B) for an event.
+    /// \param element_fq_id The full qualified ID of the element.
+    /// \param element_properties Properties of the event.
+    /// \return The EventDataControlComposite containing pointers to the control structures.
+    EventDataControlComposite<> CreateEventControlComposite(const ElementFqId element_fq_id,
+                                                            const SkeletonEventProperties& element_properties) noexcept;
+
+    /// \brief Creates shared memory storage for a generic (type-erased) event.
+    /// \param element_fq_id The full qualified ID of the element.
+    /// \param element_properties Properties of the event.
+    /// \param sample_size The size of a single data sample.
+    /// \param sample_alignment The alignment of the data sample.
+    /// \return A pair containing the data storage pointer (void*) and the control composite.
+    std::pair<void*, EventDataControlComposite<>> CreateEventDataFromOpenedSharedMemory(
+        const ElementFqId element_fq_id,
+        const SkeletonEventProperties& element_properties,
+        size_t sample_size,
+        size_t sample_alignment) noexcept;
+
+    template <typename SampleType>
+    std::pair<EventDataStorage<SampleType>*, EventDataControlComposite<>> OpenEventDataFromOpenedSharedMemory(
+        const ElementFqId element_fq_id);
+
+    void RemoveSharedMemory();
+    void RemoveStaleSharedMemoryArtefacts() const;
+
+    /// \brief Cleans up all allocated slots for this SkeletonEvent of any previous running instance
+    /// \details Note: Only invoke _after_ a crash was detected!
+    void CleanupSharedMemoryAfterCrash();
+
+    score::cpp::optional<EventMetaInfo> GetEventMetaInfo(const ElementFqId element_fq_id) const;
+
+    void Reset();
+
+  private:
+    class ShmResourceStorageSizes
+    {
+      public:
+        // Suppress "AUTOSAR C++14 M11-0-1" rule findings. This rule states: "Member data in non-POD class types shall
+        // be private.". There are no class invariants to maintain which could be violated by directly accessing member
+        // variables.
+        // coverity[autosar_cpp14_m11_0_1_violation]
+        std::size_t data_size;
+        // coverity[autosar_cpp14_m11_0_1_violation]
+        std::size_t control_qm_size;
+        // coverity[autosar_cpp14_m11_0_1_violation]
+        score::cpp::optional<std::size_t> control_asil_b_size;
+    };
+
+    /// \brief Calculates needed sizes for shm-objects for data and ctrl either via simulation or a rough estimation
+    /// depending on config.
+    /// \return storage sizes for the different shm-objects
+    ShmResourceStorageSizes CalculateShmResourceStorageSizes(SkeletonBinding::SkeletonEventBindings& events,
+                                                             SkeletonBinding::SkeletonFieldBindings& fields);
+    /// \brief Calculates needed sizes for shm-objects for data and ctrl via simulation of allocations against a heap
+    /// backed memory resource.
+    /// \return storage sizes for the different shm-objects
+    ShmResourceStorageSizes CalculateShmResourceStorageSizesBySimulation(
+        SkeletonBinding::SkeletonEventBindings& events,
+        SkeletonBinding::SkeletonFieldBindings& fields);
+
+    bool CreateSharedMemoryForData(
+        const LolaServiceInstanceDeployment&,
+        const std::size_t shm_size,
+        std::optional<SkeletonBinding::RegisterShmObjectTraceCallback> register_shm_object_trace_callback);
+    bool CreateSharedMemoryForControl(const LolaServiceInstanceDeployment& instance,
+                                      const QualityType asil_level,
+                                      const std::size_t shm_size);
+    bool OpenSharedMemoryForData(
+        const std::optional<SkeletonBinding::RegisterShmObjectTraceCallback> register_shm_object_trace_callback);
+    bool OpenSharedMemoryForControl(const QualityType asil_level);
+    void InitializeSharedMemoryForData(const std::shared_ptr<score::memory::shared::ManagedMemoryResource>& memory);
+    void InitializeSharedMemoryForControl(const QualityType asil_level,
+                                          const std::shared_ptr<score::memory::shared::ManagedMemoryResource>& memory);
+
+    QualityType quality_type_;
+    const IShmPathBuilder& shm_path_builder_;
+    const LolaServiceInstanceDeployment& lola_service_instance_deployment_;
+    const LolaServiceTypeDeployment& lola_service_type_deployment_;
+    LolaServiceInstanceId::InstanceId lola_instance_id_;
+    LolaServiceTypeDeployment::ServiceId lola_service_id_;
+
+    score::cpp::optional<std::string> data_storage_path_;
+    score::cpp::optional<std::string> data_control_qm_path_;
+    score::cpp::optional<std::string> data_control_asil_path_;
+
+    ServiceDataStorage* storage_;
+    ServiceDataControl* control_qm_;
+    ServiceDataControl* control_asil_b_;
+    std::shared_ptr<score::memory::shared::ManagedMemoryResource> storage_resource_;
+    std::shared_ptr<score::memory::shared::ManagedMemoryResource> control_qm_resource_;
+    std::shared_ptr<score::memory::shared::ManagedMemoryResource> control_asil_resource_;
+};
+
+template <typename SampleType>
+// Suppress "AUTOSAR C++14 M3-2-2" rule finding. This rule declares: "The One Definition Rule shall not be
+// violated.".
+// The "Skeleton" is a template class with its declaration and definition in different places within the same header
+// file, it does not violate the One Definition Rule
+// Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
+// implicitly". This is a false positive, no way to throw std::bad_variant_access.
+// coverity[autosar_cpp14_m3_2_2_violation]
+// coverity[autosar_cpp14_a15_5_3_violation : FALSE]
+auto SkeletonMemoryManager::CreateEventDataFromOpenedSharedMemory(const ElementFqId element_fq_id,
+                                                                  const SkeletonEventProperties& element_properties)
+    -> std::pair<EventDataStorage<SampleType>*, EventDataControlComposite<>>
+{
+    auto* typed_event_data_storage_ptr = storage_resource_->construct<EventDataStorage<SampleType>>(
+        element_properties.number_of_slots,
+        memory::shared::PolymorphicOffsetPtrAllocator<SampleType>(*storage_resource_));
+
+    auto inserted_data_slots = storage_->events_.emplace(std::piecewise_construct,
+                                                         std::forward_as_tuple(element_fq_id),
+                                                         std::forward_as_tuple(typed_event_data_storage_ptr));
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(inserted_data_slots.second,
+                                                "Couldn't register/emplace event-storage in data-section.");
+
+    constexpr DataTypeMetaInfo sample_meta_info{sizeof(SampleType), static_cast<std::uint8_t>(alignof(SampleType))};
+    auto* event_data_raw_array = typed_event_data_storage_ptr->data();
+    auto inserted_meta_info =
+        storage_->events_metainfo_.emplace(std::piecewise_construct,
+                                           std::forward_as_tuple(element_fq_id),
+                                           std::forward_as_tuple(sample_meta_info, event_data_raw_array));
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(inserted_meta_info.second,
+                                                "Couldn't register/emplace event-meta-info in data-section.");
+
+    return {typed_event_data_storage_ptr, CreateEventControlComposite(element_fq_id, element_properties)};
+}
+
+template <typename SampleType>
+// Suppress "AUTOSAR C++14 M3-2-2" rule finding. This rule declares: "The One Definition Rule shall not be
+// violated.".
+// The "Skeleton" is a template class with its declaration and definition in different places within the same header
+// file, it does not violate the One Definition Rule
+// Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
+// implicitly". No way for 'OffsetPtr::get()' which called from 'event_data_storage_it->second.template' to throw an
+// exception but we can't mark 'OffsetPtr::get()' as ''.
+// coverity[autosar_cpp14_m3_2_2_violation]
+// coverity[autosar_cpp14_a15_5_3_violation]
+auto SkeletonMemoryManager::OpenEventDataFromOpenedSharedMemory(const ElementFqId element_fq_id)
+    -> std::pair<EventDataStorage<SampleType>*, EventDataControlComposite<>>
+{
+    // Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be
+    // called implicitly". This is a false positive, std::less which is used by std::map::find could throw an exception
+    // if the key value is not comparable and in our case the key is comparable. so no way for 'event_controls_.find()'
+    // to throw an exception.
+    // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
+    auto find_element = [](auto& map, const ElementFqId& target_element_fq_id) -> auto {
+        const auto it = map.find(target_element_fq_id);
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(it != map.cend(), "Could not find element fq id in map");
+        return it;
+    };
+
+    score::cpp::ignore = find_element(storage_->events_metainfo_, element_fq_id);
+    const auto event_data_storage_it = find_element(storage_->events_, element_fq_id);
+    const auto event_control_qm_it = find_element(control_qm_->event_controls_, element_fq_id);
+
+    EventDataControl* event_data_control_asil_b{nullptr};
+    if (quality_type_ == QualityType::kASIL_B)
+    {
+        const auto event_control_asil_b_it = find_element(control_asil_b_->event_controls_, element_fq_id);
+        // Suppress "AUTOSAR C++14 M7-5-1" rule. This rule declares:
+        // A function shall not return a reference or a pointer to an automatic variable (including parameters), defined
+        // within the function.
+        // Suppress "AUTOSAR C++14 M7-5-2": The address of an object with automatic storage shall not be assigned to
+        // another object that may persist after the first object has ceased to exist.
+        // The result pointer is still valid outside this method until Skeleton object (as a holder) is alive.
+        // coverity[autosar_cpp14_m7_5_1_violation]
+        // coverity[autosar_cpp14_m7_5_2_violation]
+        // coverity[autosar_cpp14_a3_8_1_violation]
+        event_data_control_asil_b = &(event_control_asil_b_it->second.data_control);
+    }
+
+    // Suppress "AUTOSAR C++14 A5-3-2" rule finding. This rule declares: "Null pointers shall not be dereferenced.".
+    // The "event_data_storage_it" variable is an iterator of interprocess map returned by the "find_element" method.
+    // A check is made that the iterator is not equal to map.cend(). Therefore, the call to "event_data_storage_it->"
+    // does not return nullptr.
+    // coverity[autosar_cpp14_a5_3_2_violation]
+    auto* const typed_event_data_storage_ptr =
+        event_data_storage_it->second.template get<EventDataStorage<SampleType>>();
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(typed_event_data_storage_ptr != nullptr,
+                                                "Could not get EventDataStorage*");
+
+    // Suppress "AUTOSAR C++14 A3-8-1" rule findings. This rule declares:
+    // "An object shall not be accessed outside of its lifetime"
+    // The "event_data_control_asil_b" and "typed_event_data_storage_ptr" are still valid lifetime even returned pointer
+    // to internal state until Skeleton object is alive.
+    // coverity[autosar_cpp14_a3_8_1_violation]
+    return {typed_event_data_storage_ptr,
+            // The lifetime of the "event_data_control_asil_b" object lasts as long as the Skeleton is alive.
+            // coverity[autosar_cpp14_m7_5_1_violation]
+            // coverity[autosar_cpp14_m7_5_2_violation]
+            // coverity[autosar_cpp14_a3_8_1_violation]
+            EventDataControlComposite{&event_control_qm_it->second.data_control, event_data_control_asil_b}};
+}
+
+}  // namespace score::mw::com::impl::lola
+
+#endif  // SCORE_MW_COM_IMPL_BINDINGS_LOLA_SKELETON_MEMORY_MANAGER_H

--- a/score/mw/com/impl/bindings/lola/skeleton_test.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_test.cpp
@@ -1166,9 +1166,10 @@ TEST_P(SkeletonRegisterParamaterisedFixture, ValidEventMetaInfoExistAfterEventIs
     void* const dumb_event_data_storage = dumb_event_reg_result.first->data();
 
     // Expect, that we can then retrieve the meta-info of the registered events
-    auto event_foo_meta_info_ptr = skeleton_->GetEventMetaInfo(ElementFqId{
+    SkeletonAttorney skeleton_test_attorney{*skeleton_};
+    auto event_foo_meta_info_ptr = skeleton_test_attorney.GetEventMetaInfo(ElementFqId{
         lola_service_type_deployment->service_id_, test::kFooEventId, test::kDefaultLolaInstanceId, element_type});
-    auto event_dumb_meta_info_ptr = skeleton_->GetEventMetaInfo(ElementFqId{
+    auto event_dumb_meta_info_ptr = skeleton_test_attorney.GetEventMetaInfo(ElementFqId{
         lola_service_type_deployment->service_id_, test::kDumbEventId, test::kDefaultLolaInstanceId, element_type});
 
     // and the meta-info for these events is valid
@@ -1234,7 +1235,8 @@ TEST_P(SkeletonRegisterParamaterisedFixture, NoMetaInfoExistsForInvalidElementId
     const std::uint16_t UNKNOWN_EVENT_ID{99U};
     ElementFqId event_unknown_fqn{
         lola_service_type_deployment->service_id_, UNKNOWN_EVENT_ID, test::kDefaultLolaInstanceId, element_type};
-    auto event_unknown_meta_info = skeleton_->GetEventMetaInfo(event_unknown_fqn);
+    SkeletonAttorney skeleton_test_attorney{*skeleton_};
+    auto event_unknown_meta_info = skeleton_test_attorney.GetEventMetaInfo(event_unknown_fqn);
 
     // we expect the meta-info for this event is invalid
     ASSERT_FALSE(event_unknown_meta_info.has_value());

--- a/score/mw/com/impl/bindings/lola/test/skeleton_event_component_test.cpp
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_event_component_test.cpp
@@ -312,7 +312,7 @@ TEST_F(SkeletonEventComponentTestFixture, SkeletonWillCalculateEventMetaInfoFrom
     ASSERT_TRUE(prepare_offer_result.has_value());
 
     // When getting the EventMetaInfo for the skeleton event
-    const auto event_meta_info = parent_skeleton_->GetEventMetaInfo(fake_element_fq_id_);
+    const auto event_meta_info = SkeletonAttorney{*parent_skeleton_}.GetEventMetaInfo(fake_element_fq_id_);
 
     // Then the event meta info should correspond to the type of the skeleton event
     ASSERT_TRUE(event_meta_info.has_value());

--- a/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h
@@ -21,6 +21,7 @@
 #include "score/mw/com/impl/bindings/lola/shm_path_builder.h"
 #include "score/mw/com/impl/bindings/lola/shm_path_builder_mock.h"
 #include "score/mw/com/impl/bindings/lola/skeleton.h"
+#include "score/mw/com/impl/bindings/lola/skeleton_memory_manager.h"
 #include "score/mw/com/impl/bindings/mock_binding/tracing/tracing_runtime.h"
 #include "score/mw/com/impl/configuration/lola_event_instance_deployment.h"
 #include "score/mw/com/impl/configuration/lola_service_instance_deployment.h"
@@ -361,6 +362,31 @@ static const ElementFqId kDummyElementFqId{1U, 2U, 3U, ServiceElementType::EVENT
 
 }  // namespace test
 
+class SkeletonMemoryManagerTestAttorney
+{
+  public:
+    SkeletonMemoryManagerTestAttorney(SkeletonMemoryManager& skeleton_memory_manager) noexcept
+        : skeleton_memory_manager_{skeleton_memory_manager}
+    {
+    }
+
+    ServiceDataControl* GetServiceDataControl(const QualityType quality_type) const noexcept
+    {
+        if (quality_type == QualityType::kASIL_QM)
+        {
+            return skeleton_memory_manager_.control_qm_;
+        }
+        if (quality_type == QualityType::kASIL_B)
+        {
+            return skeleton_memory_manager_.control_asil_b_;
+        }
+        return nullptr;
+    }
+
+  private:
+    SkeletonMemoryManager& skeleton_memory_manager_;
+};
+
 class SkeletonAttorney
 {
   public:
@@ -368,15 +394,7 @@ class SkeletonAttorney
 
     ServiceDataControl* GetServiceDataControl(const QualityType quality_type) const noexcept
     {
-        if (quality_type == QualityType::kASIL_QM)
-        {
-            return skeleton_.control_qm_;
-        }
-        if (quality_type == QualityType::kASIL_B)
-        {
-            return skeleton_.control_asil_b_;
-        }
-        return nullptr;
+        return SkeletonMemoryManagerTestAttorney{skeleton_.memory_manager_}.GetServiceDataControl(quality_type);
     }
 
   private:

--- a/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h
@@ -383,6 +383,19 @@ class SkeletonMemoryManagerTestAttorney
         return nullptr;
     }
 
+    score::cpp::optional<EventMetaInfo> GetEventMetaInfo(const ElementFqId element_fq_id) const
+    {
+        auto search = skeleton_memory_manager_.storage_->events_metainfo_.find(element_fq_id);
+        if (search == skeleton_memory_manager_.storage_->events_metainfo_.cend())
+        {
+            return score::cpp::nullopt;
+        }
+        else
+        {
+            return search->second;
+        }
+    }
+
   private:
     SkeletonMemoryManager& skeleton_memory_manager_;
 };
@@ -395,6 +408,11 @@ class SkeletonAttorney
     ServiceDataControl* GetServiceDataControl(const QualityType quality_type) const noexcept
     {
         return SkeletonMemoryManagerTestAttorney{skeleton_.memory_manager_}.GetServiceDataControl(quality_type);
+    }
+
+    score::cpp::optional<EventMetaInfo> GetEventMetaInfo(const ElementFqId element_fq_id) const
+    {
+        return SkeletonMemoryManagerTestAttorney{skeleton_.memory_manager_}.GetEventMetaInfo(element_fq_id);
     }
 
   private:

--- a/score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_impl.h
+++ b/score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_impl.h
@@ -22,6 +22,7 @@
 #include "score/mw/com/impl/configuration/someip_service_instance_deployment.h"
 #include "score/mw/com/impl/data_type_meta_info.h"
 #include "score/mw/com/impl/skeleton_base.h"
+#include "score/mw/com/impl/tracing/skeleton_event_tracing_data.h"
 
 #include "score/mw/log/logging.h"
 

--- a/score/mw/com/test/shared_memory_storage/test_resources.h
+++ b/score/mw/com/test/shared_memory_storage/test_resources.h
@@ -63,6 +63,30 @@ class ProxyTestAttorney
     Proxy& proxy_;
 };
 
+class SkeletonMemoryManagerTestAttorney
+{
+  public:
+    SkeletonMemoryManagerTestAttorney(SkeletonMemoryManager& skeleton_memory_manager) noexcept
+        : skeleton_memory_manager_{skeleton_memory_manager}
+    {
+    }
+
+    ServiceDataStorage& GetServiceDataStorage() const noexcept
+    {
+        SCORE_LANGUAGE_FUTURECPP_ASSERT(skeleton_memory_manager_.storage_ != nullptr);
+        return *skeleton_memory_manager_.storage_;
+    }
+
+    score::memory::shared::ManagedMemoryResource& GetServiceDataStorageResource() const noexcept
+    {
+        SCORE_LANGUAGE_FUTURECPP_ASSERT(skeleton_memory_manager_.storage_resource_ != nullptr);
+        return *skeleton_memory_manager_.storage_resource_;
+    }
+
+  private:
+    SkeletonMemoryManager& skeleton_memory_manager_;
+};
+
 class SkeletonAttorney
 {
   public:
@@ -70,13 +94,18 @@ class SkeletonAttorney
 
     score::cpp::optional<uintptr_t> GetEventMetaInfoAddress(const ElementFqId element_fq_id) const noexcept
     {
-        auto search = skeleton_.storage_->events_metainfo_.find(element_fq_id);
-        if (search == skeleton_.storage_->events_metainfo_.cend())
+        SkeletonMemoryManagerTestAttorney skeleton_memory_manager_attorney{skeleton_.memory_manager_};
+
+        auto& service_data_storage = skeleton_memory_manager_attorney.GetServiceDataStorage();
+        auto search = service_data_storage.events_metainfo_.find(element_fq_id);
+        if (search == service_data_storage.events_metainfo_.cend())
         {
             return {};
         }
         void* const meta_info_address = &search->second;
-        return memory::shared::SubtractPointersBytes(meta_info_address, skeleton_.storage_resource_->getBaseAddress());
+
+        const auto& service_data_storage_resource = skeleton_memory_manager_attorney.GetServiceDataStorageResource();
+        return memory::shared::SubtractPointersBytes(meta_info_address, service_data_storage_resource.getBaseAddress());
     }
 
   private:


### PR DESCRIPTION
The Skeleton currently performs Skeleton specific functionality (e.g.
PrepareOffer, PrepareStopOffer(), managing instance / usage marker
files, managing method subscription etc.). It also performs all
functionality to create / open shared memory and also insert events into
the maps in shared memory.

This commit splits up the functionality so that we have a single class
which is responsible for interacting with shared memory. This makes the
code much easier to navigate since the old skeleton code was a huge
monolith and also will allow us to optionally split up our unit tests as
well into skeleton functionality and shared memory operations. We could
even introduce an interface for SkeletonMemoryManager to completely
decouple the skeleton functionality tests from shared memory.

For now, we treat Skeleton and SkeletonMemoryManager as a single unit,
so we don't test the public interface of SkeletonMemoryManager.

Depends-on: https://github.com/eclipse-score/communication/pull/247