### PR TITLE
Use auto for GetAsStringView result

### DIFF
--- a/score/mw/com/impl/configuration/binding_service_type_deployment_impl.h
+++ b/score/mw/com/impl/configuration/binding_service_type_deployment_impl.h
@@ -74,7 +74,7 @@ auto ConvertJsonToServiceElementIdMap(const json::Object& json_object, const std
     std::unordered_map<std::string, ServiceElementIdType> service_element_map{};
     for (auto& it : service_element_json)
     {
-        const score::cpp::string_view event_name_view{it.first.GetAsStringView()};
+        const auto event_name_view{it.first.GetAsStringView()};
         const std::string event_name{event_name_view.data(), event_name_view.size()};
         auto event_instance_deployment_json = it.second.As<ServiceElementIdType>().value();
         const auto insert_result =

--- a/score/mw/com/impl/configuration/configuration_common_resources.h
+++ b/score/mw/com/impl/configuration/configuration_common_resources.h
@@ -202,7 +202,7 @@ auto ConvertJsonToServiceElementMap(const json::Object& json_object, std::string
     ServiceElementInstanceMapping service_element_map{};
     for (auto& it : service_element_json)
     {
-        const score::cpp::string_view event_name_view{it.first.GetAsStringView()};
+        const auto event_name_view{it.first.GetAsStringView()};
         const std::string event_name{event_name_view.data(), event_name_view.size()};
         auto event_instance_deployment_json = it.second.As<score::json::Object>().value();
         const auto insert_result =


### PR DESCRIPTION
This would allow the change of the return type of GetAsStringView from custom string view to std::string_view and be source code compatible.