### PR TITLE
Feature/extraction skeleton service elements

### DIFF
--- a/score/mw/com/impl/skeleton_base.cpp
+++ b/score/mw/com/impl/skeleton_base.cpp
@@ -23,6 +23,7 @@
 
 #include "score/mw/log/logging.h"
 
+#include <score/assert.hpp>
 #include <score/utility.hpp>
 
 #include <algorithm>
@@ -104,22 +105,7 @@ SkeletonBase::SkeletonBase(SkeletonBase&& other) noexcept
       skeleton_mock_{std::move(other.skeleton_mock_)},
       service_offered_flag_{std::move(other.service_offered_flag_)}
 {
-    // Since the address of this skeleton has changed, we need update the address stored in each of the events and
-    // fields belonging to the skeleton.
-    for (auto& event : events_)
-    {
-        event.second.get().UpdateSkeletonReference(*this);
-    }
-
-    for (auto& field : fields_)
-    {
-        field.second.get().UpdateSkeletonReference(*this);
-    }
-
-    for (auto& method : methods_)
-    {
-        method.second.get().UpdateSkeletonReference(*this);
-    }
+    UpdateAllServiceElementReferences();
 }
 
 // Suppress "AUTOSAR C++14 A6-2-1" rule violation. The rule states "Move and copy assignment operators shall either move
@@ -142,21 +128,8 @@ SkeletonBase& SkeletonBase::operator=(SkeletonBase&& other) noexcept
     skeleton_mock_ = std::move(other.skeleton_mock_);
     service_offered_flag_ = std::move(other.service_offered_flag_);
 
-    // Since the address of this skeleton has changed, we need update the address stored in each of the events and
-    // fields belonging to the skeleton.
-    for (auto& event : events_)
-    {
-        event.second.get().UpdateSkeletonReference(*this);
-    }
+    UpdateAllServiceElementReferences();
 
-    for (auto& field : fields_)
-    {
-        field.second.get().UpdateSkeletonReference(*this);
-    }
-    for (auto& method : methods_)
-    {
-        method.second.get().UpdateSkeletonReference(*this);
-    }
     return *this;
 }
 
@@ -317,6 +290,105 @@ auto SkeletonBase::AreBindingsValid() const noexcept -> bool
         });
 
     return is_skeleton_binding_valid && are_service_element_bindings_valid;
+}
+
+void SkeletonBase::UpdateAllServiceElementReferences() noexcept
+{
+    for (auto& event : events_)
+    {
+        event.second.get().UpdateSkeletonReference(*this);
+    }
+    for (auto& field : fields_)
+    {
+        field.second.get().UpdateSkeletonReference(*this);
+    }
+    for (auto& method : methods_)
+    {
+        method.second.get().UpdateSkeletonReference(*this);
+    }
+}
+
+SkeletonBaseView::SkeletonBaseView(SkeletonBase& skeleton_base) : skeleton_base_{skeleton_base} {}
+
+InstanceIdentifier SkeletonBaseView::GetAssociatedInstanceIdentifier() const
+{
+    return skeleton_base_.instance_id_;
+}
+
+SkeletonBinding* SkeletonBaseView::GetBinding() const
+{
+    return skeleton_base_.binding_.get();
+}
+
+void SkeletonBaseView::RegisterEvent(const std::string_view event_name, SkeletonEventBase& event)
+{
+    const auto result = skeleton_base_.events_.emplace(event_name, event);
+    const bool was_event_inserted = result.second;
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(was_event_inserted, "Event cannot be registered as it already exists.");
+}
+
+void SkeletonBaseView::RegisterField(const std::string_view field_name, SkeletonFieldBase& field)
+{
+    const auto result = skeleton_base_.fields_.emplace(field_name, field);
+    const bool was_field_inserted = result.second;
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(was_field_inserted, "Field cannot be registered as it already exists.");
+}
+
+void SkeletonBaseView::RegisterMethod(const std::string_view method_name, SkeletonMethodBase& method)
+{
+    const auto result = skeleton_base_.methods_.emplace(method_name, method);
+    const bool was_method_inserted = result.second;
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(was_method_inserted, "Method cannot be registered as it already exists.");
+}
+
+void SkeletonBaseView::UpdateEvent(const std::string_view event_name, SkeletonEventBase& event) noexcept
+{
+    auto event_name_it = skeleton_base_.events_.find(event_name);
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(
+        event_name_it != skeleton_base_.events_.cend(),
+        "SkeletonBaseView::UpdateEvent failed to update event because the requested event doesn't exist");
+
+    event_name_it->second = event;
+}
+
+void SkeletonBaseView::UpdateField(const std::string_view field_name, SkeletonFieldBase& field) noexcept
+{
+    auto field_name_it = skeleton_base_.fields_.find(field_name);
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(
+        field_name_it != skeleton_base_.fields_.cend(),
+        "SkeletonBaseView::UpdateField failed to update field because the requested field doesn't exist");
+
+    field_name_it->second = field;
+}
+
+void SkeletonBaseView::UpdateMethod(const std::string_view method_name, SkeletonMethodBase& method) noexcept
+{
+    auto method_it = skeleton_base_.methods_.find(method_name);
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(
+        method_it != skeleton_base_.methods_.cend(),
+        "SkeletonBaseView::UpdateMethod failed to update method because the requested method doesn't exist");
+
+    method_it->second = method;
+}
+
+const SkeletonBase::SkeletonEvents& SkeletonBaseView::GetEvents() const noexcept
+{
+    return skeleton_base_.events_;
+}
+
+const SkeletonBase::SkeletonFields& SkeletonBaseView::GetFields() const noexcept
+{
+    return skeleton_base_.fields_;
+}
+
+const SkeletonBase::SkeletonMethods& SkeletonBaseView::GetMethods() const noexcept
+{
+    return skeleton_base_.methods_;
+}
+
+bool SkeletonBaseView::AreBindingsValid() const
+{
+    return skeleton_base_.AreBindingsValid();
 }
 
 score::cpp::optional<InstanceIdentifier> GetInstanceIdentifier(const InstanceSpecifier& specifier)

--- a/score/mw/com/impl/skeleton_base.h
+++ b/score/mw/com/impl/skeleton_base.h
@@ -23,9 +23,6 @@
 
 #include "score/result/result.h"
 
-#include "score/mw/log/logging.h"
-
-#include <score/assert.hpp>
 #include <score/optional.hpp>
 #include <score/span.hpp>
 
@@ -87,7 +84,7 @@ class SkeletonBase
     }
 
   protected:
-    bool AreBindingsValid() const noexcept;
+    [[nodiscard]] bool AreBindingsValid() const noexcept;
 
     // Suppress "AUTOSAR C++14 A11-3-1", The rule states: "Friend declarations shall not be used".
     // Design decision. This class provides a view to the private members of this class.
@@ -111,107 +108,39 @@ class SkeletonBase
     [[nodiscard]] score::Result<void> OfferServiceEvents() const noexcept;
     [[nodiscard]] score::Result<void> OfferServiceFields() const noexcept;
 
+    void UpdateAllServiceElementReferences() noexcept;
+
     FlagOwner service_offered_flag_;
 };
 
 class SkeletonBaseView
 {
   public:
-    explicit SkeletonBaseView(SkeletonBase& skeleton_base) : skeleton_base_{skeleton_base} {}
+    explicit SkeletonBaseView(SkeletonBase& skeleton_base);
 
-    InstanceIdentifier GetAssociatedInstanceIdentifier() const
-    {
-        return skeleton_base_.instance_id_;
-    }
+    [[nodiscard]] InstanceIdentifier GetAssociatedInstanceIdentifier() const;
 
-    SkeletonBinding* GetBinding() const
-    {
-        return skeleton_base_.binding_.get();
-    }
+    [[nodiscard]] SkeletonBinding* GetBinding() const;
 
-    void RegisterEvent(const std::string_view event_name, SkeletonEventBase& event)
-    {
-        const auto result = skeleton_base_.events_.emplace(event_name, event);
-        const bool was_event_inserted = result.second;
-        SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(was_event_inserted, "Event cannot be registered as it already exists.");
-    }
+    void RegisterEvent(std::string_view event_name, SkeletonEventBase& event);
 
-    void RegisterField(const std::string_view field_name, SkeletonFieldBase& field)
-    {
-        const auto result = skeleton_base_.fields_.emplace(field_name, field);
-        const bool was_field_inserted = result.second;
-        SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(was_field_inserted, "Field cannot be registered as it already exists.");
-    }
+    void RegisterField(std::string_view field_name, SkeletonFieldBase& field);
 
-    void RegisterMethod(const std::string_view method_name, SkeletonMethodBase& method)
-    {
-        const auto result = skeleton_base_.methods_.emplace(method_name, method);
-        const bool was_method_inserted = result.second;
-        SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(was_method_inserted,
-                                                "Method cannot be registered as it already exists.");
-    }
+    void RegisterMethod(std::string_view method_name, SkeletonMethodBase& method);
 
-    // Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be
-    // called implicitly". std::terminate() is implicitly called from std::map::at in case the container doesn't
-    // have the mapped element. This function is called by the move constructor and as we register the event name in
-    // the events_ container during SkeletonEvent construction so we are sure that the event_name already exists, so
-    // no way for throwing std::out_of_range which leds to std::terminate().
-    // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-    void UpdateEvent(const std::string_view event_name, SkeletonEventBase& event) noexcept
-    {
-        // Suppress "AUTOSAR C++14 A15-4-2" rule finding. This rule states: "If a function is declared to be
-        // noexcept, noexcept(true) or noexcept(<true condition>), then it shall not exit with an exception"
-        // This function is indirectly called by the move constructor and as we register the event name in the
-        // events_ container during SkeletonEvent construction so we are sure the event name already exists, so no
-        // way for throwing std::out_of_range which leds to std::terminate().
-        // coverity[autosar_cpp14_a15_4_2_violation] : FALSE]
-        skeleton_base_.events_.at(event_name) = event;
-    }
+    void UpdateEvent(std::string_view event_name, SkeletonEventBase& event) noexcept;
 
-    void UpdateField(const std::string_view field_name, SkeletonFieldBase& field) noexcept
-    {
-        auto field_name_it = skeleton_base_.fields_.find(field_name);
-        if (field_name_it == skeleton_base_.fields_.cend())
-        {
-            score::mw::log::LogError("lola")
-                << "SkeletonBaseView::UpdateField failed to update field because the requested field doesn't exist";
-            std::terminate();
-        }
+    void UpdateField(std::string_view field_name, SkeletonFieldBase& field) noexcept;
 
-        field_name_it->second = field;
-    }
+    void UpdateMethod(std::string_view method_name, SkeletonMethodBase& method) noexcept;
 
-    void UpdateMethod(const std::string_view method_name, SkeletonMethodBase& method) noexcept
-    {
-        auto method_it = skeleton_base_.methods_.find(method_name);
-        if (method_it == skeleton_base_.methods_.cend())
-        {
-            score::mw::log::LogError("lola")
-                << "SkeletonBaseView::UpdateMethod failed to update method because the requested method doesn't exist";
-            std::terminate();
-        }
-        method_it->second = method;
-    }
+    [[nodiscard]] const SkeletonBase::SkeletonEvents& GetEvents() const noexcept;
 
-    const SkeletonBase::SkeletonEvents& GetEvents() const noexcept
-    {
-        return skeleton_base_.events_;
-    }
+    [[nodiscard]] const SkeletonBase::SkeletonFields& GetFields() const noexcept;
 
-    const SkeletonBase::SkeletonFields& GetFields() const noexcept
-    {
-        return skeleton_base_.fields_;
-    }
+    [[nodiscard]] const SkeletonBase::SkeletonMethods& GetMethods() const noexcept;
 
-    const SkeletonBase::SkeletonMethods& GetMethods() const noexcept
-    {
-        return skeleton_base_.methods_;
-    }
-
-    bool AreBindingsValid() const
-    {
-        return skeleton_base_.AreBindingsValid();
-    }
+    [[nodiscard]] bool AreBindingsValid() const;
 
   private:
     SkeletonBase& skeleton_base_;


### PR DESCRIPTION
Ticket:
Ticket Extract move assign / construction functionality in SkeletonBase into separate class #91
91 is the issue
Issue link: https://github.com/eclipse-score/communication/issues/91

Context:
The original change introduced a new SkeletonServiceElements wrapper class and moved the events_, fields_, and methods_ maps from SkeletonBase into that wrapper. The intention was to separate the service-element map handling and remove duplicated UpdateSkeletonReference loops from the SkeletonBase move constructor and move assignment operator.

Review feedback summary:
After review, the SkeletonServiceElements wrapper was considered unnecessary because it did not provide real encapsulation. SkeletonBase still needs to directly operate on the registered events, fields, and methods for service offering, stop-offering, tracing callback setup, binding validation, and post-move reference fix-up.

Therefore, I updated the approach to keep the useful part of the refactor while removing the unnecessary wrapper abstraction.

Updated solution:
The updated implementation keeps events_, fields_, and methods_ directly inside SkeletonBase and removes the SkeletonServiceElements wrapper class.

The duplicated post-move reference update logic is now extracted into a private SkeletonBase helper:

    UpdateAllServiceElementReferences()

This method updates the back-reference of every registered event, field, and method to the new SkeletonBase instance after move construction or move assignment.

This keeps the move constructor and move assignment operator simple and avoids duplicated loops, while also avoiding the additional wrapper class that the review identified as unnecessary.

Changes made:
[ 1] Removed SkeletonServiceElements wrapper class.
[ 2] Removed skeleton_service_elements.h.
[ 3] Removed skeleton_service_elements.cpp.
[ 4] Removed skeleton_service_elements_test.cpp.
[ 5] Removed skeleton_service_elements Bazel library target.
[ 6] Removed skeleton_service_elements_test Bazel test target.
[ 7] Restored events_, fields_, and methods_ as direct members of SkeletonBase.
[ 8] Kept SkeletonBase::UpdateAllServiceElementReferences() as the common helper for post-move reference fix-up.
[ 9] Updated SkeletonBase move constructor to move events_, fields_, and methods_, then call UpdateAllServiceElementReferences().
[10] Updated SkeletonBase move assignment operator to move events_, fields_, and methods_, then call UpdateAllServiceElementReferences().
[11] Updated all internal SkeletonBase logic to use events_, fields_, and methods_ directly again.
[12] Made UpdateEvent, UpdateField, and UpdateMethod symmetric.
[13] Replaced the previous event-specific std::map::at() behavior with the same find() + SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE() + defensive std::terminate() pattern used for all three update methods.
[14] Removed the overdone logging from UpdateField and UpdateMethod.
[15] Removed the unnecessary test refactor because the public SkeletonBase / SkeletonBaseView API did not change.
[16] Kept the existing SkeletonBase-level test coverage for registration, move construction, move assignment, and back-reference fix-up.

Why this still solves the ticket:
The core issue was duplicated move construction / move assignment logic in SkeletonBase, specifically the repeated loops that update registered service elements after a SkeletonBase object is moved.

That duplication is now removed by UpdateAllServiceElementReferences().

So the ticket use case is still solved, but without introducing the SkeletonServiceElements wrapper because the reviewer pointed out that the wrapper did not add enough value.

Final design:
- SkeletonBase continues to own the service element maps directly.
- Move constructor and move assignment remain responsible for moving the members.
- UpdateAllServiceElementReferences() centralizes the post-move back-reference update.
- UpdateEvent, UpdateField, and UpdateMethod now follow the same consistent behavior.
- No downstream API breakage is expected because SkeletonBase::SkeletonEvents, SkeletonBase::SkeletonFields, and SkeletonBase::SkeletonMethods are still available as type aliases.

Validation:
- git diff --check passed locally in the generated patch environment.
- Bazel tests passed be in the repo environment with:

    bazel test //score/mw/com/impl:skeleton_base_test
    bazel test //...

The updated version solves the same ticket more directly:
it removes duplicated move-operation logic through UpdateAllServiceElementReferences(), keeps the maps inside SkeletonBase, and avoids unnecessary structural changes.
 
Summary :
a)The first version solved the issue by extracting the maps into a new wrapper class, but the review showed that this abstraction was not useful.
b)Forking: Created my own sandbox to work in.
c)Upstream: Linked my local repo to the main project to stay updated.
d)Feature Branch: Isolated my specific work so it doesn't get mixed up.
e)Bazel: Used the project's specific build tool to ensure high code quality.