### PR TITLE
mw/com: add missing unit tests and enable build qnx 8

### DIFF
--- a/score/mw/com/impl/bindings/lola/service_discovery/client/BUILD
+++ b/score/mw/com/impl/bindings/lola/service_discovery/client/BUILD
@@ -50,9 +50,6 @@ cc_gtest_unit_test(
         "service_discovery_client_worker_thread_test.cpp",
     ],
     features = COMPILER_WARNING_FEATURES,
-    target_compatible_with = select({
-        "//conditions:default": [],
-    }),
     visibility = [
         "//score/mw/com/impl/bindings/lola/service_discovery/client:__pkg__",
     ],

--- a/score/mw/com/impl/bindings/lola/service_discovery/client/BUILD
+++ b/score/mw/com/impl/bindings/lola/service_discovery/client/BUILD
@@ -43,17 +43,14 @@ cc_gtest_unit_test(
     srcs = [
         "service_discovery_client_find_service_test.cpp",
         "service_discovery_client_offer_service_test.cpp",
+        "service_discovery_client_sequence_test.cpp",
         "service_discovery_client_start_find_service_test.cpp",
         "service_discovery_client_stop_find_service_test.cpp",
         "service_discovery_client_stop_offer_service_test.cpp",
         "service_discovery_client_worker_thread_test.cpp",
     ],
     features = COMPILER_WARNING_FEATURES,
-    # TODO: Ticket-253098
     target_compatible_with = select({
-        "@score_bazel_platforms//settings:x86_64-qnx": [
-            "@score_bazel_platforms//version:sdp_7.1.0",
-        ],
         "//conditions:default": [],
     }),
     visibility = [

--- a/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client_sequence_test.cpp
+++ b/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client_sequence_test.cpp
@@ -457,8 +457,6 @@ TEST_F(ServiceDiscoveryClientFixture, FilesystemIsNotRecrawledIfExactSameSearchA
     // Expecting per crawl and watch of the filesystem for a specific instance we expect one "new" watch, no more!
     EXPECT_CALL(inotify_instance_mock_, AddWatch(_, _)).Times(1);
 
-    WhichContainsAServiceDiscoveryClient();
-
     FindServiceHandle expected_handle_1{make_FindServiceHandle(1U)};
     FindServiceHandle expected_handle_2{make_FindServiceHandle(2U)};
 
@@ -572,9 +570,6 @@ TEST_F(ServiceDiscoveryClientFixture, FilesystemIsNotRecrawledIfAnySearchAlready
 
     // Given a ServiceDiscoveryClient with mocked inotify instance and an offered service instance
     WhichContainsAServiceDiscoveryClient().WithAnOfferedService(kConfigStoreQm1.GetInstanceIdentifier());
-
-    // and given
-    EXPECT_TRUE(service_discovery_client_->OfferService(kConfigStoreQm1.GetInstanceIdentifier()).has_value());
 
     // When starting the same service discovery for above offer twice recursively
     testing::MockFunction<void(std::vector<HandleType>, FindServiceHandle)> inner_handler{};

--- a/score/mw/com/impl/bindings/lola/test/proxy_component_test.cpp
+++ b/score/mw/com/impl/bindings/lola/test/proxy_component_test.cpp
@@ -272,9 +272,6 @@ class ProxyServiceDiscoveryFixture : public ProxyWithRealMemFixture
 // Test to check that race condition in Ticket-169333 does not occur.
 TEST_F(ProxyServiceDiscoveryFixture, CallingStartFindServiceInHandlerAndStartFindServiceInMainThreadDoesNotDeadLock)
 {
-#if defined(__QNX__) && __QNX__ >= 800 && defined(__x86_64__)
-    GTEST_SKIP() << "TODO: Ticket-253098 Inotify not supported on QNX 8 x86_64 filesystem";
-#else
     MockFunction<void(ServiceHandleContainer<HandleType>, FindServiceHandle)> find_service_handler_2{};
 
     // Given a real ServiceDiscovery and a configuration that contains no events
@@ -303,15 +300,11 @@ TEST_F(ProxyServiceDiscoveryFixture, CallingStartFindServiceInHandlerAndStartFin
 
     // Then we expect that both calls to StartFindService are called without a dead lock and both handlers are called
     handler_done_notifier_.waitWithAbort(stop_token_);
-#endif
 }
 
 // Test to check that race condition in Ticket-169333 does not occur.
 TEST_F(ProxyServiceDiscoveryFixture, CallingStartFindServiceInHandlerAndStopFindServiceInMainThreadDoesNotDeadLock)
 {
-#if defined(__QNX__) && __QNX__ >= 800 && defined(__x86_64__)
-    GTEST_SKIP() << "TODO: Ticket-253098 Inotify not supported on QNX 8 x86_64 filesystem";
-#else
     // Given a real ServiceDiscovery and a configuration that contains no events
     WithARealServiceDiscovery().WithAConfigurationContainingNoEvents();
     const InstanceIdentifier instance_identifier{config_store_->GetInstanceIdentifier()};
@@ -335,15 +328,11 @@ TEST_F(ProxyServiceDiscoveryFixture, CallingStartFindServiceInHandlerAndStopFind
     // Then we expect that both the call to StartFindService in the handler and the call to StopFindService are called
     // without a dead lock and that the handler are finishes
     handler_done_notifier_.waitWithAbort(stop_token_);
-#endif
 }
 
 // Test to check that race condition in Ticket-169333 does not occur.
 TEST_F(ProxyServiceDiscoveryFixture, CallingStopFindServiceInHandlerAndStartFindServiceInMainThreadDoesNotDeadLock)
 {
-#if defined(__QNX__) && __QNX__ >= 800 && defined(__x86_64__)
-    GTEST_SKIP() << "TODO: Ticket-253098 Inotify not supported on QNX 8 x86_64 filesystem";
-#else
     MockFunction<void(ServiceHandleContainer<HandleType>, FindServiceHandle)> find_service_handler_2{};
 
     // Given a real ServiceDiscovery and a configuration that contains no events
@@ -372,15 +361,11 @@ TEST_F(ProxyServiceDiscoveryFixture, CallingStopFindServiceInHandlerAndStartFind
 
     // Then we expect that both calls to StartFindService are called without a dead lock and both handlers are called
     handler_done_notifier_.waitWithAbort(stop_token_);
-#endif
 }
 
 // Test to check that race condition in Ticket-169333 does not occur.
 TEST_F(ProxyServiceDiscoveryFixture, CallingStopFindServiceInHandlerAndStopFindServiceInMainThreadDoesNotDeadLock)
 {
-#if defined(__QNX__) && __QNX__ >= 800 && defined(__x86_64__)
-    GTEST_SKIP() << "TODO: Ticket-253098 Inotify not supported on QNX 8 x86_64 filesystem";
-#else
     // Given a real ServiceDiscovery and a configuration that contains no events
     WithARealServiceDiscovery().WithAConfigurationContainingNoEvents();
     const InstanceIdentifier instance_identifier{config_store_->GetInstanceIdentifier()};
@@ -404,7 +389,6 @@ TEST_F(ProxyServiceDiscoveryFixture, CallingStopFindServiceInHandlerAndStopFindS
     // Then we expect that both the call to StartFindService in the handler and the call to StopFindService are called
     // without a dead lock and that the handler are finishes
     handler_done_notifier_.waitWithAbort(stop_token_);
-#endif
 }
 
 }  // namespace


### PR DESCRIPTION
- Add service_discovery_client_sequence_test to the BUILD file
- enable service_discovery_client_test to run on QNX 8