### PR TITLE
Suya add get and set and notification support to the fields in the configuration

### DIFF
--- a/score/mw/com/design/configuration/structural_view.puml
+++ b/score/mw/com/design/configuration/structural_view.puml
@@ -68,13 +68,8 @@ package "configuration" {
     - number_of_sample_slots_ : std::optional<SampleSlotCountType>
     - number_of_tracing_slots_ : TracingSlotSizeType
     __
-    + LolaFieldInstanceDeployment(number_of_sample_slots : std::optional<SampleSlotCountType>, max_subscribers : std::optional<SubscriberCountType>, max_concurrent_allocations : std::optional<std::uint8_t>, enforce_max_samples : bool, number_of_tracing_slots : TracingSlotSizeType, use_get_if_available : bool, use_set_if_available : bool) noexcept
     {static} + CreateFromJson(json_object : const score::json::Object&) : LolaFieldInstanceDeployment
     + Serialize() const : score::json::Object
-    + SetNumberOfSampleSlots(number_of_sample_slots : SampleSlotCountType) noexcept : void
-    + GetNumberOfSampleSlots() const noexcept : std::optional<SampleSlotCountType>
-    + GetNumberOfSampleSlotsExcludingTracingSlot() const noexcept : std::optional<SampleSlotCountType>
-    + GetNumberOfTracingSlots() const noexcept : TracingSlotSizeType
     --
     <u>Type Aliases:</u>
     using SampleSlotCountType as std::uint16_t

--- a/score/mw/com/design/configuration/structural_view.puml
+++ b/score/mw/com/design/configuration/structural_view.puml
@@ -59,11 +59,27 @@ package "configuration" {
   }
 
   class "score::mw::com::impl::LolaFieldInstanceDeployment" {
-    + max_samples_: std::uint16_t
-    + max_subscribers_: std::uint8_t
-    + enforce_max_samples_ : score::cpp::optional<bool>
-    + is_set_configured: bool
-    + is_get_configured: bool
+    {static} + constexpr serializationVersion : std::uint32_t
+    + max_subscribers_ : std::optional<SubscriberCountType>
+    + max_concurrent_allocations_ : std::optional<std::uint8_t>
+    + enforce_max_samples_ : bool
+    + use_get_if_available_ : bool
+    + use_set_if_available_ : bool
+    - number_of_sample_slots_ : std::optional<SampleSlotCountType>
+    - number_of_tracing_slots_ : TracingSlotSizeType
+    __
+    + LolaFieldInstanceDeployment(number_of_sample_slots : std::optional<SampleSlotCountType>, max_subscribers : std::optional<SubscriberCountType>, max_concurrent_allocations : std::optional<std::uint8_t>, enforce_max_samples : bool, number_of_tracing_slots : TracingSlotSizeType, use_get_if_available : bool, use_set_if_available : bool) noexcept
+    {static} + CreateFromJson(json_object : const score::json::Object&) : LolaFieldInstanceDeployment
+    + Serialize() const : score::json::Object
+    + SetNumberOfSampleSlots(number_of_sample_slots : SampleSlotCountType) noexcept : void
+    + GetNumberOfSampleSlots() const noexcept : std::optional<SampleSlotCountType>
+    + GetNumberOfSampleSlotsExcludingTracingSlot() const noexcept : std::optional<SampleSlotCountType>
+    + GetNumberOfTracingSlots() const noexcept : TracingSlotSizeType
+    --
+    <u>Type Aliases:</u>
+    using SampleSlotCountType as std::uint16_t
+    using SubscriberCountType as std::uint8_t
+    using TracingSlotSizeType as std::uint8_t
   }
 
   class "score::mw::com::impl::LolaMethodInstanceDeployment" {

--- a/score/mw/com/impl/bindings/lola/skeleton_test.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_test.cpp
@@ -1143,9 +1143,9 @@ TEST_P(SkeletonRegisterParamaterisedFixture, ValidEventMetaInfoExistAfterEventIs
         fields_.emplace(test::kDumbEventName, dumb_event);
 
         lola_field_inst_depls.push_back(
-            {test::kFooEventName, LolaFieldInstanceDeployment{number_of_slots, 10U, 1U, true, 0}});
+            {test::kFooEventName, LolaFieldInstanceDeployment{number_of_slots, 10U, 1U, true, 0, false, false}});
         lola_field_inst_depls.push_back(
-            {test::kDumbEventName, LolaFieldInstanceDeployment{number_of_slots, 10U, 1U, true, 0}});
+            {test::kDumbEventName, LolaFieldInstanceDeployment{number_of_slots, 10U, 1U, true, 0, false, false}});
     }
     ServiceInstanceDeployment service_instance_deployment{
         test::kFooService,

--- a/score/mw/com/impl/bindings/lola/test/proxy_component_test.cpp
+++ b/score/mw/com/impl/bindings/lola/test/proxy_component_test.cpp
@@ -111,7 +111,7 @@ class ProxyWithRealMemFixture : public ::testing::Test
         LolaServiceInstanceDeployment lola_service_instance_deployment{
             LolaServiceInstanceId{kElementFqId.instance_id_},
             {{kEventName, LolaEventInstanceDeployment{10U, 10U, 2U, true, 0}},
-             {kNonProvidedEventName, LolaFieldInstanceDeployment{10U, 10U, 2U, true, 0}}}};
+             {kNonProvidedEventName, LolaEventInstanceDeployment{10U, 10U, 2U, true, 0}}}};
         LolaServiceTypeDeployment lola_service_type_deployment{
             kElementFqId.service_id_,
             {{kEventName, LolaEventId{kElementFqId.element_id_}},

--- a/score/mw/com/impl/bindings/lola/test/skeleton_component_test.cpp
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_component_test.cpp
@@ -186,7 +186,7 @@ class SkeletonComponentTestFixture : public ::testing::Test
             {test::kFooEventName, LolaEventInstanceDeployment{kNumberOfSlots, 10U, 1U, true, 0}});
         fields_.emplace(test::kFooFieldName, mock_field_binding_);
         lola_field_instance_deployments_.push_back(
-            {test::kFooFieldName, LolaEventInstanceDeployment{kNumberOfSlots, 10U, 1U, true, 0}});
+            {test::kFooFieldName, LolaFieldInstanceDeployment{kNumberOfSlots, 10U, 1U, true, 0, false, false}});
         service_instance_deployment_ = std::make_unique<ServiceInstanceDeployment>(
             test::kFooService,
             CreateLolaServiceInstanceDeployment(test::kDefaultLolaInstanceId,

--- a/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h
@@ -251,7 +251,7 @@ static const ServiceInstanceDeployment kValidInstanceDeploymentWithField{
     CreateLolaServiceInstanceDeployment(
         kDefaultLolaInstanceId,
         {},
-        {{test::kFooEventName, LolaFieldInstanceDeployment{test::kMaxSlots, 10U, 1U, true, 0}}},
+        {{test::kFooEventName, LolaFieldInstanceDeployment{test::kMaxSlots, 10U, 1U, true, 0, false, false}}},
         {},
         {},
         {},
@@ -296,7 +296,7 @@ static const ServiceInstanceDeployment kValidAsilInstanceDeploymentWithField{
     CreateLolaServiceInstanceDeployment(
         kDefaultLolaInstanceId,
         {},
-        {{test::kFooEventName, LolaFieldInstanceDeployment{test::kMaxSlots, 10U, 1U, true, 0}}},
+        {{test::kFooEventName, LolaFieldInstanceDeployment{test::kMaxSlots, 10U, 1U, true, 0, false, false}}},
         {},
         {},
         {},

--- a/score/mw/com/impl/configuration/BUILD
+++ b/score/mw/com/impl/configuration/BUILD
@@ -202,8 +202,8 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     deps = [
-        ":lola_event_instance_deployment",
         ":configuration_common_resources",
+        ":lola_event_instance_deployment",
     ],
 )
 

--- a/score/mw/com/impl/configuration/BUILD
+++ b/score/mw/com/impl/configuration/BUILD
@@ -201,7 +201,10 @@ cc_library(
     hdrs = ["lola_field_instance_deployment.h"],
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
-    deps = [":lola_event_instance_deployment"],
+    deps = [
+        ":lola_event_instance_deployment",
+        ":configuration_common_resources",
+    ],
 )
 
 cc_library(

--- a/score/mw/com/impl/configuration/README.md
+++ b/score/mw/com/impl/configuration/README.md
@@ -349,7 +349,7 @@ Within the `service-instance` json object, there are further binding independent
 - `events`
 - `fields`
 
-the `event` and `field` json objects, which are the items in the corresponding arrays are property-wise identical.
+the event and field json objects share most configuration properties, but fields have two additional optional properties (useGetIfAvailable, useSetIfAvailable) not present on events.
 Additionally, there is the following constraint:
 For each event or field enlisted in the `events` and `fields` arrays on the [service-type->bindings](#bindings) level of
 the `service-type` a `service-instance` is based on, a corresponding instance specific event or field object has to exist.
@@ -428,6 +428,12 @@ The properties of a field or an event object on the instance level are:
   tracing are different and the tracing subsystem has to explicitly know, how many slots/samples it is allowed to access
   in parallel at most. Furthermore, setting the value of `numberOfIpcTracingSlots` to 0 or not configuring it all,
   explicitly means, that tracing for this event or field is disabled.
+- `useGetIfAvailable`: (optional, field only, default `false`) - When `true`, the getter for this field will be
+  used if the service type declares a getter. This is a consumer/proxy side configuration hint. On the provider
+  (skeleton) side this setting has no effect.
+- `useSetIfAvailable`: (optional, field only, default `false`) - When `true`, the setter for this field will be
+  used if the service type declares a setter. This is a consumer/proxy side configuration hint. On the provider
+  (skeleton) side this setting has no effect.
 
 ###### methods within an instance
 
@@ -593,3 +599,5 @@ is being used, whether a property is mandatory or optional or irrelevant, the fo
 | _serviceInstances.instances.events.maxSubscribers_ <br> _serviceInstances.instances.fields.maxSubscribers_                   | required      | -          |                                                                                                                                                                                       |
 | _serviceInstances.instances.events.enforceMaxSamples_ <br> _serviceInstances.instances.fields.enforceMaxSamples_             | optional      | -          | if not given on skeleton side, defaults to true                                                                                                                                       |
 | _serviceInstances.instances.events.numberOfIpcTracingSlots_ <br> _serviceInstances.instances.fields.numberOfIpcTracingSlots_ | optional      | -          | if not given on skeleton side, defaults to 0, which means tracing for this event is disabled.                                                                                         |
+| _serviceInstances.instances.fields.useGetIfAvailable_                                                                        | -             | optional   | if not given, defaults to false. Signals that the field getter should be used when the service type declares one.                                                                      |
+| _serviceInstances.instances.fields.useSetIfAvailable_                                                                        | -             | optional   | if not given, defaults to false. Signals that the field setter should be used when the service type declares one.                                                                      |

--- a/score/mw/com/impl/configuration/config_parser.cpp
+++ b/score/mw/com/impl/configuration/config_parser.cpp
@@ -79,6 +79,8 @@ constexpr auto kFieldEnforceMaxSamplesKey = "enforceMaxSamples"sv;
 constexpr auto kFieldMaxConcurrentAllocationsKey = "maxConcurrentAllocations"sv;
 constexpr auto kFieldUseGetIfAvailableKey = "useGetIfAvailable"sv;
 constexpr auto kFieldUseSetIfAvailableKey = "useSetIfAvailable"sv;
+constexpr auto kFieldUseGetIfAvailableDefault = false;
+constexpr auto kFieldUseSetIfAvailableDefault = false;
 constexpr auto kLolaShmSizeKey = "shm-size"sv;
 constexpr auto kLolaControlAsilBShmSizeKey = "control-asil-b-shm-size"sv;
 constexpr auto kLolaControlQmShmSizeKey = "control-qm-shm-size"sv;
@@ -488,10 +490,10 @@ auto ParseLolaFieldInstanceDeployment(const score::json::Object& json_map, LolaS
         const auto number_of_tracing_slots =
             deployment_parser.RetrieveJsonElement<NumberOfIpcTracingSlots_t>(kNumberOfIpcTracingSlotsKey)
                 .value_or(kNumberOfIpcTracingSlotsDefault);
-        const auto use_get_if_available =
-            deployment_parser.RetrieveJsonElement<bool>(kFieldUseGetIfAvailableKey).value_or(false);
-        const auto use_set_if_available =
-            deployment_parser.RetrieveJsonElement<bool>(kFieldUseSetIfAvailableKey).value_or(false);
+        const auto use_get_if_available = deployment_parser.RetrieveJsonElement<bool>(kFieldUseGetIfAvailableKey)
+                                              .value_or(kFieldUseGetIfAvailableDefault);
+        const auto use_set_if_available = deployment_parser.RetrieveJsonElement<bool>(kFieldUseSetIfAvailableKey)
+                                              .value_or(kFieldUseSetIfAvailableDefault);
 
         auto field_deployment = LolaFieldInstanceDeployment(number_of_sample_slots,
                                                             max_subscribers,

--- a/score/mw/com/impl/configuration/config_parser.cpp
+++ b/score/mw/com/impl/configuration/config_parser.cpp
@@ -77,6 +77,8 @@ constexpr auto kFieldNumberOfSampleSlotsKey = "numberOfSampleSlots"sv;
 constexpr auto kFieldMaxSubscribersKey = "maxSubscribers"sv;
 constexpr auto kFieldEnforceMaxSamplesKey = "enforceMaxSamples"sv;
 constexpr auto kFieldMaxConcurrentAllocationsKey = "maxConcurrentAllocations"sv;
+constexpr auto kFieldUseGetIfAvailableKey = "useGetIfAvailable"sv;
+constexpr auto kFieldUseSetIfAvailableKey = "useSetIfAvailable"sv;
 constexpr auto kLolaShmSizeKey = "shm-size"sv;
 constexpr auto kLolaControlAsilBShmSizeKey = "control-asil-b-shm-size"sv;
 constexpr auto kLolaControlQmShmSizeKey = "control-qm-shm-size"sv;
@@ -486,12 +488,18 @@ auto ParseLolaFieldInstanceDeployment(const score::json::Object& json_map, LolaS
         const auto number_of_tracing_slots =
             deployment_parser.RetrieveJsonElement<NumberOfIpcTracingSlots_t>(kNumberOfIpcTracingSlotsKey)
                 .value_or(kNumberOfIpcTracingSlotsDefault);
+        const auto use_get_if_available =
+            deployment_parser.RetrieveJsonElement<bool>(kFieldUseGetIfAvailableKey).value_or(false);
+        const auto use_set_if_available =
+            deployment_parser.RetrieveJsonElement<bool>(kFieldUseSetIfAvailableKey).value_or(false);
 
         auto field_deployment = LolaFieldInstanceDeployment(number_of_sample_slots,
                                                             max_subscribers,
                                                             kMaxConcurrentAllocationsDefault,
                                                             enforce_max_samples,
-                                                            number_of_tracing_slots);
+                                                            number_of_tracing_slots,
+                                                            use_get_if_available,
+                                                            use_set_if_available);
         const auto emplace_result = service.fields_.emplace(std::piecewise_construct,
                                                             std::forward_as_tuple(std::move(field_name_value)),
                                                             std::forward_as_tuple(field_deployment));

--- a/score/mw/com/impl/configuration/config_parser_test.cpp
+++ b/score/mw/com/impl/configuration/config_parser_test.cpp
@@ -2103,6 +2103,262 @@ TEST(ConfigParser, LolaFieldOptionalEnforceMaxSamples)
     EXPECT_EQ(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").enforce_max_samples_, false);
 }
 
+TEST(ConfigParser, LolaFieldUseGetIfAvailableSetToTrue)
+{
+    // Given a JSON with optional attribute `useGetIfAvailable` set to true for a field
+    auto j2 = R"(
+  {
+    "serviceTypes": [
+        {
+          "serviceTypeName": "/score/ncar/services/TirePressureService",
+          "version": {
+              "major": 12,
+              "minor": 34
+          },
+          "bindings": [
+              {
+                  "binding": "SHM",
+                  "serviceId": 1234,
+                  "fields": [
+                      {
+                          "fieldName": "CurrentTemperatureFrontLeft",
+                          "fieldId": 20
+                      }
+                  ]
+              }
+          ]
+        }
+    ],
+    "serviceInstances": [
+        {
+            "instanceSpecifier": "abc/abc/TirePressurePort",
+            "serviceTypeName": "/score/ncar/services/TirePressureService",
+            "version": {
+                "major": 12,
+                "minor": 34
+            },
+            "instances": [
+                {
+                  "instanceId": 1234,
+                  "asil-level": "QM",
+                  "binding": "SHM",
+                  "events": [],
+                  "fields": [
+                    {
+                          "fieldName": "CurrentTemperatureFrontLeft",
+                          "numberOfSampleSlots": 50,
+                          "maxSubscribers": 5,
+                          "useGetIfAvailable": true
+                      }
+                  ]
+                }
+            ]
+        }
+    ]
+  }
+)"_json;
+    const auto config = score::mw::com::impl::configuration::Parse(std::move(j2));
+
+    const auto deployment =
+        config.GetServiceInstances().at(InstanceSpecifier::Create(std::string{"abc/abc/TirePressurePort"}).value());
+
+    const auto deploymentInfo = std::get<LolaServiceInstanceDeployment>(deployment.bindingInfo_);
+    EXPECT_TRUE(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_get_if_available_);
+    EXPECT_FALSE(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_set_if_available_);
+}
+
+TEST(ConfigParser, LolaFieldUseSetIfAvailableSetToTrue)
+{
+    // Given a JSON with optional attribute `useSetIfAvailable` set to true for a field
+    auto j2 = R"(
+  {
+    "serviceTypes": [
+        {
+          "serviceTypeName": "/score/ncar/services/TirePressureService",
+          "version": {
+              "major": 12,
+              "minor": 34
+          },
+          "bindings": [
+              {
+                  "binding": "SHM",
+                  "serviceId": 1234,
+                  "fields": [
+                      {
+                          "fieldName": "CurrentTemperatureFrontLeft",
+                          "fieldId": 20
+                      }
+                  ]
+              }
+          ]
+        }
+    ],
+    "serviceInstances": [
+        {
+            "instanceSpecifier": "abc/abc/TirePressurePort",
+            "serviceTypeName": "/score/ncar/services/TirePressureService",
+            "version": {
+                "major": 12,
+                "minor": 34
+            },
+            "instances": [
+                {
+                  "instanceId": 1234,
+                  "asil-level": "QM",
+                  "binding": "SHM",
+                  "events": [],
+                  "fields": [
+                    {
+                          "fieldName": "CurrentTemperatureFrontLeft",
+                          "numberOfSampleSlots": 50,
+                          "maxSubscribers": 5,
+                          "useSetIfAvailable": true
+                      }
+                  ]
+                }
+            ]
+        }
+    ]
+  }
+)"_json;
+    const auto config = score::mw::com::impl::configuration::Parse(std::move(j2));
+
+    const auto deployment =
+        config.GetServiceInstances().at(InstanceSpecifier::Create(std::string{"abc/abc/TirePressurePort"}).value());
+
+    const auto deploymentInfo = std::get<LolaServiceInstanceDeployment>(deployment.bindingInfo_);
+    EXPECT_FALSE(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_get_if_available_);
+    EXPECT_TRUE(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_set_if_available_);
+}
+
+TEST(ConfigParser, LolaFieldOmittingBothFlagsDefaultsBothToFalse)
+{
+    // Given a JSON for a field without `useGetIfAvailable` or `useSetIfAvailable`
+    auto j2 = R"(
+  {
+    "serviceTypes": [
+        {
+          "serviceTypeName": "/score/ncar/services/TirePressureService",
+          "version": {
+              "major": 12,
+              "minor": 34
+          },
+          "bindings": [
+              {
+                  "binding": "SHM",
+                  "serviceId": 1234,
+                  "fields": [
+                      {
+                          "fieldName": "CurrentTemperatureFrontLeft",
+                          "fieldId": 20
+                      }
+                  ]
+              }
+          ]
+        }
+    ],
+    "serviceInstances": [
+        {
+            "instanceSpecifier": "abc/abc/TirePressurePort",
+            "serviceTypeName": "/score/ncar/services/TirePressureService",
+            "version": {
+                "major": 12,
+                "minor": 34
+            },
+            "instances": [
+                {
+                  "instanceId": 1234,
+                  "asil-level": "QM",
+                  "binding": "SHM",
+                  "events": [],
+                  "fields": [
+                    {
+                          "fieldName": "CurrentTemperatureFrontLeft",
+                          "numberOfSampleSlots": 50,
+                          "maxSubscribers": 5
+                      }
+                  ]
+                }
+            ]
+        }
+    ]
+  }
+)"_json;
+    const auto config = score::mw::com::impl::configuration::Parse(std::move(j2));
+
+    const auto deployment =
+        config.GetServiceInstances().at(InstanceSpecifier::Create(std::string{"abc/abc/TirePressurePort"}).value());
+
+    const auto deploymentInfo = std::get<LolaServiceInstanceDeployment>(deployment.bindingInfo_);
+    EXPECT_FALSE(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_get_if_available_);
+    EXPECT_FALSE(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_set_if_available_);
+}
+
+TEST(ConfigParser, LolaFieldBothFlagsSetToTrue)
+{
+    // Given a JSON with both `useGetIfAvailable` and `useSetIfAvailable` set to true for a field
+    auto j2 = R"(
+  {
+    "serviceTypes": [
+        {
+          "serviceTypeName": "/score/ncar/services/TirePressureService",
+          "version": {
+              "major": 12,
+              "minor": 34
+          },
+          "bindings": [
+              {
+                  "binding": "SHM",
+                  "serviceId": 1234,
+                  "fields": [
+                      {
+                          "fieldName": "CurrentTemperatureFrontLeft",
+                          "fieldId": 20
+                      }
+                  ]
+              }
+          ]
+        }
+    ],
+    "serviceInstances": [
+        {
+            "instanceSpecifier": "abc/abc/TirePressurePort",
+            "serviceTypeName": "/score/ncar/services/TirePressureService",
+            "version": {
+                "major": 12,
+                "minor": 34
+            },
+            "instances": [
+                {
+                  "instanceId": 1234,
+                  "asil-level": "QM",
+                  "binding": "SHM",
+                  "events": [],
+                  "fields": [
+                    {
+                          "fieldName": "CurrentTemperatureFrontLeft",
+                          "numberOfSampleSlots": 50,
+                          "maxSubscribers": 5,
+                          "useGetIfAvailable": true,
+                          "useSetIfAvailable": true
+                      }
+                  ]
+                }
+            ]
+        }
+    ]
+  }
+)"_json;
+    const auto config = score::mw::com::impl::configuration::Parse(std::move(j2));
+
+    const auto deployment =
+        config.GetServiceInstances().at(InstanceSpecifier::Create(std::string{"abc/abc/TirePressurePort"}).value());
+
+    const auto deploymentInfo = std::get<LolaServiceInstanceDeployment>(deployment.bindingInfo_);
+    EXPECT_TRUE(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_get_if_available_);
+    EXPECT_TRUE(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_set_if_available_);
+}
+
 TEST(ConfigParser, EmptyServiceTypes)
 {
     // Given a JSON with necessary attribute `serviceTypes` being empty (which is allowed)

--- a/score/mw/com/impl/configuration/config_parser_test.cpp
+++ b/score/mw/com/impl/configuration/config_parser_test.cpp
@@ -116,6 +116,8 @@ TEST_F(ConfigParserFixture, ParseExampleJson)
     EXPECT_EQ(secondDeploymentInfo.fields_.at("CurrentTemperatureFrontLeft").max_subscribers_.value(), 6);
     EXPECT_EQ(secondDeploymentInfo.fields_.at("CurrentTemperatureFrontLeft").enforce_max_samples_, true);
     EXPECT_EQ(secondDeploymentInfo.fields_.at("CurrentTemperatureFrontLeft").max_concurrent_allocations_.value(), 1);
+    EXPECT_FALSE(secondDeploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_get_if_available_);
+    EXPECT_FALSE(secondDeploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_set_if_available_);
 
     const auto service_deployment = config.GetServiceTypes().at(deployments.service_);
     const auto* const lola_service_type_deployment =
@@ -2157,12 +2159,16 @@ TEST(ConfigParser, LolaFieldUseGetIfAvailableSetToTrue)
     ]
   }
 )"_json;
+
+    // When parsing the JSON
     const auto config = score::mw::com::impl::configuration::Parse(std::move(j2));
 
     const auto deployment =
         config.GetServiceInstances().at(InstanceSpecifier::Create(std::string{"abc/abc/TirePressurePort"}).value());
 
     const auto deploymentInfo = std::get<LolaServiceInstanceDeployment>(deployment.bindingInfo_);
+
+    // Then use_get_if_available_ is true and use_set_if_available_ defaults to false
     EXPECT_TRUE(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_get_if_available_);
     EXPECT_FALSE(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_set_if_available_);
 }
@@ -2221,12 +2227,16 @@ TEST(ConfigParser, LolaFieldUseSetIfAvailableSetToTrue)
     ]
   }
 )"_json;
+
+    // When parsing the JSON
     const auto config = score::mw::com::impl::configuration::Parse(std::move(j2));
 
     const auto deployment =
         config.GetServiceInstances().at(InstanceSpecifier::Create(std::string{"abc/abc/TirePressurePort"}).value());
 
     const auto deploymentInfo = std::get<LolaServiceInstanceDeployment>(deployment.bindingInfo_);
+
+    // Then use_set_if_available_ is true and use_get_if_available_ defaults to false
     EXPECT_FALSE(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_get_if_available_);
     EXPECT_TRUE(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_set_if_available_);
 }
@@ -2284,12 +2294,16 @@ TEST(ConfigParser, LolaFieldOmittingBothFlagsDefaultsBothToFalse)
     ]
   }
 )"_json;
+
+    // When parsing the JSON
     const auto config = score::mw::com::impl::configuration::Parse(std::move(j2));
 
     const auto deployment =
         config.GetServiceInstances().at(InstanceSpecifier::Create(std::string{"abc/abc/TirePressurePort"}).value());
 
     const auto deploymentInfo = std::get<LolaServiceInstanceDeployment>(deployment.bindingInfo_);
+
+    // Then both flags default to false
     EXPECT_FALSE(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_get_if_available_);
     EXPECT_FALSE(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_set_if_available_);
 }
@@ -2355,6 +2369,8 @@ TEST(ConfigParser, LolaFieldBothFlagsSetToTrue)
         config.GetServiceInstances().at(InstanceSpecifier::Create(std::string{"abc/abc/TirePressurePort"}).value());
 
     const auto deploymentInfo = std::get<LolaServiceInstanceDeployment>(deployment.bindingInfo_);
+
+    // Then both flags are true
     EXPECT_TRUE(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_get_if_available_);
     EXPECT_TRUE(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_set_if_available_);
 }

--- a/score/mw/com/impl/configuration/configuration_test.cpp
+++ b/score/mw/com/impl/configuration/configuration_test.cpp
@@ -184,7 +184,8 @@ TEST_F(ConfigurationFixture, ConfigIsCorrectlyParsedFromFile)
     const std::vector<uid_t> allowed_provider_ids_b{15};
 
     const LolaEventInstanceDeployment lola_event_instance{event_max_samples, event_max_subscribers, 1U, true, 0};
-    const LolaFieldInstanceDeployment lola_field_instance{field_max_samples, field_max_subscribers, 1U, true, 7};
+    const LolaFieldInstanceDeployment lola_field_instance{
+        field_max_samples, field_max_subscribers, 1U, true, 7, false, false};
     const LolaMethodInstanceDeployment lola_method_instance{method_queue_size};
 
     const LolaServiceInstanceDeployment::EventInstanceMapping instance_events{

--- a/score/mw/com/impl/configuration/example/mw_com_config.json
+++ b/score/mw/com/impl/configuration/example/mw_com_config.json
@@ -61,7 +61,9 @@
                             "fieldName": "CurrentTemperatureFrontLeft",
                             "numberOfSampleSlots": 60,
                             "maxSubscribers": 6,
-                            "numberOfIpcTracingSlots": 7
+                            "numberOfIpcTracingSlots": 7,
+                            "useGetIfAvailable": false,
+                            "useSetIfAvailable": false
                         }
                     ],
                     "methods": [

--- a/score/mw/com/impl/configuration/lola_field_instance_deployment.cpp
+++ b/score/mw/com/impl/configuration/lola_field_instance_deployment.cpp
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -11,3 +11,179 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 #include "score/mw/com/impl/configuration/lola_field_instance_deployment.h"
+
+#include "score/mw/com/impl/configuration/configuration_common_resources.h"
+
+#include "score/mw/log/logging.h"
+
+#include <score/optional.hpp>
+#include <exception>
+
+namespace score::mw::com::impl
+{
+
+namespace
+{
+
+constexpr auto kNumberOfSampleSlotsKey = "numberOfSampleSlots";
+constexpr auto kSubscribersKey = "maxSubscribers";
+constexpr auto kMaxConcurrentAllocationsKey = "maxConcurrentAllocations";
+constexpr auto kEnforceMaxSamplesKey = "enforceMaxSamples";
+constexpr auto kNumberOfIpcTracingSlotsKey = "numberOfIpcTracingSlots";
+constexpr auto kUseGetIfAvailableKey = "useGetIfAvailable";
+constexpr auto kUseSetIfAvailableKey = "useSetIfAvailable";
+constexpr LolaFieldInstanceDeployment::TracingSlotSizeType kNumberOfIpcTracingSlotsDefault{0U};
+
+}  // namespace
+
+LolaFieldInstanceDeployment::LolaFieldInstanceDeployment(std::optional<SampleSlotCountType> number_of_sample_slots,
+                                                         std::optional<SubscriberCountType> max_subscribers,
+                                                         std::optional<std::uint8_t> max_concurrent_allocations,
+                                                         const bool enforce_max_samples,
+                                                         const TracingSlotSizeType number_of_tracing_slots,
+                                                         const bool use_get_if_available,
+                                                         const bool use_set_if_available) noexcept
+    : max_subscribers_{max_subscribers},
+      max_concurrent_allocations_{max_concurrent_allocations},
+      enforce_max_samples_{enforce_max_samples},
+      use_get_if_available_{use_get_if_available},
+      use_set_if_available_{use_set_if_available},
+      number_of_sample_slots_{number_of_sample_slots},
+      number_of_tracing_slots_{number_of_tracing_slots}
+{
+}
+
+LolaFieldInstanceDeployment::LolaFieldInstanceDeployment(const score::json::Object& json_object) noexcept
+    : LolaFieldInstanceDeployment(LolaFieldInstanceDeployment::CreateFromJson(json_object))
+{
+}
+
+LolaFieldInstanceDeployment LolaFieldInstanceDeployment::CreateFromJson(const score::json::Object& json_object) noexcept
+{
+
+    const auto serialization_version = GetValueFromJson<std::uint32_t>(json_object, kSerializationVersionKey);
+    if (serialization_version != serializationVersion)
+    {
+        std::terminate();
+    }
+
+    const auto number_of_sample_slots =
+        GetOptionalValueFromJson<SampleSlotCountType>(json_object, kNumberOfSampleSlotsKey);
+    const auto max_subscribers = GetOptionalValueFromJson<SubscriberCountType>(json_object, kSubscribersKey);
+    const auto max_concurrent_allocations =
+        GetOptionalValueFromJson<std::uint8_t>(json_object, kMaxConcurrentAllocationsKey);
+    const auto enforce_max_samples = GetValueFromJson<bool>(json_object, kEnforceMaxSamplesKey);
+    const auto number_of_tracing_slots_opt =
+        GetOptionalValueFromJson<TracingSlotSizeType>(json_object, kNumberOfIpcTracingSlotsKey);
+
+    auto number_of_tracing_slots = number_of_tracing_slots_opt.value_or(kNumberOfIpcTracingSlotsDefault);
+
+    // getter and setters are optional fields. If not provided, we set them to false as default value.
+    const auto use_get_if_available =
+        GetOptionalValueFromJson<bool>(json_object, kUseGetIfAvailableKey).value_or(false);
+    const auto use_set_if_available =
+        GetOptionalValueFromJson<bool>(json_object, kUseSetIfAvailableKey).value_or(false);
+
+    return LolaFieldInstanceDeployment(number_of_sample_slots,
+                                       max_subscribers,
+                                       max_concurrent_allocations,
+                                       enforce_max_samples,
+                                       number_of_tracing_slots,
+                                       use_get_if_available,
+                                       use_set_if_available);
+}
+
+// Suppress "AUTOSAR C++14 A15-5-3" rule finding. This rule states: "The std::terminate() function shall not be called
+//                                                                   implicitly"
+// false positive std::bad_optional_access. We check and early exit in case the optional is empty.
+// coverity[autosar_cpp14_a15_5_3_violation]
+score::json::Object LolaFieldInstanceDeployment::Serialize() const noexcept
+{
+    score::json::Object json_object{};
+    if (number_of_sample_slots_.has_value())
+    {
+        json_object[kNumberOfSampleSlotsKey] = score::json::Any{number_of_sample_slots_.value()};
+    }
+    if (max_subscribers_.has_value())
+    {
+        json_object[kSubscribersKey] = score::json::Any{max_subscribers_.value()};
+    }
+    json_object[kSerializationVersionKey] = json::Any{serializationVersion};
+
+    if (max_concurrent_allocations_.has_value())
+    {
+        json_object[kMaxConcurrentAllocationsKey] = score::json::Any{max_concurrent_allocations_.value()};
+    }
+
+    json_object[kEnforceMaxSamplesKey] = score::json::Any{enforce_max_samples_};
+
+    // We always turn of ipc tracing. I.e., serialize  kNumberOfIpcTracingSlotsKey as false
+    json_object[kNumberOfIpcTracingSlotsKey] = static_cast<std::uint8_t>(0U);
+
+    json_object[kUseGetIfAvailableKey] = score::json::Any{use_get_if_available_};
+    json_object[kUseSetIfAvailableKey] = score::json::Any{use_set_if_available_};
+
+    return json_object;
+}
+
+// Suppress "AUTOSAR C++14 A15-5-3" rule finding. This rule states: "The std::terminate() function shall not be called
+//                                                                   implicitly"
+// false positive std::bad_optional_access. We check and early exit in case the optional is empty.
+// coverity[autosar_cpp14_a15_5_3_violation]
+auto LolaFieldInstanceDeployment::GetNumberOfSampleSlots() const noexcept -> std::optional<SampleSlotCountType>
+{
+    if (!number_of_sample_slots_.has_value())
+    {
+        return {};
+    }
+
+    const auto intermediate = static_cast<std::uint32_t>(number_of_sample_slots_.value()) +
+                              static_cast<std::uint32_t>(number_of_tracing_slots_);
+    if (intermediate > std::numeric_limits<std::uint16_t>::max())
+    {
+        ::score::mw::log::LogFatal("lola")
+            << "Number of sample slots + number of tracing slots exceeds sample slot limit. Terminating.";
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(false);
+    }
+    return static_cast<std::uint16_t>(intermediate);
+}
+
+auto LolaFieldInstanceDeployment::GetNumberOfSampleSlotsExcludingTracingSlot() const noexcept
+    -> std::optional<SampleSlotCountType>
+{
+    if (!number_of_sample_slots_.has_value())
+    {
+        return {};
+    }
+    return *number_of_sample_slots_;
+}
+
+auto LolaFieldInstanceDeployment::GetNumberOfTracingSlots() const noexcept -> TracingSlotSizeType
+{
+    return number_of_tracing_slots_;
+}
+
+void LolaFieldInstanceDeployment::SetNumberOfSampleSlots(SampleSlotCountType number_of_sample_slots) noexcept
+{
+
+    number_of_sample_slots_ = number_of_sample_slots;
+}
+
+bool operator==(const LolaFieldInstanceDeployment& lhs, const LolaFieldInstanceDeployment& rhs) noexcept
+{
+    const bool number_of_sample_slots_equal = (lhs.number_of_sample_slots_ == rhs.number_of_sample_slots_);
+    const bool number_of_tracing_slots_equal = (lhs.number_of_tracing_slots_ == rhs.number_of_tracing_slots_);
+    const bool max_subscribers_equal = (lhs.max_subscribers_ == rhs.max_subscribers_);
+    const bool max_concurrent_allocations_equal = (lhs.max_concurrent_allocations_ == rhs.max_concurrent_allocations_);
+    const bool enforce_max_samples_equal = (lhs.enforce_max_samples_ == rhs.enforce_max_samples_);
+    const bool use_get_if_available_equal = (lhs.use_get_if_available_ == rhs.use_get_if_available_);
+    const bool use_set_if_available_equal = (lhs.use_set_if_available_ == rhs.use_set_if_available_);
+    // Adding Brackets to the expression does not give additional value since only one logical operator is used which
+    // is independent of the execution order
+    // coverity[autosar_cpp14_a5_2_6_violation]
+    return (number_of_sample_slots_equal && number_of_tracing_slots_equal && max_subscribers_equal &&
+            max_concurrent_allocations_equal && enforce_max_samples_equal && 
+            use_get_if_available_equal && use_set_if_available_equal);
+}
+
+}  // namespace score::mw::com::impl

--- a/score/mw/com/impl/configuration/lola_field_instance_deployment.cpp
+++ b/score/mw/com/impl/configuration/lola_field_instance_deployment.cpp
@@ -182,8 +182,8 @@ bool operator==(const LolaFieldInstanceDeployment& lhs, const LolaFieldInstanceD
     // is independent of the execution order
     // coverity[autosar_cpp14_a5_2_6_violation]
     return (number_of_sample_slots_equal && number_of_tracing_slots_equal && max_subscribers_equal &&
-            max_concurrent_allocations_equal && enforce_max_samples_equal && 
-            use_get_if_available_equal && use_set_if_available_equal);
+            max_concurrent_allocations_equal && enforce_max_samples_equal && use_get_if_available_equal &&
+            use_set_if_available_equal);
 }
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/configuration/lola_field_instance_deployment.h
+++ b/score/mw/com/impl/configuration/lola_field_instance_deployment.h
@@ -81,11 +81,9 @@ class LolaFieldInstanceDeployment
     // Non-zero values greater than one for this parameter only make sense on the skeleton side. For the proxy it is
     // just important if the tracing is enabled or not, i.e., if this variable is zero or non-zero.
     TracingSlotSizeType number_of_tracing_slots_;
-
 };
 
 bool operator==(const LolaFieldInstanceDeployment& lhs, const LolaFieldInstanceDeployment& rhs) noexcept;
-
 
 }  // namespace score::mw::com::impl
 

--- a/score/mw/com/impl/configuration/lola_field_instance_deployment.h
+++ b/score/mw/com/impl/configuration/lola_field_instance_deployment.h
@@ -13,12 +13,79 @@
 #ifndef SCORE_MW_COM_IMPL_CONFIGURATION_LOLA_FIELD_INSTANCE_DEPLOYMENT_H
 #define SCORE_MW_COM_IMPL_CONFIGURATION_LOLA_FIELD_INSTANCE_DEPLOYMENT_H
 
-#include "score/mw/com/impl/configuration/lola_event_instance_deployment.h"
+#include "score/json/json_parser.h"
+
+#include <score/optional.hpp>
+
+#include <cstdint>
+#include <optional>
+#include <string>
 
 namespace score::mw::com::impl
 {
 
-using LolaFieldInstanceDeployment = LolaEventInstanceDeployment;
+class LolaFieldInstanceDeployment
+{
+  public:
+    using SampleSlotCountType = std::uint16_t;
+    using SubscriberCountType = std::uint8_t;
+    using TracingSlotSizeType = std::uint8_t;
+
+    explicit LolaFieldInstanceDeployment(std::optional<SampleSlotCountType> number_of_sample_slots,
+                                         std::optional<SubscriberCountType> max_subscribers,
+                                         std::optional<std::uint8_t> max_concurrent_allocations,
+                                         const bool enforce_max_samples,
+                                         const TracingSlotSizeType number_of_tracing_slots,
+                                         const bool use_get_if_available,
+                                         const bool use_set_if_available) noexcept;
+
+    explicit LolaFieldInstanceDeployment(const score::json::Object& json_object) noexcept;
+
+    static LolaFieldInstanceDeployment CreateFromJson(const score::json::Object& json_object) noexcept;
+
+    score::json::Object Serialize() const noexcept;
+
+    void SetNumberOfSampleSlots(SampleSlotCountType number_of_sample_slots) noexcept;
+
+    [[nodiscard]] std::optional<SampleSlotCountType> GetNumberOfSampleSlots() const noexcept;
+    [[nodiscard]] std::optional<SampleSlotCountType> GetNumberOfSampleSlotsExcludingTracingSlot() const noexcept;
+
+    [[nodiscard]] TracingSlotSizeType GetNumberOfTracingSlots() const noexcept;
+
+    /// \brief max subscribers slots is only relevant/required on skeleton side. On the proxy side it is irrelevant.
+    ///         Therefore, it is optional!
+    // Note the struct is not compliant to POD type containing non-POD member.
+    // The struct is used as a config storage obtained by performing the parsing json object.
+    // Public access is more convenient to reach the following members of the struct.
+    // coverity[autosar_cpp14_m11_0_1_violation]
+    std::optional<SubscriberCountType> max_subscribers_;
+    // coverity[autosar_cpp14_m11_0_1_violation]
+    std::optional<std::uint8_t> max_concurrent_allocations_;
+    // coverity[autosar_cpp14_m11_0_1_violation]
+    bool enforce_max_samples_;
+    // coverity[autosar_cpp14_m11_0_1_violation]
+    bool use_get_if_available_{false};
+    // coverity[autosar_cpp14_m11_0_1_violation]
+    bool use_set_if_available_{false};
+
+    // False positive, variable is used outside of the file.
+    // coverity[autosar_cpp14_a0_1_1_violation : FALSE]
+    constexpr static std::uint32_t serializationVersion = 1U;
+
+    friend bool operator==(const LolaFieldInstanceDeployment& lhs, const LolaFieldInstanceDeployment& rhs) noexcept;
+
+  private:
+    /// \brief number of sample slots is only relevant/required on skeleton side, where slots get allocated. On the
+    ///         proxy side it is irrelevant. Therefore, it is optional!
+    std::optional<SampleSlotCountType> number_of_sample_slots_;
+    // Non-zero values greater than one for this parameter only make sense on the skeleton side. For the proxy it is
+    // just important if the tracing is enabled or not, i.e., if this variable is zero or non-zero.
+    TracingSlotSizeType number_of_tracing_slots_;
+
+};
+
+bool operator==(const LolaFieldInstanceDeployment& lhs, const LolaFieldInstanceDeployment& rhs) noexcept;
+
 
 }  // namespace score::mw::com::impl
 

--- a/score/mw/com/impl/configuration/lola_field_instance_deployment.h
+++ b/score/mw/com/impl/configuration/lola_field_instance_deployment.h
@@ -64,9 +64,9 @@ class LolaFieldInstanceDeployment
     // coverity[autosar_cpp14_m11_0_1_violation]
     bool enforce_max_samples_;
     // coverity[autosar_cpp14_m11_0_1_violation]
-    bool use_get_if_available_{false};
+    bool use_get_if_available_;
     // coverity[autosar_cpp14_m11_0_1_violation]
-    bool use_set_if_available_{false};
+    bool use_set_if_available_;
 
     // False positive, variable is used outside of the file.
     // coverity[autosar_cpp14_a0_1_1_violation : FALSE]

--- a/score/mw/com/impl/configuration/lola_field_instance_deployment_test.cpp
+++ b/score/mw/com/impl/configuration/lola_field_instance_deployment_test.cpp
@@ -66,41 +66,45 @@ TEST_F(LolaFieldInstanceDeploymentFixture, CanCreateFromSerializedObjectWithoutO
 TEST_F(LolaFieldInstanceDeploymentFixture, UseGetIfAvailableIsTrueAfterRoundTripSerialisation)
 {
     // Given a field deployment with use_get_if_available set to true
+    constexpr bool kUseGetIfAvailable{true};
+    constexpr bool kUseSetIfAvailable{false};
     const LolaFieldInstanceDeployment unit{MakeLolaFieldInstanceDeployment(kMaxSamples,
                                                                            kMaxSubscribers,
                                                                            kMaxConcurrentAllocations,
                                                                            kEnforceMaxSamples,
                                                                            kNumberOfTracingSlots,
-                                                                           /*use_get*/ true,
-                                                                           /*use_set*/ false)};
+                                                                           kUseGetIfAvailable,
+                                                                           kUseSetIfAvailable)};
 
     // When serialising and deserialising
     const auto serialized_unit{unit.Serialize()};
     const LolaFieldInstanceDeployment reconstructed_unit{serialized_unit};
 
     // Then use_get_if_available is preserved and use_set_if_available is unaffected
-    EXPECT_TRUE(reconstructed_unit.use_get_if_available_);
-    EXPECT_FALSE(reconstructed_unit.use_set_if_available_);
+    EXPECT_EQ(reconstructed_unit.use_get_if_available_, kUseGetIfAvailable);
+    EXPECT_EQ(reconstructed_unit.use_set_if_available_, kUseSetIfAvailable);
 }
 
 TEST_F(LolaFieldInstanceDeploymentFixture, UseSetIfAvailableIsTrueAfterRoundTripSerialisation)
 {
     // Given a field deployment with use_set_if_available set to true
+    constexpr bool kUseGetIfAvailable{false};
+    constexpr bool kUseSetIfAvailable{true};
     const LolaFieldInstanceDeployment unit{MakeLolaFieldInstanceDeployment(kMaxSamples,
                                                                            kMaxSubscribers,
                                                                            kMaxConcurrentAllocations,
                                                                            kEnforceMaxSamples,
                                                                            kNumberOfTracingSlots,
-                                                                           /*use_get*/ false,
-                                                                           /*use_set*/ true)};
+                                                                           kUseGetIfAvailable,
+                                                                           kUseSetIfAvailable)};
 
     // When serialising and deserialising
     const auto serialized_unit{unit.Serialize()};
     const LolaFieldInstanceDeployment reconstructed_unit{serialized_unit};
 
     // Then use_set_if_available is preserved and use_get_if_available is unaffected
-    EXPECT_FALSE(reconstructed_unit.use_get_if_available_);
-    EXPECT_TRUE(reconstructed_unit.use_set_if_available_);
+    EXPECT_EQ(reconstructed_unit.use_get_if_available_, kUseGetIfAvailable);
+    EXPECT_EQ(reconstructed_unit.use_set_if_available_, kUseSetIfAvailable);
 }
 
 TEST_F(LolaFieldInstanceDeploymentFixture, BothFlagsDefaultToFalseAfterRoundTripSerialisation)
@@ -117,50 +121,26 @@ TEST_F(LolaFieldInstanceDeploymentFixture, BothFlagsDefaultToFalseAfterRoundTrip
     EXPECT_FALSE(reconstructed_unit.use_set_if_available_);
 }
 
-TEST_F(LolaFieldInstanceDeploymentFixture, UseGetAndUseSetFlagsAreIndependentOfEachOther)
+TEST_F(LolaFieldInstanceDeploymentFixture, BothFlagsSetToTrueAfterRoundTripSerialisation)
 {
-    // Given four deployments covering all flag combinations
-    const LolaFieldInstanceDeployment both_false{MakeLolaFieldInstanceDeployment(kMaxSamples,
-                                                                                 kMaxSubscribers,
-                                                                                 kMaxConcurrentAllocations,
-                                                                                 kEnforceMaxSamples,
-                                                                                 kNumberOfTracingSlots,
-                                                                                 false,
-                                                                                 false)};
-    const LolaFieldInstanceDeployment get_only{MakeLolaFieldInstanceDeployment(kMaxSamples,
-                                                                               kMaxSubscribers,
-                                                                               kMaxConcurrentAllocations,
-                                                                               kEnforceMaxSamples,
-                                                                               kNumberOfTracingSlots,
-                                                                               true,
-                                                                               false)};
-    const LolaFieldInstanceDeployment set_only{MakeLolaFieldInstanceDeployment(kMaxSamples,
-                                                                               kMaxSubscribers,
-                                                                               kMaxConcurrentAllocations,
-                                                                               kEnforceMaxSamples,
-                                                                               kNumberOfTracingSlots,
-                                                                               false,
-                                                                               true)};
-    const LolaFieldInstanceDeployment both_true{MakeLolaFieldInstanceDeployment(kMaxSamples,
-                                                                                kMaxSubscribers,
-                                                                                kMaxConcurrentAllocations,
-                                                                                kEnforceMaxSamples,
-                                                                                kNumberOfTracingSlots,
-                                                                                true,
-                                                                                true)};
+    // Given a field deployment with both flags set to true
+    constexpr bool kUseGetIfAvailable{true};
+    constexpr bool kUseSetIfAvailable{true};
+    const LolaFieldInstanceDeployment unit{MakeLolaFieldInstanceDeployment(kMaxSamples,
+                                                                           kMaxSubscribers,
+                                                                           kMaxConcurrentAllocations,
+                                                                           kEnforceMaxSamples,
+                                                                           kNumberOfTracingSlots,
+                                                                           kUseGetIfAvailable,
+                                                                           kUseSetIfAvailable)};
 
-    // Then each combination holds exactly the values set, independently
-    EXPECT_FALSE(both_false.use_get_if_available_);
-    EXPECT_FALSE(both_false.use_set_if_available_);
+    // When serialising and deserialising
+    const auto serialized_unit{unit.Serialize()};
+    const LolaFieldInstanceDeployment reconstructed_unit{serialized_unit};
 
-    EXPECT_TRUE(get_only.use_get_if_available_);
-    EXPECT_FALSE(get_only.use_set_if_available_);
-
-    EXPECT_FALSE(set_only.use_get_if_available_);
-    EXPECT_TRUE(set_only.use_set_if_available_);
-
-    EXPECT_TRUE(both_true.use_get_if_available_);
-    EXPECT_TRUE(both_true.use_set_if_available_);
+    // Then both flags are preserved as true
+    EXPECT_EQ(reconstructed_unit.use_get_if_available_, kUseGetIfAvailable);
+    EXPECT_EQ(reconstructed_unit.use_set_if_available_, kUseSetIfAvailable);
 }
 
 TEST(LolaFieldInstanceDeploymentDeathTest, CreatingFromSerializedObjectWithMismatchedSerializationVersionTerminates)

--- a/score/mw/com/impl/configuration/lola_field_instance_deployment_test.cpp
+++ b/score/mw/com/impl/configuration/lola_field_instance_deployment_test.cpp
@@ -22,6 +22,15 @@ namespace
 {
 
 using LolaFieldInstanceDeploymentFixture = ConfigurationStructsFixture;
+
+namespace
+{
+constexpr std::uint16_t kMaxSamples{12U};
+constexpr std::uint8_t kMaxSubscribers{13U};
+constexpr std::uint8_t kMaxConcurrentAllocations{14U};
+constexpr bool kEnforceMaxSamples{true};
+constexpr std::uint8_t kNumberOfTracingSlots{1U};
+}  // namespace
 TEST_F(LolaFieldInstanceDeploymentFixture, CanCreateFromSerializedObjectWithOptionals)
 {
     const LolaFieldInstanceDeployment unit{MakeLolaFieldInstanceDeployment()};
@@ -35,25 +44,123 @@ TEST_F(LolaFieldInstanceDeploymentFixture, CanCreateFromSerializedObjectWithOpti
 
 TEST_F(LolaFieldInstanceDeploymentFixture, CanCreateFromSerializedObjectWithoutOptionals)
 {
-    const std::uint16_t max_samples{12};
-    const std::optional<std::uint8_t> max_subscribers{13};
-    const std::optional<std::uint8_t> max_concurrent_allocations{};
-    const bool enforce_max_samples{true};
-    const auto use_get_if_available{false};
-    const auto use_set_if_available{false};
 
-    const LolaFieldInstanceDeployment unit{MakeLolaFieldInstanceDeployment(max_samples,
-                                                                           max_subscribers,
-                                                                           max_concurrent_allocations,
-                                                                           enforce_max_samples,
-                                                                           use_get_if_available,
-                                                                           use_set_if_available)};
+    const std::optional<std::uint8_t> kNoMaxConcurrentAllocations{};
+    constexpr std::uint8_t kNoTracingSlots{0U};
+
+    const LolaFieldInstanceDeployment unit{MakeLolaFieldInstanceDeployment(kMaxSamples,
+                                                                           kMaxSubscribers,
+                                                                           kNoMaxConcurrentAllocations,
+                                                                           kEnforceMaxSamples,
+                                                                           kNoTracingSlots,
+                                                                           /*use_get*/ false,
+                                                                           /*use_set*/ false)};
 
     const auto serialized_unit{unit.Serialize()};
 
     LolaFieldInstanceDeployment reconstructed_unit{serialized_unit};
 
     ExpectLolaFieldInstanceDeploymentObjectsEqual(reconstructed_unit, unit);
+}
+
+TEST_F(LolaFieldInstanceDeploymentFixture, UseGetIfAvailableIsTrueAfterRoundTripSerialisation)
+{
+    // Given a field deployment with use_get_if_available set to true
+    const LolaFieldInstanceDeployment unit{MakeLolaFieldInstanceDeployment(kMaxSamples,
+                                                                           kMaxSubscribers,
+                                                                           kMaxConcurrentAllocations,
+                                                                           kEnforceMaxSamples,
+                                                                           kNumberOfTracingSlots,
+                                                                           /*use_get*/ true,
+                                                                           /*use_set*/ false)};
+
+    // When serialising and deserialising
+    const auto serialized_unit{unit.Serialize()};
+    const LolaFieldInstanceDeployment reconstructed_unit{serialized_unit};
+
+    // Then use_get_if_available is preserved and use_set_if_available is unaffected
+    EXPECT_TRUE(reconstructed_unit.use_get_if_available_);
+    EXPECT_FALSE(reconstructed_unit.use_set_if_available_);
+}
+
+TEST_F(LolaFieldInstanceDeploymentFixture, UseSetIfAvailableIsTrueAfterRoundTripSerialisation)
+{
+    // Given a field deployment with use_set_if_available set to true
+    const LolaFieldInstanceDeployment unit{MakeLolaFieldInstanceDeployment(kMaxSamples,
+                                                                           kMaxSubscribers,
+                                                                           kMaxConcurrentAllocations,
+                                                                           kEnforceMaxSamples,
+                                                                           kNumberOfTracingSlots,
+                                                                           /*use_get*/ false,
+                                                                           /*use_set*/ true)};
+
+    // When serialising and deserialising
+    const auto serialized_unit{unit.Serialize()};
+    const LolaFieldInstanceDeployment reconstructed_unit{serialized_unit};
+
+    // Then use_set_if_available is preserved and use_get_if_available is unaffected
+    EXPECT_FALSE(reconstructed_unit.use_get_if_available_);
+    EXPECT_TRUE(reconstructed_unit.use_set_if_available_);
+}
+
+TEST_F(LolaFieldInstanceDeploymentFixture, BothFlagsDefaultToFalseAfterRoundTripSerialisation)
+{
+    // Given a field deployment constructed without specifying the new boolean flags
+    const LolaFieldInstanceDeployment unit{MakeLolaFieldInstanceDeployment()};
+
+    // When serialising and deserialising
+    const auto serialized_unit{unit.Serialize()};
+    const LolaFieldInstanceDeployment reconstructed_unit{serialized_unit};
+
+    // Then both flags default to false
+    EXPECT_FALSE(reconstructed_unit.use_get_if_available_);
+    EXPECT_FALSE(reconstructed_unit.use_set_if_available_);
+}
+
+TEST_F(LolaFieldInstanceDeploymentFixture, UseGetAndUseSetFlagsAreIndependentOfEachOther)
+{
+    // Given four deployments covering all flag combinations
+    const LolaFieldInstanceDeployment both_false{MakeLolaFieldInstanceDeployment(kMaxSamples,
+                                                                                 kMaxSubscribers,
+                                                                                 kMaxConcurrentAllocations,
+                                                                                 kEnforceMaxSamples,
+                                                                                 kNumberOfTracingSlots,
+                                                                                 false,
+                                                                                 false)};
+    const LolaFieldInstanceDeployment get_only{MakeLolaFieldInstanceDeployment(kMaxSamples,
+                                                                               kMaxSubscribers,
+                                                                               kMaxConcurrentAllocations,
+                                                                               kEnforceMaxSamples,
+                                                                               kNumberOfTracingSlots,
+                                                                               true,
+                                                                               false)};
+    const LolaFieldInstanceDeployment set_only{MakeLolaFieldInstanceDeployment(kMaxSamples,
+                                                                               kMaxSubscribers,
+                                                                               kMaxConcurrentAllocations,
+                                                                               kEnforceMaxSamples,
+                                                                               kNumberOfTracingSlots,
+                                                                               false,
+                                                                               true)};
+    const LolaFieldInstanceDeployment both_true{MakeLolaFieldInstanceDeployment(kMaxSamples,
+                                                                                kMaxSubscribers,
+                                                                                kMaxConcurrentAllocations,
+                                                                                kEnforceMaxSamples,
+                                                                                kNumberOfTracingSlots,
+                                                                                true,
+                                                                                true)};
+
+    // Then each combination holds exactly the values set, independently
+    EXPECT_FALSE(both_false.use_get_if_available_);
+    EXPECT_FALSE(both_false.use_set_if_available_);
+
+    EXPECT_TRUE(get_only.use_get_if_available_);
+    EXPECT_FALSE(get_only.use_set_if_available_);
+
+    EXPECT_FALSE(set_only.use_get_if_available_);
+    EXPECT_TRUE(set_only.use_set_if_available_);
+
+    EXPECT_TRUE(both_true.use_get_if_available_);
+    EXPECT_TRUE(both_true.use_set_if_available_);
 }
 
 TEST(LolaFieldInstanceDeploymentDeathTest, CreatingFromSerializedObjectWithMismatchedSerializationVersionTerminates)

--- a/score/mw/com/impl/configuration/lola_field_instance_deployment_test.cpp
+++ b/score/mw/com/impl/configuration/lola_field_instance_deployment_test.cpp
@@ -39,9 +39,15 @@ TEST_F(LolaFieldInstanceDeploymentFixture, CanCreateFromSerializedObjectWithoutO
     const std::optional<std::uint8_t> max_subscribers{13};
     const std::optional<std::uint8_t> max_concurrent_allocations{};
     const bool enforce_max_samples{true};
+    const auto use_get_if_available{false};
+    const auto use_set_if_available{false};
 
-    const LolaFieldInstanceDeployment unit{
-        MakeLolaFieldInstanceDeployment(max_samples, max_subscribers, max_concurrent_allocations, enforce_max_samples)};
+    const LolaFieldInstanceDeployment unit{MakeLolaFieldInstanceDeployment(max_samples,
+                                                                           max_subscribers,
+                                                                           max_concurrent_allocations,
+                                                                           enforce_max_samples,
+                                                                           use_get_if_available,
+                                                                           use_set_if_available)};
 
     const auto serialized_unit{unit.Serialize()};
 

--- a/score/mw/com/impl/configuration/lola_service_instance_deployment_test.cpp
+++ b/score/mw/com/impl/configuration/lola_service_instance_deployment_test.cpp
@@ -119,7 +119,7 @@ TEST(LolaServiceInstanceDeployment, ContainsEventReturnsFalseIfEventMissing)
     EXPECT_FALSE(unit.ContainsEvent("def"));
 }
 
-TEST(LolaServiceInstanceDeployment, ContainsFieldReturnsTrueIfEventPresent)
+TEST(LolaServiceInstanceDeployment, ContainsFieldReturnsTrueIfFieldPresent)
 {
     LolaServiceInstanceDeployment unit{LolaServiceInstanceId{LolaServiceInstanceId{2U}}};
     auto temp = MakeLolaFieldInstanceDeployment();
@@ -127,7 +127,7 @@ TEST(LolaServiceInstanceDeployment, ContainsFieldReturnsTrueIfEventPresent)
     EXPECT_TRUE(unit.ContainsField("abc"));
 }
 
-TEST(LolaServiceInstanceDeployment, ContainsFieldReturnsFalseIfEventMissing)
+TEST(LolaServiceInstanceDeployment, ContainsFieldReturnsFalseIfFieldMissing)
 {
     LolaServiceInstanceDeployment unit{LolaServiceInstanceId{2U}};
     auto temp = MakeLolaFieldInstanceDeployment();

--- a/score/mw/com/impl/configuration/lola_service_instance_deployment_test.cpp
+++ b/score/mw/com/impl/configuration/lola_service_instance_deployment_test.cpp
@@ -122,7 +122,7 @@ TEST(LolaServiceInstanceDeployment, ContainsEventReturnsFalseIfEventMissing)
 TEST(LolaServiceInstanceDeployment, ContainsFieldReturnsTrueIfEventPresent)
 {
     LolaServiceInstanceDeployment unit{LolaServiceInstanceId{LolaServiceInstanceId{2U}}};
-    auto temp = MakeDefaultLolaEventInstanceDeployment();
+    auto temp = MakeLolaFieldInstanceDeployment();
     unit.fields_.emplace(std::make_pair("abc", temp));
     EXPECT_TRUE(unit.ContainsField("abc"));
 }
@@ -130,7 +130,7 @@ TEST(LolaServiceInstanceDeployment, ContainsFieldReturnsTrueIfEventPresent)
 TEST(LolaServiceInstanceDeployment, ContainsFieldReturnsFalseIfEventMissing)
 {
     LolaServiceInstanceDeployment unit{LolaServiceInstanceId{2U}};
-    auto temp = MakeDefaultLolaEventInstanceDeployment();
+    auto temp = MakeLolaFieldInstanceDeployment();
     unit.fields_.emplace(std::make_pair("abc", temp));
     EXPECT_FALSE(unit.ContainsField("def"));
 }

--- a/score/mw/com/impl/configuration/mw_com_config_schema.json
+++ b/score/mw/com/impl/configuration/mw_com_config_schema.json
@@ -110,18 +110,6 @@
                                                 "type": "integer",
                                                 "title": "Service Field Id",
                                                 "description": "Binding technology specific field id. LoLa supports 8 bit, while SOME/IP supports 15 bit."
-                                            },
-                                            "Get": {
-                                                "type": "boolean",
-                                                "title": "Service Field Getter",
-                                                "description": "Specify if a getter function is available.",
-                                                "default": false
-                                            },
-                                            "Set": {
-                                                "type": "boolean",
-                                                "title": "Service Field Setter",
-                                                "description": "Specify if a setter function is available. Default value is false.",
-                                                "default": false
                                             }
                                         }
                                     }
@@ -389,6 +377,18 @@
                                                 "default": 0,
                                                 "minimum": 0,
                                                 "maximum": 255
+                                            },
+                                            "useGetIfAvailable": {
+                                                "type": "boolean",
+                                                "title": "Use Field Getter If Available",
+                                                "description": "When true, the getter for this field will be used if the service type declares one.",
+                                                "default": false
+                                            },
+                                            "useSetIfAvailable": {
+                                                "type": "boolean",
+                                                "title": "Use Field Setter If Available",
+                                                "description": "When true, the setter for this field will be used if the service type declares one.",
+                                                "default": false
                                             }
                                         }
                                     }

--- a/score/mw/com/impl/configuration/mw_com_config_schema.json
+++ b/score/mw/com/impl/configuration/mw_com_config_schema.json
@@ -381,14 +381,14 @@
                                             "useGetIfAvailable": {
                                                 "type": "boolean",
                                                 "title": "Use Field Getter If Available",
-                                                "description": "When true, the getter for this field will be used if the service type declares one.",
-                                                "default": false
+                                                "description": "When true, the getter for this field will be used if the service type declares one in the C++ service interface. Applicable for proxy/consumer side.",
+                                                "default": true
                                             },
                                             "useSetIfAvailable": {
                                                 "type": "boolean",
                                                 "title": "Use Field Setter If Available",
-                                                "description": "When true, the setter for this field will be used if the service type declares one.",
-                                                "default": false
+                                                "description": "When true, the setter for this field will be used if the service type declares one in the C++ service interface. Applicable for proxy/consumer side.",
+                                                "default": true
                                             }
                                         }
                                     }

--- a/score/mw/com/impl/configuration/test/configuration_test_resources.cpp
+++ b/score/mw/com/impl/configuration/test/configuration_test_resources.cpp
@@ -49,10 +49,17 @@ LolaFieldInstanceDeployment MakeLolaFieldInstanceDeployment(
     const std::optional<std::uint8_t> max_subscribers,
     const std::optional<std::uint8_t> max_concurrent_allocations,
     bool enforce_max_samples,
-    std::uint8_t number_of_tracing_slots) noexcept
+    std::uint8_t number_of_tracing_slots,
+    const bool use_get_if_available,
+    const bool use_set_if_available) noexcept
 {
-    const LolaFieldInstanceDeployment unit{
-        max_samples, max_subscribers, max_concurrent_allocations, enforce_max_samples, number_of_tracing_slots};
+    const LolaFieldInstanceDeployment unit{max_samples,
+                                           max_subscribers,
+                                           max_concurrent_allocations,
+                                           enforce_max_samples,
+                                           number_of_tracing_slots,
+                                           use_get_if_available,
+                                           use_set_if_available};
     return unit;
 }
 
@@ -172,6 +179,8 @@ void ConfigurationStructsFixture::ExpectLolaFieldInstanceDeploymentObjectsEqual(
     EXPECT_EQ(lhs.max_concurrent_allocations_, rhs.max_concurrent_allocations_);
     EXPECT_EQ(lhs.enforce_max_samples_, rhs.enforce_max_samples_);
     EXPECT_EQ(lhs.GetNumberOfSampleSlotsExcludingTracingSlot(), rhs.GetNumberOfSampleSlotsExcludingTracingSlot());
+    EXPECT_EQ(lhs.use_get_if_available_, rhs.use_get_if_available_);
+    EXPECT_EQ(lhs.use_set_if_available_, rhs.use_set_if_available_);
 }
 
 void ConfigurationStructsFixture::ExpectLolaMethodInstanceDeploymentObjectsEqual(

--- a/score/mw/com/impl/configuration/test/configuration_test_resources.h
+++ b/score/mw/com/impl/configuration/test/configuration_test_resources.h
@@ -55,7 +55,9 @@ LolaFieldInstanceDeployment MakeLolaFieldInstanceDeployment(
     const std::optional<std::uint8_t> max_subscribers = 13U,
     const std::optional<std::uint8_t> max_concurrent_allocations = 14U,
     const bool enforce_max_samples = true,
-    std::uint8_t number_of_tracing_slots = 1U) noexcept;
+    std::uint8_t number_of_tracing_slots = 1U,
+    const bool use_get_if_available = false,
+    const bool use_set_if_available = false) noexcept;
 
 LolaMethodInstanceDeployment MakeDefaultLolaMethodInstanceDeployment() noexcept;
 

--- a/score/mw/com/impl/plumbing/proxy_event_field_binding_factory_test.cpp
+++ b/score/mw/com/impl/plumbing/proxy_event_field_binding_factory_test.cpp
@@ -56,7 +56,7 @@ const LolaServiceInstanceDeployment kLolaServiceInstanceDeployment{
     LolaServiceInstanceId{kInstanceId},
     {{kDummyEventName, LolaEventInstanceDeployment{{1U}, {3U}, 1U, true, 0}},
      {kDummyGenericProxyEventName, LolaEventInstanceDeployment{{1U}, {3U}, 1U, true, 0}}},
-    {{kDummyFieldName, LolaFieldInstanceDeployment{{1U}, {3U}, 1U, true, 0}}}};
+    {{kDummyFieldName, LolaFieldInstanceDeployment{{1U}, {3U}, 1U, true, 0, false, false}}}};
 const LolaServiceTypeDeployment kLolaServiceTypeDeployment{
     kServiceId,
     {{kDummyEventName, kDummyEventId}, {kDummyGenericProxyEventName, kDummyGenericProxyId}},

--- a/score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_test.cpp
+++ b/score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_test.cpp
@@ -45,7 +45,7 @@ const auto kInstanceSpecifier = InstanceSpecifier::Create(std::string{"/my_dummy
 const LolaServiceInstanceDeployment kLolaServiceInstanceDeployment{
     LolaServiceInstanceId{kInstanceId},
     {{kDummyEventName, LolaEventInstanceDeployment{{1U}, {3U}, 1U, true, 0U}}},
-    {{kDummyFieldName, LolaFieldInstanceDeployment{{1U}, {3U}, 1U, true, 0U}}}};
+    {{kDummyFieldName, LolaFieldInstanceDeployment{{1U}, {3U}, 1U, true, 0U, false, false}}}};
 const LolaServiceTypeDeployment kLolaServiceTypeDeployment{kServiceId,
                                                            {{kDummyEventName, kDummyEventId}},
                                                            {{kDummyFieldName, kDummyFieldId}}};
@@ -240,7 +240,7 @@ TEST_P(SkeletonServiceElementBindingFactoryParamaterisedDeathTest,
     const LolaServiceInstanceDeployment lola_service_instance_deployment_with_invalid_names{
         LolaServiceInstanceId{kInstanceId},
         {{incorrect_event_name, LolaEventInstanceDeployment{{1U}, {3U}, 1U, true, 0U}}},
-        {{incorrect_field_name, LolaFieldInstanceDeployment{{1U}, {3U}, 1U, true, 0U}}}};
+        {{incorrect_field_name, LolaFieldInstanceDeployment{{1U}, {3U}, 1U, true, 0U, false, false}}}};
 
     ConfigurationStore config_store_with_invalid_service_element_names{
         kInstanceSpecifier,
@@ -268,7 +268,7 @@ TEST_P(SkeletonServiceElementBindingFactoryParamaterisedDeathTest,
     const LolaServiceInstanceDeployment lola_service_instance_deployment_without_event_sample_slots{
         LolaServiceInstanceId{kInstanceId},
         {{kDummyEventName, LolaEventInstanceDeployment{{}, {3U}, 1U, true, 0U}}},
-        {{kDummyFieldName, LolaFieldInstanceDeployment{{}, {3U}, 1U, true, 0U}}}};
+        {{kDummyFieldName, LolaFieldInstanceDeployment{{}, {3U}, 1U, true, 0U, false, false}}}};
 
     ConfigurationStore config_store_with_invalid_service_element_names{
         kInstanceSpecifier,
@@ -297,7 +297,7 @@ TEST_P(SkeletonServiceElementBindingFactoryParamaterisedDeathTest,
     const LolaServiceInstanceDeployment lola_service_instance_deployment_without_max_subscribers{
         LolaServiceInstanceId{kInstanceId},
         {{kDummyEventName, LolaEventInstanceDeployment{{1U}, {}, 1U, true, 0U}}},
-        {{kDummyFieldName, LolaFieldInstanceDeployment{{2U}, {}, 1U, true, 0U}}}};
+        {{kDummyFieldName, LolaFieldInstanceDeployment{{2U}, {}, 1U, true, 0U, false, false}}}};
 
     ConfigurationStore config_store_with_invalid_service_element_names{
         kInstanceSpecifier,

--- a/score/mw/com/impl/test/dummy_instance_identifier_builder.cpp
+++ b/score/mw/com/impl/test/dummy_instance_identifier_builder.cpp
@@ -49,7 +49,8 @@ InstanceIdentifier DummyInstanceIdentifierBuilder::CreateValidLolaInstanceIdenti
 
 InstanceIdentifier DummyInstanceIdentifierBuilder::CreateValidLolaInstanceIdentifierWithField()
 {
-    return CreateValidLolaInstanceIdentifierWithField({{"test_field", LolaFieldInstanceDeployment{1, 1, 1, true, 0}}});
+    return CreateValidLolaInstanceIdentifierWithField(
+        {{"test_field", LolaFieldInstanceDeployment{1, 1, 1, true, 0, false, false}}});
 }
 
 InstanceIdentifier DummyInstanceIdentifierBuilder::CreateValidLolaInstanceIdentifierWithEvent(

--- a/score/mw/com/impl/test/dummy_instance_identifier_builder.h
+++ b/score/mw/com/impl/test/dummy_instance_identifier_builder.h
@@ -38,7 +38,7 @@ class DummyInstanceIdentifierBuilder
         const LolaServiceInstanceDeployment::EventInstanceMapping& events);
     InstanceIdentifier CreateValidLolaInstanceIdentifierWithField();
     InstanceIdentifier CreateValidLolaInstanceIdentifierWithField(
-        const LolaServiceInstanceDeployment::EventInstanceMapping& events);
+        const LolaServiceInstanceDeployment::FieldInstanceMapping& fields);
     InstanceIdentifier CreateLolaInstanceIdentifierWithoutInstanceId();
     InstanceIdentifier CreateLolaInstanceIdentifierWithoutTypeDeployment();
     InstanceIdentifier CreateBlankBindingInstanceIdentifier();

--- a/score/mw/com/impl/tracing/configuration/tracing_filter_config.cpp
+++ b/score/mw/com/impl/tracing/configuration/tracing_filter_config.cpp
@@ -228,15 +228,33 @@ std::size_t FindNumberOfTracingSlots(
                 std::terminate();
             }
 
-            const auto& service_instance_map = [service_element_type, &lola_service_instance_deployment]() {
-                if (service_element_type == ServiceElementType::EVENT)
+            const auto service_element_name = service_element.service_element_name.data();
+
+            LolaEventInstanceDeployment::TracingSlotSizeType slots_per_tracing_point{0U};
+            if (service_element_type == ServiceElementType::EVENT)
+            {
+                const auto it = lola_service_instance_deployment->events_.find(service_element_name);
+                if (it == lola_service_instance_deployment->events_.end())
                 {
-                    return lola_service_instance_deployment->events_;
+                    score::mw::log::LogFatal("lola")
+                        << "Requested service element (" << service_element << ") does not exist.";
+                    std::terminate();
                 }
-                if (service_element_type == ServiceElementType::FIELD)
+                slots_per_tracing_point = it->second.GetNumberOfTracingSlots();
+            }
+            else if (service_element_type == ServiceElementType::FIELD)
+            {
+                const auto it = lola_service_instance_deployment->fields_.find(service_element_name);
+                if (it == lola_service_instance_deployment->fields_.end())
                 {
-                    return lola_service_instance_deployment->fields_;
+                    score::mw::log::LogFatal("lola")
+                        << "Requested service element (" << service_element << ") does not exist.";
+                    std::terminate();
                 }
+                slots_per_tracing_point = it->second.GetNumberOfTracingSlots();
+            }
+            else
+            {
                 // LCOV_EXCL_START Defensive programming.
                 // This function is only used internally and only ever called with EVENT or FIELD ServiceElementType,
                 // thus the following lines can never be reached.
@@ -244,18 +262,7 @@ std::size_t FindNumberOfTracingSlots(
                     << "Lola: invalid service element (" << service_element_type << ") provided.";
                 std::terminate();
                 // LCOV_EXCL_STOP
-            }();
-
-            const auto service_element_name = service_element.service_element_name.data();
-            const auto service_element_name_it = service_instance_map.find(service_element_name);
-
-            if (service_element_name_it == service_instance_map.end())
-            {
-                score::mw::log::LogFatal("lola")
-                    << "Requested service element (" << service_element << ") does not exist.";
-                std::terminate();
             }
-            const auto slots_per_tracing_point = service_element_name_it->second.GetNumberOfTracingSlots();
 
             number_of_needed_traceing_slots += slots_per_tracing_point;
         }

--- a/score/mw/com/impl/tracing/configuration/tracing_filter_config_test.cpp
+++ b/score/mw/com/impl/tracing/configuration/tracing_filter_config_test.cpp
@@ -580,7 +580,14 @@ class ConfigurationFixture : public ::testing::Test
     Instance MakeLolaServiceInstanceDeployment(std::optional<SampleSlotCountType> number_of_sample_slots,
                                                const TracingSlotSizeType number_of_tracing_slots)
     {
-        return Instance(number_of_sample_slots, 1U, 1U, false, number_of_tracing_slots);
+        if constexpr (std::is_same<Instance, LolaFieldInstanceDeployment>::value)
+        {
+            return Instance(number_of_sample_slots, 1U, 1U, false, number_of_tracing_slots, false, false);
+        }
+        else
+        {
+            return Instance(number_of_sample_slots, 1U, 1U, false, number_of_tracing_slots);
+        }
     }
 
     InstanceSpecifier MakeInstanceSpecifier(std::string_view instance_specifier_sv)

--- a/score/mw/com/impl/tracing/skeleton_event_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/skeleton_event_tracing_test.cpp
@@ -51,7 +51,7 @@ const std::string kDummyFieldName{"my_dummy_field"};
 const LolaServiceInstanceDeployment kLolaServiceInstanceDeploymentWithEventAndField{
     LolaServiceInstanceId{1U},
     {{kDummyEventName, LolaEventInstanceDeployment{10U, 10U, 2U, true, 0}}},
-    {{kDummyFieldName, LolaFieldInstanceDeployment{10U, 10U, 2U, true, 0}}}
+    {{kDummyFieldName, LolaFieldInstanceDeployment{10U, 10U, 2U, true, 0, false, false}}}
 
 };
 const LolaServiceTypeDeployment kLolaServiceTypeDeploymentWithEventAndField{2U,


### PR DESCRIPTION
Add useGetIfAvailable/useSetIfAvailable to LoLa field deployment

- Introduce dedicated LolaFieldInstanceDeployment class replacing the
  former LolaEventInstanceDeployment type alias, adding field-specific
  members use_get_if_available_ and use_set_if_available_.
- Fix mw_com_config_schema.json: move useGetIfAvailable and
  useSetIfAvailable into the field "properties" object so they are
  correctly validated when additionalProperties is false.
- Adapt existing test and add new tests for LolaFieldInstanceDeployment
- Update PUML diagram and readme document

Issue: SWP-250429