### PR TITLE
mw:com: make get mem resource proxy const

### DIFF
--- a/score/mw/com/impl/bindings/lola/test_doubles/fake_memory_resource.h
+++ b/score/mw/com/impl/bindings/lola/test_doubles/fake_memory_resource.h
@@ -22,7 +22,15 @@ namespace score::mw::com::impl::lola
 class FakeMemoryResource : public memory::shared::ManagedMemoryResource
 {
   public:
+    [[deprecated(
+        "SPP_DEPRECATION: Please use const getMemoryResourceProxy() noexcept instead, which is the non-deprecated "
+        "version of this function. This function will be removed in a future release.")]]
     const memory::shared::MemoryResourceProxy* getMemoryResourceProxy() noexcept override
+    {
+        return nullptr;
+    }
+
+    const memory::shared::MemoryResourceProxy* getMemoryResourceProxy() const noexcept override
     {
         return nullptr;
     }


### PR DESCRIPTION
This requires bump from baselibs to get this PR working,
since this requires changes from the Interface of ManagedMemoryResource to add a const method interface which is overridden by this PR