### PR TITLE
Rework concurrency groups for GitHub Actions

### DIFF
--- a/.github/workflows/address_undefined_behavior_leak_sanitizer.yml
+++ b/.github/workflows/address_undefined_behavior_leak_sanitizer.yml
@@ -23,7 +23,7 @@ on:
     types: [checks_requested]
   workflow_call:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: address_undefined_behavior_leak_sanitizer-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request'}}
 jobs:
     build_and_test_asan_ubsan_lsan:

--- a/.github/workflows/build_and_test_host.yml
+++ b/.github/workflows/build_and_test_host.yml
@@ -28,7 +28,7 @@ on:
         type: boolean
         default: true
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: build_and_test_host-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request'}}
 jobs:
     prepare_build_and_test_host_matrix:

--- a/.github/workflows/build_and_test_qnx.yml
+++ b/.github/workflows/build_and_test_qnx.yml
@@ -30,7 +30,7 @@ on:
         required: true
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: build_and_test_qnx-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request_target'}}
 
 env:

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -23,7 +23,7 @@ permissions:
   contents: read
 
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: coverage_report-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request'}}
 
 jobs:

--- a/.github/workflows/thread_sanitizer.yml
+++ b/.github/workflows/thread_sanitizer.yml
@@ -22,7 +22,7 @@ on:
     types: [checks_requested]
   workflow_call:
 concurrency:
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  group: thread_sanitizer-${{ github.event.pull_request.number || github.run_id }}
   cancel-in-progress: ${{ github.event_name == 'pull_request'}}
 jobs:
     build_and_test_tsan:


### PR DESCRIPTION
When these reusable workflows are triggered from the automated_release.yml workflow, the will all have the same workflow name. Thus, always only _one_ will run, and the release creation will fail.

With this change, we hard-code the "job type" to ensure, that multiple can run in parallel