### PR TITLE
Bump checkout action to v6.0.2

### DIFF
--- a/.github/workflows/address_undefined_behavior_leak_sanitizer.yml
+++ b/.github/workflows/address_undefined_behavior_leak_sanitizer.yml
@@ -32,7 +32,7 @@ jobs:
         contents: read
       steps:
         - name: Checkout repository
-          uses: actions/checkout@v4.2.2
+          uses: actions/checkout@v6.0.2
         - name: Free Disk Space (Ubuntu)
           uses: eclipse-score/more-disk-space@v1
           with:

--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -35,7 +35,7 @@ jobs:
       release-tag: ${{ steps.release-tag.outputs.release-tag }}
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.0.2
 
       - name: Set release tag from workflow dispatch input
         id: release-tag
@@ -99,7 +99,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.0.2
 
       - name: Download coverage report artifact
         uses: actions/download-artifact@v4
@@ -128,7 +128,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.0.2
 
       - name: Report success
         run: |
@@ -149,7 +149,7 @@ jobs:
       contents: write
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.0.2
 
       - name: Delete draft release due to failure
         run: |

--- a/.github/workflows/build_and_test_host.yml
+++ b/.github/workflows/build_and_test_host.yml
@@ -86,7 +86,7 @@ jobs:
         contents: read
       steps:
         - name: Checkout repository
-          uses: actions/checkout@v4.2.2
+          uses: actions/checkout@v6.0.2
         - name: Free Disk Space (Ubuntu)
           uses: eclipse-score/more-disk-space@v1
           with:

--- a/.github/workflows/build_and_test_qnx.yml
+++ b/.github/workflows/build_and_test_qnx.yml
@@ -114,7 +114,7 @@ jobs:
         pull-requests: read
       steps:
         - name: Checkout repository
-          uses: actions/checkout@v4.2.2
+          uses: actions/checkout@v6.0.2
           with:
             ref: ${{ github.head_ref || github.event.pull_request.head.ref || github.ref }}
             repository: ${{ github.event.pull_request.head.repo.full_name || github.repository }}

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -34,7 +34,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4.2.2
+        uses: actions/checkout@v6.0.2
 
       - name: Free Disk Space (Ubuntu)
         uses: eclipse-score/more-disk-space@v1

--- a/.github/workflows/thread_sanitizer.yml
+++ b/.github/workflows/thread_sanitizer.yml
@@ -31,7 +31,7 @@ jobs:
         contents: read
       steps:
         - name: Checkout repository
-          uses: actions/checkout@v4.2.2
+          uses: actions/checkout@v6.0.2
         - name: Free Disk Space (Ubuntu)
           uses: eclipse-score/more-disk-space@v1
           with:


### PR DESCRIPTION
Fixes a warning about using a deprecated Node.js version in the CI.