### PR TITLE
Remove dependency to score_logging

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -23,7 +23,6 @@ build --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
 
 common --@score_baselibs//score/json:base_library=nlohmann
 common --@score_baselibs//score/memory/shared/flags:use_typedshmd=False
-common --@score_logging//score/mw/log/flags:KRemote_Logging=False
 common --//score/mw/com/flags:tracing_library=@score_baselibs//score/analysis/tracing/generic_trace_library/stub_implementation
 common --extra_toolchains=@gcc_toolchain_x86_64//:cc_toolchain
 common --extra_toolchains=@score_toolchains_rust//toolchains/ferrocene:ferrocene_x86_64_unknown_linux_gnu

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -23,18 +23,15 @@ bazel_dep(name = "rules_cc", version = "0.1.5")
 bazel_dep(name = "rules_python", version = "1.5.1")
 bazel_dep(name = "rules_rust", version = "0.68.1-score")
 bazel_dep(name = "score_baselibs", version = "0.2.5")
+git_override(
+    module_name = "score_baselibs",
+    commit = "69bd8297dc5de97db3362d8ea1da634883e7c27a",
+    remote = "https://github.com/eclipse-score/baselibs.git",
+)
+
 bazel_dep(name = "score_baselibs_rust", version = "0.1.0")
 bazel_dep(name = "score_bazel_platforms", version = "0.1.2")
 bazel_dep(name = "score_crates", version = "0.0.9", repo_name = "score_communication_crate_index")
-bazel_dep(name = "score_logging", version = "0.1.0")
-
-# TODO: Remove once new logging release is available https://github.com/eclipse-score/logging/issues/80
-git_override(
-    module_name = "score_logging",
-    commit = "38e8762881d512c89ae5c2e5e5238fd791d327df",
-    remote = "https://github.com/eclipse-score/logging.git",
-)
-
 bazel_dep(name = "score_tooling", version = "1.1.2")
 
 # Dependencies required for development that will not get propagated to our users as transitive dependencies

--- a/examples/.bazelrc
+++ b/examples/.bazelrc
@@ -1,3 +1,8 @@
+# Do not use automatically C++ generated toolchains
+common --action_env=BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1
+common --platforms=@score_bazel_platforms//:x86_64-linux-gcc_12.2.0-posix
+common --extra_toolchains=@score_gcc_x86_64_toolchain//:x86_64-linux
+
 common --registry=https://raw.githubusercontent.com/eclipse-score/bazel_registry/refs/heads/main/
 common --registry=https://bcr.bazel.build
 

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -6,11 +6,8 @@ local_path_override(
 
 bazel_dep(name = "rules_cc", version = "0.1.5")
 bazel_dep(name = "score_baselibs", version = "0.2.5")
-bazel_dep(name = "score_logging", version = "0.1.0")
-
-# TODO: Remove once new logging release is available https://github.com/eclipse-score/logging/issues/80
 git_override(
-    module_name = "score_logging",
-    commit = "38e8762881d512c89ae5c2e5e5238fd791d327df",
-    remote = "https://github.com/eclipse-score/logging.git",
+    module_name = "score_baselibs",
+    commit = "69bd8297dc5de97db3362d8ea1da634883e7c27a",
+    remote = "https://github.com/eclipse-score/baselibs.git",
 )

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -11,3 +11,21 @@ git_override(
     commit = "69bd8297dc5de97db3362d8ea1da634883e7c27a",
     remote = "https://github.com/eclipse-score/baselibs.git",
 )
+
+# Only required to build the example, shall be replaceable with nearly every other C++ Toolchain setup
+bazel_dep(name = "score_bazel_platforms", version = "0.1.2", dev_dependency = True)
+bazel_dep(name = "score_bazel_cpp_toolchains", version = "0.3.0", dev_dependency = True)
+
+score_gcc = use_extension("@score_bazel_cpp_toolchains//extensions:gcc.bzl", "gcc", dev_dependency = True)
+score_gcc.toolchain(
+    name = "score_gcc_x86_64_toolchain",
+    target_cpu = "x86_64",
+    target_os = "linux",
+    use_base_constraints_only = True,
+    use_default_package = True,
+    version = "12.2.0",
+)
+use_repo(
+    score_gcc,
+    "score_gcc_x86_64_toolchain",
+)

--- a/score/mw/com/BUILD
+++ b/score/mw/com/BUILD
@@ -96,7 +96,7 @@ cc_library(
         "@score_baselibs//score/filesystem",
         "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/memory:string_literal",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -144,7 +144,7 @@ cc_gtest_unit_test(
         ":types",
         "//score/mw/com/impl:runtime_mock",
         "//score/mw/com/impl/test:runtime_mock_guard",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/mw/com/example/ipc_bridge/BUILD
+++ b/score/mw/com/example/ipc_bridge/BUILD
@@ -30,7 +30,7 @@ cc_binary(
         "//score/mw/com",
         "@boost.program_options",
         "@score_baselibs//score/language/futurecpp",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -46,7 +46,7 @@ cc_library(
     deps = [
         ":datatype",
         "//score/mw/com",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/mw/com/impl/BUILD
+++ b/score/mw/com/impl/BUILD
@@ -49,7 +49,7 @@ cc_library(
         ":error",
         "//score/mw/com/impl/plumbing",
         "@score_baselibs//score/language/futurecpp",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
     tags = ["FFI"],
     visibility = [
@@ -83,7 +83,7 @@ cc_library(
         ":proxy_base",
         ":proxy_event_base",
         "//score/mw/com/impl/tracing:proxy_event_tracing",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -107,8 +107,8 @@ cc_library(
         "//score/mw/com/impl/plumbing:event",
         "//score/mw/com/impl/tracing:proxy_event_tracing",
         "@score_baselibs//score/language/futurecpp",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/result",
-        "@score_logging//score/mw/log",
     ],
 )
 
@@ -208,8 +208,8 @@ cc_library(
         "//score/mw/com/impl/plumbing:event",
         "//score/mw/com/impl/plumbing:sample_allocatee_ptr",
         "//score/mw/com/impl/tracing:skeleton_event_tracing",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/result",
-        "@score_logging//score/mw/log",
     ],
 )
 
@@ -231,8 +231,8 @@ cc_library(
         "//score/mw/com/impl/plumbing:field",
         "//score/mw/com/impl/plumbing:sample_allocatee_ptr",
         "@score_baselibs//score/language/futurecpp",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/result",
-        "@score_logging//score/mw/log",
     ],
 )
 
@@ -328,8 +328,8 @@ cc_library(
         ":skeleton_event_base",
         "//score/mw/com/impl/methods:skeleton_method_base",
         "@score_baselibs//score/language/futurecpp",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/result",
-        "@score_logging//score/mw/log",
     ],
 )
 
@@ -364,7 +364,7 @@ cc_library(
     srcs = ["find_service_handle.cpp"],
     hdrs = ["find_service_handle.h"],
     features = COMPILER_WARNING_FEATURES,
-    implementation_deps = ["@score_logging//score/mw/log"],
+    implementation_deps = ["@score_baselibs//score/mw/log"],
     tags = ["FFI"],
     visibility = [
         "//score/mw/com:__pkg__",
@@ -650,8 +650,8 @@ cc_library(
     ],
     deps = [
         ":error",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/result",
-        "@score_logging//score/mw/log",
     ],
 )
 
@@ -680,7 +680,7 @@ cc_library(
     hdrs = ["service_element_type.h"],
     features = COMPILER_WARNING_FEATURES,
     implementation_deps = [
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
     tags = ["FFI"],
     visibility = [
@@ -880,8 +880,8 @@ cc_library(
         "@score_baselibs//score/concurrency:long_running_threads_container",
         "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/memory/shared:types",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/utils/meyer_singleton",
-        "@score_logging//score/mw/log",
     ],
 )
 
@@ -961,8 +961,8 @@ cc_test(
         ":runtime",
         "@googletest//:gtest_main",
         "@score_baselibs//score/language/safecpp/coverage_termination_handler",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/utils/meyer_singleton/test:single_test_per_process_fixture",
-        "@score_logging//score/mw/log",
     ],
 )
 
@@ -976,7 +976,7 @@ cc_gtest_unit_test(
         "//score/mw/com/impl/bindings/lola:runtime_mock",
         "//score/mw/com/impl/configuration/test:configuration_store",
         "@score_baselibs//score/language/futurecpp",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -1017,8 +1017,8 @@ cc_gtest_unit_test(
     srcs = ["service_element_type_test.cpp"],
     deps = [
         ":service_element_type",
-        "@score_logging//score/mw/log",
-        #"@score_logging//score/mw/log/test/fake_recorder_environment:auto_register_fake_recorder_env",
+        "@score_baselibs//score/mw/log",
+        #"@score_baselibs//score/mw/log/test/fake_recorder_environment:auto_register_fake_recorder_env",
     ],
 )
 
@@ -1043,7 +1043,7 @@ cc_unit_test(
         "@googletest//:gtest_main",
         "@score_baselibs//score/analysis/tracing/generic_trace_library/mock:trace_library_mock",
         "@score_baselibs//score/language/futurecpp:futurecpp_test_support",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -1052,8 +1052,8 @@ cc_gtest_unit_test(
     srcs = ["find_service_handle_test.cpp"],
     deps = [
         ":find_service_handle",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/mw/log:recorder_mock",
-        "@score_logging//score/mw/log",
     ],
 )
 

--- a/score/mw/com/impl/bindings/lola/BUILD
+++ b/score/mw/com/impl/bindings/lola/BUILD
@@ -31,7 +31,7 @@ cc_library(
         "//score/mw/com/impl/configuration",
         "@score_baselibs//score/concurrency",
         "@score_baselibs//score/language/futurecpp",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -134,7 +134,7 @@ cc_library(
         "@score_baselibs//score/concurrency:long_running_threads_container",
         "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/memory/shared",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -386,12 +386,12 @@ cc_library(
         "@score_baselibs//score/memory/shared:pointer_arithmetic_util",
         "@score_baselibs//score/memory/shared/flock:flock_mutex_and_lock",
         "@score_baselibs//score/memory/shared/flock:shared_flock_mutex",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/os:errno_logging",
         "@score_baselibs//score/os:fcntl",
         "@score_baselibs//score/os:glob",
         "@score_baselibs//score/os:unistd",
         "@score_baselibs//score/result",
-        "@score_logging//score/mw/log",
     ],
 )
 
@@ -408,7 +408,7 @@ cc_library(
     deps = [
         "//score/mw/com/impl:service_element_type",
         "//score/mw/com/impl/configuration",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -495,7 +495,7 @@ cc_library(
     srcs = ["application_id_pid_mapping.cpp"],
     hdrs = ["application_id_pid_mapping.h"],
     features = COMPILER_WARNING_FEATURES,
-    implementation_deps = ["@score_logging//score/mw/log"],
+    implementation_deps = ["@score_baselibs//score/mw/log"],
     tags = ["FFI"],
     visibility = ["//score/mw/com/impl/bindings/lola:__subpackages__"],
     deps = [
@@ -512,7 +512,7 @@ cc_library(
     srcs = ["application_id_pid_mapping_entry.cpp"],
     hdrs = ["application_id_pid_mapping_entry.h"],
     features = COMPILER_WARNING_FEATURES,
-    implementation_deps = ["@score_logging//score/mw/log"],
+    implementation_deps = ["@score_baselibs//score/mw/log"],
     tags = ["FFI"],
     visibility = ["//score/mw/com/impl/bindings/lola:__subpackages__"],
     deps = [],
@@ -606,7 +606,7 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     implementation_deps = [
         "@score_baselibs//score/language/safecpp/safe_math",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
     tags = ["FFI"],
     visibility = ["//score/mw/com/impl/bindings/lola:__subpackages__"],
@@ -703,7 +703,7 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     implementation_deps = [
         "//score/mw/com/impl:error",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
     tags = ["FFI"],
     visibility = ["//score/mw/com/impl/bindings/lola:__subpackages__"],
@@ -731,7 +731,7 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     implementation_deps = [
         "@score_baselibs//score/language/futurecpp",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
     tags = ["FFI"],
     visibility = ["//score/mw/com/impl/bindings/lola:__subpackages__"],
@@ -759,8 +759,8 @@ cc_library(
         "//score/mw/com/impl:runtime",
         "//score/mw/com/impl/bindings/lola:runtime",
         "@score_baselibs//score/language/futurecpp",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/result",
-        "@score_logging//score/mw/log",
     ],
 )
 
@@ -818,7 +818,7 @@ cc_library(
     ],
     deps = [
         "//score/mw/com/impl/configuration",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -833,7 +833,7 @@ cc_library(
     ],
     deps = [
         "//score/mw/com/impl/configuration",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -941,7 +941,7 @@ cc_unit_test(
         "@score_baselibs//score/language/safecpp/coverage_termination_handler",
         "@score_baselibs//score/memory/shared:polymorphic_offset_ptr_allocator",
         "@score_baselibs//score/memory/shared/fake:fake_memory_resources",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -1137,7 +1137,7 @@ cc_gtest_unit_test(
     features = COMPILER_WARNING_FEATURES,
     deps = [
         ":element_fq_id",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -1150,7 +1150,7 @@ cc_gtest_unit_test(
     deps = [
         ":event_data_storage",
         "@score_baselibs//score/containers:dynamic_array",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -1415,8 +1415,8 @@ cc_unit_test(
         "@googletest//:gtest_main",
         "@score_baselibs//score/language/futurecpp:futurecpp_test_support",
         "@score_baselibs//score/memory:data_type_size_info",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/result",
-        "@score_logging//score/mw/log",
     ],
 )
 

--- a/score/mw/com/impl/bindings/lola/messaging/BUILD
+++ b/score/mw/com/impl/bindings/lola/messaging/BUILD
@@ -45,7 +45,7 @@ cc_library(
     ],
     features = COMPILER_WARNING_FEATURES,
     implementation_deps = [
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
     tags = ["FFI"],
     visibility = ["//score/mw/com/impl/bindings/lola:__pkg__"],
@@ -218,8 +218,8 @@ cc_library(
     visibility = ["//score/mw/com/impl/bindings/lola:__pkg__"],
     deps = [
         "@score_baselibs//score/memory/shared:pointer_arithmetic_util",
+        "@score_baselibs//score/mw/log",
         "@score_communication//score/message_passing",
-        "@score_logging//score/mw/log",
     ],
 )
 
@@ -236,8 +236,8 @@ cc_library(
         ":message_passing_service",
         ":message_passing_service_instance_factory",
         "@score_baselibs//score/language/futurecpp",
+        "@score_baselibs//score/mw/log",
         "@score_communication//score/message_passing",
-        "@score_logging//score/mw/log",
     ],
 )
 

--- a/score/mw/com/impl/bindings/lola/methods/BUILD
+++ b/score/mw/com/impl/bindings/lola/methods/BUILD
@@ -28,7 +28,7 @@ cc_library(
     deps = [
         "//score/mw/com/impl/bindings/lola:proxy_instance_identifier",
         "//score/mw/com/impl/configuration",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -64,7 +64,7 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     implementation_deps = [
         "@score_baselibs//score/language/futurecpp",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
     tags = ["FFI"],
     visibility = ["//score/mw/com/impl/bindings/lola:__pkg__"],
@@ -138,7 +138,7 @@ cc_unit_test(
         "@score_baselibs//score/memory/shared:memory_resource_proxy",
         "@score_baselibs//score/memory/shared:pointer_arithmetic_util",
         "@score_baselibs//score/memory/shared/fake:fake_memory_resources",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/mw/com/impl/bindings/lola/tracing/BUILD
+++ b/score/mw/com/impl/bindings/lola/tracing/BUILD
@@ -36,7 +36,7 @@ cc_library(
         "@score_baselibs//score/language/safecpp/safe_math",
         "@score_baselibs//score/language/safecpp/scoped_function:move_only_scoped_function",
         "@score_baselibs//score/memory/shared:i_shared_memory_resource",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/mw/com/impl/configuration/BUILD
+++ b/score/mw/com/impl/configuration/BUILD
@@ -51,7 +51,8 @@ cc_library(
         ":quality_type",
         ":service_type_deployment",
         ":someip_service_instance_deployment",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
+        "@score_baselibs//score/quality/compiler_warnings",
     ],
     tags = ["FFI"],
     visibility = [
@@ -82,7 +83,7 @@ cc_library(
         "//score/mw/com/impl:instance_specifier",
         "//score/mw/com/impl/tracing/configuration:service_element_identifier",
         "//score/mw/com/impl/tracing/configuration:tracing_config",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -91,7 +92,7 @@ cc_library(
     srcs = ["global_configuration.cpp"],
     hdrs = ["global_configuration.h"],
     features = COMPILER_WARNING_FEATURES,
-    implementation_deps = ["@score_logging//score/mw/log"],
+    implementation_deps = ["@score_baselibs//score/mw/log"],
     tags = ["FFI"],
     visibility = [
         "//score/mw/com/impl/configuration:__subpackages__",
@@ -107,7 +108,7 @@ cc_library(
     srcs = ["tracing_configuration.cpp"],
     hdrs = ["tracing_configuration.h"],
     features = COMPILER_WARNING_FEATURES,
-    implementation_deps = ["@score_logging//score/mw/log"],
+    implementation_deps = ["@score_baselibs//score/mw/log"],
     tags = ["FFI"],
     visibility = [
         "//score/mw/com/impl/configuration:__subpackages__",
@@ -140,7 +141,7 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     implementation_deps = [
         ":configuration_common_resources",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
     tags = ["FFI"],
     visibility = ["//score/mw/com/impl:__subpackages__"],
@@ -404,7 +405,7 @@ cc_library(
     deps = [
         "@score_baselibs//score/json",
         "@score_baselibs//score/language/futurecpp",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/mw/com/impl/plumbing/BUILD
+++ b/score/mw/com/impl/plumbing/BUILD
@@ -333,7 +333,7 @@ cc_library(
         "//score/mw/com/impl/bindings/lola",
         "//score/mw/com/impl/bindings/lola:partial_restart_path_builder",
         "//score/mw/com/impl/bindings/lola:shm_path_builder",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
     tags = ["FFI"],
     deps = [
@@ -879,8 +879,8 @@ cc_test(
         "//score/mw/com/impl/test:runtime_mock_guard",
         "@googletest//:gtest_main",
         "@score_baselibs//score/language/safecpp/coverage_termination_handler",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/os/mocklib:fcntl_mock",
-        "@score_logging//score/mw/log",
     ],
 )
 

--- a/score/mw/com/impl/tracing/BUILD
+++ b/score/mw/com/impl/tracing/BUILD
@@ -164,7 +164,7 @@ cc_library(
         "//score/mw/com/impl:runtime",
         "//score/mw/com/impl/tracing/configuration:service_element_instance_identifier_view",
         "@score_baselibs//score/language/futurecpp",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -276,8 +276,8 @@ cc_gtest_unit_test(
         ":tracing_test_resources",
         "//score/mw/com/impl/bindings/mock_binding/tracing:tracing_runtime",
         "@score_baselibs//score/analysis/tracing/generic_trace_library/mock:trace_library_mock",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/mw/log:recorder_mock",
-        "@score_logging//score/mw/log",
     ],
 )
 

--- a/score/mw/com/impl/tracing/configuration/BUILD
+++ b/score/mw/com/impl/tracing/configuration/BUILD
@@ -64,7 +64,7 @@ cc_library(
     srcs = ["tracing_filter_config.cpp"],
     hdrs = ["tracing_filter_config.h"],
     features = COMPILER_WARNING_FEATURES,
-    implementation_deps = ["@score_logging//score/mw/log"],
+    implementation_deps = ["@score_baselibs//score/mw/log"],
     tags = ["FFI"],
     visibility = ["//score/mw/com/impl:__subpackages__"],
     deps = [
@@ -83,7 +83,7 @@ cc_library(
     srcs = ["tracing_filter_config_mock.cpp"],
     hdrs = ["tracing_filter_config_mock.h"],
     features = COMPILER_WARNING_FEATURES,
-    implementation_deps = ["@score_logging//score/mw/log"],
+    implementation_deps = ["@score_baselibs//score/mw/log"],
     visibility = ["//score/mw/com/impl:__subpackages__"],
     deps = [
         ":i_tracing_filter_config",
@@ -96,7 +96,7 @@ cc_library(
     srcs = ["tracing_config.cpp"],
     hdrs = ["tracing_config.h"],
     features = COMPILER_WARNING_FEATURES,
-    implementation_deps = ["@score_logging//score/mw/log"],
+    implementation_deps = ["@score_baselibs//score/mw/log"],
     tags = ["FFI"],
     visibility = [
         "//score/mw/com/impl/configuration:__pkg__",
@@ -113,7 +113,7 @@ cc_library(
     deps = [
         ":hash_helper_utility",
         "@score_baselibs//score/language/futurecpp",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -128,7 +128,7 @@ cc_library(
         ":hash_helper_for_service_element_and_se_view",
         "//score/mw/com/impl:service_element_type",
         "@score_baselibs//score/language/futurecpp",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -143,7 +143,7 @@ cc_library(
         ":hash_helper_for_service_element_and_se_view",
         "//score/mw/com/impl:service_element_type",
         "@score_baselibs//score/language/futurecpp",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -153,7 +153,7 @@ cc_library(
     hdrs = ["service_element_instance_identifier_view.h"],
     features = COMPILER_WARNING_FEATURES,
     implementation_deps = [
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
     tags = ["FFI"],
     visibility = ["//score/mw/com/impl:__subpackages__"],
@@ -176,7 +176,7 @@ cc_library(
     deps = [
         ":hash_helper_utility",
         ":service_element_identifier_view",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -222,7 +222,7 @@ cc_library(
     hdrs = ["tracing_filter_config_parser.h"],
     features = COMPILER_WARNING_FEATURES,
     implementation_deps = [
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
     tags = ["FFI"],
     visibility = ["//score/mw/com/impl:__subpackages__"],

--- a/score/mw/com/impl/util/BUILD
+++ b/score/mw/com/impl/util/BUILD
@@ -76,7 +76,7 @@ cc_gtest_unit_test(
     features = COMPILER_WARNING_FEATURES,
     deps = [
         ":type_erased_storage",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/mw/com/performance_benchmarks/api_microbenchmarks/BUILD
+++ b/score/mw/com/performance_benchmarks/api_microbenchmarks/BUILD
@@ -41,7 +41,7 @@ cc_binary(
         "//score/mw/com",
         "@google_benchmark//:benchmark_main",
         "@score_baselibs//score/language/futurecpp",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -60,7 +60,7 @@ cc_binary(
         "//score/mw/com",
         "@google_benchmark//:benchmark_main",
         "@score_baselibs//score/language/futurecpp",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -81,6 +81,6 @@ cc_binary(
         "//score/mw/com",
         "@google_benchmark//:benchmark_main",
         "@score_baselibs//score/language/futurecpp",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )

--- a/score/mw/com/performance_benchmarks/macro_benchmark/BUILD
+++ b/score/mw/com/performance_benchmarks/macro_benchmark/BUILD
@@ -69,7 +69,7 @@ cc_library(
         "//score/mw/com/performance_benchmarks/common_test_resources:stop_token_sig_term_handler",
         "@boost.program_options",
         "@score_baselibs//score/language/futurecpp",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -84,7 +84,7 @@ cc_library(
     deps = [
         ":common_resources",
         "@score_baselibs//score/json",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -102,7 +102,7 @@ cc_library(
         "//score/mw/com",
         "//score/mw/com/performance_benchmarks/common_test_resources:shared_memory_object_creator",
         "//score/mw/com/performance_benchmarks/common_test_resources:stop_token_sig_term_handler",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -143,7 +143,7 @@ cc_binary(
         "//score/mw/com",
         "//score/mw/com/performance_benchmarks/common_test_resources:shared_memory_object_creator",
         "//score/mw/com/performance_benchmarks/common_test_resources:shared_memory_object_guard",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -176,7 +176,7 @@ cc_binary(
         "//score/mw/com",
         "//score/mw/com/performance_benchmarks/common_test_resources:shared_memory_object_creator",
         "//score/mw/com/performance_benchmarks/common_test_resources:shared_memory_object_guard",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/mw/com/test/api/BUILD
+++ b/score/mw/com/test/api/BUILD
@@ -32,7 +32,7 @@ cc_gtest_unit_test(
     features = COMPILER_WARNING_FEATURES,
     deps = [
         ":api",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/mw/com/test/common_test_resources/BUILD
+++ b/score/mw/com/test/common_test_resources/BUILD
@@ -46,8 +46,8 @@ cc_library(
     deps = [
         ":bigdata_type",
         "//score/mw/com",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/os/utils/interprocess:interprocess_notification",
-        "@score_logging//score/mw/log",
     ],
 )
 
@@ -125,7 +125,7 @@ cc_library(
     ],
     deps = [
         "@score_baselibs//score/language/futurecpp",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/mw/com/test/field_initial_value/BUILD
+++ b/score/mw/com/test/field_initial_value/BUILD
@@ -45,7 +45,7 @@ cc_binary(
         ":test_datatype",
         "//score/mw/com",
         "//score/mw/com/test/common_test_resources:sctf_test_runner",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -61,7 +61,7 @@ cc_binary(
         ":test_datatype",
         "//score/mw/com",
         "//score/mw/com/test/common_test_resources:sctf_test_runner",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/mw/com/test/find_any_semantics/BUILD
+++ b/score/mw/com/test/find_any_semantics/BUILD
@@ -50,8 +50,8 @@ cc_binary(
         ":test_datatype",
         "//score/mw/com",
         "//score/mw/com/test/common_test_resources:sctf_test_runner",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/result",
-        "@score_logging//score/mw/log",
     ],
 )
 
@@ -67,7 +67,7 @@ cc_binary(
         ":test_datatype",
         "//score/mw/com",
         "//score/mw/com/test/common_test_resources:sctf_test_runner",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/mw/com/test/flock/BUILD
+++ b/score/mw/com/test/flock/BUILD
@@ -26,8 +26,8 @@ cc_binary(
         "@score_baselibs//score/filesystem",
         "@score_baselibs//score/memory/shared/flock:exclusive_flock_mutex",
         "@score_baselibs//score/memory/shared/flock:shared_flock_mutex",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/os:fcntl",
-        "@score_logging//score/mw/log",
     ],
 )
 

--- a/score/mw/com/test/methods/methods_test_resources/BUILD
+++ b/score/mw/com/test/methods/methods_test_resources/BUILD
@@ -38,8 +38,8 @@ cc_library(
         "//score/mw/com",
         "//score/mw/com/test/common_test_resources:assert_handler",
         "//score/mw/com/test/common_test_resources:sctf_test_runner",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/result",
-        "@score_logging//score/mw/log",
     ],
 )
 
@@ -57,7 +57,7 @@ cc_library(
         "//score/mw/com/test/common_test_resources:assert_handler",
         "//score/mw/com/test/common_test_resources:sctf_test_runner",
         "//score/mw/com/test/methods/methods_test_resources:proxy_container",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -72,8 +72,8 @@ cc_library(
     deps = [
         "//score/mw/com/test/common_test_resources:shared_memory_object_creator",
         "//score/mw/com/test/common_test_resources:shared_memory_object_guard",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/os/utils/interprocess:interprocess_notification",
         "@score_baselibs//score/result",
-        "@score_logging//score/mw/log",
     ],
 )

--- a/score/mw/com/test/partial_restart/consumer_restart/BUILD
+++ b/score/mw/com/test/partial_restart/consumer_restart/BUILD
@@ -38,7 +38,7 @@ cc_binary(
         "//score/mw/com/test/common_test_resources:test_resources",
         "@boost.program_options",
         "@score_baselibs//score/language/futurecpp",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/mw/com/test/partial_restart/provider_restart/BUILD
+++ b/score/mw/com/test/partial_restart/provider_restart/BUILD
@@ -37,7 +37,7 @@ cc_binary(
         "//score/mw/com/test/common_test_resources:test_resources",
         "@boost.program_options",
         "@score_baselibs//score/language/futurecpp",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/mw/com/test/partial_restart/provider_restart_max_subscribers/BUILD
+++ b/score/mw/com/test/partial_restart/provider_restart_max_subscribers/BUILD
@@ -38,7 +38,7 @@ cc_binary(
         "//score/mw/com/test/common_test_resources:test_resources",
         "@boost.program_options",
         "@score_baselibs//score/language/futurecpp",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/mw/com/test/separate_reception_threads/BUILD
+++ b/score/mw/com/test/separate_reception_threads/BUILD
@@ -32,7 +32,7 @@ cc_binary(
         "@boost.program_options",
         "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/language/safecpp/scoped_function:move_only_scoped_function",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/mw/com/test/service_discovery_during_consumer_crash/BUILD
+++ b/score/mw/com/test/service_discovery_during_consumer_crash/BUILD
@@ -49,7 +49,7 @@ cc_binary(
         "//score/mw/com/test/common_test_resources:test_resources",
         "@boost.program_options",
         "@score_baselibs//score/language/futurecpp",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/mw/com/test/service_discovery_during_provider_crash/BUILD
+++ b/score/mw/com/test/service_discovery_during_provider_crash/BUILD
@@ -49,7 +49,7 @@ cc_binary(
         "//score/mw/com/test/common_test_resources:test_resources",
         "@boost.program_options",
         "@score_baselibs//score/language/futurecpp",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/mw/com/test/service_discovery_offer_and_search/BUILD
+++ b/score/mw/com/test/service_discovery_offer_and_search/BUILD
@@ -54,8 +54,8 @@ cc_binary(
         "//score/mw/com/test/common_test_resources:common_service",
         "//score/mw/com/test/common_test_resources:sctf_test_runner",
         "//score/mw/com/test/common_test_resources:sync_utils",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/result",
-        "@score_logging//score/mw/log",
     ],
 )
 
@@ -73,7 +73,7 @@ cc_binary(
         "//score/mw/com/test/common_test_resources:proxy_observer",
         "//score/mw/com/test/common_test_resources:sctf_test_runner",
         "//score/mw/com/test/common_test_resources:sync_utils",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/mw/com/test/service_discovery_search_and_offer/BUILD
+++ b/score/mw/com/test/service_discovery_search_and_offer/BUILD
@@ -47,7 +47,7 @@ cc_binary(
         "//score/mw/com/test/common_test_resources:common_service",
         "//score/mw/com/test/common_test_resources:sctf_test_runner",
         "//score/mw/com/test/common_test_resources:sync_utils",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 
@@ -64,7 +64,7 @@ cc_binary(
         "//score/mw/com/test/common_test_resources:proxy_observer",
         "//score/mw/com/test/common_test_resources:sctf_test_runner",
         "//score/mw/com/test/common_test_resources:sync_utils",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/mw/com/test/smokeyeyes/BUILD
+++ b/score/mw/com/test/smokeyeyes/BUILD
@@ -28,7 +28,7 @@ cc_binary(
         "//score/mw/com",
         "@boost.interprocess",
         "@boost.program_options",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/mw/com/test/subscribe_handler/BUILD
+++ b/score/mw/com/test/subscribe_handler/BUILD
@@ -28,7 +28,7 @@ cc_binary(
         "//score/mw/com/test/common_test_resources:sample_sender_receiver",
         "//score/mw/com/test/common_test_resources:sctf_test_runner",
         "//score/mw/com/test/common_test_resources:shared_memory_object_guard",
-        "@score_logging//score/mw/log",
+        "@score_baselibs//score/mw/log",
     ],
 )
 


### PR DESCRIPTION
In order to avoid cyclic dependencies, we remove this dependencies, as it is also no longer needed.