### PR TITLE
actions: Fix typo in coverage_report workflow

### DIFF
--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -17,7 +17,7 @@ on:
     outputs:
       artifact-name:
         description: 'Name of the coverage report artifact'
-        value: ${{ jobs.coverage-report.outputs.artifact-name }}
+        value: ${{ jobs.coverage_report.outputs.artifact-name }}
 
 permissions:
   contents: read


### PR DESCRIPTION
Without this typo fix, the upload of coverage jobs did not work, as the name of the to uploaded files was empty.

The download still works, because on empty name, everything is downloaded.