### PR TITLE
github/workflows: Fix Bazel Caching

### DIFF
--- a/.github/workflows/address_undefined_behavior_leak_sanitizer.yml
+++ b/.github/workflows/address_undefined_behavior_leak_sanitizer.yml
@@ -17,6 +17,8 @@
 
 name: Test communication module with address and UB and leak sanitizer
 on:
+  push:
+    branches: [main]
   pull_request:
     types: [opened, reopened, synchronize]
   merge_group:
@@ -37,12 +39,13 @@ jobs:
           uses: eclipse-score/more-disk-space@v1
           with:
             level: 4
-        - uses: bazel-contrib/setup-bazel@0.18.0
+        - uses: castler/setup-bazel@79bc547e94dea617d8524202a81e5cbcc3b6d9ea
           with:
             bazelisk-cache: true
             disk-cache: "build_and_test_asan_ubsan_lsan"
+            disk-cache-key: "main"
             repository-cache: true
-            cache-save: ${{ github.event_name == 'merge_group' }}
+            cache-save: ${{ github.ref == 'refs/heads/main' }}
         - name: Allow linux-sandbox
           uses: ./actions/unblock_user_namespace_for_linux_sandbox
         - name: Bazel test communication targets with address and UB and leak sanitizer

--- a/.github/workflows/build_and_test_host.yml
+++ b/.github/workflows/build_and_test_host.yml
@@ -16,6 +16,8 @@
 
 name: Bazel Build & Test communication module
 on:
+  push:
+    branches: [main]
   pull_request:
     types: [opened, reopened, synchronize]
   merge_group:
@@ -91,12 +93,13 @@ jobs:
           uses: eclipse-score/more-disk-space@v1
           with:
             level: 4
-        - uses: bazel-contrib/setup-bazel@0.18.0
+        - uses: castler/setup-bazel@79bc547e94dea617d8524202a81e5cbcc3b6d9ea
           with:
             bazelisk-cache: true
             disk-cache: build_and_test_host${{ matrix.identifier }}
+            disk-cache-key: "main"
             repository-cache: true
-            cache-save: ${{ github.event_name == 'merge_group' }}
+            cache-save: ${{ github.ref == 'refs/heads/main' }}
         - name: Allow linux-sandbox
           uses: ./actions/unblock_user_namespace_for_linux_sandbox
         - name: Bazel build communication targets

--- a/.github/workflows/build_and_test_qnx.yml
+++ b/.github/workflows/build_and_test_qnx.yml
@@ -16,6 +16,8 @@
 
 name: Bazel Build & Test communication module (target-platforms)
 on:
+  push:
+    branches: [main]
   pull_request_target:
     types: [opened, reopened, synchronize, labeled, unlabeled]
   merge_group:
@@ -123,12 +125,13 @@ jobs:
           with:
             level: 4
         - name: Setup Bazel
-          uses: bazel-contrib/setup-bazel@0.18.0
+          uses: castler/setup-bazel@79bc547e94dea617d8524202a81e5cbcc3b6d9ea
           with:
             bazelisk-cache: true
             disk-cache: build_and_test_qnx
+            disk-cache-key: "main"
             repository-cache: true
-            cache-save: ${{ github.event_name == 'merge_group' }}
+            cache-save: ${{ github.ref == 'refs/heads/main' }}
         - name: Allow linux-sandbox
           uses: ./actions/unblock_user_namespace_for_linux_sandbox
         - name: Setup QNX License

--- a/.github/workflows/thread_sanitizer.yml
+++ b/.github/workflows/thread_sanitizer.yml
@@ -16,6 +16,8 @@
 
 name: Test communication module with thread sanitizer
 on:
+  push:
+    branches: [main]
   pull_request:
     types: [opened, reopened, synchronize]
   merge_group:
@@ -36,12 +38,13 @@ jobs:
           uses: eclipse-score/more-disk-space@v1
           with:
             level: 4
-        - uses: bazel-contrib/setup-bazel@0.18.0
+        - uses: castler/setup-bazel@79bc547e94dea617d8524202a81e5cbcc3b6d9ea
           with:
             bazelisk-cache: true
             disk-cache: "build_and_test_tsan"
+            disk-cache-key: "main"
             repository-cache: true
-            cache-save: ${{ github.event_name == 'merge_group' }}
+            cache-save: ${{ github.ref == 'refs/heads/main' }}
         - name: Allow linux-sandbox
           uses: ./actions/unblock_user_namespace_for_linux_sandbox
         - name: Bazel test communication targets with thread sanitizer


### PR DESCRIPTION
There are multiple things to consider.

1st:
bazel-contrib/setup-bazel is creating a hash over each build file, for the upload into the GitHub cache. Meaning, if you change something in any BUILD file, it will change the cache and you will have _zero_ disk-cache hits. To overcome this, we try out a change to provide a custom key.

2nd:
You cannot share Github caches between "feature branches". Meaning, the cache needs to be created from the default branch - in our case. Main. In order to achieve this, we will run the workflows again, after they have been merged to main

3rd:
Garbage collection of old caches. GitHub Caches are immutable. This means, you can not update them. In our updates `setup-bazel`, we always create one new cache per key, and remove the old one.

We will test the setup now here in our repository. Once we see it is improving the situation, we will contribute the changes to bazel-contrib/setup-bazel.