### PR TITLE
Expose SamplePtr age in C++ API

### DIFF
--- a/score/mw/com/impl/bindings/lola/sample_ptr.h
+++ b/score/mw/com/impl/bindings/lola/sample_ptr.h
@@ -105,11 +105,12 @@ class SamplePtr final
 
     /// \brief Compares two SamplePtr instances based on their timestamp
     /// \param other SamplePtr to compare against
-    /// \return true if this instance is older than \p other, false otherwise or if any of the SamplePtr are invalid  
+    /// \return true if this instance is older than \p other, false otherwise or if any of the SamplePtr are invalid
     bool operator<(const SamplePtr& other) const noexcept
     {
-        if(!(*this) || !other) {
-             return false;
+        if (!(*this) || !other)
+        {
+            return false;
         }
 
         return timestamp_ < other.timestamp_;
@@ -120,7 +121,8 @@ class SamplePtr final
     /// \return true if this instance is newer than \p other, false otherwise or if any of the SamplePtr are invalid
     bool operator>(const SamplePtr& other) const noexcept
     {
-        if(!(*this) || !other) {
+        if (!(*this) || !other)
+        {
             return false;
         }
         return timestamp_ > other.timestamp_;

--- a/score/mw/com/impl/bindings/lola/sample_ptr.h
+++ b/score/mw/com/impl/bindings/lola/sample_ptr.h
@@ -50,6 +50,7 @@ class SamplePtr final
               TransactionLogIndex transaction_log_idx) noexcept
         : SamplePtr{ptr, std::make_optional<SlotDecrementer>(event_data_ctrl_local, slot_index, transaction_log_idx)}
     {
+        timestamp_ = (event_data_ctrl)[slot_indicator.GetIndex()].GetTimeStamp();
     }
 
     ~SamplePtr() noexcept = default;
@@ -102,6 +103,29 @@ class SamplePtr final
         return managed_object_;
     }
 
+    /// \brief Compares two SamplePtr instances based on their timestamp
+    /// \param other SamplePtr to compare against
+    /// \return true if this instance is older than \p other, false otherwise or if any of the SamplePtr are invalid  
+    bool operator<(const SamplePtr& other) const noexcept
+    {
+        if(!(*this) || !other) {
+             return false;
+        }
+
+        return timestamp_ < other.timestamp_;
+    }
+
+    /// \brief Compares two SamplePtr instances based on their timestamp
+    /// \param other SamplePtr to compare against
+    /// \return true if this instance is newer than \p other, false otherwise or if any of the SamplePtr are invalid
+    bool operator>(const SamplePtr& other) const noexcept
+    {
+        if(!(*this) || !other) {
+            return false;
+        }
+        return timestamp_ > other.timestamp_;
+    }
+
   private:
     explicit SamplePtr(pointer managed_object, std::optional<SlotDecrementer>&& slog_decrementer) noexcept
         : managed_object_{managed_object}, slot_decrementer_{std::move(slog_decrementer)}
@@ -110,6 +134,7 @@ class SamplePtr final
 
     pointer managed_object_;
     std::optional<SlotDecrementer> slot_decrementer_;
+    EventSlotStatus::EventTimeStamp timestamp_;
 };
 
 }  // namespace score::mw::com::impl::lola

--- a/score/mw/com/impl/bindings/lola/sample_ptr.h
+++ b/score/mw/com/impl/bindings/lola/sample_ptr.h
@@ -50,7 +50,7 @@ class SamplePtr final
               TransactionLogIndex transaction_log_idx) noexcept
         : SamplePtr{ptr, std::make_optional<SlotDecrementer>(event_data_ctrl_local, slot_index, transaction_log_idx)}
     {
-        timestamp_ = (event_data_ctrl)[slot_indicator.GetIndex()].GetTimeStamp();
+        timestamp_ = (event_data_ctrl_local)[slot_index].GetTimeStamp();
     }
 
     ~SamplePtr() noexcept = default;

--- a/score/mw/com/impl/bindings/lola/sample_ptr.h
+++ b/score/mw/com/impl/bindings/lola/sample_ptr.h
@@ -49,7 +49,7 @@ class SamplePtr final
               const SlotIndexType slot_index) noexcept
         : SamplePtr{ptr, std::make_optional<SlotDecrementer>(event_data_ctrl_local, slot_index)}
     {
-        timestamp_ = (event_data_ctrl)[slot_indicator.GetIndex()].GetTimeStamp();
+        timestamp_ = (event_data_ctrl_local)[slot_index].GetTimeStamp();
     }
 
     ~SamplePtr() noexcept = default;

--- a/score/mw/com/impl/bindings/lola/sample_ptr.h
+++ b/score/mw/com/impl/bindings/lola/sample_ptr.h
@@ -104,11 +104,12 @@ class SamplePtr final
 
     /// \brief Compares two SamplePtr instances based on their timestamp
     /// \param other SamplePtr to compare against
-    /// \return true if this instance is older than \p other, false otherwise or if any of the SamplePtr are invalid  
+    /// \return true if this instance is older than \p other, false otherwise or if any of the SamplePtr are invalid
     bool operator<(const SamplePtr& other) const noexcept
     {
-        if(!(*this) || !other) {
-             return false;
+        if (!(*this) || !other)
+        {
+            return false;
         }
 
         return timestamp_ < other.timestamp_;
@@ -119,7 +120,8 @@ class SamplePtr final
     /// \return true if this instance is newer than \p other, false otherwise or if any of the SamplePtr are invalid
     bool operator>(const SamplePtr& other) const noexcept
     {
-        if(!(*this) || !other) {
+        if (!(*this) || !other)
+        {
             return false;
         }
         return timestamp_ > other.timestamp_;

--- a/score/mw/com/impl/bindings/lola/sample_ptr.h
+++ b/score/mw/com/impl/bindings/lola/sample_ptr.h
@@ -49,6 +49,7 @@ class SamplePtr final
               const SlotIndexType slot_index) noexcept
         : SamplePtr{ptr, std::make_optional<SlotDecrementer>(event_data_ctrl_local, slot_index)}
     {
+        timestamp_ = (event_data_ctrl)[slot_indicator.GetIndex()].GetTimeStamp();
     }
 
     ~SamplePtr() noexcept = default;
@@ -101,6 +102,29 @@ class SamplePtr final
         return managed_object_;
     }
 
+    /// \brief Compares two SamplePtr instances based on their timestamp
+    /// \param other SamplePtr to compare against
+    /// \return true if this instance is older than \p other, false otherwise or if any of the SamplePtr are invalid  
+    bool operator<(const SamplePtr& other) const noexcept
+    {
+        if(!(*this) || !other) {
+             return false;
+        }
+
+        return timestamp_ < other.timestamp_;
+    }
+
+    /// \brief Compares two SamplePtr instances based on their timestamp
+    /// \param other SamplePtr to compare against
+    /// \return true if this instance is newer than \p other, false otherwise or if any of the SamplePtr are invalid
+    bool operator>(const SamplePtr& other) const noexcept
+    {
+        if(!(*this) || !other) {
+            return false;
+        }
+        return timestamp_ > other.timestamp_;
+    }
+
   private:
     explicit SamplePtr(pointer managed_object, std::optional<SlotDecrementer>&& slog_decrementer) noexcept
         : managed_object_{managed_object}, slot_decrementer_{std::move(slog_decrementer)}
@@ -109,6 +133,7 @@ class SamplePtr final
 
     pointer managed_object_;
     std::optional<SlotDecrementer> slot_decrementer_;
+    EventSlotStatus::EventTimeStamp timestamp_;
 };
 
 }  // namespace score::mw::com::impl::lola

--- a/score/mw/com/impl/bindings/lola/sample_ptr_test.cpp
+++ b/score/mw/com/impl/bindings/lola/sample_ptr_test.cpp
@@ -57,7 +57,7 @@ class SamplePtrTest : public ::testing::Test
         return slot.value();
     }
 
-     SamplePtr<std::uint8_t> CreateSamplePtr(const EventSlotStatus::EventTimeStamp timestamp,
+    SamplePtr<std::uint8_t> CreateSamplePtr(const EventSlotStatus::EventTimeStamp timestamp,
                                             const std::size_t slot_index)
     {
         AllocateSlot(timestamp);

--- a/score/mw/com/impl/bindings/lola/sample_ptr_test.cpp
+++ b/score/mw/com/impl/bindings/lola/sample_ptr_test.cpp
@@ -56,6 +56,19 @@ class SamplePtrTest : public ::testing::Test
         skeleton_event_data_control_local_.EventReady(slot.value(), timestamp);
         return slot.value();
     }
+
+     SamplePtr<std::uint8_t> CreateSamplePtr(const EventSlotStatus::EventTimeStamp timestamp,
+                                            const std::size_t slot_index)
+    {
+        AllocateSlot(timestamp);
+        auto slot_indicator = event_data_control_.ReferenceNextEvent(slot_index, transaction_log_index_);
+        EXPECT_TRUE(slot_indicator.IsValid());
+
+        dummy_storage_.push_back(std::make_unique<std::uint8_t>(0U));
+        return SamplePtr<std::uint8_t>{
+            dummy_storage_.back().get(), event_data_control_, slot_indicator, transaction_log_index_};
+    }
+    std::vector<std::unique_ptr<std::uint8_t>> dummy_storage_;
 };
 
 /// \brief Templated test fixture for SamplePtr functionality that works for both void and non-void types
@@ -198,5 +211,148 @@ TEST_F(SamplePtrTest, StarOp)
     EXPECT_EQ(val1.member2_, 44);
 }
 
+TEST_F(SamplePtrTest, GreaterThanReturnsTrueWhenLeftSampleHasNewerTimestamp)
+{
+    constexpr EventSlotStatus::EventTimeStamp kOlderTimestamp{10U};
+    constexpr EventSlotStatus::EventTimeStamp kNewerTimestamp{42U};
+
+    auto older_sample = CreateSamplePtr(kOlderTimestamp, 0U);
+    auto newer_sample = CreateSamplePtr(kNewerTimestamp, 1U);
+
+    const bool result = newer_sample > older_sample;
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(SamplePtrTest, GreaterThanReturnsFalseWhenLeftSampleHasOlderTimestamp)
+{
+    constexpr EventSlotStatus::EventTimeStamp kOlderTimestamp{10U};
+    constexpr EventSlotStatus::EventTimeStamp kNewerTimestamp{42U};
+
+    auto older_sample = CreateSamplePtr(kOlderTimestamp, 0U);
+    auto newer_sample = CreateSamplePtr(kNewerTimestamp, 1U);
+
+    const bool result = older_sample > newer_sample;
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(SamplePtrTest, SortByTimestampOrdersSamplesFromNewestToOldest)
+{
+    constexpr EventSlotStatus::EventTimeStamp kOldestTimestamp{10U};
+    constexpr EventSlotStatus::EventTimeStamp kMiddleTimestamp{42U};
+    constexpr EventSlotStatus::EventTimeStamp kNewestTimestamp{43U};
+
+    std::vector<SamplePtr<std::uint8_t>> samples{};
+    samples.emplace_back(CreateSamplePtr(kOldestTimestamp, 0U));
+    samples.emplace_back(CreateSamplePtr(kMiddleTimestamp, 1U));
+    samples.emplace_back(CreateSamplePtr(kNewestTimestamp, 2U));
+
+    std::sort(samples.begin(), samples.end(), [](const auto& lhs, const auto& rhs) {
+        return lhs > rhs;
+    });
+
+    EXPECT_TRUE(samples[0] > samples[1]);
+    EXPECT_TRUE(samples[0] > samples[2]);
+    EXPECT_TRUE(samples[1] > samples[2]);
+    EXPECT_FALSE(samples[2] > samples[0]);
+    EXPECT_FALSE(samples[2] > samples[1]);
+}
+
+TEST_F(SamplePtrTest, LessThanReturnsTrueWhenLeftSampleHasOlderTimestamp)
+{
+    constexpr EventSlotStatus::EventTimeStamp kOlderTimestamp{10U};
+    constexpr EventSlotStatus::EventTimeStamp kNewerTimestamp{42U};
+
+    auto older_sample = CreateSamplePtr(kOlderTimestamp, 0U);
+    auto newer_sample = CreateSamplePtr(kNewerTimestamp, 1U);
+
+    const bool result = older_sample < newer_sample;
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(SamplePtrTest, LessThanReturnsFalseWhenLeftSampleHasNewerTimestamp)
+{
+    constexpr EventSlotStatus::EventTimeStamp kOlderTimestamp{10U};
+    constexpr EventSlotStatus::EventTimeStamp kNewerTimestamp{42U};
+
+    auto older_sample = CreateSamplePtr(kOlderTimestamp, 0U);
+    auto newer_sample = CreateSamplePtr(kNewerTimestamp, 1U);
+
+    const bool result = newer_sample < older_sample;
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(SamplePtrTest, SortByTimestampOrdersSamplesFromOldestToNewest)
+{
+    constexpr EventSlotStatus::EventTimeStamp kOldestTimestamp{10U};
+    constexpr EventSlotStatus::EventTimeStamp kMiddleTimestamp{42U};
+    constexpr EventSlotStatus::EventTimeStamp kNewestTimestamp{43U};
+
+    std::vector<SamplePtr<std::uint8_t>> samples{};
+    samples.emplace_back(CreateSamplePtr(kOldestTimestamp, 0U));
+    samples.emplace_back(CreateSamplePtr(kMiddleTimestamp, 1U));
+    samples.emplace_back(CreateSamplePtr(kNewestTimestamp, 2U));
+
+    std::sort(samples.begin(), samples.end(), [](const auto& lhs, const auto& rhs) {
+        return lhs < rhs;
+    });
+
+    EXPECT_TRUE(samples[0] < samples[1]);
+    EXPECT_TRUE(samples[0] < samples[2]);
+    EXPECT_TRUE(samples[1] < samples[2]);
+    EXPECT_FALSE(samples[2] < samples[0]);
+    EXPECT_FALSE(samples[2] < samples[1]);
+}
+
+TEST_F(SamplePtrTest, GreaterThanReturnsFalseWhenLeftSampleIsInvalid)
+{
+    constexpr EventSlotStatus::EventTimeStamp kTimestamp{42U};
+
+    SamplePtr<std::uint8_t> invalid_sample{};
+    auto valid_sample = CreateSamplePtr(kTimestamp, 0U);
+
+    const bool result = invalid_sample > valid_sample;
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(SamplePtrTest, GreaterThanReturnsFalseWhenRightSampleIsInvalid)
+{
+    constexpr EventSlotStatus::EventTimeStamp kTimestamp{42U};
+
+    auto valid_sample = CreateSamplePtr(kTimestamp, 0U);
+    SamplePtr<std::uint8_t> invalid_sample{};
+
+    const bool result = valid_sample > invalid_sample;
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(SamplePtrTest, LessThanReturnsFalseWhenLeftSampleIsInvalid)
+{
+    constexpr EventSlotStatus::EventTimeStamp kTimestamp{42U};
+
+    SamplePtr<std::uint8_t> invalid_sample{};
+    auto valid_sample = CreateSamplePtr(kTimestamp, 0U);
+
+    const bool result = invalid_sample < valid_sample;
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(SamplePtrTest, LessThanReturnsFalseWhenRightSampleIsInvalid)
+{
+    constexpr EventSlotStatus::EventTimeStamp kTimestamp{42U};
+
+    auto valid_sample = CreateSamplePtr(kTimestamp, 0U);
+    SamplePtr<std::uint8_t> invalid_sample{};
+
+    const bool result = valid_sample < invalid_sample;
+
+    EXPECT_FALSE(result);
+}
 }  // namespace
 }  // namespace score::mw::com::impl::lola

--- a/score/mw/com/impl/bindings/lola/sample_ptr_test.cpp
+++ b/score/mw/com/impl/bindings/lola/sample_ptr_test.cpp
@@ -52,7 +52,7 @@ class SamplePtrTest : public ::testing::Test
         return slot.value();
     }
 
-     SamplePtr<std::uint8_t> CreateSamplePtr(const EventSlotStatus::EventTimeStamp timestamp,
+    SamplePtr<std::uint8_t> CreateSamplePtr(const EventSlotStatus::EventTimeStamp timestamp,
                                             const std::size_t slot_index)
     {
         AllocateSlot(timestamp);

--- a/score/mw/com/impl/bindings/lola/sample_ptr_test.cpp
+++ b/score/mw/com/impl/bindings/lola/sample_ptr_test.cpp
@@ -53,15 +53,15 @@ class SamplePtrTest : public ::testing::Test
     }
 
     SamplePtr<std::uint8_t> CreateSamplePtr(const EventSlotStatus::EventTimeStamp timestamp,
-                                            const std::size_t slot_index)
+                                            const EventSlotStatus::EventTimeStamp last_search_time)
     {
         AllocateSlot(timestamp);
-        auto slot_indicator = event_data_control_.ReferenceNextEvent(slot_index, transaction_log_index_);
-        EXPECT_TRUE(slot_indicator.IsValid());
+        auto slot_index = consumer_event_data_control_local_.ReferenceNextEvent(last_search_time);
+        EXPECT_TRUE(slot_index.has_value());
 
         dummy_storage_.push_back(std::make_unique<std::uint8_t>(0U));
         return SamplePtr<std::uint8_t>{
-            dummy_storage_.back().get(), event_data_control_, slot_indicator, transaction_log_index_};
+            dummy_storage_.back().get(), consumer_event_data_control_local_, slot_index.value()};
     }
     std::vector<std::unique_ptr<std::uint8_t>> dummy_storage_;
 };

--- a/score/mw/com/impl/bindings/lola/sample_ptr_test.cpp
+++ b/score/mw/com/impl/bindings/lola/sample_ptr_test.cpp
@@ -51,6 +51,19 @@ class SamplePtrTest : public ::testing::Test
         provider_event_data_control_local_.EventReady(slot.value(), timestamp);
         return slot.value();
     }
+
+     SamplePtr<std::uint8_t> CreateSamplePtr(const EventSlotStatus::EventTimeStamp timestamp,
+                                            const std::size_t slot_index)
+    {
+        AllocateSlot(timestamp);
+        auto slot_indicator = event_data_control_.ReferenceNextEvent(slot_index, transaction_log_index_);
+        EXPECT_TRUE(slot_indicator.IsValid());
+
+        dummy_storage_.push_back(std::make_unique<std::uint8_t>(0U));
+        return SamplePtr<std::uint8_t>{
+            dummy_storage_.back().get(), event_data_control_, slot_indicator, transaction_log_index_};
+    }
+    std::vector<std::unique_ptr<std::uint8_t>> dummy_storage_;
 };
 
 /// \brief Templated test fixture for SamplePtr functionality that works for both void and non-void types
@@ -179,5 +192,148 @@ TEST_F(SamplePtrTest, StarOp)
     EXPECT_EQ(val1.member2_, 44);
 }
 
+TEST_F(SamplePtrTest, GreaterThanReturnsTrueWhenLeftSampleHasNewerTimestamp)
+{
+    constexpr EventSlotStatus::EventTimeStamp kOlderTimestamp{10U};
+    constexpr EventSlotStatus::EventTimeStamp kNewerTimestamp{42U};
+
+    auto older_sample = CreateSamplePtr(kOlderTimestamp, 0U);
+    auto newer_sample = CreateSamplePtr(kNewerTimestamp, 1U);
+
+    const bool result = newer_sample > older_sample;
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(SamplePtrTest, GreaterThanReturnsFalseWhenLeftSampleHasOlderTimestamp)
+{
+    constexpr EventSlotStatus::EventTimeStamp kOlderTimestamp{10U};
+    constexpr EventSlotStatus::EventTimeStamp kNewerTimestamp{42U};
+
+    auto older_sample = CreateSamplePtr(kOlderTimestamp, 0U);
+    auto newer_sample = CreateSamplePtr(kNewerTimestamp, 1U);
+
+    const bool result = older_sample > newer_sample;
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(SamplePtrTest, SortByTimestampOrdersSamplesFromNewestToOldest)
+{
+    constexpr EventSlotStatus::EventTimeStamp kOldestTimestamp{10U};
+    constexpr EventSlotStatus::EventTimeStamp kMiddleTimestamp{42U};
+    constexpr EventSlotStatus::EventTimeStamp kNewestTimestamp{43U};
+
+    std::vector<SamplePtr<std::uint8_t>> samples{};
+    samples.emplace_back(CreateSamplePtr(kOldestTimestamp, 0U));
+    samples.emplace_back(CreateSamplePtr(kMiddleTimestamp, 1U));
+    samples.emplace_back(CreateSamplePtr(kNewestTimestamp, 2U));
+
+    std::sort(samples.begin(), samples.end(), [](const auto& lhs, const auto& rhs) {
+        return lhs > rhs;
+    });
+
+    EXPECT_TRUE(samples[0] > samples[1]);
+    EXPECT_TRUE(samples[0] > samples[2]);
+    EXPECT_TRUE(samples[1] > samples[2]);
+    EXPECT_FALSE(samples[2] > samples[0]);
+    EXPECT_FALSE(samples[2] > samples[1]);
+}
+
+TEST_F(SamplePtrTest, LessThanReturnsTrueWhenLeftSampleHasOlderTimestamp)
+{
+    constexpr EventSlotStatus::EventTimeStamp kOlderTimestamp{10U};
+    constexpr EventSlotStatus::EventTimeStamp kNewerTimestamp{42U};
+
+    auto older_sample = CreateSamplePtr(kOlderTimestamp, 0U);
+    auto newer_sample = CreateSamplePtr(kNewerTimestamp, 1U);
+
+    const bool result = older_sample < newer_sample;
+
+    EXPECT_TRUE(result);
+}
+
+TEST_F(SamplePtrTest, LessThanReturnsFalseWhenLeftSampleHasNewerTimestamp)
+{
+    constexpr EventSlotStatus::EventTimeStamp kOlderTimestamp{10U};
+    constexpr EventSlotStatus::EventTimeStamp kNewerTimestamp{42U};
+
+    auto older_sample = CreateSamplePtr(kOlderTimestamp, 0U);
+    auto newer_sample = CreateSamplePtr(kNewerTimestamp, 1U);
+
+    const bool result = newer_sample < older_sample;
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(SamplePtrTest, SortByTimestampOrdersSamplesFromOldestToNewest)
+{
+    constexpr EventSlotStatus::EventTimeStamp kOldestTimestamp{10U};
+    constexpr EventSlotStatus::EventTimeStamp kMiddleTimestamp{42U};
+    constexpr EventSlotStatus::EventTimeStamp kNewestTimestamp{43U};
+
+    std::vector<SamplePtr<std::uint8_t>> samples{};
+    samples.emplace_back(CreateSamplePtr(kOldestTimestamp, 0U));
+    samples.emplace_back(CreateSamplePtr(kMiddleTimestamp, 1U));
+    samples.emplace_back(CreateSamplePtr(kNewestTimestamp, 2U));
+
+    std::sort(samples.begin(), samples.end(), [](const auto& lhs, const auto& rhs) {
+        return lhs < rhs;
+    });
+
+    EXPECT_TRUE(samples[0] < samples[1]);
+    EXPECT_TRUE(samples[0] < samples[2]);
+    EXPECT_TRUE(samples[1] < samples[2]);
+    EXPECT_FALSE(samples[2] < samples[0]);
+    EXPECT_FALSE(samples[2] < samples[1]);
+}
+
+TEST_F(SamplePtrTest, GreaterThanReturnsFalseWhenLeftSampleIsInvalid)
+{
+    constexpr EventSlotStatus::EventTimeStamp kTimestamp{42U};
+
+    SamplePtr<std::uint8_t> invalid_sample{};
+    auto valid_sample = CreateSamplePtr(kTimestamp, 0U);
+
+    const bool result = invalid_sample > valid_sample;
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(SamplePtrTest, GreaterThanReturnsFalseWhenRightSampleIsInvalid)
+{
+    constexpr EventSlotStatus::EventTimeStamp kTimestamp{42U};
+
+    auto valid_sample = CreateSamplePtr(kTimestamp, 0U);
+    SamplePtr<std::uint8_t> invalid_sample{};
+
+    const bool result = valid_sample > invalid_sample;
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(SamplePtrTest, LessThanReturnsFalseWhenLeftSampleIsInvalid)
+{
+    constexpr EventSlotStatus::EventTimeStamp kTimestamp{42U};
+
+    SamplePtr<std::uint8_t> invalid_sample{};
+    auto valid_sample = CreateSamplePtr(kTimestamp, 0U);
+
+    const bool result = invalid_sample < valid_sample;
+
+    EXPECT_FALSE(result);
+}
+
+TEST_F(SamplePtrTest, LessThanReturnsFalseWhenRightSampleIsInvalid)
+{
+    constexpr EventSlotStatus::EventTimeStamp kTimestamp{42U};
+
+    auto valid_sample = CreateSamplePtr(kTimestamp, 0U);
+    SamplePtr<std::uint8_t> invalid_sample{};
+
+    const bool result = valid_sample < invalid_sample;
+
+    EXPECT_FALSE(result);
+}
 }  // namespace
 }  // namespace score::mw::com::impl::lola

--- a/score/mw/com/impl/plumbing/rust/sample_ptr.rs
+++ b/score/mw/com/impl/plumbing/rust/sample_ptr.rs
@@ -41,6 +41,7 @@ struct SlotDecrementer {
 struct LolaBinding<T> {
     _managed_object: *const T,
     _slot_decrementer: CxxOptional<SlotDecrementer>,
+    _timestamp: u32,
 }
 
 #[repr(C)]

--- a/score/mw/com/impl/plumbing/sample_ptr.h
+++ b/score/mw/com/impl/plumbing/sample_ptr.h
@@ -145,11 +145,6 @@ class SamplePtr final
 
     bool operator<(const SamplePtr& other) const noexcept
     {
-        if (!(*this) || !other)
-        {
-            return false;
-        }
-
         return std::visit(
             score::cpp::overload(
                 [](const lola::SamplePtr<SampleType>& lhs, const lola::SamplePtr<SampleType>& rhs) noexcept -> bool {
@@ -164,11 +159,6 @@ class SamplePtr final
 
     bool operator>(const SamplePtr& other) const noexcept
     {
-        if (!(*this) || !other)
-        {
-            return false;
-        }
-
         return std::visit(
             score::cpp::overload(
                 [](const lola::SamplePtr<SampleType>& lhs, const lola::SamplePtr<SampleType>& rhs) noexcept -> bool {

--- a/score/mw/com/impl/plumbing/sample_ptr.h
+++ b/score/mw/com/impl/plumbing/sample_ptr.h
@@ -143,6 +143,43 @@ class SamplePtr final
         return get();
     }
 
+    bool operator<(const SamplePtr& other) const noexcept
+    {
+        if (!(*this) || !other)
+        {
+            return false;
+        }
+
+        return std::visit(
+            score::cpp::overload(
+                [](const lola::SamplePtr<SampleType>& lhs, const lola::SamplePtr<SampleType>& rhs) noexcept -> bool {
+                    return lhs < rhs;
+                },
+                [](const auto&, const auto&) noexcept -> bool {
+                    return false;
+                }),
+            binding_sample_ptr_,
+            other.binding_sample_ptr_);
+    }
+
+    bool operator>(const SamplePtr& other) const noexcept
+    {
+        if (!(*this) || !other)
+        {
+            return false;
+        }
+
+        return std::visit(
+            score::cpp::overload(
+                [](const lola::SamplePtr<SampleType>& lhs, const lola::SamplePtr<SampleType>& rhs) noexcept -> bool {
+                    return lhs > rhs;
+                },
+                [](const auto&, const auto&) noexcept -> bool {
+                    return false;
+                }),
+            binding_sample_ptr_,
+            other.binding_sample_ptr_);
+    }
     explicit operator bool() const noexcept
     {
         return std::holds_alternative<score::cpp::blank>(binding_sample_ptr_) == false;

--- a/score/mw/com/impl/plumbing/sample_ptr_test.cpp
+++ b/score/mw/com/impl/plumbing/sample_ptr_test.cpp
@@ -11,6 +11,10 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 #include "score/mw/com/impl/plumbing/sample_ptr.h"
+#include "score/mw/com/impl/bindings/lola/event_data_control.h"
+#include "score/mw/com/impl/bindings/lola/proxy_event_data_control_local_view.h"
+#include "score/mw/com/impl/bindings/lola/skeleton_event_data_control_local_view.h"
+#include "score/mw/com/impl/bindings/lola/test_doubles/fake_memory_resource.h"
 
 #include <gtest/gtest.h>
 
@@ -24,6 +28,47 @@ namespace
 {
 
 using TestSampleType = std::uint8_t;
+constexpr std::size_t kMaxSlots{5U};
+constexpr std::size_t kMaxSubscribers{5U};
+const lola::TransactionLogId kDummyTransactionLogId{10U};
+
+class LolaForwardingSamplePtrTest : public ::testing::Test
+{
+  protected:
+    lola::FakeMemoryResource memory_{};
+    lola::EventDataControl event_data_control_{kMaxSlots, memory_, kMaxSubscribers};
+    lola::ProxyEventDataControlLocalView<> proxy_event_data_control_local_{event_data_control_};
+    lola::SkeletonEventDataControlLocalView<> skeleton_event_data_control_local_{event_data_control_};
+
+    lola::TransactionLogSet::TransactionLogIndex transaction_log_index_ =
+        proxy_event_data_control_local_.GetTransactionLogSet().RegisterProxyElement(kDummyTransactionLogId).value();
+
+    lola::SlotIndexType AllocateSlot(lola::EventSlotStatus::EventTimeStamp timestamp)
+    {
+        auto slot = skeleton_event_data_control_local_.AllocateNextSlot();
+        EXPECT_TRUE(slot.has_value());
+        skeleton_event_data_control_local_.EventReady(slot.value(), timestamp);
+        return slot.value();
+    }
+
+    SamplePtr<std::uint8_t> CreateImplSamplePtr(const lola::EventSlotStatus::EventTimeStamp timestamp,
+                                                const std::size_t slot_index)
+    {
+        AllocateSlot(timestamp);
+
+        auto slot_result = proxy_event_data_control_local_.ReferenceNextEvent(slot_index, transaction_log_index_);
+        EXPECT_TRUE(slot_result.has_value());
+
+        dummy_storage_.push_back(std::make_unique<std::uint8_t>(0U));
+
+        lola::SamplePtr<std::uint8_t> lola_sample{
+            dummy_storage_.back().get(), proxy_event_data_control_local_, slot_result.value(), transaction_log_index_};
+
+        return SamplePtr<std::uint8_t>{std::move(lola_sample), SampleReferenceGuard{}};
+    }
+
+    std::vector<std::unique_ptr<std::uint8_t>> dummy_storage_{};
+};
 
 /// \brief Templated test fixture for SamplePtr functionality that works for both void and non-void types
 template <typename T>
@@ -335,6 +380,38 @@ TYPED_TEST(SamplePtrGenericTypeTest, MovingSamplePtrWillMoveSampleReferenceGuard
 
     // Then the nubmer of available samples will not change.
     EXPECT_EQ(tracker.GetNumAvailableSamples(), max_num_samples - 1);
+}
+
+TEST_F(LolaForwardingSamplePtrTest, GreaterThanReturnsTrueWhenForwardedLolaSampleIsNewer)
+{
+    auto older_sample = CreateImplSamplePtr(10U, 0U);
+    auto newer_sample = CreateImplSamplePtr(42U, 1U);
+
+    EXPECT_TRUE(newer_sample > older_sample);
+}
+
+TEST_F(LolaForwardingSamplePtrTest, GreaterThanReturnsFalseWhenForwardedLolaSampleIsOlder)
+{
+    auto older_sample = CreateImplSamplePtr(10U, 0U);
+    auto newer_sample = CreateImplSamplePtr(42U, 1U);
+
+    EXPECT_FALSE(older_sample > newer_sample);
+}
+
+TEST_F(LolaForwardingSamplePtrTest, LessThanReturnsTrueWhenForwardedLolaSampleIsOlder)
+{
+    auto older_sample = CreateImplSamplePtr(10U, 0U);
+    auto newer_sample = CreateImplSamplePtr(42U, 1U);
+
+    EXPECT_TRUE(older_sample < newer_sample);
+}
+
+TEST_F(LolaForwardingSamplePtrTest, LessThanReturnsFalseWhenForwardedLolaSampleIsNewer)
+{
+    auto older_sample = CreateImplSamplePtr(10U, 0U);
+    auto newer_sample = CreateImplSamplePtr(42U, 1U);
+
+    EXPECT_FALSE(newer_sample < older_sample);
 }
 
 }  // namespace

--- a/score/mw/com/impl/plumbing/sample_ptr_test.cpp
+++ b/score/mw/com/impl/plumbing/sample_ptr_test.cpp
@@ -11,6 +11,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 #include "score/mw/com/impl/plumbing/sample_ptr.h"
+#include "score/mw/com/impl/bindings/lola/consumer_event_data_control_local_view.h"
+#include "score/mw/com/impl/bindings/lola/event_data_control.h"
+#include "score/mw/com/impl/bindings/lola/provider_event_data_control_local_view.h"
+#include "score/mw/com/impl/bindings/lola/test_doubles/fake_memory_resource.h"
+#include "score/mw/com/impl/bindings/lola/transaction_log.h"
 
 #include <gtest/gtest.h>
 
@@ -24,6 +29,43 @@ namespace
 {
 
 using TestSampleType = std::uint8_t;
+constexpr std::size_t kMaxSlots{5U};
+
+class LolaForwardingSamplePtrTest : public ::testing::Test
+{
+  protected:
+    lola::FakeMemoryResource memory_{};
+    lola::EventDataControl event_data_control_{kMaxSlots, memory_};
+    lola::TransactionLog transaction_log_{kMaxSlots, memory_};
+    lola::ProviderEventDataControlLocalView<> provider_event_data_control_local_{event_data_control_};
+    lola::ConsumerEventDataControlLocalView<> consumer_event_data_control_local_{event_data_control_, transaction_log_};
+
+    lola::SlotIndexType AllocateSlot(lola::EventSlotStatus::EventTimeStamp timestamp)
+    {
+        auto slot = provider_event_data_control_local_.AllocateNextSlot();
+        EXPECT_TRUE(slot.has_value());
+        provider_event_data_control_local_.EventReady(slot.value(), timestamp);
+        return slot.value();
+    }
+
+    SamplePtr<std::uint8_t> CreateImplSamplePtr(const lola::EventSlotStatus::EventTimeStamp timestamp,
+                                                const lola::EventSlotStatus::EventTimeStamp last_search_time)
+    {
+        AllocateSlot(timestamp);
+
+        auto slot_result = consumer_event_data_control_local_.ReferenceNextEvent(last_search_time);
+        EXPECT_TRUE(slot_result.has_value());
+
+        dummy_storage_.push_back(std::make_unique<std::uint8_t>(0U));
+
+        lola::SamplePtr<std::uint8_t> lola_sample{
+            dummy_storage_.back().get(), consumer_event_data_control_local_, slot_result.value()};
+
+        return SamplePtr<std::uint8_t>{std::move(lola_sample), SampleReferenceGuard{}};
+    }
+
+    std::vector<std::unique_ptr<std::uint8_t>> dummy_storage_{};
+};
 
 /// \brief Templated test fixture for SamplePtr functionality that works for both void and non-void types
 template <typename T>
@@ -335,6 +377,38 @@ TYPED_TEST(SamplePtrGenericTypeTest, MovingSamplePtrWillMoveSampleReferenceGuard
 
     // Then the nubmer of available samples will not change.
     EXPECT_EQ(tracker.GetNumAvailableSamples(), max_num_samples - 1);
+}
+
+TEST_F(LolaForwardingSamplePtrTest, GreaterThanReturnsTrueWhenForwardedLolaSampleIsNewer)
+{
+    auto older_sample = CreateImplSamplePtr(10U, 0U);
+    auto newer_sample = CreateImplSamplePtr(42U, 1U);
+
+    EXPECT_TRUE(newer_sample > older_sample);
+}
+
+TEST_F(LolaForwardingSamplePtrTest, GreaterThanReturnsFalseWhenForwardedLolaSampleIsOlder)
+{
+    auto older_sample = CreateImplSamplePtr(10U, 0U);
+    auto newer_sample = CreateImplSamplePtr(42U, 1U);
+
+    EXPECT_FALSE(older_sample > newer_sample);
+}
+
+TEST_F(LolaForwardingSamplePtrTest, LessThanReturnsTrueWhenForwardedLolaSampleIsOlder)
+{
+    auto older_sample = CreateImplSamplePtr(10U, 0U);
+    auto newer_sample = CreateImplSamplePtr(42U, 1U);
+
+    EXPECT_TRUE(older_sample < newer_sample);
+}
+
+TEST_F(LolaForwardingSamplePtrTest, LessThanReturnsFalseWhenForwardedLolaSampleIsNewer)
+{
+    auto older_sample = CreateImplSamplePtr(10U, 0U);
+    auto newer_sample = CreateImplSamplePtr(42U, 1U);
+
+    EXPECT_FALSE(newer_sample < older_sample);
 }
 
 }  // namespace


### PR DESCRIPTION
I’m interested in contributing to this project and started by looking into Issue #13.

## Changes
- updated the constructor to carry the necessary context
- added a `GetTimestamp()` function as requested
- implemented a unit test to verify the behavior

## Questions
- Are there any specific commit message or PR guidelines I should follow?
- Is there a preferred way to assign or request reviewers?

## Design question
For the default/null constructors, I currently initialize the internal state (`event_data_ctrl_ = nullptr`, empty `slot_indicator_`, etc.) so that `GetTimestamp()` safely returns a default value.

Does this align with the intended design, or would you prefer a different approach for representing an "invalid" `SamplePtr`?

I was advised to reach out to @crimson11 for this part of the code, as he likely has deeper insight into the design.