### PR TITLE
Make sure that the generated C++ toolchain is not used

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -18,6 +18,8 @@ common --http_connector_attempts=10
 common --http_connector_retry_max_timeout=1s
 common --http_timeout_scaling=2.0
 
+# Do not use automatically C++ generated toolchains
+build --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 
 common --@score_baselibs//score/json:base_library=nlohmann
 common --@score_baselibs//score/memory/shared/flags:use_typedshmd=False


### PR DESCRIPTION
For all our tests we want to make sure we use the hermetic toolchain. Disabling the automatically generated toolchain makes it easier to avoid accidental use of the toolchain from the host.