### PR TITLE
Reduce content out of the main .bazelrc

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -73,39 +73,10 @@ common --registry=https://bcr.bazel.build
 # Enable colored output for gtest
 build --test_env="GTEST_COLOR=1"
 
-# With this instrumentation filter for our two main components, we ensure that `bazel coverage //...` is yielding the correct results
-coverage --instrumentation_filter="^//score/message_passing[/:],^//score/mw/com[/:],-//score/mw/com/performance_benchmarks[/:],-//score/mw/.*/test[/:]".
-coverage --experimental_generate_llvm_lcov
-coverage --experimental_use_llvm_covmap
-coverage --combined_report=lcov
-coverage --coverage_report_generator=@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main
-coverage --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux
-coverage --extra_toolchains=@ferrocene_x86_64_unknown_linux_gnu_llvm//:rust_ferrocene_toolchain
-coverage --test_env=COVERAGE_GCOV_OPTIONS=-bcu
-# TODO set toolchain feature once possible
-# These compile time options are required to cover abnormal termination cases. In GCC one can use `__gcc_dump()`, but this does not work with LLVM
-# LLVM provided these compile-time options in combination with a specific profile setting which is enabled in bazel via `LLVM_PROFILE_CONTINUOUS_MODE`
-coverage --test_env=LLVM_PROFILE_CONTINUOUS_MODE=1
-coverage --cxxopt -mllvm
-coverage --cxxopt -runtime-counter-relocation
-
-# Clang-tidy configuration
-# Run clang-tidy on all C++ targets with: bazel test --config=clang-tidy //...
-test:clang-tidy --aspects=//:tools/lint/linters.bzl%clang_tidy_aspect
-test:clang-tidy --output_groups=+rules_lint_report
-# Use LLVM toolchain for clang-tidy so it can find system headers
-test:clang-tidy --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux
-test:clang-tidy --extra_toolchains=@ferrocene_x86_64_unknown_linux_gnu_llvm//:rust_ferrocene_toolchain
-
+# Configuration options required for quality assurance
+import %workspace%/quality/coverage.bazelrc
 import %workspace%/quality/sanitizer/sanitizer.bazelrc
-
-common:codeql --platform_suffix=codeql
-common:codeql --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux
-common:codeql --sandbox_writable_path=/var/tmp
-common:codeql --nouse_action_cache
-common:codeql --noremote_accept_cached
-common:codeql --noremote_upload_local_results
-common:codeql --disk_cache=
+import %workspace%/quality/static_analysis/static_analysis.bazelrc
 
 # Use native sphinx_build_binary instead of the wrapper
 build --//docs/sphinx/utils:use_native_sphinx_build

--- a/quality/coverage.bazelrc
+++ b/quality/coverage.bazelrc
@@ -1,0 +1,28 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+# With this instrumentation filter for our two main components, we ensure that `bazel coverage //...` is yielding the correct results
+coverage --instrumentation_filter="^//score/message_passing[/:],^//score/mw/com[/:],-//score/mw/com/performance_benchmarks[/:],-//score/mw/.*/test[/:]".
+coverage --experimental_generate_llvm_lcov
+coverage --experimental_use_llvm_covmap
+coverage --combined_report=lcov
+coverage --coverage_report_generator=@bazel_tools//tools/test/CoverageOutputGenerator/java/com/google/devtools/coverageoutputgenerator:Main
+coverage --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux
+coverage --extra_toolchains=@ferrocene_x86_64_unknown_linux_gnu_llvm//:rust_ferrocene_toolchain
+coverage --test_env=COVERAGE_GCOV_OPTIONS=-bcu
+# TODO set toolchain feature once possible
+# These compile time options are required to cover abnormal termination cases. In GCC one can use `__gcc_dump()`, but this does not work with LLVM
+# LLVM provided these compile-time options in combination with a specific profile setting which is enabled in bazel via `LLVM_PROFILE_CONTINUOUS_MODE`
+coverage --test_env=LLVM_PROFILE_CONTINUOUS_MODE=1
+coverage --cxxopt -mllvm
+coverage --cxxopt -runtime-counter-relocation

--- a/quality/static_analysis/static_analysis.bazelrc
+++ b/quality/static_analysis/static_analysis.bazelrc
@@ -1,0 +1,28 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+# Clang-tidy configuration
+# Run clang-tidy on all C++ targets with: bazel test --config=clang-tidy //...
+test:clang-tidy --aspects=//:tools/lint/linters.bzl%clang_tidy_aspect
+test:clang-tidy --output_groups=+rules_lint_report
+# Use LLVM toolchain for clang-tidy so it can find system headers
+test:clang-tidy --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux
+test:clang-tidy --extra_toolchains=@ferrocene_x86_64_unknown_linux_gnu_llvm//:rust_ferrocene_toolchain
+
+common:codeql --platform_suffix=codeql
+common:codeql --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux
+common:codeql --sandbox_writable_path=/var/tmp
+common:codeql --nouse_action_cache
+common:codeql --noremote_accept_cached
+common:codeql --noremote_upload_local_results
+common:codeql --disk_cache=


### PR DESCRIPTION
This still gets included by the main .bazelrc but moving it to separate files make it easier to read and to differentiate what we need and what users might need.
Right now in the .bazelrc file there are 3 types of parameters, some that the user will need for sure to make it work, some that does not need, and some that might need depending on functionality.