### PR TITLE
Use Result<void> directly instead of aliases

### DIFF
--- a/score/mw/com/design/events_fields/event_lola_model.puml
+++ b/score/mw/com/design/events_fields/event_lola_model.puml
@@ -69,8 +69,8 @@ class lola::Skeleton {
   -control_qm_: SkeletonDataControl*
   -control_asil_b_: SkeletonDataControl*
   +Skeleton(const InstanceIdentifier&, SkeletonEvents&)
-  +PrepareOffer(): ResultBlank
-  +PrepareStopOffer(): ResultBlank
+  +PrepareOffer(): Result<void>
+  +PrepareStopOffer(): Result<void>
   +Register(ElementFqId, size_t numberOfSlots): std::pair<EventDataStorage*, EventDataControlComposite<>>
   +GetInstanceQualityType() const: QualityType
 }

--- a/score/mw/com/design/ipc_tracing/structural_event_field_extensions.puml
+++ b/score/mw/com/design/ipc_tracing/structural_event_field_extensions.puml
@@ -25,7 +25,7 @@ class "score::mw::com::impl::tracing::ProxyEventTracingData" {
 
 class "score::mw::com::impl::SkeletonEventBase" {
   +SkeletonEventBase(std::unique_ptr<SkeletonEventBindingBase> binding)
-  +PrepareOffer(): score::ResultBlank
+  +PrepareOffer(): score::Result<void>
   +PrepareStopOffer(): void
   +UpdateSkeletonReference(SkeletonBase& base_skeleton): void
   -binding_: std::unique_ptr<SkeletonEventBindingBase>
@@ -34,13 +34,13 @@ class "score::mw::com::impl::SkeletonEventBase" {
 
 class "score::mw::com::impl::ProxyEventBase" {
   +ProxyEventBase(proxy_event_binding: std::unique_ptr<ProxyEventBindingBase> proxy_event_binding)
-  +Subscribe(size_t max_sample_count): ResultBlank
+  +Subscribe(size_t max_sample_count): Result<void>
   +GetSubscriptionState() : SubscriptionState
   +Unsubscribe(): void
   +GetFreeSampleCount(): Result<size_t>
   +GetNumNewSamplesAvailable(): Result<std::size_t>
-  +SetReceiveHandler(EventReceiveHandler handler) : ResultBlank
-  +UnsetReceiveHandler() : ResultBlank
+  +SetReceiveHandler(EventReceiveHandler handler) : Result<void>
+  +UnsetReceiveHandler() : Result<void>
   +IsBindingValid() : bool
   -binding_base_ : std::unique_ptr<ProxyEventBindingBase>
   -tracker_ : std::unique_ptr<SampleReferenceTracker>

--- a/score/mw/com/design/partial_restart/proxy_restart_sequence.puml
+++ b/score/mw/com/design/partial_restart/proxy_restart_sequence.puml
@@ -59,7 +59,7 @@ group Restart Detection && Recovery
         TransactionLogSet -[#white]> TransactionLogSet
         activate TransactionLogSet
         RollbackExecutor -> TransactionLogSet: RollbackProxyTransactions()
-        RollbackExecutor <-- TransactionLogSet: return ResultBlank
+        RollbackExecutor <-- TransactionLogSet: return Result<void>
         deactivate TransactionLogSet
 
         opt if transaction log rollback failed

--- a/score/mw/com/design/partial_restart/transaction_log_model.puml
+++ b/score/mw/com/design/partial_restart/transaction_log_model.puml
@@ -12,8 +12,8 @@ class "lola::TransactionLog" {
   +ReferenceTransactionAbort(SlotIndexType slot_index) : void
   +DereferenceTransactionBegin(SlotIndexType slot_index) : void
   +DereferenceTransactionCommit(SlotIndexType slot_index) : void
-  +RollbackProxyElementLog(const DereferenceSlotCallback&, const UnsubscribeCallback&) : ResultBlank
-  +RollbackSkeletonTracingElementLog(const DereferenceSlotCallback&) : ResultBlank
+  +RollbackProxyElementLog(const DereferenceSlotCallback&, const UnsubscribeCallback&) : Result<void>
+  +RollbackSkeletonTracingElementLog(const DereferenceSlotCallback&) : Result<void>
   +ContainsTransactions() const : bool
   -reference_count_slots_ : TransactionLogSlots
   -subscribe_transactions_ : TransactionLogSlot
@@ -21,8 +21,8 @@ class "lola::TransactionLog" {
 }
 
 class "lola::TransactionLogSet" {
-  +RollbackProxyTransactions(const TransactionLogId&, TransactionLog::DereferenceSlotCallback,TransactionLog::UnsubscribeCallback) : ResultBlank
-  +RollbackSkeletonTracingTransactions(TransactionLog::DereferenceSlotCallback) : ResultBlank
+  +RollbackProxyTransactions(const TransactionLogId&, TransactionLog::DereferenceSlotCallback,TransactionLog::UnsubscribeCallback) : Result<void>
+  +RollbackSkeletonTracingTransactions(TransactionLog::DereferenceSlotCallback) : Result<void>
   +RegisterProxyElement(const TransactionLogId&) : score::Result<TransactionLogIndex>
   +RegisterSkeletonTracingElement() : TransactionLogIndex
   +Unregister(TransactionLogIndex) : void

--- a/score/mw/com/design/service_discovery/structural_view.puml
+++ b/score/mw/com/design/service_discovery/structural_view.puml
@@ -57,7 +57,7 @@ interface "score::mw::com::impl::IServiceDiscovery" as IServiceDiscovery {
   + StartFindService(FindServiceHandler, const InstanceSpecifier): FindServiceHandle
   + StartFindService(FindServiceHandler, InstanceIdentifier): FindServiceHandle>
   + StartFindService(FindServiceHandler, EnrichedInstanceIdentifier): FindServiceHandle
-  + StopFindService(const FindServiceHandle): ResultBlank
+  + StopFindService(const FindServiceHandle): Result<void>
 }
 
 class "os::IONotify" as IONotify {

--- a/score/mw/com/design/skeleton_proxy/generic_skeleton/generic_skeleton_model.puml
+++ b/score/mw/com/design/skeleton_proxy/generic_skeleton/generic_skeleton_model.puml
@@ -18,7 +18,7 @@ abstract class "score::mw::com::impl::SkeletonBase"
   -skeleton_binding_ : std::unique_ptr<SkeletonBinding>
   -identifier_ : InstanceIdentifier
   +GetAssociatedInstanceIdentifier() : const InstanceIdentifier&
-  +OfferService(): ResultBlank
+  +OfferService(): Result<void>
   +StopOfferService(): void
   ..
   <u>Notes:</u>
@@ -26,7 +26,7 @@ abstract class "score::mw::com::impl::SkeletonBase"
 }
 
 abstract class "SkeletonBinding" {
-  +{abstract} PrepareOffer() = 0: ResultBlank
+  +{abstract} PrepareOffer() = 0: Result<void>
   +{abstract} PrepareStopOffer() = 0: void
 }
 
@@ -37,13 +37,13 @@ class "mw::com::impl::GenericSkeleton" #yellow {
   +Create(const InstanceIdentifier&, const GenericSkeletonServiceElementInfo&, MethodCallProcessingMode): Result<GenericSkeleton>
   +Create(const InstanceSpecifier&, const GenericSkeletonServiceElementInfo&, MethodCallProcessingMode): Result<GenericSkeleton>
   +events_ : EventMap
-  +OfferService(): ResultBlank
+  +OfferService(): Result<void>
   +StopOfferService(): void
 }
 
 class "lola::Skeleton" {
   +Skeleton(const InstanceIdentifier&, MethodCallProcessingMode)
-  +PrepareOffer(): ResultBlank
+  +PrepareOffer(): Result<void>
   +PrepareStopOffer(): void
   +Register(ElementFqId element_fq_id, const SkeletonEventProperties& event_properties, std::size_t size, std::size_t alignment): std::pair<score::memory::shared::OffsetPtr<void>, EventDataControlComposite>
   +RegisterGeneric(ElementFqId element_fq_id, const SkeletonEventProperties& event_properties, std::size_t size, std::size_t alignment): std::pair<score::memory::shared::OffsetPtr<void>, EventDataControlComposite>
@@ -53,12 +53,12 @@ class "lola::Skeleton" {
 }
 
 class "mw::com::impl::SkeletonEvent<SampleType>" {
-  +Send(const SampleType&): ResultBlank
+  +Send(const SampleType&): Result<void>
   +Allocate(): Result<SampleAllocateePtr<SampleType>>
 }
 
 abstract class "SkeletonEventBindingBase" {
-  +{abstract} PrepareOffer() = 0: ResultBlank
+  +{abstract} PrepareOffer() = 0: Result<void>
   +{abstract} PrepareStopOffer() = 0: void
   +{abstract} GetBindingType() = 0: BindingType
   +{abstract} SetSkeletonEventTracingData(impl::tracing::SkeletonEventTracingData tracing_data) = 0: void
@@ -66,7 +66,7 @@ abstract class "SkeletonEventBindingBase" {
 
 abstract class "SkeletonEventBinding<SampleType>"
 {
-  +{abstract} Send(const SampleType&) = 0: ResultBlank
+  +{abstract} Send(const SampleType&) = 0: Result<void>
   +{abstract} Allocate() = 0: Result<SampleAllocateePtr<SampleType>>
 }
 
@@ -78,7 +78,7 @@ class "SampleAllocateePtr<SampleType>" {
 
 class "lola::SkeletonEvent<SampleType>" {
   +SkeletonEvent(lola::Skeleton& parent, const SkeletonEventProperties& event_properties, const ElementFqId& element_fq_id)
-  +Send(const SampleType&) : ResultBlank
+  +Send(const SampleType&) : Result<void>
   +Allocate(): Result<SampleAllocateePtr<SampleType>>
   -skeleton_event_common_ : lola::SkeletonEventCommon
 }
@@ -102,19 +102,19 @@ class "ServiceElementMap" {
 
 abstract class "mw::com::impl::SkeletonEventBase" #yellow {
   +SkeletonEventBase(SkeletonBase&, const std::string_view, std::unique_ptr<SkeletonEventBindingBase>)
-  +OfferService(): ResultBlank
+  +OfferService(): Result<void>
   +StopOfferService(): void
 }
 
 class "mw::com::impl::GenericSkeletonEvent" #yellow {
   +GenericSkeletonEvent(SkeletonBase&, const std::string_view, std::unique_ptr<GenericSkeletonEventBinding>)
-  +Send(SampleAllocateePtr<void> sample): ResultBlank
+  +Send(SampleAllocateePtr<void> sample): Result<void>
   +Allocate(): Result<SampleAllocateePtr<void>>
   +GetSizeInfo() const : DataTypeMetaInfo
 }
 
 abstract class "GenericSkeletonEventBinding" #yellow {
-  +{abstract} Send(SampleAllocateePtr<void> sample) = 0: ResultBlank
+  +{abstract} Send(SampleAllocateePtr<void> sample) = 0: Result<void>
   +{abstract} Allocate() = 0: Result<SampleAllocateePtr<void>>
   +{abstract} GetSizeInfo() const = 0: std::pair<size_t, size_t>
 }
@@ -136,10 +136,10 @@ class "lola::SkeletonEventCommon" #yellow {
 
 class "lola::GenericSkeletonEvent" #yellow {
   +GenericSkeletonEvent(lola::Skeleton& parent, const SkeletonEventProperties& event_properties, const ElementFqId& element_fq_id, const DataTypeMetaInfo& size_info, impl::tracing::SkeletonEventTracingData tracing_data)
-  +Send(score::mw::com::impl::SampleAllocateePtr<void> sample): ResultBlank
+  +Send(score::mw::com::impl::SampleAllocateePtr<void> sample): Result<void>
   +Allocate(): Result<score::mw::com::impl::SampleAllocateePtr<void>>
   +GetSizeInfo() const : std::pair<size_t, size_t>
-  +PrepareOffer(): ResultBlank
+  +PrepareOffer(): Result<void>
   +PrepareStopOffer(): void
   +GetBindingType(): BindingType
   +SetSkeletonEventTracingData(impl::tracing::SkeletonEventTracingData tracing_data): void

--- a/score/mw/com/design/skeleton_proxy/proxy_binding_model.puml
+++ b/score/mw/com/design/skeleton_proxy/proxy_binding_model.puml
@@ -39,7 +39,7 @@ abstract class "score::mw::com::impl::ProxyBase" as ScoreMwComImplProxyBase {
   +{static} FindService(InstanceIdentifier): Result<ServiceHandleContainer<HandleType>>
   +{static} StartFindService(FindServiceHandler<HandleType>, InstanceSpecifier): Result<FindServiceHandle>
   +{static} StartFindService(FindServiceHandler<HandleType>, InstanceIdentifier): Result<FindServiceHandle>
-  +{static} StopFindService(FindServiceHandle): ResultBlank
+  +{static} StopFindService(FindServiceHandle): Result<void>
 
   +GetHandle() : const HandleType&
   --
@@ -76,13 +76,13 @@ class "lola::Proxy" as LolaProxy {
 class "score::mw::com::impl::ProxyEventBase" as ScoreMwComImplProxyEventBase {
   +ProxyEventBase(std::unique_ptr<ProxyEventBindingBase> proxy_event_binding)
 
-  +Subscribe(size_t max_sample_count): ResultBlank
+  +Subscribe(size_t max_sample_count): Result<void>
   +GetSubscriptionState() : SubscriptionState
   +Unsubscribe(): void
   +GetFreeSampleCount(): Result<size_t>
   +GetNumNewSamplesAvailable(): Result<std::size_t>
-  +SetReceiveHandler(EventReceiveHandler handler) : ResultBlank
-  +UnsetReceiveHandler() : ResultBlank
+  +SetReceiveHandler(EventReceiveHandler handler) : Result<void>
+  +UnsetReceiveHandler() : Result<void>
   +IsBindingValid() : bool
 }
 
@@ -155,13 +155,13 @@ class "lola::SubscriptionStateMachine" as LolaSubscriptionStateMachine {
 }
 
 class "mw::com::impl::ProxyField<SampleType>" as MwComImplProxyFieldTemplate {
-  +Subscribe(size_t max_sample_count): ResultBlank
+  +Subscribe(size_t max_sample_count): Result<void>
   +GetSubscriptionState() : SubscriptionState
   +Unsubscribe(): void
   +GetFreeSampleCount(): Result<size_t>
   +GetNumNewSamplesAvailable(): Result<std::size_t>
-  +SetReceiveHandler(EventReceiveHandler handler) : ResultBlank
-  +UnsetReceiveHandler() : ResultBlank
+  +SetReceiveHandler(EventReceiveHandler handler) : Result<void>
+  +UnsetReceiveHandler() : Result<void>
   +GetNewSamples<F>(F&& receiver, size_t max_num_samples): Result<size_t>
   +Get(): Future<SampleType>
   +Set(const SampleType& value): Future<SampleType>

--- a/score/mw/com/design/skeleton_proxy/skeleton_binding_model.puml
+++ b/score/mw/com/design/skeleton_proxy/skeleton_binding_model.puml
@@ -16,7 +16,7 @@ class SkeletonEventBinding<SampleType> {
 }
 
 abstract class "SkeletonEventBindingBase" as SkeletonEventBindingBase {
-    +PrepareOffer() = 0: score::ResultBlank
+    +PrepareOffer() = 0: score::Result<void>
     +PrepareStopOffer() = 0: void
     +GetMaxSize() = 0: std::size_t
 }
@@ -49,7 +49,7 @@ class SkeletonBinding {
     using SkeletonFieldBindings = std::unordered_map<std::string_view, std::tuple<SkeletonEventBindingBase&,
     SkeletonServiceMethodBinding, SkeletonServiceMethodBinding»
     --
-    +PrepareOffer(SkeletonEventBindings&, SkeletonFieldBindings&) = 0 : ResultBlank
+    +PrepareOffer(SkeletonEventBindings&, SkeletonFieldBindings&) = 0 : Result<void>
     +PrepareStopOffer() = 0 : void
     --
     Notes:
@@ -66,14 +66,14 @@ class "score::mw::com::impl::SkeletonField<SampleType>" as SkeletonField {
     -skeleton_service_method_dispatch_set_: SkeletonServiceMethod <void, SampleType>
 
     +SkeletonField(SkeletonBase& parent, std::string field_name)
-    +Update(const SampleType& data): ResultBlank
-    +Update(SampleAllocateePtr<SampleType>): ResultBlank
+    +Update(const SampleType& data): Result<void>
+    +Update(SampleAllocateePtr<SampleType>): Result<void>
     +Allocate(): SampleAllocateePtr<SampleType>
     +RegisterGetHandler(std::function<Future<SampleType>()> getHandler): Result<void>
     +RegisterSetHandler(std::function<Future<SampleType>(const SampleType& data)> setHandler):Result<void>
 
     -IsInitialValueSaved(): bool
-    -DoDeferredUpdate(): ResultBlank
+    -DoDeferredUpdate(): Result<void>
 
     --
     SkeletonField will dispatch update call to impl::skeletonEvent via skeleton_event_dispatch_. On moving, the
@@ -89,12 +89,12 @@ abstract class "score::mw::com::impl::SkeletonFieldBase" as SkeletonFieldBase {
     -is_initial_value_set_: bool
 
     +SkeletonFieldBase(SkeletonBase&, std::string_view field_name, std::unique_ptr<impl::SkeletonEventBase>)
-    +PrepareOffer(): ResultBlank
+    +PrepareOffer(): Result<void>
     +PrepareStopOffer(): void
     +UpdateSkeletonReference(SkeletonBase& base_skeleton): void
 
     -IsInitialValueSaved(): bool = 0
-    -DoDeferredUpdate(): ResultBlank = 0
+    -DoDeferredUpdate(): Result<void> = 0
     --
     In production, the constructor receives a SkeletonEvent<SampleType> from impl::SkeletonField which is
     assigned to the base class pointer, skeleton_event_dispatch_.
@@ -106,7 +106,7 @@ abstract class "score::mw::com::impl::SkeletonFieldBase" as SkeletonFieldBase {
 class "score::mw::com::impl::SkeletonEventBase" as SkeletonEventBase {
     -binding_: std::unique_ptr<SkeletonEventBindingBase>
     +SkeletonEventBase(std::unique_ptr<SkeletonEventBindingBase> binding)
-    +PrepareOffer(): score::ResultBlank
+    +PrepareOffer(): score::Result<void>
     +PrepareStopOffer(): void
     +UpdateSkeletonReference(SkeletonBase& base_skeleton): void
 
@@ -146,7 +146,7 @@ class DummySkeleton <<generated>> {
 
 class "lola::Skeleton" as lola_Skeleton {
     Skeleton(InstanceIdentifier, SkeletonEvents&)
-    +PrepareOffer(SkeletonBinding::SkeletonEventBindings&, SkeletonBinding::SkeletonFieldBindings&): ResultBlank
+    +PrepareOffer(SkeletonBinding::SkeletonEventBindings&, SkeletonBinding::SkeletonFieldBindings&): Result<void>
     +PrepareStopOffer(): void
 
     template <typename SampleType>
@@ -158,7 +158,7 @@ class "lola::SkeletonEvent<SampleType>" as lola_SkeletonEvent {
     +Send(SampleType const&): void
     +Send(SampleAllocateePtr<SampleType>): void
     +Allocate(): SampleAllocateePtr<SampleType>
-    +PrepareOffer(): score::ResultBlank
+    +PrepareOffer(): score::Result<void>
     +PrepareStopOffer(): void
 }
 

--- a/score/mw/com/design/skeleton_proxy/skeleton_create_offer_seq.puml
+++ b/score/mw/com/design/skeleton_proxy/skeleton_create_offer_seq.puml
@@ -130,10 +130,10 @@ deactivate ServiceDataControl
 LolaSkeleton --> LolaSkeletonEvent: return EventDataStorage, EventDataControl
 deactivate LolaSkeleton
 
-LolaSkeletonEvent --> SkeletonEvent: return ResultBlank
+LolaSkeletonEvent --> SkeletonEvent: return Result<void>
 deactivate LolaSkeletonEvent
 
-SkeletonEvent --> SkeletonBase: return ResultBlank
+SkeletonEvent --> SkeletonBase: return Result<void>
 deactivate SkeletonEvent
 
 end loop
@@ -143,7 +143,7 @@ deactivate SkeletonEvent
 
 SkeletonBase -> ServiceDiscovery: OfferService(InstanceIdentifier)
 activate ServiceDiscovery
-ServiceDiscovery --> SkeletonBase: return ResultBlank
+ServiceDiscovery --> SkeletonBase: return Result<void>
 deactivate ServiceDiscovery
 
 SkeletonBase --> GenSkeleton

--- a/score/mw/com/design/skeleton_proxy/skeleton_proxy_binding_model.puml
+++ b/score/mw/com/design/skeleton_proxy/skeleton_proxy_binding_model.puml
@@ -23,7 +23,7 @@ abstract class "SkeletonBinding" {
   using SkeletonEventBindings = std::unordered_map<std::string_view, SkeletonEventBindingBase&>
   using SkeletonFieldBindings = std::unordered_map<std::string_view, std::tuple<SkeletonEventBindingBase&, SkeletonServiceMethodBinding, SkeletonServiceMethodBinding>>
 
-  +{abstract} PrepareOffer(SkeletonEventBindings&, SkeletonFieldBindings&) = 0: ResultBlank
+  +{abstract} PrepareOffer(SkeletonEventBindings&, SkeletonFieldBindings&) = 0: Result<void>
   +{abstract} PrepareStopOffer() = 0: void
   --
   Notes:
@@ -32,7 +32,7 @@ abstract class "SkeletonBinding" {
 
 class "lola::Skeleton" as LolaSkeleton {
   Skeleton(InstanceIdentifier, SkeletonEvents&
-  +PrepareOffer(SkeletonBinding::SkeletonEventBindings&, SkeletonBinding::SkeletonFieldBindings&): ResultBlank
+  +PrepareOffer(SkeletonBinding::SkeletonEventBindings&, SkeletonBinding::SkeletonFieldBindings&): Result<void>
   +PrepareStopOffer(): void
 
   +template <typename SampleType>\n Register(ElementFqId, size_t num_slots): std::pair<EventDataStorage<SampleType>*, EventDataControlComposite<>>
@@ -73,7 +73,7 @@ class "score::mw::com::impl::SkeletonEventBase" as ScoreMwComImplSkeletonEventBa
   - binding_: std::unique_ptr<SkeletonEventBindingBase>
   --
   +SkeletonEventBase(std::unique_ptr<SkeletonEventBindingBase> binding)
-  +PrepareOffer(): score::ResultBlank
+  +PrepareOffer(): score::Result<void>
   +PrepareStopOffer(): void
   +UpdateSkeletonReference(SkeletonBase& base_skeleton): void
   --
@@ -90,7 +90,7 @@ class "score::mw::com::impl::SkeletonEventBase" as ScoreMwComImplSkeletonEventBa
 
 class "score::mw::com::impl::SkeletonFieldBase" as ScoreMwComImplSkeletonFieldBase {
   +SkeletonFieldBase(SkeletonBase&, std::string_view field_name, std::unique_ptr<impl::SkeletonEventBase>)
-  +PrepareOffer(): ResultBlank
+  +PrepareOffer(): Result<void>
   +PrepareStopOffer(): void
   +UpdateSkeletonReference(SkeletonBase& base_skeleton): void
   --
@@ -100,7 +100,7 @@ class "score::mw::com::impl::SkeletonFieldBase" as ScoreMwComImplSkeletonFieldBa
   #was_prepare_offer_called_ : bool
   --
   +{abstract} IsInitialValueSaved(): bool = 0
-  +{abstract} DoDeferredUpdate(): ResultBlank = 0
+  +{abstract} DoDeferredUpdate(): Result<void> = 0
   -is_initial_value_set_: bool
   --
   In production, the constructor receives a SkeletonEvent<SampleType> from
@@ -111,7 +111,7 @@ class "score::mw::com::impl::SkeletonFieldBase" as ScoreMwComImplSkeletonFieldBa
 }
 
 abstract class "SkeletonEventBindingBase" as SkeletonEventBindingBase {
-  +{abstract} PrepareOffer() = 0: score::ResultBlank
+  +{abstract} PrepareOffer() = 0: score::Result<void>
   +{abstract} PrepareStopOffer() = 0: void
   +{abstract} GetMaxSize() = 0: std::size_t
 }
@@ -137,7 +137,7 @@ class "lola::SkeletonEvent<SampleType>" as LolaSkeletonEventTemplate {
   +Send(SampleType const&): void
   +Send(SampleAllocateePtr<SampleType>): void
   +Allocate(): SampleAllocateePtr<SampleType>
-  +PrepareOffer(): score::ResultBlank
+  +PrepareOffer(): score::Result<void>
   +PrepareStopOffer(): void
 }
 
@@ -147,14 +147,14 @@ class "SkeletonEventBindingFactory<SampleType>" as SkeletonEventBindingFactoryTe
 
 class "score::mw::com::impl::SkeletonField<SampleType>" as ScoreMwComImplSkeletonFieldTemplate {
   +SkeletonField(SkeletonBase& parent, std::string field_name)
-  +Update(const SampleType& data): ResultBlank
-  +Update(SampleAllocateePtr<SampleType>): ResultBlank
+  +Update(const SampleType& data): Result<void>
+  +Update(SampleAllocateePtr<SampleType>): Result<void>
   +Allocate(): SampleAllocateePtr<SampleType>
   +RegisterGetHandler(std::function<Future<SampleType>()> getHandler): Result<void>
   +RegisterSetHandler(std::function<Future<SampleType>(const SampleType& data)> setHandler):Result<void>
   --
   -IsInitialValueSaved(): bool
-  -DoDeferredUpdate(): ResultBlank
+  -DoDeferredUpdate(): Result<void>
   -skeleton_service_method_dispatch_get_: SkeletonServiceMethod<Future<SampleType>, void>
   -skeleton_service_method_dispatch_set_: SkeletonServiceMethod <void, SampleType>
   --
@@ -200,7 +200,7 @@ abstract class "score::mw::com::impl::ProxyBase" as ScoreMwComImplProxyBase {
   +{static} FindService(InstanceIdentifier): Result<ServiceHandleContainer<HandleType>>
   +{static} StartFindService(FindServiceHandler<HandleType>, InstanceSpecifier): Result<FindServiceHandle>
   +{static} StartFindService(FindServiceHandler<HandleType>, InstanceIdentifier): Result<FindServiceHandle>
-  +{static} StopFindService(FindServiceHandle): ResultBlank
+  +{static} StopFindService(FindServiceHandle): Result<void>
 
   +GetHandle() : const HandleType&
   --
@@ -237,13 +237,13 @@ class "lola::Proxy" as LolaProxy {
 class "score::mw::com::impl::ProxyEventBase" as ScoreMwComImplProxyEventBase {
   +ProxyEventBase(std::unique_ptr<ProxyEventBindingBase> proxy_event_binding)
 
-  +Subscribe(size_t max_sample_count): ResultBlank
+  +Subscribe(size_t max_sample_count): Result<void>
   +GetSubscriptionState() : SubscriptionState
   +Unsubscribe(): void
   +GetFreeSampleCount(): Result<size_t>
   +GetNumNewSamplesAvailable(): Result<std::size_t>
-  +SetReceiveHandler(EventReceiveHandler handler) : ResultBlank
-  +UnsetReceiveHandler() : ResultBlank
+  +SetReceiveHandler(EventReceiveHandler handler) : Result<void>
+  +UnsetReceiveHandler() : Result<void>
   +IsBindingValid() : bool
 }
 
@@ -315,13 +315,13 @@ class "lola::SubscriptionStateMachine" as LolaSubscriptionStateMachine {
 }
 
 class "mw::com::impl::ProxyField<SampleType>" as MwComImplProxyFieldTemplate {
-  +Subscribe(size_t max_sample_count): ResultBlank
+  +Subscribe(size_t max_sample_count): Result<void>
   +GetSubscriptionState() : SubscriptionState
   +Unsubscribe(): void
   +GetFreeSampleCount(): Result<size_t>
   +GetNumNewSamplesAvailable(): Result<std::size_t>
-  +SetReceiveHandler(EventReceiveHandler handler) : ResultBlank
-  +UnsetReceiveHandler() : ResultBlank
+  +SetReceiveHandler(EventReceiveHandler handler) : Result<void>
+  +UnsetReceiveHandler() : Result<void>
   +template <typename F>\n GetNewSamples(F&& receiver, size_t max_num_samples): Result<size_t>
   +Get(): Future<SampleType>
   +Set(const SampleType& value): Future<SampleType>

--- a/score/mw/com/doc/user_facing_API_examples.md
+++ b/score/mw/com/doc/user_facing_API_examples.md
@@ -1004,7 +1004,7 @@ if (find_handle.has_value()) {
 - Requires valid `FindServiceHandle` from `StartFindService()`
 - Stops callback notifications
 - Safe to call even if discovery already completed
-- Returns `ResultBlank` - check for errors
+- Returns `Result<void>` - check for errors
 
 </details>
 
@@ -1109,7 +1109,7 @@ if (spec.has_value()) {
 
 **Key Points**:
 - Takes only `max_sample_count` parameter
-- Returns `ResultBlank` - check with `has_value()` before use
+- Returns `Result<void>` - check with `has_value()` before use
 - Must subscribe before calling `GetNewSamples()`
 
 </details>
@@ -1279,7 +1279,7 @@ if (result.has_value()) {
 **Key Points**:
 - Removes handler registered with `SetReceiveHandler()`
 - Safe to call even if no handler registered
-- Returns `ResultBlank` - check for errors
+- Returns `Result<void>` - check for errors
 
 </details>
 
@@ -1477,7 +1477,7 @@ if (skeleton_result.has_value()) {
 
 **Key Points**:
 - Call after skeleton creation to enable service discovery
-- Returns `ResultBlank` - check with `has_value()` for success
+- Returns `Result<void>` - check with `has_value()` for success
 - Service remains offered until `StopOfferService()` or skeleton destruction
 - After offering, you can send events and update fields
 - Proxies cannot discover the service after `OfferService()` succeeds
@@ -1580,7 +1580,7 @@ if (skeleton_result.has_value()) {
 - Copy-based accepts `const EventType&` and zero-copy accepts `SampleAllocateePtr<EventType>`
 - Zero-copy requires `Allocate()` first and uses less memory bandwidth
 - Must call `OfferService()` before sending
-- Returns `ResultBlank` - check with `has_value()`
+- Returns `Result<void>` - check with `has_value()`
 
 </details>
 
@@ -1696,7 +1696,7 @@ if (skeleton_result.has_value()) {
 - Initial field value must be set before `OfferService()` is called
 - Copy-based accepts `const FieldType&` and zero-copy accepts `SampleAllocateePtr<FieldType>`
 - Zero-copy requires `Allocate()` first and uses less memory bandwidth
-- Returns `ResultBlank` - check with `has_value()`
+- Returns `Result<void>` - check with `has_value()`
 
 </details>
 

--- a/score/mw/com/impl/bindings/lola/generic_proxy_event.cpp
+++ b/score/mw/com/impl/bindings/lola/generic_proxy_event.cpp
@@ -33,7 +33,7 @@ GenericProxyEvent::GenericProxyEvent(Proxy& parent, const ElementFqId element_fq
 {
 }
 
-ResultBlank GenericProxyEvent::Subscribe(const std::size_t max_sample_count) noexcept
+Result<void> GenericProxyEvent::Subscribe(const std::size_t max_sample_count) noexcept
 {
     return proxy_event_common_.Subscribe(max_sample_count);
 }
@@ -87,12 +87,12 @@ bool GenericProxyEvent::HasSerializedFormat() const noexcept
     return false;
 }
 
-ResultBlank GenericProxyEvent::SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) noexcept
+Result<void> GenericProxyEvent::SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) noexcept
 {
     return proxy_event_common_.SetReceiveHandler(std::move(handler));
 }
 
-ResultBlank GenericProxyEvent::UnsetReceiveHandler() noexcept
+Result<void> GenericProxyEvent::UnsetReceiveHandler() noexcept
 {
     return proxy_event_common_.UnsetReceiveHandler();
 }

--- a/score/mw/com/impl/bindings/lola/generic_proxy_event.h
+++ b/score/mw/com/impl/bindings/lola/generic_proxy_event.h
@@ -57,7 +57,7 @@ class GenericProxyEvent final : public GenericProxyEventBinding
 
     ~GenericProxyEvent() noexcept override = default;
 
-    ResultBlank Subscribe(const std::size_t max_sample_count) noexcept override;
+    Result<void> Subscribe(const std::size_t max_sample_count) noexcept override;
     void Unsubscribe() noexcept override;
 
     SubscriptionState GetSubscriptionState() const noexcept override;
@@ -66,8 +66,8 @@ class GenericProxyEvent final : public GenericProxyEventBinding
     std::size_t GetSampleSize() const noexcept override;
     bool HasSerializedFormat() const noexcept override;
 
-    ResultBlank SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) noexcept override;
-    ResultBlank UnsetReceiveHandler() noexcept override;
+    Result<void> SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) noexcept override;
+    Result<void> UnsetReceiveHandler() noexcept override;
     pid_t GetEventSourcePid() const noexcept;
     ElementFqId GetElementFQId() const noexcept;
     std::optional<std::uint16_t> GetMaxSampleCount() const noexcept override;

--- a/score/mw/com/impl/bindings/lola/generic_skeleton_event.cpp
+++ b/score/mw/com/impl/bindings/lola/generic_skeleton_event.cpp
@@ -30,7 +30,7 @@ GenericSkeletonEvent::GenericSkeletonEvent(Skeleton& parent,
 {
 }
 
-ResultBlank GenericSkeletonEvent::PrepareOffer() noexcept
+Result<void> GenericSkeletonEvent::PrepareOffer() noexcept
 {
     const auto registration_result =
         skeleton_event_common_.GetParent().RegisterGeneric(skeleton_event_common_.GetElementFQId(),
@@ -45,7 +45,7 @@ ResultBlank GenericSkeletonEvent::PrepareOffer() noexcept
     return {};
 }
 
-ResultBlank GenericSkeletonEvent::Send(score::mw::com::impl::SampleAllocateePtr<void> sample) noexcept
+Result<void> GenericSkeletonEvent::Send(score::mw::com::impl::SampleAllocateePtr<void> sample) noexcept
 {
     return skeleton_event_common_.Send(sample);
 }

--- a/score/mw/com/impl/bindings/lola/generic_skeleton_event.h
+++ b/score/mw/com/impl/bindings/lola/generic_skeleton_event.h
@@ -40,13 +40,13 @@ class GenericSkeletonEvent : public GenericSkeletonEventBinding
                          const DataTypeMetaInfo& size_info,
                          impl::tracing::SkeletonEventTracingData tracing_data = {});
 
-    ResultBlank Send(score::mw::com::impl::SampleAllocateePtr<void> sample) noexcept override;
+    Result<void> Send(score::mw::com::impl::SampleAllocateePtr<void> sample) noexcept override;
 
     Result<score::mw::com::impl::SampleAllocateePtr<void>> Allocate() noexcept override;
 
     std::pair<size_t, size_t> GetSizeInfo() const noexcept override;
 
-    ResultBlank PrepareOffer() noexcept override;
+    Result<void> PrepareOffer() noexcept override;
     void PrepareStopOffer() noexcept override;
     BindingType GetBindingType() const noexcept override;
     void SetSkeletonEventTracingData(impl::tracing::SkeletonEventTracingData tracing_data) noexcept override

--- a/score/mw/com/impl/bindings/lola/messaging/i_message_passing_service.h
+++ b/score/mw/com/impl/bindings/lola/messaging/i_message_passing_service.h
@@ -84,7 +84,7 @@ class IMessagePassingService
     ///        the new shared memory region and close all methods shared memory regions that were in the process that
     ///        restarted.
     using ServiceMethodSubscribedHandler = safecpp::CopyableScopedFunction<
-        score::ResultBlank(ProxyInstanceIdentifier proxy_instance_identifier, uid_t proxy_uid, pid_t proxy_pid)>;
+        score::Result<void>(ProxyInstanceIdentifier proxy_instance_identifier, uid_t proxy_uid, pid_t proxy_pid)>;
 
     /// \brief Handler which will be called when the proxy process sends a message that it has called a method.
     ///
@@ -278,10 +278,10 @@ class IMessagePassingService
     /// \param proxy_instance_identifier See arguments documentation for ServiceMethodSubscribedHandler.
     /// \param target_node_id Since this function is called by the Proxy process, target_node_id is the PID of the
     ///        Skeleton process which the subscribe call is sent to (i.e. which contains the corresponding Skeleton)
-    virtual ResultBlank SubscribeServiceMethod(const QualityType asil_level,
-                                               const SkeletonInstanceIdentifier& skeleton_instance_identifier,
-                                               const ProxyInstanceIdentifier& proxy_instance_identifier,
-                                               const pid_t target_node_id) = 0;
+    virtual Result<void> SubscribeServiceMethod(const QualityType asil_level,
+                                                const SkeletonInstanceIdentifier& skeleton_instance_identifier,
+                                                const ProxyInstanceIdentifier& proxy_instance_identifier,
+                                                const pid_t target_node_id) = 0;
 
     /// \brief Blocking call which is called on Proxy side to trigger the Skeleton to process a method call. The
     /// callback registered with RegisterOnServiceMethodSubscribed will be called on the Skeleton side and a response
@@ -296,10 +296,10 @@ class IMessagePassingService
     ///        call. Until asynchronous method calls are supported, this will always be 0.
     /// \param target_node_id Since this function is called by the Proxy process, target_node_id is the PID of the
     ///        Skeleton process which the method call is sent to (i.e. which contains the corresponding Skeleton)
-    virtual ResultBlank CallMethod(const QualityType asil_level,
-                                   const ProxyMethodInstanceIdentifier& proxy_method_instance_identifier,
-                                   const std::size_t queue_position,
-                                   const pid_t target_node_id) = 0;
+    virtual Result<void> CallMethod(const QualityType asil_level,
+                                    const ProxyMethodInstanceIdentifier& proxy_method_instance_identifier,
+                                    const std::size_t queue_position,
+                                    const pid_t target_node_id) = 0;
 
   private:
     /// \brief Unregister handler that was registered with RegisterOnServiceMethodSubscribedHandler

--- a/score/mw/com/impl/bindings/lola/messaging/i_message_passing_service_instance.h
+++ b/score/mw/com/impl/bindings/lola/messaging/i_message_passing_service_instance.h
@@ -49,14 +49,14 @@ class IMessagePassingServiceInstance
                                              const IMessagePassingService::HandlerRegistrationNoType registration_no,
                                              const pid_t target_node_id) noexcept = 0;
 
-    virtual ResultBlank RegisterOnServiceMethodSubscribedHandler(
+    virtual Result<void> RegisterOnServiceMethodSubscribedHandler(
         const SkeletonInstanceIdentifier skeleton_instance_identifier,
         IMessagePassingService::ServiceMethodSubscribedHandler subscribed_callback,
         IMessagePassingService::AllowedConsumerUids allowed_proxy_uids) = 0;
 
-    virtual ResultBlank RegisterMethodCallHandler(const ProxyMethodInstanceIdentifier proxy_method_instance_identifier,
-                                                  IMessagePassingService::MethodCallHandler method_call_callback,
-                                                  const uid_t allowed_proxy_uid) = 0;
+    virtual Result<void> RegisterMethodCallHandler(const ProxyMethodInstanceIdentifier proxy_method_instance_identifier,
+                                                   IMessagePassingService::MethodCallHandler method_call_callback,
+                                                   const uid_t allowed_proxy_uid) = 0;
 
     virtual void UnregisterOnServiceMethodSubscribedHandler(
         SkeletonInstanceIdentifier skeleton_instance_identifier) = 0;
@@ -71,13 +71,13 @@ class IMessagePassingServiceInstance
 
     virtual void UnregisterEventNotificationExistenceChangedCallback(const ElementFqId event_id) noexcept = 0;
 
-    virtual ResultBlank SubscribeServiceMethod(const SkeletonInstanceIdentifier& skeleton_instance_identifier,
-                                               const ProxyInstanceIdentifier& proxy_instance_identifier,
-                                               const pid_t target_node_id) = 0;
+    virtual Result<void> SubscribeServiceMethod(const SkeletonInstanceIdentifier& skeleton_instance_identifier,
+                                                const ProxyInstanceIdentifier& proxy_instance_identifier,
+                                                const pid_t target_node_id) = 0;
 
-    virtual ResultBlank CallMethod(const ProxyMethodInstanceIdentifier& proxy_method_instance_identifier,
-                                   const std::size_t queue_position,
-                                   const pid_t target_node_id) = 0;
+    virtual Result<void> CallMethod(const ProxyMethodInstanceIdentifier& proxy_method_instance_identifier,
+                                    const std::size_t queue_position,
+                                    const pid_t target_node_id) = 0;
 };
 
 }  // namespace score::mw::com::impl::lola

--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service.cpp
@@ -200,7 +200,7 @@ void MessagePassingService::UnregisterEventNotificationExistenceChangedCallback(
     instance.UnregisterEventNotificationExistenceChangedCallback(event_id);
 }
 
-ResultBlank MessagePassingService::SubscribeServiceMethod(
+Result<void> MessagePassingService::SubscribeServiceMethod(
     const QualityType asil_level,
     const SkeletonInstanceIdentifier& skeleton_instance_identifier,
     const ProxyInstanceIdentifier& proxy_instance_identifier,
@@ -211,10 +211,10 @@ ResultBlank MessagePassingService::SubscribeServiceMethod(
     return instance.SubscribeServiceMethod(skeleton_instance_identifier, proxy_instance_identifier, target_node_id);
 }
 
-ResultBlank MessagePassingService::CallMethod(const QualityType asil_level,
-                                              const ProxyMethodInstanceIdentifier& proxy_method_instance_identifier,
-                                              std::size_t queue_position,
-                                              const pid_t target_node_id)
+Result<void> MessagePassingService::CallMethod(const QualityType asil_level,
+                                               const ProxyMethodInstanceIdentifier& proxy_method_instance_identifier,
+                                               std::size_t queue_position,
+                                               const pid_t target_node_id)
 {
     auto& instance = GetMessagePassingServiceInstance(asil_level);
 

--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service.h
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service.h
@@ -139,19 +139,19 @@ class MessagePassingService final : public IMessagePassingService
     /// method shared memory region and wants to subscribe. The callback registered with RegisterMethodCall will be
     /// called on the Skeleton side and a response will be returned.
     /// \details see IMessagePassingService::SubscribeServiceMethod
-    ResultBlank SubscribeServiceMethod(const QualityType asil_level,
-                                       const SkeletonInstanceIdentifier& skeleton_instance_identifier,
-                                       const ProxyInstanceIdentifier& proxy_instance_identifier,
-                                       const pid_t target_node_id) override;
+    Result<void> SubscribeServiceMethod(const QualityType asil_level,
+                                        const SkeletonInstanceIdentifier& skeleton_instance_identifier,
+                                        const ProxyInstanceIdentifier& proxy_instance_identifier,
+                                        const pid_t target_node_id) override;
 
     /// \brief Blocking call which is called on Proxy side to trigger the Skeleton to process a method call. The
     /// callback registered with RegisterOnServiceMethodSubscribed will be called on the Skeleton side and a response
     /// will be returned.
     /// \details see IMessagePassingService::CallMethod
-    ResultBlank CallMethod(const QualityType asil_level,
-                           const ProxyMethodInstanceIdentifier& proxy_method_instance_identifier,
-                           std::size_t queue_position,
-                           const pid_t target_node_id) override;
+    Result<void> CallMethod(const QualityType asil_level,
+                            const ProxyMethodInstanceIdentifier& proxy_method_instance_identifier,
+                            std::size_t queue_position,
+                            const pid_t target_node_id) override;
 
   private:
     using Engine = score::message_passing::Engine;

--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance.cpp
@@ -72,7 +72,7 @@ struct MethodCallUnserializedPayload
     std::size_t queue_position;
 };
 
-using MethodUnserializedReply = score::ResultBlank;
+using MethodUnserializedReply = score::Result<void>;
 using MethodReplyPayload = ErrorSerializer<MethodErrc>::SerializedErrorType;
 
 constexpr std::uint32_t kMaxSendSize{32U};
@@ -102,7 +102,7 @@ bool DeserializeFromPayload(const score::cpp::span<const std::uint8_t> payload, 
 
 /// \brief Function which deserializes a reply payload which is received when calling SendWaitReply in CallMethod or
 /// SubscribeServiceMethod.
-/// \return The outer result returns an error if SendWaitReply itself returned an error. The inner ResultBlank contains
+/// \return The outer result returns an error if SendWaitReply itself returned an error. The inner Result<void> contains
 /// the result encoded in the message itself.
 score::Result<MethodUnserializedReply> DeserializeFromMethodReplyPayload(
     const score::cpp::span<const std::uint8_t> payload) noexcept
@@ -143,7 +143,7 @@ auto SerializeToMessage(const std::uint8_t message_id, const T& t) noexcept -> s
     return out;
 }
 
-auto SerializeToMethodReplyMessage(score::ResultBlank reply_result) noexcept
+auto SerializeToMethodReplyMessage(score::Result<void> reply_result) noexcept
     -> std::array<std::uint8_t, sizeof(MethodReplyPayload)>
 {
     static_assert(std::is_trivially_copyable_v<MethodReplyPayload>);
@@ -289,14 +289,15 @@ MessagePassingServiceInstance::MessagePassingServiceInstance(
 
 message_passing::MessageCallback MessagePassingServiceInstance::CreateSendMessageWithReplyCallback()
 {
-    auto message_callback_with_reply_scoped_function = std::make_shared<
-        score::safecpp::MoveOnlyScopedFunction<score::ResultBlank(uid_t, pid_t, score::cpp::span<const std::uint8_t>)>>(
-        message_callback_scope_,
-        [this](uid_t sender_uid,
-               pid_t sender_pid,
-               score::cpp::span<const std::uint8_t> message) noexcept -> score::ResultBlank {
-            return this->MessageCallbackWithReply(sender_uid, sender_pid, message);
-        });
+    auto message_callback_with_reply_scoped_function =
+        std::make_shared<score::safecpp::MoveOnlyScopedFunction<score::Result<void>(
+            uid_t, pid_t, score::cpp::span<const std::uint8_t>)>>(
+            message_callback_scope_,
+            [this](uid_t sender_uid,
+                   pid_t sender_pid,
+                   score::cpp::span<const std::uint8_t> message) noexcept -> score::Result<void> {
+                return this->MessageCallbackWithReply(sender_uid, sender_pid, message);
+            });
 
     // Note. When received_send_message_with_reply_callback returns an error, the message passing connection with the
     // client will be disconnected. Therefore, we only return an error from the callback when the error is unrecoverable
@@ -393,7 +394,7 @@ void MessagePassingServiceInstance::MessageCallback(const pid_t sender_pid,
     }
 }
 
-score::ResultBlank MessagePassingServiceInstance::MessageCallbackWithReply(
+score::Result<void> MessagePassingServiceInstance::MessageCallbackWithReply(
     const uid_t sender_uid,
     const pid_t sender_pid,
     const score::cpp::span<const std::uint8_t> message)
@@ -587,7 +588,7 @@ void MessagePassingServiceInstance::HandleOutdatedNodeIdMsg(const score::cpp::sp
     client_cache_.RemoveMessagePassingClient(pid_to_unregister);
 }
 
-score::ResultBlank MessagePassingServiceInstance::HandleSubscribeServiceMethodMsg(
+score::Result<void> MessagePassingServiceInstance::HandleSubscribeServiceMethodMsg(
     const score::cpp::span<const std::uint8_t> payload,
     const uid_t sender_uid,
     const pid_t sender_node_id)
@@ -604,7 +605,7 @@ score::ResultBlank MessagePassingServiceInstance::HandleSubscribeServiceMethodMs
                                              sender_node_id);
 }
 
-score::ResultBlank MessagePassingServiceInstance::HandleCallMethodMsg(
+score::Result<void> MessagePassingServiceInstance::HandleCallMethodMsg(
     const score::cpp::span<const std::uint8_t> payload,
     const uid_t sender_uid)
 {
@@ -619,7 +620,7 @@ score::ResultBlank MessagePassingServiceInstance::HandleCallMethodMsg(
         unserialized_payload.proxy_method_instance_identifier, unserialized_payload.queue_position, sender_uid);
 }
 
-score::ResultBlank MessagePassingServiceInstance::CallSubscribeServiceMethodLocally(
+score::Result<void> MessagePassingServiceInstance::CallSubscribeServiceMethodLocally(
     const SkeletonInstanceIdentifier& skeleton_instance_identifier,
     const ProxyInstanceIdentifier& proxy_instance_identifier,
     const uid_t proxy_uid,
@@ -660,7 +661,7 @@ score::ResultBlank MessagePassingServiceInstance::CallSubscribeServiceMethodLoca
     return invocation_result.value();
 }
 
-score::ResultBlank MessagePassingServiceInstance::CallServiceMethodLocally(
+score::Result<void> MessagePassingServiceInstance::CallServiceMethodLocally(
     const ProxyMethodInstanceIdentifier& proxy_method_instance_identifier,
     const std::size_t queue_position,
     const uid_t proxy_uid)
@@ -700,7 +701,7 @@ score::ResultBlank MessagePassingServiceInstance::CallServiceMethodLocally(
     return {};
 }
 
-ResultBlank MessagePassingServiceInstance::CallSubscribeServiceMethodRemotely(
+Result<void> MessagePassingServiceInstance::CallSubscribeServiceMethodRemotely(
     const SkeletonInstanceIdentifier& skeleton_instance_identifier,
     const ProxyInstanceIdentifier& proxy_instance_identifier,
     const pid_t target_node_id)
@@ -728,12 +729,12 @@ ResultBlank MessagePassingServiceInstance::CallSubscribeServiceMethodRemotely(
         score::mw::log::LogError("lola")
             << "MessagePassingService: Parsing SubscribeServiceMethodMessage reply from node_id " << target_node_id
             << "failed during deserialization";
-        return MakeUnexpected<Blank>(deserialization_result.error());
+        return MakeUnexpected<void>(deserialization_result.error());
     }
     return deserialization_result.value();
 }
 
-ResultBlank MessagePassingServiceInstance::CallServiceMethodRemotely(
+Result<void> MessagePassingServiceInstance::CallServiceMethodRemotely(
     const ProxyMethodInstanceIdentifier& proxy_method_instance_identifier,
     const std::size_t queue_position,
     const pid_t target_node_id)
@@ -768,7 +769,7 @@ ResultBlank MessagePassingServiceInstance::CallServiceMethodRemotely(
     {
         score::mw::log::LogError("lola") << "MessagePassingService: CallServiceMethodMessage reply from node_id "
                                          << target_node_id << "returned failure";
-        return MakeUnexpected<Blank>(method_call_result.error());
+        return MakeUnexpected<void>(method_call_result.error());
     }
     return {};
 }
@@ -1120,7 +1121,7 @@ void MessagePassingServiceInstance::UnregisterEventNotification(
     }
 }
 
-ResultBlank MessagePassingServiceInstance::RegisterOnServiceMethodSubscribedHandler(
+Result<void> MessagePassingServiceInstance::RegisterOnServiceMethodSubscribedHandler(
     const SkeletonInstanceIdentifier skeleton_instance_identifier,
     IMessagePassingService::ServiceMethodSubscribedHandler subscribed_callback,
     IMessagePassingService::AllowedConsumerUids allowed_proxy_uids)
@@ -1140,7 +1141,7 @@ ResultBlank MessagePassingServiceInstance::RegisterOnServiceMethodSubscribedHand
     return {};
 }
 
-ResultBlank MessagePassingServiceInstance::RegisterMethodCallHandler(
+Result<void> MessagePassingServiceInstance::RegisterMethodCallHandler(
     const ProxyMethodInstanceIdentifier proxy_method_instance_identifier,
     IMessagePassingService::MethodCallHandler method_call_callback,
     const uid_t allowed_proxy_uid)
@@ -1387,7 +1388,7 @@ QualityType MessagePassingServiceInstance::GetPartnerQualityType() const
     }
 }
 
-ResultBlank MessagePassingServiceInstance::SubscribeServiceMethod(
+Result<void> MessagePassingServiceInstance::SubscribeServiceMethod(
     const SkeletonInstanceIdentifier& skeleton_instance_identifier,
     const ProxyInstanceIdentifier& proxy_instance_identifier,
     const pid_t target_node_id)
@@ -1415,7 +1416,7 @@ ResultBlank MessagePassingServiceInstance::SubscribeServiceMethod(
     }
 }
 
-ResultBlank MessagePassingServiceInstance::CallMethod(
+Result<void> MessagePassingServiceInstance::CallMethod(
     const ProxyMethodInstanceIdentifier& proxy_method_instance_identifier,
     std::size_t queue_position,
     const pid_t target_node_id)

--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance.h
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance.h
@@ -80,14 +80,14 @@ class MessagePassingServiceInstance : public IMessagePassingServiceInstance
                                      const IMessagePassingService::HandlerRegistrationNoType registration_no,
                                      const pid_t target_node_id) noexcept override;
 
-    ResultBlank RegisterOnServiceMethodSubscribedHandler(
+    Result<void> RegisterOnServiceMethodSubscribedHandler(
         const SkeletonInstanceIdentifier skeleton_instance_identifier,
         IMessagePassingService::ServiceMethodSubscribedHandler subscribed_callback,
         IMessagePassingService::AllowedConsumerUids allowed_proxy_uids) override;
 
-    ResultBlank RegisterMethodCallHandler(const ProxyMethodInstanceIdentifier proxy_method_instance_identifier,
-                                          IMessagePassingService::MethodCallHandler method_call_callback,
-                                          const uid_t allowed_proxy_uid) override;
+    Result<void> RegisterMethodCallHandler(const ProxyMethodInstanceIdentifier proxy_method_instance_identifier,
+                                           IMessagePassingService::MethodCallHandler method_call_callback,
+                                           const uid_t allowed_proxy_uid) override;
 
     void UnregisterOnServiceMethodSubscribedHandler(
         const SkeletonInstanceIdentifier skeleton_instance_identifier) override;
@@ -115,13 +115,13 @@ class MessagePassingServiceInstance : public IMessagePassingServiceInstance
     /// \param event_id The event to stop monitoring.
     void UnregisterEventNotificationExistenceChangedCallback(const ElementFqId event_id) noexcept override;
 
-    ResultBlank SubscribeServiceMethod(const SkeletonInstanceIdentifier& skeleton_instance_identifier,
-                                       const ProxyInstanceIdentifier& proxy_instance_identifier,
-                                       const pid_t target_node_id) override;
+    Result<void> SubscribeServiceMethod(const SkeletonInstanceIdentifier& skeleton_instance_identifier,
+                                        const ProxyInstanceIdentifier& proxy_instance_identifier,
+                                        const pid_t target_node_id) override;
 
-    ResultBlank CallMethod(const ProxyMethodInstanceIdentifier& proxy_method_instance_identifier,
-                           const std::size_t queue_position,
-                           const pid_t target_node_id) override;
+    Result<void> CallMethod(const ProxyMethodInstanceIdentifier& proxy_method_instance_identifier,
+                            const std::size_t queue_position,
+                            const pid_t target_node_id) override;
 
   private:
     enum class MessageType : std::uint8_t
@@ -184,9 +184,9 @@ class MessagePassingServiceInstance : public IMessagePassingServiceInstance
     message_passing::MessageCallback CreateSendMessageWithReplyCallback();
 
     void MessageCallback(const pid_t sender_pid, const score::cpp::span<const std::uint8_t> message) noexcept;
-    score::ResultBlank MessageCallbackWithReply(const uid_t sender_uid,
-                                                const pid_t sender_pid,
-                                                const score::cpp::span<const std::uint8_t> message);
+    score::Result<void> MessageCallbackWithReply(const uid_t sender_uid,
+                                                 const pid_t sender_pid,
+                                                 const score::cpp::span<const std::uint8_t> message);
     void HandleNotifyEventMsg(const score::cpp::span<const std::uint8_t> payload, const pid_t sender_node_id) noexcept;
     void HandleRegisterNotificationMsg(const score::cpp::span<const std::uint8_t> payload,
                                        const pid_t sender_node_id) noexcept;
@@ -194,10 +194,10 @@ class MessagePassingServiceInstance : public IMessagePassingServiceInstance
                                          const pid_t sender_node_id) noexcept;
     void HandleOutdatedNodeIdMsg(const score::cpp::span<const std::uint8_t> payload,
                                  const pid_t sender_node_id) noexcept;
-    score::ResultBlank HandleSubscribeServiceMethodMsg(const score::cpp::span<const std::uint8_t> payload,
-                                                       const uid_t sender_uid,
-                                                       const pid_t sender_node_id);
-    score::ResultBlank HandleCallMethodMsg(const score::cpp::span<const std::uint8_t> payload, const uid_t sender_uid);
+    score::Result<void> HandleSubscribeServiceMethodMsg(const score::cpp::span<const std::uint8_t> payload,
+                                                        const uid_t sender_uid,
+                                                        const pid_t sender_node_id);
+    score::Result<void> HandleCallMethodMsg(const score::cpp::span<const std::uint8_t> payload, const uid_t sender_uid);
 
     std::uint32_t NotifyEventLocally(const ElementFqId event_id) noexcept;
     void NotifyEventRemote(const ElementFqId event_id) noexcept;
@@ -207,20 +207,21 @@ class MessagePassingServiceInstance : public IMessagePassingServiceInstance
                                            const pid_t target_node_id) noexcept;
     void SendRegisterEventNotificationMessage(const ElementFqId event_id, const pid_t target_node_id) noexcept;
 
-    score::ResultBlank CallSubscribeServiceMethodLocally(const SkeletonInstanceIdentifier& skeleton_instance_identifier,
-                                                         const ProxyInstanceIdentifier& proxy_instance_identifier,
-                                                         const uid_t proxy_uid,
-                                                         const pid_t proxy_pid);
-    score::ResultBlank CallServiceMethodLocally(const ProxyMethodInstanceIdentifier& proxy_method_instance_identifier,
-                                                const std::size_t queue_position,
-                                                const uid_t proxy_uid);
+    score::Result<void> CallSubscribeServiceMethodLocally(
+        const SkeletonInstanceIdentifier& skeleton_instance_identifier,
+        const ProxyInstanceIdentifier& proxy_instance_identifier,
+        const uid_t proxy_uid,
+        const pid_t proxy_pid);
+    score::Result<void> CallServiceMethodLocally(const ProxyMethodInstanceIdentifier& proxy_method_instance_identifier,
+                                                 const std::size_t queue_position,
+                                                 const uid_t proxy_uid);
 
-    ResultBlank CallSubscribeServiceMethodRemotely(const SkeletonInstanceIdentifier& skeleton_instance_identifier,
-                                                   const ProxyInstanceIdentifier& proxy_instance_identifier,
-                                                   const pid_t target_node_id);
-    ResultBlank CallServiceMethodRemotely(const ProxyMethodInstanceIdentifier& proxy_method_instance_identifier,
-                                          const std::size_t queue_position,
-                                          const pid_t target_node_id);
+    Result<void> CallSubscribeServiceMethodRemotely(const SkeletonInstanceIdentifier& skeleton_instance_identifier,
+                                                    const ProxyInstanceIdentifier& proxy_instance_identifier,
+                                                    const pid_t target_node_id);
+    Result<void> CallServiceMethodRemotely(const ProxyMethodInstanceIdentifier& proxy_method_instance_identifier,
+                                           const std::size_t queue_position,
+                                           const pid_t target_node_id);
 
     /// \brief Function to convert ClientQualityType to a QualityType
     ///

--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance_methods_test.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance_methods_test.cpp
@@ -51,7 +51,7 @@ struct MethodCallUnserializedPayload
     std::size_t queue_position;
 };
 
-using MethodUnserializedReply = score::ResultBlank;
+using MethodUnserializedReply = score::Result<void>;
 using MethodReplyPayload = ErrorSerializer<MethodErrc>::SerializedErrorType;
 
 constexpr pid_t kLocalPid{1};
@@ -100,7 +100,7 @@ class MessagePassingServiceInstanceMethodsFixture : public ::testing::Test
             .WillByDefault(Return(ByMove(std::move(client_connection_mock_facade))));
 
         ON_CALL(client_connection_mock_, SendWaitReply(_, _))
-            .WillByDefault(Return(CreateSerializedMethodReply(score::ResultBlank{}, method_reply_buffer_)));
+            .WillByDefault(Return(CreateSerializedMethodReply(score::Result<void>{}, method_reply_buffer_)));
         ON_CALL(client_connection_mock_, GetState()).WillByDefault(testing::Return(IClientConnection::State::kReady));
 
         ON_CALL(*unistd_mock_, getpid()).WillByDefault(Return(kLocalPid));
@@ -110,7 +110,7 @@ class MessagePassingServiceInstanceMethodsFixture : public ::testing::Test
             executor_task_ = std::forward<decltype(task)>(task);
         });
 
-        ON_CALL(mock_subscribe_method_handler_, Call(_, _, _)).WillByDefault(Return(score::ResultBlank{}));
+        ON_CALL(mock_subscribe_method_handler_, Call(_, _, _)).WillByDefault(Return(score::Result<void>{}));
     }
 
     MessagePassingServiceInstanceMethodsFixture& GivenAMessagePassingServiceInstance(
@@ -212,7 +212,7 @@ class MessagePassingServiceInstanceMethodsFixture : public ::testing::Test
     }
 
     score::cpp::span<const std::uint8_t> CreateSerializedMethodReply(
-        score::ResultBlank method_reply,
+        score::Result<void> method_reply,
         std::array<std::uint8_t, sizeof(MethodReplyPayload)>& message_reply_buffer)
     {
         const MethodReplyPayload serialized_com_errc =
@@ -259,7 +259,8 @@ class MessagePassingServiceInstanceMethodsFixture : public ::testing::Test
     safecpp::Scope<> subscribe_method_handler_scope_{};
 
     ::testing::MockFunction<void(std::size_t)> mock_method_call_handler_{};
-    ::testing::MockFunction<score::ResultBlank(ProxyInstanceIdentifier, uid_t, pid_t)> mock_subscribe_method_handler_{};
+    ::testing::MockFunction<score::Result<void>(ProxyInstanceIdentifier, uid_t, pid_t)>
+        mock_subscribe_method_handler_{};
 
     // Since an SendWaitReply returns an score::cpp::span to a message (which is essentially a pointer to a message), we
     // need a buffer to store the message.
@@ -352,7 +353,7 @@ TEST_F(MessagePassingServiceInstanceRemoteCallMethodTest, CallingWithOtherProces
         EXPECT_EQ(actual_payload.queue_position, kQueuePosition);
         EXPECT_EQ(actual_payload.proxy_method_instance_identifier, kProxyMethodInstanceIdentifier);
 
-        return CreateSerializedMethodReply(score::ResultBlank{}, method_reply_buffer_);
+        return CreateSerializedMethodReply(score::Result<void>{}, method_reply_buffer_);
     })));
 
     // and expecting that the registered method call handler will NOT be called (which would happen when the client is
@@ -574,7 +575,7 @@ TEST_F(MessagePassingServiceInstanceRemoteSubscribeMethodTest, CallingWithOtherP
         EXPECT_EQ(actual_payload.skeleton_instance_identifier, kSkeletonInstanceIdentifier);
         EXPECT_EQ(actual_payload.proxy_instance_identifier, kProxyInstanceIdentifier);
 
-        return CreateSerializedMethodReply(score::ResultBlank{}, method_reply_buffer_);
+        return CreateSerializedMethodReply(score::Result<void>{}, method_reply_buffer_);
     })));
 
     // and expecting that the registered method subscribe handler will NOT be called (which would happen when the client
@@ -693,7 +694,7 @@ TEST_F(MessagePassingServiceInstanceRegisterMethodCallHandlerTest,
 using MessagePassingServiceInstanceRegisterSubscribeHandlerTest = MessagePassingServiceInstanceMethodsFixture;
 TEST_F(MessagePassingServiceInstanceRegisterSubscribeHandlerTest, ReregisteringHandlerReturnsError)
 {
-    ::testing::MockFunction<score::ResultBlank(ProxyInstanceIdentifier, uid_t, pid_t)>
+    ::testing::MockFunction<score::Result<void>(ProxyInstanceIdentifier, uid_t, pid_t)>
         mock_subscribe_method_handler_2{};
     safecpp::Scope<> subscribe_method_handler_scope_2{};
     IMessagePassingService::ServiceMethodSubscribedHandler scoped_subscribe_method_handler_2{

--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance_mock.h
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance_mock.h
@@ -37,14 +37,14 @@ class MessagePassingServiceInstanceMock : public IMessagePassingServiceInstance
                 (const ElementFqId, const IMessagePassingService::HandlerRegistrationNoType, const pid_t),
                 (noexcept, override));
 
-    MOCK_METHOD(ResultBlank,
+    MOCK_METHOD(Result<void>,
                 RegisterOnServiceMethodSubscribedHandler,
                 (SkeletonInstanceIdentifier,
                  IMessagePassingService::ServiceMethodSubscribedHandler,
                  IMessagePassingService::AllowedConsumerUids),
                 (override));
 
-    MOCK_METHOD(ResultBlank,
+    MOCK_METHOD(Result<void>,
                 RegisterMethodCallHandler,
                 (ProxyMethodInstanceIdentifier, IMessagePassingService::MethodCallHandler, uid_t),
                 (override));
@@ -58,12 +58,12 @@ class MessagePassingServiceInstanceMock : public IMessagePassingServiceInstance
 
     MOCK_METHOD(void, UnregisterEventNotificationExistenceChangedCallback, (const ElementFqId), (noexcept, override));
 
-    MOCK_METHOD(ResultBlank,
+    MOCK_METHOD(Result<void>,
                 SubscribeServiceMethod,
                 (const SkeletonInstanceIdentifier&, const ProxyInstanceIdentifier&, pid_t),
                 (override));
 
-    MOCK_METHOD(ResultBlank, CallMethod, (const ProxyMethodInstanceIdentifier&, std::size_t, pid_t), (override));
+    MOCK_METHOD(Result<void>, CallMethod, (const ProxyMethodInstanceIdentifier&, std::size_t, pid_t), (override));
 
     MOCK_METHOD(void, UnregisterOnServiceMethodSubscribedHandler, (SkeletonInstanceIdentifier), (override));
 

--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service_mock.h
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service_mock.h
@@ -56,11 +56,11 @@ class MessagePassingServiceMock : public IMessagePassingService
                 RegisterMethodCallHandler,
                 (QualityType, ProxyMethodInstanceIdentifier, MethodCallHandler, uid_t),
                 (override));
-    MOCK_METHOD(ResultBlank,
+    MOCK_METHOD(Result<void>,
                 SubscribeServiceMethod,
                 (QualityType, const SkeletonInstanceIdentifier&, const ProxyInstanceIdentifier&, pid_t),
                 (override));
-    MOCK_METHOD(ResultBlank,
+    MOCK_METHOD(Result<void>,
                 CallMethod,
                 (QualityType, const ProxyMethodInstanceIdentifier&, std::size_t, pid_t),
                 (override));

--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service_test.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service_test.cpp
@@ -437,7 +437,7 @@ TEST_F(MessagePassingServiceQMDelegationTest, RegisterOnServiceMethodSubscribedH
     // instance
     EXPECT_CALL(*asil_qm_message_passing_service_instance_mock_,
                 RegisterOnServiceMethodSubscribedHandler(kSkeletonInstanceId, _, allowed_uids))
-        .WillOnce(Return(score::ResultBlank{}));
+        .WillOnce(Return(score::Result<void>{}));
     EXPECT_CALL(*asil_b_message_passing_service_instance_mock_, RegisterOnServiceMethodSubscribedHandler(_, _, _))
         .Times(0);
 
@@ -457,7 +457,7 @@ TEST_F(MessagePassingServiceQMDelegationTest, RegisterMethodCallHandlerCallRetur
     // Expecting a call to RegisterMethodCallHandler of ASIL-QM mock instance
     EXPECT_CALL(*asil_qm_message_passing_service_instance_mock_,
                 RegisterMethodCallHandler(kProxyMethodInstanceId, _, kAllowedUid))
-        .WillOnce(Return(score::ResultBlank{}));
+        .WillOnce(Return(score::Result<void>{}));
     EXPECT_CALL(*asil_b_message_passing_service_instance_mock_, RegisterMethodCallHandler(_, _, _)).Times(0);
 
     // When calling RegisterMethodCallHandler
@@ -473,7 +473,7 @@ TEST_F(MessagePassingServiceQMDelegationTest, SubscribeServiceMethodReturnsAValu
     // Expecting a call to SubscribeServiceMethod of ASIL-QM mock instance
     EXPECT_CALL(*asil_qm_message_passing_service_instance_mock_,
                 SubscribeServiceMethod(kSkeletonInstanceId, kProxyInstanceId, kTargetNodeId))
-        .WillOnce(Return(score::ResultBlank{}));
+        .WillOnce(Return(score::Result<void>{}));
     EXPECT_CALL(*asil_b_message_passing_service_instance_mock_, SubscribeServiceMethod(_, _, _)).Times(0);
 
     // When calling SubscribeServiceMethod
@@ -489,7 +489,7 @@ TEST_F(MessagePassingServiceQMDelegationTest, CallMethodReturnsAValue)
     // Expecting a call to CallMethod of ASIL-QM mock instance
     EXPECT_CALL(*asil_qm_message_passing_service_instance_mock_,
                 CallMethod(kProxyMethodInstanceId, kQueuePosition, kTargetNodeId))
-        .WillOnce(Return(score::ResultBlank{}));
+        .WillOnce(Return(score::Result<void>{}));
     EXPECT_CALL(*asil_b_message_passing_service_instance_mock_, CallMethod(_, _, _)).Times(0);
 
     // When calling CallMethod

--- a/score/mw/com/impl/bindings/lola/messaging/method_call_registration_guard_test.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/method_call_registration_guard_test.cpp
@@ -35,7 +35,7 @@ class MethodCallRegistrationGuardFixture : public ::testing::Test
     MethodCallRegistrationGuardFixture()
     {
         ON_CALL(message_passing_service_mock_, UnregisterMethodCallHandler(_, _))
-            .WillByDefault(WithoutArgs(Invoke([this]() -> ResultBlank {
+            .WillByDefault(WithoutArgs(Invoke([this]() -> Result<void> {
                 unregister_method_call_handler_called_ = true;
                 return {};
             })));

--- a/score/mw/com/impl/bindings/lola/messaging/method_subscription_registration_guard_test.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/method_subscription_registration_guard_test.cpp
@@ -36,7 +36,7 @@ class MethodSubscriptionRegistrationGuardFixture : public ::testing::Test
     MethodSubscriptionRegistrationGuardFixture()
     {
         ON_CALL(message_passing_service_mock_, UnregisterOnServiceMethodSubscribedHandler(_, _))
-            .WillByDefault(WithoutArgs(Invoke([this]() -> ResultBlank {
+            .WillByDefault(WithoutArgs(Invoke([this]() -> Result<void> {
                 unregister_on_service_method_subscribed_handler_called_ = true;
                 return {};
             })));

--- a/score/mw/com/impl/bindings/lola/proxy.cpp
+++ b/score/mw/com/impl/bindings/lola/proxy.cpp
@@ -211,10 +211,10 @@ ProxyServiceDataControlLocalView GetProxyServiceDataControlLocalView(
 // throwing std::bad_optional_access which leds to std::terminate(). This suppression should be removed after fixing
 // [Ticket-173043](broken_link_j/Ticket-173043)
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-score::ResultBlank ExecutePartialRestartLogic(const QualityType quality_type,
-                                              const SkeletonInstanceIdentifier skeleton_instance_identifier,
-                                              const memory::shared::ManagedMemoryResource& control,
-                                              const memory::shared::ManagedMemoryResource& data) noexcept
+score::Result<void> ExecutePartialRestartLogic(const QualityType quality_type,
+                                               const SkeletonInstanceIdentifier skeleton_instance_identifier,
+                                               const memory::shared::ManagedMemoryResource& control,
+                                               const memory::shared::ManagedMemoryResource& data) noexcept
 {
     auto& service_data_storage = detail_proxy::GetServiceDataStorage(data);
 
@@ -616,7 +616,7 @@ void Proxy::UnregisterEventBinding(const std::string_view service_element_name) 
     }
 }
 
-score::ResultBlank Proxy::SetupMethods(const std::vector<std::string_view>& enabled_method_names)
+score::Result<void> Proxy::SetupMethods(const std::vector<std::string_view>& enabled_method_names)
 {
     auto enabled_method_data = GetMethodIdAndQueueSizeFromNames(enabled_method_names);
 

--- a/score/mw/com/impl/bindings/lola/proxy.h
+++ b/score/mw/com/impl/bindings/lola/proxy.h
@@ -179,7 +179,7 @@ class Proxy : public ProxyBinding
     /// been destructed.
     void UnregisterEventBinding(const std::string_view service_element_name) noexcept override;
 
-    score::ResultBlank SetupMethods(const std::vector<std::string_view>& enabled_method_names) override;
+    score::Result<void> SetupMethods(const std::vector<std::string_view>& enabled_method_names) override;
 
     QualityType GetQualityType() const noexcept;
 

--- a/score/mw/com/impl/bindings/lola/proxy_event.h
+++ b/score/mw/com/impl/bindings/lola/proxy_event.h
@@ -75,7 +75,7 @@ class ProxyEvent final : public ProxyEventBinding<SampleType>
 
     ~ProxyEvent() noexcept override = default;
 
-    ResultBlank Subscribe(const std::size_t max_sample_count) noexcept override
+    Result<void> Subscribe(const std::size_t max_sample_count) noexcept override
     {
         return proxy_event_common_.Subscribe(max_sample_count);
     }
@@ -91,11 +91,11 @@ class ProxyEvent final : public ProxyEventBinding<SampleType>
     Result<std::size_t> GetNumNewSamplesAvailable() const noexcept override;
     Result<std::size_t> GetNewSamples(Callback&& receiver, TrackerGuardFactory& tracker) noexcept override;
 
-    ResultBlank SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) noexcept override
+    Result<void> SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) noexcept override
     {
         return proxy_event_common_.SetReceiveHandler(std::move(handler));
     }
-    ResultBlank UnsetReceiveHandler() noexcept override
+    Result<void> UnsetReceiveHandler() noexcept override
     {
         return proxy_event_common_.UnsetReceiveHandler();
     }

--- a/score/mw/com/impl/bindings/lola/proxy_event_common.cpp
+++ b/score/mw/com/impl/bindings/lola/proxy_event_common.cpp
@@ -43,7 +43,7 @@ ProxyEventCommon::~ProxyEventCommon()
     Unsubscribe();
 }
 
-ResultBlank ProxyEventCommon::Subscribe(const std::size_t max_sample_count)
+Result<void> ProxyEventCommon::Subscribe(const std::size_t max_sample_count)
 {
     std::stringstream sstream{};
     sstream << "Max sample count of" << max_sample_count << "is too large: Lola only supports up to 255 samples.";
@@ -98,13 +98,13 @@ SlotCollector::SlotIndices ProxyEventCommon::GetNewSamplesSlotIndices(const std:
     return slot_collector.value().GetNewSamplesSlotIndices(max_count);
 }
 
-ResultBlank ProxyEventCommon::SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler)
+Result<void> ProxyEventCommon::SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler)
 {
     subscription_event_state_machine_.SetReceiveHandler(std::move(handler));
     return {};
 }
 
-ResultBlank ProxyEventCommon::UnsetReceiveHandler()
+Result<void> ProxyEventCommon::UnsetReceiveHandler()
 {
     subscription_event_state_machine_.UnsetReceiveHandler();
     return {};

--- a/score/mw/com/impl/bindings/lola/proxy_event_common.h
+++ b/score/mw/com/impl/bindings/lola/proxy_event_common.h
@@ -58,7 +58,7 @@ class ProxyEventCommon final
     ProxyEventCommon& operator=(const ProxyEventCommon&) = delete;
     ProxyEventCommon& operator=(ProxyEventCommon&&) noexcept = delete;
 
-    ResultBlank Subscribe(const std::size_t max_sample_count);
+    Result<void> Subscribe(const std::size_t max_sample_count);
     void Unsubscribe();
 
     SubscriptionState GetSubscriptionState() const noexcept;
@@ -79,8 +79,8 @@ class ProxyEventCommon final
     /// GetNewSamplesSlotIndices() is only called when the event is in the subscribed state.
     SlotCollector::SlotIndices GetNewSamplesSlotIndices(const std::size_t max_count) noexcept;
 
-    ResultBlank SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler);
-    ResultBlank UnsetReceiveHandler();
+    Result<void> SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler);
+    Result<void> UnsetReceiveHandler();
 
     pid_t GetEventSourcePid() const noexcept;
     ElementFqId GetElementFQId() const noexcept

--- a/score/mw/com/impl/bindings/lola/proxy_method.cpp
+++ b/score/mw/com/impl/bindings/lola/proxy_method.cpp
@@ -83,7 +83,7 @@ score::Result<score::cpp::span<std::byte>> ProxyMethod::GetReturnValueBuffer(std
     return GetReturnValueElementStorage(queue_position, return_storage_.value(), type_erased_element_info_);
 }
 
-score::ResultBlank ProxyMethod::DoCall(std::size_t queue_position)
+score::Result<void> ProxyMethod::DoCall(std::size_t queue_position)
 {
     if (!is_subscribed_)
     {

--- a/score/mw/com/impl/bindings/lola/proxy_method.h
+++ b/score/mw/com/impl/bindings/lola/proxy_method.h
@@ -54,7 +54,7 @@ class ProxyMethod : public ProxyMethodBinding
     /// \brief Performs the actual method call at the given call-queue position.
     ///
     /// See ProxyMethodBinding for details
-    score::ResultBlank DoCall(std::size_t queue_position) override;
+    score::Result<void> DoCall(std::size_t queue_position) override;
 
     TypeErasedCallQueue::TypeErasedElementInfo GetTypeErasedElementInfo() const;
 

--- a/score/mw/com/impl/bindings/lola/proxy_method_handling_test.cpp
+++ b/score/mw/com/impl/bindings/lola/proxy_method_handling_test.cpp
@@ -493,7 +493,7 @@ TEST_F(ProxySetupMethodsProxyAutoReconnectFixture,
     // handler when the service has been reoffered which succeeds
     EXPECT_CALL(*mock_service_, SubscribeServiceMethod(_, _, _, _))
         .Times(2)
-        .WillRepeatedly(Return(score::ResultBlank{}));
+        .WillRepeatedly(Return(score::Result<void>{}));
 
     // Given that SetupMethods was called
     score::cpp::ignore = proxy_->SetupMethods({kDummyMethodName0});
@@ -594,7 +594,7 @@ TEST_F(ProxySetupMethodsMessagePassingFixture, MethodsWithArgsOrReturnTypesCalls
 
     // Expecting that SubscribeServiceMethod will be called
     EXPECT_CALL(*mock_service_, SubscribeServiceMethod(_, _, _, _))
-        .WillOnce(WithArg<1>(Invoke([](auto skeleton_instance_identifier) -> ResultBlank {
+        .WillOnce(WithArg<1>(Invoke([](auto skeleton_instance_identifier) -> Result<void> {
             // Then SubscribeServiceMethod is called with a
             // SkeletonInstanceIdentifier taking values from the configuration
             EXPECT_EQ(skeleton_instance_identifier.service_id, kLolaServiceId);
@@ -639,7 +639,7 @@ TEST_F(ProxySetupMethodsMessagePassingFixture, ProxyMethodsMarkedAsSubscribedWhe
               kValidInArgsTypeErasedDataInfo, kValidReturnTypeTypeErasedDataInfo, kDummyQueueSize1}}});
 
     // Expecting that SubscribeServiceMethod will be called and returns a valid result
-    EXPECT_CALL(*mock_service_, SubscribeServiceMethod(_, _, _, _)).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(*mock_service_, SubscribeServiceMethod(_, _, _, _)).WillOnce(Return(score::Result<void>{}));
 
     // When calling SetupMethods with the name of the registered ProxyMethods
     score::cpp::ignore = proxy_->SetupMethods({kDummyMethodName0, kDummyMethodName1});
@@ -713,7 +713,7 @@ TEST_F(ProxySetupMethodsMessagePassingFixture, EnablingMethodsWithoutArgsOrRetur
 
     // Expecting that SubscribeServiceMethod will be called
     EXPECT_CALL(*mock_service_, SubscribeServiceMethod(_, _, _, _))
-        .WillOnce(WithArg<1>(Invoke([](auto skeleton_instance_identifier) -> ResultBlank {
+        .WillOnce(WithArg<1>(Invoke([](auto skeleton_instance_identifier) -> Result<void> {
             // Then SubscribeServiceMethod is called with a
             // SkeletonInstanceIdentifier taking values from the configuration
             EXPECT_EQ(skeleton_instance_identifier.service_id, kLolaServiceId);

--- a/score/mw/com/impl/bindings/lola/proxy_method_test.cpp
+++ b/score/mw/com/impl/bindings/lola/proxy_method_test.cpp
@@ -321,11 +321,11 @@ TEST_F(ProxyMethodDoCallFixture, DispatchesToMessagePassingBinding)
 
     // Expecting that CallMethod is called on the message passing binding which returns success
     EXPECT_CALL(*mock_service_, CallMethod(_, _, kDummyQueuePosition, _))
-        .WillOnce(WithArg<1>(Invoke([](auto proxy_method_instance_identifier) -> ResultBlank {
+        .WillOnce(WithArg<1>(Invoke([](auto proxy_method_instance_identifier) -> Result<void> {
             // Then CallMethod is called with a ProxyMethodInstanceIdentifier containing the application id from the
             // configuration
             EXPECT_EQ(proxy_method_instance_identifier.proxy_instance_identifier.application_id, kDummyApplicationId);
-            return ResultBlank{};
+            return Result<void>{};
         })));
 
     // When calling DoCall

--- a/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client.cpp
+++ b/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client.cpp
@@ -143,7 +143,7 @@ ServiceDiscoveryClient::~ServiceDiscoveryClient() noexcept
 // implicitly". std::terminate() is implicitly called from '.value()' in case it doesn't have value but as we check
 // before with 'has_value()' so no way for throwing std::bad_optional_access which leds to std::terminate().
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-auto ServiceDiscoveryClient::OfferService(const InstanceIdentifier instance_identifier) noexcept -> ResultBlank
+auto ServiceDiscoveryClient::OfferService(const InstanceIdentifier instance_identifier) noexcept -> Result<void>
 {
     const EnrichedInstanceIdentifier enriched_instance_identifier{instance_identifier};
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(
@@ -223,7 +223,7 @@ auto ServiceDiscoveryClient::OfferService(const InstanceIdentifier instance_iden
 
 auto ServiceDiscoveryClient::StopOfferService(
     const InstanceIdentifier instance_identifier,
-    const IServiceDiscovery::QualityTypeSelector quality_type_selector) noexcept -> ResultBlank
+    const IServiceDiscovery::QualityTypeSelector quality_type_selector) noexcept -> Result<void>
 {
     const EnrichedInstanceIdentifier enriched_instance_identifier{instance_identifier};
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(
@@ -263,7 +263,7 @@ auto ServiceDiscoveryClient::StopOfferService(
     return {};
 }
 
-auto ServiceDiscoveryClient::StopFindService(const FindServiceHandle find_service_handle) noexcept -> ResultBlank
+auto ServiceDiscoveryClient::StopFindService(const FindServiceHandle find_service_handle) noexcept -> Result<void>
 {
     {
         // Suppress Autosar C++14 A8-5-3 states that auto variables shall not be initialized using braced
@@ -701,7 +701,7 @@ auto ServiceDiscoveryClient::UnlinkWatchWithSearchRequest(
 // implicitly". std::terminate() is implicitly called from '.value()' in case it doesn't have value but as we check
 // before with 'has_value()' so no way for throwing std::bad_optional_access which leds to std::terminate().
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-ResultBlank ServiceDiscoveryClient::StartFindService(
+Result<void> ServiceDiscoveryClient::StartFindService(
     const FindServiceHandle find_service_handle,
     FindServiceHandler<HandleType> handler,
     const EnrichedInstanceIdentifier enriched_instance_identifier) noexcept

--- a/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client.h
+++ b/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client.h
@@ -53,18 +53,18 @@ class ServiceDiscoveryClient final : public IServiceDiscoveryClient
 
     ~ServiceDiscoveryClient() noexcept override;
 
-    [[nodiscard]] ResultBlank OfferService(const InstanceIdentifier instance_identifier) noexcept override;
+    [[nodiscard]] Result<void> OfferService(const InstanceIdentifier instance_identifier) noexcept override;
 
-    [[nodiscard]] ResultBlank StopOfferService(
+    [[nodiscard]] Result<void> StopOfferService(
         const InstanceIdentifier instance_identifier,
         const IServiceDiscovery::QualityTypeSelector quality_type_selector) noexcept override;
 
-    [[nodiscard]] ResultBlank StartFindService(
+    [[nodiscard]] Result<void> StartFindService(
         const FindServiceHandle find_service_handle,
         FindServiceHandler<HandleType> handler,
         const EnrichedInstanceIdentifier enriched_instance_identifier) noexcept override;
 
-    [[nodiscard]] ResultBlank StopFindService(const FindServiceHandle find_service_handle) noexcept override;
+    [[nodiscard]] Result<void> StopFindService(const FindServiceHandle find_service_handle) noexcept override;
     [[nodiscard]] Result<ServiceHandleContainer<HandleType>> FindService(
         const EnrichedInstanceIdentifier enriched_instance_identifier) noexcept override;
 

--- a/score/mw/com/impl/bindings/lola/service_discovery/flag_file.cpp
+++ b/score/mw/com/impl/bindings/lola/service_discovery/flag_file.cpp
@@ -94,7 +94,7 @@ auto GetMatchingFlagFilePaths(const EnrichedInstanceIdentifier& enriched_instanc
 
 auto RemoveMatchingFlagFiles(const EnrichedInstanceIdentifier& enriched_instance_identifier,
                              const FlagFile::Disambiguator offer_disambiguator,
-                             filesystem::Filesystem& filesystem) noexcept -> score::ResultBlank
+                             filesystem::Filesystem& filesystem) noexcept -> score::Result<void>
 {
     const auto matching_file_paths = GetMatchingFlagFilePaths(enriched_instance_identifier);
 
@@ -104,7 +104,7 @@ auto RemoveMatchingFlagFiles(const EnrichedInstanceIdentifier& enriched_instance
                                  << GetFlagFilePath(enriched_instance_identifier, offer_disambiguator);
     }
 
-    ResultBlank result{};
+    Result<void> result{};
     for (const auto& matching_file_path : matching_file_paths)
     {
         const auto remove_result = filesystem.standard->Remove(matching_file_path);
@@ -247,7 +247,7 @@ auto FlagFile::CreateSearchPath(const EnrichedInstanceIdentifier& enriched_insta
 {
     auto path = GetSearchPathForIdentifier(enriched_instance_identifier);
 
-    score::ResultBlank result{};
+    score::Result<void> result{};
     constexpr auto retry_count = 3;
     constexpr std::chrono::milliseconds backoff_time{10};
     for (auto i = 0; i < retry_count; ++i)
@@ -264,7 +264,7 @@ auto FlagFile::CreateSearchPath(const EnrichedInstanceIdentifier& enriched_insta
             if ((status.value().Type() == filesystem::FileType::kDirectory) &&
                 (status.value().Permissions() == ALL_PERMISSIONS))
             {
-                result = ResultBlank{};
+                result = Result<void>{};
                 break;
             }
         }

--- a/score/mw/com/impl/bindings/lola/skeleton.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton.cpp
@@ -238,7 +238,7 @@ Skeleton::Skeleton(const InstanceIdentifier& identifier,
 auto Skeleton::PrepareOffer(SkeletonEventBindings& events,
                             SkeletonFieldBindings& fields,
                             std::optional<RegisterShmObjectTraceCallback> register_shm_object_trace_callback)
-    -> ResultBlank
+    -> Result<void>
 {
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(
         partial_restart_path_builder_ != nullptr,
@@ -317,7 +317,7 @@ auto Skeleton::PrepareOffer(SkeletonEventBindings& events,
             on_service_method_subscribed_handler_scope_,
             [this](const ProxyInstanceIdentifier proxy_instance_identifier,
                    const uid_t proxy_uid,
-                   const pid_t proxy_pid) -> ResultBlank {
+                   const pid_t proxy_pid) -> Result<void> {
                 return OnServiceMethodsSubscribed(
                     proxy_instance_identifier, proxy_uid, QualityType::kASIL_QM, proxy_pid);
             }},
@@ -325,7 +325,7 @@ auto Skeleton::PrepareOffer(SkeletonEventBindings& events,
     if (!(qm_registration_result.has_value()))
     {
         score::mw::log::LogError("lola") << "Could not register QM service method handler. Returning error.";
-        return MakeUnexpected<Blank>(qm_registration_result.error());
+        return MakeUnexpected<void>(qm_registration_result.error());
     }
     method_subscription_registration_guard_qm_.emplace(std::move(qm_registration_result).value());
 
@@ -339,7 +339,7 @@ auto Skeleton::PrepareOffer(SkeletonEventBindings& events,
                 on_service_method_subscribed_handler_scope_,
                 [this](const ProxyInstanceIdentifier proxy_instance_identifier,
                        const uid_t proxy_uid,
-                       const pid_t proxy_pid) -> ResultBlank {
+                       const pid_t proxy_pid) -> Result<void> {
                     return OnServiceMethodsSubscribed(
                         proxy_instance_identifier, proxy_uid, QualityType::kASIL_B, proxy_pid);
                 }},
@@ -348,7 +348,7 @@ auto Skeleton::PrepareOffer(SkeletonEventBindings& events,
         {
             method_subscription_registration_guard_qm_.reset();
             score::mw::log::LogError("lola") << "Could not register ASIL-B service method handler. Returning error.";
-            return MakeUnexpected<Blank>(asil_b_registration_result.error());
+            return MakeUnexpected<void>(asil_b_registration_result.error());
         }
         score::cpp::ignore =
             method_subscription_registration_guard_asil_b_.emplace(std::move(asil_b_registration_result).value());
@@ -518,10 +518,10 @@ auto Skeleton::RegisterGeneric(const ElementFqId element_fq_id,
     return GenericRegistrationResult{type_erased_event_data_storage, event_data_control_composite};
 }
 
-ResultBlank Skeleton::OnServiceMethodsSubscribed(const ProxyInstanceIdentifier& proxy_instance_identifier,
-                                                 const uid_t proxy_uid,
-                                                 const QualityType asil_level,
-                                                 const pid_t proxy_pid)
+Result<void> Skeleton::OnServiceMethodsSubscribed(const ProxyInstanceIdentifier& proxy_instance_identifier,
+                                                  const uid_t proxy_uid,
+                                                  const QualityType asil_level,
+                                                  const pid_t proxy_pid)
 {
     // Note. we currently call the entirety of the funcitonality within OnServiceMethodsSubscribed within the mutex.
     // We potentially could optimise this and call some functionality outside of the mutex. However, we haven't
@@ -570,7 +570,7 @@ auto Skeleton::SubscribeMethods(const MethodData& method_data,
                                 const ProxyInstanceIdentifier proxy_instance_identifier,
                                 const uid_t proxy_uid,
                                 const pid_t proxy_pid,
-                                const QualityType asil_level) -> std::pair<score::ResultBlank, MethodIdsToUnsubscribe>
+                                const QualityType asil_level) -> std::pair<score::Result<void>, MethodIdsToUnsubscribe>
 {
     const auto& method_call_queues = method_data.method_call_queues_;
     for (std::size_t method_idx = 0U; method_idx != method_call_queues.size(); method_idx++)

--- a/score/mw/com/impl/bindings/lola/skeleton.h
+++ b/score/mw/com/impl/bindings/lola/skeleton.h
@@ -102,9 +102,10 @@ class Skeleton final : public SkeletonBinding
     Skeleton(Skeleton&& other) = delete;
     Skeleton& operator=(Skeleton&& other) = delete;
 
-    ResultBlank PrepareOffer(SkeletonEventBindings& events,
-                             SkeletonFieldBindings& fields,
-                             std::optional<RegisterShmObjectTraceCallback> register_shm_object_trace_callback) override;
+    Result<void> PrepareOffer(
+        SkeletonEventBindings& events,
+        SkeletonFieldBindings& fields,
+        std::optional<RegisterShmObjectTraceCallback> register_shm_object_trace_callback) override;
 
     void PrepareStopOffer(
         std::optional<UnregisterShmObjectTraceCallback> unregister_shm_object_callback) noexcept override;
@@ -165,14 +166,14 @@ class Skeleton final : public SkeletonBinding
     bool VerifyAllMethodsRegistered() const override;
 
   private:
-    ResultBlank OnServiceMethodsSubscribed(const ProxyInstanceIdentifier& proxy_instance_identifier,
-                                           const uid_t proxy_uid,
-                                           const QualityType asil_level,
-                                           const pid_t proxy_pid);
+    Result<void> OnServiceMethodsSubscribed(const ProxyInstanceIdentifier& proxy_instance_identifier,
+                                            const uid_t proxy_uid,
+                                            const QualityType asil_level,
+                                            const pid_t proxy_pid);
 
     using MethodIdsToUnsubscribe = std::vector<UniqueMethodIdentifier>;
 
-    std::pair<score::ResultBlank, MethodIdsToUnsubscribe> SubscribeMethods(
+    std::pair<score::Result<void>, MethodIdsToUnsubscribe> SubscribeMethods(
         const MethodData& method_data,
         const ProxyInstanceIdentifier proxy_instance_identifier,
         const uid_t proxy_uid,

--- a/score/mw/com/impl/bindings/lola/skeleton_event.h
+++ b/score/mw/com/impl/bindings/lola/skeleton_event.h
@@ -84,18 +84,18 @@ class SkeletonEvent final : public SkeletonEventBinding<SampleType>
 
     /// \brief Sends a value by _copy_ towards a consumer. It will allocate the necessary space and then copy the value
     /// into Shared Memory.
-    ResultBlank Send(const SampleType& value,
-                     score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>
-                         send_trace_callback) noexcept override;
+    Result<void> Send(const SampleType& value,
+                      score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>
+                          send_trace_callback) noexcept override;
 
-    ResultBlank Send(impl::SampleAllocateePtr<SampleType> sample,
-                     score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>
-                         send_trace_callback) noexcept override;
+    Result<void> Send(impl::SampleAllocateePtr<SampleType> sample,
+                      score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>
+                          send_trace_callback) noexcept override;
 
     Result<impl::SampleAllocateePtr<SampleType>> Allocate() noexcept override;
 
     /// @requirement SWS_CM_00700
-    ResultBlank PrepareOffer() noexcept override;
+    Result<void> PrepareOffer() noexcept override;
 
     void PrepareStopOffer() noexcept override;
 
@@ -132,7 +132,7 @@ template <typename SampleType>
 // 'allocated_slot_result' doesn't have value but as we check before with 'has_value()' so no way for throwing
 // std::bad_optional_access which leds to std::terminate().
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-ResultBlank SkeletonEvent<SampleType>::Send(
+Result<void> SkeletonEvent<SampleType>::Send(
     const SampleType& value,
     score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> send_trace_callback) noexcept
 {
@@ -148,14 +148,14 @@ ResultBlank SkeletonEvent<SampleType>::Send(
 }
 
 template <typename SampleType>
-ResultBlank SkeletonEvent<SampleType>::Send(
+Result<void> SkeletonEvent<SampleType>::Send(
     impl::SampleAllocateePtr<SampleType> sample,
     score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> send_trace_callback) noexcept
 {
     const auto send_result = skeleton_event_common_.Send(sample);
     if (!send_result.has_value())
     {
-        return MakeUnexpected<Blank>(send_result.error());
+        return MakeUnexpected<void>(send_result.error());
     }
 
     if (send_trace_callback.has_value())
@@ -192,7 +192,7 @@ template <typename SampleType>
 // throwing std::bad_optional_access which leds to std::terminate(). This suppression should be removed after fixing
 // [Ticket-173043](broken_link_j/Ticket-173043)
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-ResultBlank SkeletonEvent<SampleType>::PrepareOffer() noexcept
+Result<void> SkeletonEvent<SampleType>::PrepareOffer() noexcept
 {
     const auto registration_result = skeleton_event_common_.GetParent().template Register<SampleType>(
         skeleton_event_common_.GetElementFQId(), skeleton_event_common_.GetEventProperties());

--- a/score/mw/com/impl/bindings/lola/skeleton_event_common.h
+++ b/score/mw/com/impl/bindings/lola/skeleton_event_common.h
@@ -73,7 +73,7 @@ class SkeletonEventCommon
     void PrepareStopOfferCommon() noexcept;
 
     Result<SlotIndexType> AllocateSlot() noexcept;
-    ResultBlank Send(impl::SampleAllocateePtr<SampleType>& sample) noexcept;
+    Result<void> Send(impl::SampleAllocateePtr<SampleType>& sample) noexcept;
 
     // Accessors for members used by PrepareOfferCommon/PrepareStopOfferCommon
     void SetSkeletonEventTracingData(impl::tracing::SkeletonEventTracingData tracing_data) noexcept
@@ -273,7 +273,7 @@ Result<SlotIndexType> SkeletonEventCommon<SampleType>::AllocateSlot() noexcept
 }
 
 template <typename SampleType>
-ResultBlank SkeletonEventCommon<SampleType>::Send(impl::SampleAllocateePtr<SampleType>& sample) noexcept
+Result<void> SkeletonEventCommon<SampleType>::Send(impl::SampleAllocateePtr<SampleType>& sample) noexcept
 {
     const impl::SampleAllocateePtrView<SampleType> view{sample};
     auto ptr = view.template As<lola::SampleAllocateePtr<SampleType>>();

--- a/score/mw/com/impl/bindings/lola/skeleton_event_tracing_test.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_event_tracing_test.cpp
@@ -143,7 +143,7 @@ TEST_F(SkeletonEventTracingSendFixture, SendCallsAreTracedWhenEnabled)
         .WillOnce(WithArgs<4, 6, 7>(
             Invoke([&sample_data, this](impl::tracing::ITracingRuntime::TracePointDataId trace_point_data_id,
                                         const void* data_ptr,
-                                        std::size_t data_size) -> ResultBlank {
+                                        std::size_t data_size) -> Result<void> {
                 const auto timestamp = GetLastSendEventTimestamp(0U);
                 EXPECT_EQ(timestamp, trace_point_data_id);
 
@@ -212,7 +212,7 @@ TEST_F(SkeletonEventTracingSendFixture, MultipleSendCallsUsesCorrectTracePointDa
         .WillRepeatedly(WithArgs<4, 6, 7>(Invoke(
             [&sample_data, &slot_index, this](impl::tracing::ITracingRuntime::TracePointDataId trace_point_data_id,
                                               const void* data_ptr,
-                                              std::size_t data_size) -> ResultBlank {
+                                              std::size_t data_size) -> Result<void> {
                 const auto timestamp = GetLastSendEventTimestamp(slot_index);
                 EXPECT_EQ(timestamp, trace_point_data_id);
 
@@ -328,7 +328,7 @@ TEST_F(SkeletonEventTracingSendWithAllocateFixture, SendWithAllocateCallsAreTrac
         .WillOnce(WithArgs<4, 6, 7>(
             Invoke([&sample_data, this](impl::tracing::ITracingRuntime::TracePointDataId trace_point_data_id,
                                         const void* data_ptr,
-                                        std::size_t data_size) -> ResultBlank {
+                                        std::size_t data_size) -> Result<void> {
                 const auto timestamp = GetLastSendEventTimestamp(0U);
                 EXPECT_EQ(timestamp, trace_point_data_id);
 
@@ -405,7 +405,7 @@ TEST_F(SkeletonEventTracingSendWithAllocateFixture, MultipleSendCallsUsesCorrect
         .WillRepeatedly(WithArgs<4, 6, 7>(Invoke(
             [&sample_data, &slot_index, this](impl::tracing::ITracingRuntime::TracePointDataId trace_point_data_id,
                                               const void* data_ptr,
-                                              std::size_t data_size) -> ResultBlank {
+                                              std::size_t data_size) -> Result<void> {
                 const auto timestamp = GetLastSendEventTimestamp(slot_index);
                 EXPECT_EQ(timestamp, trace_point_data_id);
 

--- a/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
@@ -149,7 +149,7 @@ SkeletonMemoryManager::SkeletonMemoryManager(QualityType quality_type,
 auto SkeletonMemoryManager::CreateSharedMemory(
     SkeletonBinding::SkeletonEventBindings& events,
     SkeletonBinding::SkeletonFieldBindings& fields,
-    std::optional<SkeletonBinding::RegisterShmObjectTraceCallback> register_shm_object_trace_callback) -> ResultBlank
+    std::optional<SkeletonBinding::RegisterShmObjectTraceCallback> register_shm_object_trace_callback) -> Result<void>
 {
     const auto storage_size_calc_result = CalculateShmResourceStorageSizes(events, fields);
 
@@ -178,7 +178,7 @@ auto SkeletonMemoryManager::CreateSharedMemory(
 }
 
 auto SkeletonMemoryManager::OpenExistingSharedMemory(
-    std::optional<SkeletonBinding::RegisterShmObjectTraceCallback> register_shm_object_trace_callback) -> ResultBlank
+    std::optional<SkeletonBinding::RegisterShmObjectTraceCallback> register_shm_object_trace_callback) -> Result<void>
 {
     if (!OpenSharedMemoryForControl(QualityType::kASIL_QM))
     {

--- a/score/mw/com/impl/bindings/lola/skeleton_memory_manager.h
+++ b/score/mw/com/impl/bindings/lola/skeleton_memory_manager.h
@@ -72,7 +72,7 @@ class SkeletonMemoryManager final
     /// but there are no proxies connected to the old shared memory region). It will create the data and control shared
     /// memory regions and will initialise the ServiceDataControl and ServiceDataStorage structures in the created
     /// shared memory.
-    ResultBlank CreateSharedMemory(
+    Result<void> CreateSharedMemory(
         SkeletonBinding::SkeletonEventBindings& events,
         SkeletonBinding::SkeletonFieldBindings& fields,
         std::optional<SkeletonBinding::RegisterShmObjectTraceCallback> register_shm_object_trace_callback);
@@ -83,7 +83,7 @@ class SkeletonMemoryManager final
     /// still proxies connected to the old shared memory region. It will open the data and control shared memory regions
     /// and will store pointers to the already existing ServiceDataControl and ServiceDataStorage structures in the
     /// opened shared memory.
-    ResultBlank OpenExistingSharedMemory(
+    Result<void> OpenExistingSharedMemory(
         std::optional<SkeletonBinding::RegisterShmObjectTraceCallback> register_shm_object_trace_callback);
 
     /// \brief Creates an EventDataControlComposite and TransactionLogSet for a specific event.

--- a/score/mw/com/impl/bindings/lola/skeleton_method.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_method.cpp
@@ -46,13 +46,13 @@ SkeletonMethod::SkeletonMethod(Skeleton& skeleton, UniqueMethodIdentifier unique
     skeleton.RegisterMethod(unique_method_identifier, *this);
 }
 
-ResultBlank SkeletonMethod::RegisterHandler(SkeletonMethodBinding::TypeErasedHandler&& type_erased_callback)
+Result<void> SkeletonMethod::RegisterHandler(SkeletonMethodBinding::TypeErasedHandler&& type_erased_callback)
 {
     type_erased_callback_ = std::move(type_erased_callback);
     return {};
 }
 
-ResultBlank SkeletonMethod::OnProxyMethodSubscribeFinished(
+Result<void> SkeletonMethod::OnProxyMethodSubscribeFinished(
     const TypeErasedCallQueue::TypeErasedElementInfo type_erased_element_info,
     const std::optional<score::cpp::span<std::byte>> in_arg_queue_storage,
     const std::optional<score::cpp::span<std::byte>> return_queue_storage,
@@ -99,7 +99,7 @@ ResultBlank SkeletonMethod::OnProxyMethodSubscribeFinished(
         asil_level, proxy_method_instance_identifier, std::move(method_call_callback), allowed_proxy_uid);
     if (!(registration_result.has_value()))
     {
-        return MakeUnexpected<Blank>(registration_result.error());
+        return MakeUnexpected<void>(registration_result.error());
     }
 
     const std::lock_guard lock{registration_guards_mutex_};

--- a/score/mw/com/impl/bindings/lola/skeleton_method.h
+++ b/score/mw/com/impl/bindings/lola/skeleton_method.h
@@ -44,9 +44,9 @@ class SkeletonMethod : public SkeletonMethodBinding
   public:
     SkeletonMethod(Skeleton& skeleton, const UniqueMethodIdentifier unique_method_identifier);
 
-    ResultBlank RegisterHandler(SkeletonMethodBinding::TypeErasedHandler&& type_erased_callback) override;
+    Result<void> RegisterHandler(SkeletonMethodBinding::TypeErasedHandler&& type_erased_callback) override;
 
-    ResultBlank OnProxyMethodSubscribeFinished(
+    Result<void> OnProxyMethodSubscribeFinished(
         const TypeErasedCallQueue::TypeErasedElementInfo type_erased_element_info,
         const std::optional<score::cpp::span<std::byte>> in_arg_queue_storage,
         const std::optional<score::cpp::span<std::byte>> return_queue_storage,

--- a/score/mw/com/impl/bindings/lola/subscription_not_subscribed_states.cpp
+++ b/score/mw/com/impl/bindings/lola/subscription_not_subscribed_states.cpp
@@ -33,7 +33,7 @@ namespace score::mw::com::impl::lola
 // implicitly". std::terminate() is implicitly called from '.value()' in case it doesn't have value but as we check
 // before with 'has_value()' so no way for throwing std::bad_optional_access which leds to std::terminate().
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-ResultBlank NotSubscribedState::SubscribeEvent(const std::size_t max_sample_count) noexcept
+Result<void> NotSubscribedState::SubscribeEvent(const std::size_t max_sample_count) noexcept
 {
     auto transaction_log_registration_guard_result = TransactionLogRegistrationGuard::Create(
         state_machine_.event_control_local_.data_control, state_machine_.transaction_log_id_);

--- a/score/mw/com/impl/bindings/lola/subscription_not_subscribed_states.h
+++ b/score/mw/com/impl/bindings/lola/subscription_not_subscribed_states.h
@@ -36,7 +36,7 @@ class NotSubscribedState final : public SubscriptionStateBase
 
     ~NotSubscribedState() noexcept override = default;
 
-    ResultBlank SubscribeEvent(const std::size_t max_sample_count) noexcept override;
+    Result<void> SubscribeEvent(const std::size_t max_sample_count) noexcept override;
     void UnsubscribeEvent() noexcept override;
     void StopOfferEvent() noexcept override;
     void ReOfferEvent(const pid_t new_event_source_pid) noexcept override;

--- a/score/mw/com/impl/bindings/lola/subscription_state_base.h
+++ b/score/mw/com/impl/bindings/lola/subscription_state_base.h
@@ -42,7 +42,7 @@ class SubscriptionStateBase
     SubscriptionStateBase(SubscriptionStateBase&&) noexcept = delete;
     SubscriptionStateBase& operator=(SubscriptionStateBase&&) & noexcept = delete;
 
-    virtual ResultBlank SubscribeEvent(const std::size_t max_sample_count) noexcept = 0;
+    virtual Result<void> SubscribeEvent(const std::size_t max_sample_count) noexcept = 0;
     virtual void UnsubscribeEvent() noexcept = 0;
     virtual void StopOfferEvent() noexcept = 0;
     virtual void ReOfferEvent(const pid_t new_event_source_pid) noexcept = 0;

--- a/score/mw/com/impl/bindings/lola/subscription_state_machine.cpp
+++ b/score/mw/com/impl/bindings/lola/subscription_state_machine.cpp
@@ -70,7 +70,7 @@ const SubscriptionStateBase& SubscriptionStateMachine::GetCurrentEventState() co
     return *states_[static_cast<std::uint8_t>(current_state_idx_)];
 }
 
-ResultBlank SubscriptionStateMachine::SubscribeEvent(const std::size_t max_sample_count) noexcept
+Result<void> SubscriptionStateMachine::SubscribeEvent(const std::size_t max_sample_count) noexcept
 {
     std::lock_guard<std::mutex> lock{state_mutex_};
     return GetCurrentEventState().SubscribeEvent(max_sample_count);

--- a/score/mw/com/impl/bindings/lola/subscription_state_machine.h
+++ b/score/mw/com/impl/bindings/lola/subscription_state_machine.h
@@ -90,7 +90,7 @@ class SubscriptionStateMachine : public std::enable_shared_from_this<Subscriptio
     // State Machine Events. These are modelled by the state machine UML and cause transitions between states. The
     // thread currently processing an event will block until all queued events are processed. All other calls will be
     // non-blocking.
-    [[nodiscard]] ResultBlank SubscribeEvent(const std::size_t max_sample_count) noexcept;
+    [[nodiscard]] Result<void> SubscribeEvent(const std::size_t max_sample_count) noexcept;
     void UnsubscribeEvent() noexcept;
     void StopOfferEvent() noexcept;
     void ReOfferEvent(const pid_t new_event_source_pid) noexcept;

--- a/score/mw/com/impl/bindings/lola/subscription_subscribed_states.cpp
+++ b/score/mw/com/impl/bindings/lola/subscription_subscribed_states.cpp
@@ -25,7 +25,7 @@
 namespace score::mw::com::impl::lola
 {
 
-ResultBlank SubscribedState::SubscribeEvent(const std::size_t max_sample_count) noexcept
+Result<void> SubscribedState::SubscribeEvent(const std::size_t max_sample_count) noexcept
 {
     // Suppress "AUTOSAR C++14 A4-7-1" rule finding. This rule states: "An integer expression shall
     // not lead to data loss.".

--- a/score/mw/com/impl/bindings/lola/subscription_subscribed_states.h
+++ b/score/mw/com/impl/bindings/lola/subscription_subscribed_states.h
@@ -38,7 +38,7 @@ class SubscribedState final : public SubscriptionStateBase
 
     ~SubscribedState() noexcept override = default;
 
-    ResultBlank SubscribeEvent(const std::size_t) noexcept override;
+    Result<void> SubscribeEvent(const std::size_t) noexcept override;
     void UnsubscribeEvent() noexcept override;
     void StopOfferEvent() noexcept override;
     void ReOfferEvent(const pid_t) noexcept override;

--- a/score/mw/com/impl/bindings/lola/subscription_subscription_pending_states.cpp
+++ b/score/mw/com/impl/bindings/lola/subscription_subscription_pending_states.cpp
@@ -27,7 +27,7 @@
 namespace score::mw::com::impl::lola
 {
 
-ResultBlank SubscriptionPendingState::SubscribeEvent(const std::size_t max_sample_count) noexcept
+Result<void> SubscriptionPendingState::SubscribeEvent(const std::size_t max_sample_count) noexcept
 {
     // Suppress "AUTOSAR C++14 A4-7-1" rule finding. This rule states: "An integer expression shall
     // not lead to data loss.".

--- a/score/mw/com/impl/bindings/lola/subscription_subscription_pending_states.h
+++ b/score/mw/com/impl/bindings/lola/subscription_subscription_pending_states.h
@@ -39,7 +39,7 @@ class SubscriptionPendingState final : public SubscriptionStateBase
 
     ~SubscriptionPendingState() noexcept override = default;
 
-    ResultBlank SubscribeEvent(const std::size_t max_sample_count) noexcept override;
+    Result<void> SubscribeEvent(const std::size_t max_sample_count) noexcept override;
     void UnsubscribeEvent() noexcept override;
     void StopOfferEvent() noexcept override;
     void ReOfferEvent(const pid_t new_event_source_pid) noexcept override;

--- a/score/mw/com/impl/bindings/lola/test/skeleton_component_test.cpp
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_component_test.cpp
@@ -410,7 +410,7 @@ TEST_F(SkeletonComponentTestFixture, DataShmObjectSizeCalc_Simulation_QM)
 
     // Expecting that the event and field are offered during the simulation dry run
     ON_CALL(mock_event_binding_, PrepareOffer())
-        .WillByDefault(testing::Invoke([&unit, lola_service_type_deployment]() -> ResultBlank {
+        .WillByDefault(testing::Invoke([&unit, lola_service_type_deployment]() -> Result<void> {
             ElementFqId element_fq_id{lola_service_type_deployment->service_id_,
                                       test::kFooEventId,
                                       test::kDefaultLolaInstanceId,
@@ -419,7 +419,7 @@ TEST_F(SkeletonComponentTestFixture, DataShmObjectSizeCalc_Simulation_QM)
             return {};
         }));
     ON_CALL(mock_field_binding_, PrepareOffer())
-        .WillByDefault(testing::Invoke([&unit, lola_service_type_deployment]() -> ResultBlank {
+        .WillByDefault(testing::Invoke([&unit, lola_service_type_deployment]() -> Result<void> {
             ElementFqId element_fq_id{lola_service_type_deployment->service_id_,
                                       test::kFooFieldId,
                                       test::kDefaultLolaInstanceId,
@@ -470,7 +470,7 @@ TEST_F(SkeletonComponentTestFixture, DataShmObjectSizeCalc_Simulation_AsilB)
 
     // Expecting that the event and field are offered during the simulation dry run
     ON_CALL(mock_event_binding_, PrepareOffer())
-        .WillByDefault(testing::Invoke([&unit, lola_service_type_deployment]() -> ResultBlank {
+        .WillByDefault(testing::Invoke([&unit, lola_service_type_deployment]() -> Result<void> {
             ElementFqId element_fq_id{lola_service_type_deployment->service_id_,
                                       test::kFooEventId,
                                       test::kDefaultLolaInstanceId,
@@ -479,7 +479,7 @@ TEST_F(SkeletonComponentTestFixture, DataShmObjectSizeCalc_Simulation_AsilB)
             return {};
         }));
     ON_CALL(mock_field_binding_, PrepareOffer())
-        .WillByDefault(testing::Invoke([&unit, lola_service_type_deployment]() -> ResultBlank {
+        .WillByDefault(testing::Invoke([&unit, lola_service_type_deployment]() -> Result<void> {
             ElementFqId element_fq_id{lola_service_type_deployment->service_id_,
                                       test::kFooFieldId,
                                       test::kDefaultLolaInstanceId,

--- a/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.cpp
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.cpp
@@ -177,7 +177,7 @@ SkeletonMockedMemoryFixture::SkeletonMockedMemoryFixture()
     ON_CALL(lola_runtime_mock_, GetApplicationId()).WillByDefault(::testing::Return(kDummyApplicationId));
     ON_CALL(lola_runtime_mock_, GetLolaMessaging()).WillByDefault(::testing::ReturnRef(message_passing_mock_));
 
-    ON_CALL(filesystem_fake_.GetUtils(), CreateDirectories(_, _)).WillByDefault(Return(score::ResultBlank{}));
+    ON_CALL(filesystem_fake_.GetUtils(), CreateDirectories(_, _)).WillByDefault(Return(score::Result<void>{}));
 
     // Default behaviour for path builders
     ON_CALL(shm_path_builder_mock_, GetControlChannelShmName(_, QualityType::kASIL_QM))

--- a/score/mw/com/impl/bindings/lola/tracing/tracing_runtime_test.cpp
+++ b/score/mw/com/impl/bindings/lola/tracing/tracing_runtime_test.cpp
@@ -773,7 +773,7 @@ TEST_F(RegisterWithGenericTraceApiFixture, Registration_OK)
     // and expect, that it calls then RegisterTraceDoneCB at the GenericTraceAPI with the trace client id, which has
     // been returned by the RegisterClient call
     EXPECT_CALL(*generic_trace_api_mock_.get(), RegisterTraceDoneCB(trace_client_id_, _))
-        .WillOnce(Return(score::ResultBlank{}));
+        .WillOnce(Return(score::Result<void>{}));
 
     // expect the UuT to return true, when we call RegisterWithGenericTraceApi on it
     EXPECT_TRUE(tracing_runtime_.RegisterWithGenericTraceApi());
@@ -826,7 +826,7 @@ class TraceDoneCallbackFixture : public RegisterWithGenericTraceApiFixture
                 Invoke([this](auto trace_done_callback) -> analysis::tracing::RegisterTraceDoneCallBackResult {
                     trace_done_callback_ = std::move(trace_done_callback);
                     static_cast<void>(trace_done_callback);
-                    return score::ResultBlank{};
+                    return score::Result<void>{};
                 })));
     }
 

--- a/score/mw/com/impl/bindings/lola/transaction_log.cpp
+++ b/score/mw/com/impl/bindings/lola/transaction_log.cpp
@@ -174,8 +174,8 @@ void TransactionLog::DereferenceTransactionCommit(SlotIndexType slot_index) noex
     slot.SetTransactionEnd(false);
 }
 
-ResultBlank TransactionLog::RollbackProxyElementLog(const DereferenceSlotCallback& dereference_slot_callback,
-                                                    const UnsubscribeCallback& unsubscribe_callback) noexcept
+Result<void> TransactionLog::RollbackProxyElementLog(const DereferenceSlotCallback& dereference_slot_callback,
+                                                     const UnsubscribeCallback& unsubscribe_callback) noexcept
 {
     const bool was_no_subscribe_recorded{!subscribe_transactions_.GetTransactionBegin() &&
                                          !subscribe_transactions_.GetTransactionEnd()};
@@ -196,7 +196,7 @@ ResultBlank TransactionLog::RollbackProxyElementLog(const DereferenceSlotCallbac
     return rollback_subscribe_transactions_result;
 }
 
-ResultBlank TransactionLog::RollbackSkeletonTracingElementLog(
+Result<void> TransactionLog::RollbackSkeletonTracingElementLog(
     const DereferenceSlotCallback& dereference_slot_callback) noexcept
 {
     const auto rollback_increment_transactions_result = RollbackIncrementTransactions(dereference_slot_callback);
@@ -208,7 +208,7 @@ ResultBlank TransactionLog::RollbackSkeletonTracingElementLog(
 // std::out_of_range As we already do an index check before accessing, so no way for throwing std::out_of_rang which
 // leds to calling std::terminate().
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-ResultBlank TransactionLog::RollbackIncrementTransactions(
+Result<void> TransactionLog::RollbackIncrementTransactions(
     const DereferenceSlotCallback& dereference_slot_callback) noexcept
 {
     for (SlotIndexType slot_idx = 0U; slot_idx < reference_count_slots_.size(); ++slot_idx)
@@ -242,7 +242,7 @@ ResultBlank TransactionLog::RollbackIncrementTransactions(
     return {};
 }
 
-ResultBlank TransactionLog::RollbackSubscribeTransactions(const UnsubscribeCallback& unsubscribe_callback) noexcept
+Result<void> TransactionLog::RollbackSubscribeTransactions(const UnsubscribeCallback& unsubscribe_callback) noexcept
 {
     const bool was_subscribe_succesfully_recorded{subscribe_transactions_.GetTransactionBegin() &&
                                                   subscribe_transactions_.GetTransactionEnd()};

--- a/score/mw/com/impl/bindings/lola/transaction_log.h
+++ b/score/mw/com/impl/bindings/lola/transaction_log.h
@@ -96,8 +96,8 @@ class TransactionLog
     /// This function should be called when trying to create a Proxy service element that had previously crashed. It
     /// will decrement all reference counts that the old Proxy had incremented in the EventDataControl which were
     /// recorded in this TransactionLog.
-    ResultBlank RollbackProxyElementLog(const DereferenceSlotCallback& dereference_slot_callback,
-                                        const UnsubscribeCallback& unsubscribe_callback) noexcept;
+    Result<void> RollbackProxyElementLog(const DereferenceSlotCallback& dereference_slot_callback,
+                                         const UnsubscribeCallback& unsubscribe_callback) noexcept;
 
     /// \brief Rollback all previous increments that were recorded in the transaction log.
     /// \param dereference_slot_callback Callback which will decrement the slot in EventDataControl with the provided
@@ -106,7 +106,7 @@ class TransactionLog
     /// This function should be called when trying to create a Skeleton service element that had previously crashed. It
     /// will decrement all reference counts that the old Skeleton (due to tracing) had incremented in the
     /// EventDataControl which were recorded in this TransactionLog.
-    ResultBlank RollbackSkeletonTracingElementLog(const DereferenceSlotCallback& dereference_slot_callback) noexcept;
+    Result<void> RollbackSkeletonTracingElementLog(const DereferenceSlotCallback& dereference_slot_callback) noexcept;
 
     /// \brief Checks whether the TransactionLog contains any transactions
     /// \return Returns true if there is at least one Subscribe transaction or Reference transaction that hasn't been
@@ -114,8 +114,8 @@ class TransactionLog
     bool ContainsTransactions() const noexcept;
 
   private:
-    ResultBlank RollbackIncrementTransactions(const DereferenceSlotCallback& dereference_slot_callback) noexcept;
-    ResultBlank RollbackSubscribeTransactions(const UnsubscribeCallback& unsubscribe_callback) noexcept;
+    Result<void> RollbackIncrementTransactions(const DereferenceSlotCallback& dereference_slot_callback) noexcept;
+    Result<void> RollbackSubscribeTransactions(const UnsubscribeCallback& unsubscribe_callback) noexcept;
 
     /// \brief Vector containing one TransactionLogSlot for each slot in the corresponding control vector.
     TransactionLogSlots reference_count_slots_;

--- a/score/mw/com/impl/bindings/lola/transaction_log_rollback_executor.cpp
+++ b/score/mw/com/impl/bindings/lola/transaction_log_rollback_executor.cpp
@@ -96,7 +96,7 @@ void TransactionLogRollbackExecutor::PrepareRollback(lola::IRuntime& lola_runtim
 // Suppress "AUTOSAR C++14 A15-5-3" rule findings. This rule states: "The std::terminate() function shall not be called
 // implicitly". This is a false positive, no way for implicit calling std::terminate().
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-ResultBlank TransactionLogRollbackExecutor::RollbackTransactionLogs() noexcept
+Result<void> TransactionLogRollbackExecutor::RollbackTransactionLogs() noexcept
 {
     auto& lola_runtime = GetBindingRuntime<lola::IRuntime>(BindingType::kLoLa);
     auto& rollback_synchronization = lola_runtime.GetRollbackSynchronization();

--- a/score/mw/com/impl/bindings/lola/transaction_log_rollback_executor.h
+++ b/score/mw/com/impl/bindings/lola/transaction_log_rollback_executor.h
@@ -41,7 +41,7 @@ class TransactionLogRollbackExecutor
     /// \details Besides the pure transaction rollback, there is also some preparation needed/done once for a given
     ///          service_data_control (independent from the number of local proxy instances referring to it). This
     ///          is done by an internal call to #PrepareRollback
-    ResultBlank RollbackTransactionLogs() noexcept;
+    Result<void> RollbackTransactionLogs() noexcept;
 
   private:
     /// \brief Prepares the rollback of proxy service instance specific transaction logs.

--- a/score/mw/com/impl/bindings/lola/transaction_log_set.cpp
+++ b/score/mw/com/impl/bindings/lola/transaction_log_set.cpp
@@ -78,7 +78,7 @@ void TransactionLogSet::MarkTransactionLogsNeedRollback(const TransactionLogId& 
     }
 }
 
-ResultBlank TransactionLogSet::RollbackProxyTransactions(
+Result<void> TransactionLogSet::RollbackProxyTransactions(
     const TransactionLogId& transaction_log_id,
     const TransactionLog::DereferenceSlotCallback dereference_slot_callback,
     const TransactionLog::UnsubscribeCallback unsubscribe_callback)
@@ -89,7 +89,7 @@ ResultBlank TransactionLogSet::RollbackProxyTransactions(
     // Keep trying to rollback a TransactionLog. If a rollback succeeds, return. If a rollback fails, try to rollback
     // the next TransactionLog. If there are only TransactionLogs remaining which cannot be rolled back, return an
     // error.
-    ResultBlank rollback_result{};
+    Result<void> rollback_result{};
     for (const auto transaction_log_node_it : transaction_log_node_iterators_to_be_rolled_back)
     {
         rollback_result = transaction_log_node_it->GetTransactionLog().RollbackProxyElementLog(
@@ -103,7 +103,7 @@ ResultBlank TransactionLogSet::RollbackProxyTransactions(
     return rollback_result;
 }
 
-ResultBlank TransactionLogSet::RollbackSkeletonTracingTransactions(
+Result<void> TransactionLogSet::RollbackSkeletonTracingTransactions(
     const TransactionLog::DereferenceSlotCallback dereference_slot_callback)
 {
     if (!skeleton_tracing_transaction_log_.IsActive())

--- a/score/mw/com/impl/bindings/lola/transaction_log_set.h
+++ b/score/mw/com/impl/bindings/lola/transaction_log_set.h
@@ -179,12 +179,12 @@ class TransactionLogSet
     /// rollbacks. This prevents one thread calling RollbackProxyTransactions and then registering a new TransactionLog.
     /// Then another thread with the same transaction_log_id calls RollbackProxyTransactions which would rollback and
     /// destroy the newly created TransactionLog.
-    ResultBlank RollbackProxyTransactions(const TransactionLogId& transaction_log_id,
-                                          const TransactionLog::DereferenceSlotCallback dereference_slot_callback,
-                                          const TransactionLog::UnsubscribeCallback unsubscribe_callback);
+    Result<void> RollbackProxyTransactions(const TransactionLogId& transaction_log_id,
+                                           const TransactionLog::DereferenceSlotCallback dereference_slot_callback,
+                                           const TransactionLog::UnsubscribeCallback unsubscribe_callback);
 
     /// \brief If a Skeleton TransactionLog exists, performs a rollback on it.
-    ResultBlank RollbackSkeletonTracingTransactions(
+    Result<void> RollbackSkeletonTracingTransactions(
         const TransactionLog::DereferenceSlotCallback dereference_slot_callback);
 
     /// \brief Creates a new transaction log in the DynamicArray of transaction logs.

--- a/score/mw/com/impl/bindings/mock_binding/generic_proxy_event.h
+++ b/score/mw/com/impl/bindings/mock_binding/generic_proxy_event.h
@@ -46,7 +46,7 @@ class GenericProxyEvent : public GenericProxyEventBinding
 
     MOCK_METHOD(SubscriptionState, GetSubscriptionState, (), (const, noexcept, override));
     MOCK_METHOD(void, Unsubscribe, (), (noexcept, override));
-    MOCK_METHOD(ResultBlank, Subscribe, (std::size_t), (noexcept, override));
+    MOCK_METHOD(Result<void>, Subscribe, (std::size_t), (noexcept, override));
     MOCK_METHOD(Result<std::size_t>, GetNumNewSamplesAvailable, (), (const, noexcept, override));
     MOCK_METHOD(std::size_t, GetSampleSize, (), (const, noexcept, override));
     MOCK_METHOD(bool, HasSerializedFormat, (), (const, noexcept, override));
@@ -54,8 +54,8 @@ class GenericProxyEvent : public GenericProxyEventBinding
                 GetNewSamples,
                 (typename GenericProxyEventBinding::Callback&&, TrackerGuardFactory&),
                 (noexcept, override));
-    MOCK_METHOD(ResultBlank, SetReceiveHandler, (std::weak_ptr<ScopedEventReceiveHandler>), (noexcept, override));
-    MOCK_METHOD(ResultBlank, UnsetReceiveHandler, (), (noexcept, override));
+    MOCK_METHOD(Result<void>, SetReceiveHandler, (std::weak_ptr<ScopedEventReceiveHandler>), (noexcept, override));
+    MOCK_METHOD(Result<void>, UnsetReceiveHandler, (), (noexcept, override));
     MOCK_METHOD(std::optional<std::uint16_t>, GetMaxSampleCount, (), (const, noexcept, override));
     MOCK_METHOD(BindingType, GetBindingType, (), (const, noexcept, override));
     MOCK_METHOD(void, NotifyServiceInstanceChangedAvailability, (bool, pid_t), (noexcept, override));

--- a/score/mw/com/impl/bindings/mock_binding/generic_skeleton_event.h
+++ b/score/mw/com/impl/bindings/mock_binding/generic_skeleton_event.h
@@ -27,12 +27,12 @@ class GenericSkeletonEvent : public GenericSkeletonEventBinding
     //  Use explicit 'score::mw::com::impl::SampleAllocateePtr' to avoid ambiguity
     // with the 'mock_binding::SampleAllocateePtr' alias (which is a unique_ptr).
 
-    MOCK_METHOD(ResultBlank, Send, (score::mw::com::impl::SampleAllocateePtr<void>), (noexcept, override));
+    MOCK_METHOD(Result<void>, Send, (score::mw::com::impl::SampleAllocateePtr<void>), (noexcept, override));
 
     MOCK_METHOD(Result<score::mw::com::impl::SampleAllocateePtr<void>>, Allocate, (), (noexcept, override));
 
     MOCK_METHOD((std::pair<size_t, size_t>), GetSizeInfo, (), (const, noexcept, override));
-    MOCK_METHOD(ResultBlank, PrepareOffer, (), (noexcept, override));
+    MOCK_METHOD(Result<void>, PrepareOffer, (), (noexcept, override));
     MOCK_METHOD(void, PrepareStopOffer, (), (noexcept, override));
     MOCK_METHOD(BindingType, GetBindingType, (), (const, noexcept, override));
     MOCK_METHOD(void, SetSkeletonEventTracingData, (impl::tracing::SkeletonEventTracingData), (noexcept, override));

--- a/score/mw/com/impl/bindings/mock_binding/proxy.h
+++ b/score/mw/com/impl/bindings/mock_binding/proxy.h
@@ -30,7 +30,7 @@ class Proxy : public ProxyBinding
     MOCK_METHOD(bool, IsEventProvided, (const std::string_view), (const, noexcept, override));
     MOCK_METHOD(void, RegisterEventBinding, (std::string_view, ProxyEventBindingBase&), (noexcept, override));
     MOCK_METHOD(void, UnregisterEventBinding, (std::string_view), (noexcept, override));
-    MOCK_METHOD(ResultBlank, SetupMethods, (const std::vector<std::string_view>& enabled_method_names), (override));
+    MOCK_METHOD(Result<void>, SetupMethods, (const std::vector<std::string_view>& enabled_method_names), (override));
 };
 
 class ProxyFacade : public ProxyBinding
@@ -55,7 +55,7 @@ class ProxyFacade : public ProxyBinding
         proxy_.UnregisterEventBinding(service_element_name);
     }
 
-    ResultBlank SetupMethods(const std::vector<std::string_view>& enabled_method_names) override
+    Result<void> SetupMethods(const std::vector<std::string_view>& enabled_method_names) override
     {
         return proxy_.SetupMethods(enabled_method_names);
     }

--- a/score/mw/com/impl/bindings/mock_binding/proxy_event.h
+++ b/score/mw/com/impl/bindings/mock_binding/proxy_event.h
@@ -36,10 +36,10 @@ class ProxyEventBase : public ProxyEventBindingBase
 
     MOCK_METHOD(SubscriptionState, GetSubscriptionState, (), (const, noexcept, override));
     MOCK_METHOD(void, Unsubscribe, (), (noexcept, override));
-    MOCK_METHOD(ResultBlank, Subscribe, (std::size_t), (noexcept, override));
+    MOCK_METHOD(Result<void>, Subscribe, (std::size_t), (noexcept, override));
     MOCK_METHOD(Result<std::size_t>, GetNumNewSamplesAvailable, (), (const, noexcept, override));
-    MOCK_METHOD(ResultBlank, SetReceiveHandler, (std::weak_ptr<ScopedEventReceiveHandler>), (noexcept, override));
-    MOCK_METHOD(ResultBlank, UnsetReceiveHandler, (), (noexcept, override));
+    MOCK_METHOD(Result<void>, SetReceiveHandler, (std::weak_ptr<ScopedEventReceiveHandler>), (noexcept, override));
+    MOCK_METHOD(Result<void>, UnsetReceiveHandler, (), (noexcept, override));
     MOCK_METHOD(std::optional<std::uint16_t>, GetMaxSampleCount, (), (const, noexcept, override));
     MOCK_METHOD(BindingType, GetBindingType, (), (const, noexcept, override));
     MOCK_METHOD(void, NotifyServiceInstanceChangedAvailability, (bool, pid_t), (noexcept, override));
@@ -66,14 +66,14 @@ class ProxyEvent : public ProxyEventBinding<SampleType>
 
     MOCK_METHOD(SubscriptionState, GetSubscriptionState, (), (const, noexcept, override));
     MOCK_METHOD(void, Unsubscribe, (), (noexcept, override));
-    MOCK_METHOD(ResultBlank, Subscribe, (std::size_t), (noexcept, override));
+    MOCK_METHOD(Result<void>, Subscribe, (std::size_t), (noexcept, override));
     MOCK_METHOD(Result<std::size_t>, GetNumNewSamplesAvailable, (), (const, noexcept, override));
     MOCK_METHOD(Result<std::size_t>,
                 GetNewSamples,
                 (typename ProxyEventBinding<SampleType>::Callback&&, TrackerGuardFactory&),
                 (noexcept, override));
-    MOCK_METHOD(ResultBlank, SetReceiveHandler, (std::weak_ptr<ScopedEventReceiveHandler>), (noexcept, override));
-    MOCK_METHOD(ResultBlank, UnsetReceiveHandler, (), (noexcept, override));
+    MOCK_METHOD(Result<void>, SetReceiveHandler, (std::weak_ptr<ScopedEventReceiveHandler>), (noexcept, override));
+    MOCK_METHOD(Result<void>, UnsetReceiveHandler, (), (noexcept, override));
     MOCK_METHOD(std::optional<std::uint16_t>, GetMaxSampleCount, (), (const, noexcept, override));
     MOCK_METHOD(BindingType, GetBindingType, (), (const, noexcept, override));
     MOCK_METHOD(void, NotifyServiceInstanceChangedAvailability, (bool, pid_t), (noexcept, override));
@@ -139,7 +139,7 @@ class ProxyEventFacade : public ProxyEventBinding<SampleType>
     {
         return proxy_event_.Unsubscribe();
     }
-    ResultBlank Subscribe(std::size_t n) noexcept override
+    Result<void> Subscribe(std::size_t n) noexcept override
     {
         return proxy_event_.Subscribe(n);
     }
@@ -152,11 +152,11 @@ class ProxyEventFacade : public ProxyEventBinding<SampleType>
     {
         return proxy_event_.GetNewSamples(std::move(callback), tracker_guard_factory);
     }
-    ResultBlank SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) noexcept override
+    Result<void> SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) noexcept override
     {
         return proxy_event_.SetReceiveHandler(handler);
     }
-    ResultBlank UnsetReceiveHandler() noexcept override
+    Result<void> UnsetReceiveHandler() noexcept override
     {
         return proxy_event_.UnsetReceiveHandler();
     }

--- a/score/mw/com/impl/bindings/mock_binding/proxy_method.h
+++ b/score/mw/com/impl/bindings/mock_binding/proxy_method.h
@@ -29,7 +29,7 @@ class ProxyMethod : public ProxyMethodBinding
 
     MOCK_METHOD(score::Result<score::cpp::span<std::byte>>, GetInArgsBuffer, (std::size_t), (override));
     MOCK_METHOD(score::Result<score::cpp::span<std::byte>>, GetReturnValueBuffer, (std::size_t), (override));
-    MOCK_METHOD(ResultBlank, DoCall, (std::size_t), (override));
+    MOCK_METHOD(Result<void>, DoCall, (std::size_t), (override));
 };
 
 class ProxyMethodFacade : public ProxyMethodBinding
@@ -48,7 +48,7 @@ class ProxyMethodFacade : public ProxyMethodBinding
         return proxy_method_.GetReturnValueBuffer(queue_position);
     }
 
-    score::ResultBlank DoCall(std::size_t queue_position) override
+    score::Result<void> DoCall(std::size_t queue_position) override
     {
         return proxy_method_.DoCall(queue_position);
     }

--- a/score/mw/com/impl/bindings/mock_binding/skeleton.h
+++ b/score/mw/com/impl/bindings/mock_binding/skeleton.h
@@ -28,7 +28,7 @@ class Skeleton : public SkeletonBinding
 
     ~Skeleton() override = default;
 
-    MOCK_METHOD(ResultBlank,
+    MOCK_METHOD(Result<void>,
                 PrepareOffer,
                 (SkeletonEventBindings&, SkeletonFieldBindings&, std::optional<RegisterShmObjectTraceCallback>),
                 (noexcept, override, final));
@@ -43,9 +43,9 @@ class SkeletonFacade : public SkeletonBinding
     SkeletonFacade(Skeleton& skeleton) : SkeletonBinding{}, skeleton_{skeleton} {}
     ~SkeletonFacade() override = default;
 
-    ResultBlank PrepareOffer(SkeletonEventBindings& skeleton_event_binding,
-                             SkeletonFieldBindings& skeleton_field_binding,
-                             std::optional<RegisterShmObjectTraceCallback> callback) override final
+    Result<void> PrepareOffer(SkeletonEventBindings& skeleton_event_binding,
+                              SkeletonFieldBindings& skeleton_field_binding,
+                              std::optional<RegisterShmObjectTraceCallback> callback) override final
     {
         return skeleton_.PrepareOffer(skeleton_event_binding, skeleton_field_binding, std::move(callback));
     }

--- a/score/mw/com/impl/bindings/mock_binding/skeleton_event.h
+++ b/score/mw/com/impl/bindings/mock_binding/skeleton_event.h
@@ -26,7 +26,7 @@ namespace score::mw::com::impl::mock_binding
 class SkeletonEventBase : public SkeletonEventBindingBase
 {
   public:
-    MOCK_METHOD(ResultBlank, PrepareOffer, (), (noexcept, override));
+    MOCK_METHOD(Result<void>, PrepareOffer, (), (noexcept, override));
     MOCK_METHOD(void, PrepareStopOffer, (), (noexcept, override));
     MOCK_METHOD(std::size_t, GetMaxSize, (), (const, noexcept, override));
     MOCK_METHOD(BindingType, GetBindingType, (), (const, noexcept, override));
@@ -37,18 +37,18 @@ template <typename SampleType>
 class SkeletonEvent : public SkeletonEventBinding<SampleType>
 {
   public:
-    MOCK_METHOD(ResultBlank,
+    MOCK_METHOD(Result<void>,
                 Send,
                 (const SampleType& value,
                  score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>),
                 (noexcept, override));
-    MOCK_METHOD(ResultBlank,
+    MOCK_METHOD(Result<void>,
                 Send,
                 (score::mw::com::impl::SampleAllocateePtr<SampleType> sample,
                  score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>),
                 (noexcept, override));
     MOCK_METHOD(Result<score::mw::com::impl::SampleAllocateePtr<SampleType>>, Allocate, (), (noexcept, override));
-    MOCK_METHOD(ResultBlank, PrepareOffer, (), (noexcept, override));
+    MOCK_METHOD(Result<void>, PrepareOffer, (), (noexcept, override));
     MOCK_METHOD(void, PrepareStopOffer, (), (noexcept, override));
     MOCK_METHOD(std::size_t, GetMaxSize, (), (const, noexcept, override));
     MOCK_METHOD(BindingType, GetBindingType, (), (const, noexcept, override));
@@ -67,13 +67,13 @@ class SkeletonEventFacade : public SkeletonEventBinding<SampleType>
     }
 
     ~SkeletonEventFacade() override = default;
-    ResultBlank Send(
+    Result<void> Send(
         const SampleType& value,
         score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> callback) noexcept override
     {
         return skeleton_event_.Send(value, std::move(callback));
     };
-    ResultBlank Send(
+    Result<void> Send(
         score::mw::com::impl::SampleAllocateePtr<SampleType> sample,
         score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> callback) noexcept override
     {
@@ -83,7 +83,7 @@ class SkeletonEventFacade : public SkeletonEventBinding<SampleType>
     {
         return skeleton_event_.Allocate();
     };
-    ResultBlank PrepareOffer() noexcept override
+    Result<void> PrepareOffer() noexcept override
     {
         return skeleton_event_.PrepareOffer();
     }

--- a/score/mw/com/impl/bindings/mock_binding/skeleton_method.h
+++ b/score/mw/com/impl/bindings/mock_binding/skeleton_method.h
@@ -23,7 +23,7 @@ namespace score::mw::com::impl::mock_binding
 class SkeletonMethod : public SkeletonMethodBinding
 {
   public:
-    MOCK_METHOD(ResultBlank, RegisterHandler, (TypeErasedHandler&&), (override));
+    MOCK_METHOD(Result<void>, RegisterHandler, (TypeErasedHandler&&), (override));
 };
 
 class SkeletonMethodFacade : public SkeletonMethodBinding
@@ -33,7 +33,7 @@ class SkeletonMethodFacade : public SkeletonMethodBinding
         : SkeletonMethodBinding(), skeleton_method_{skeleton_method} {};
     ~SkeletonMethodFacade() override = default;
 
-    ResultBlank RegisterHandler(TypeErasedHandler&& cb) override
+    Result<void> RegisterHandler(TypeErasedHandler&& cb) override
     {
         return skeleton_method_.RegisterHandler(std::move(cb));
     }

--- a/score/mw/com/impl/error_serializer.cpp
+++ b/score/mw/com/impl/error_serializer.cpp
@@ -42,7 +42,7 @@ auto ErrorSerializer<ErrorCode>::SerializeError(const ErrorCode error_code) -> S
 }
 
 template <typename ErrorCode>
-auto ErrorSerializer<ErrorCode>::Deserialize(const SerializedErrorType serialized_error_code) -> score::ResultBlank
+auto ErrorSerializer<ErrorCode>::Deserialize(const SerializedErrorType serialized_error_code) -> score::Result<void>
 {
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(
         ((static_cast<SerializedErrorType>(ErrorCode::kInvalid) <= serialized_error_code) &&

--- a/score/mw/com/impl/error_serializer.h
+++ b/score/mw/com/impl/error_serializer.h
@@ -56,7 +56,7 @@ class ErrorSerializer
     ///        (e.g. a score::Result::has_value() == false)
     static SerializedErrorType SerializeError(const ErrorCode error_code);
 
-    static score::ResultBlank Deserialize(const SerializedErrorType serialized_error);
+    static score::Result<void> Deserialize(const SerializedErrorType serialized_error);
 };
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/generic_skeleton.cpp
+++ b/score/mw/com/impl/generic_skeleton.cpp
@@ -127,7 +127,7 @@ const GenericSkeleton::EventMap& GenericSkeleton::GetEvents() const noexcept
     return events_;
 }
 
-ResultBlank GenericSkeleton::OfferService() noexcept
+Result<void> GenericSkeleton::OfferService() noexcept
 {
     return SkeletonBase::OfferService();
 }

--- a/score/mw/com/impl/generic_skeleton.h
+++ b/score/mw/com/impl/generic_skeleton.h
@@ -76,7 +76,7 @@ class GenericSkeleton : public SkeletonBase
 
     /// @brief Offers the service instance.
     /// @return A blank result, or an error if offering fails.
-    [[nodiscard]] ResultBlank OfferService() noexcept;
+    [[nodiscard]] Result<void> OfferService() noexcept;
 
     /// @brief Stops offering the service instance.
     void StopOfferService() noexcept;

--- a/score/mw/com/impl/generic_skeleton_event.cpp
+++ b/score/mw/com/impl/generic_skeleton_event.cpp
@@ -43,7 +43,7 @@ GenericSkeletonEvent::GenericSkeletonEvent(SkeletonBase& skeleton_base,
     }
 }
 
-ResultBlank GenericSkeletonEvent::Send(SampleAllocateePtr<void> sample) noexcept
+Result<void> GenericSkeletonEvent::Send(SampleAllocateePtr<void> sample) noexcept
 {
     if (!service_offered_flag_.IsSet())
     {

--- a/score/mw/com/impl/generic_skeleton_event.h
+++ b/score/mw/com/impl/generic_skeleton_event.h
@@ -32,7 +32,7 @@ class GenericSkeletonEvent : public SkeletonEventBase
                          const std::string_view event_name,
                          std::unique_ptr<GenericSkeletonEventBinding> binding);
 
-    ResultBlank Send(SampleAllocateePtr<void> sample) noexcept;
+    Result<void> Send(SampleAllocateePtr<void> sample) noexcept;
 
     Result<SampleAllocateePtr<void>> Allocate() noexcept;
 

--- a/score/mw/com/impl/generic_skeleton_event_binding.h
+++ b/score/mw/com/impl/generic_skeleton_event_binding.h
@@ -27,7 +27,7 @@ namespace score::mw::com::impl
 class GenericSkeletonEventBinding : public SkeletonEventBindingBase
 {
   public:
-    virtual ResultBlank Send(SampleAllocateePtr<void> sample) noexcept = 0;
+    virtual Result<void> Send(SampleAllocateePtr<void> sample) noexcept = 0;
 
     virtual Result<SampleAllocateePtr<void>> Allocate() noexcept = 0;
 

--- a/score/mw/com/impl/generic_skeleton_event_test.cpp
+++ b/score/mw/com/impl/generic_skeleton_event_test.cpp
@@ -76,13 +76,13 @@ class GenericSkeletonEventTest : public ::testing::Test
         ON_CALL(binding_runtime_mock_, GetServiceDiscoveryClient())
             .WillByDefault(ReturnRef(service_discovery_client_mock_));
 
-        ON_CALL(service_discovery_mock_, OfferService(_)).WillByDefault(Return(score::ResultBlank{}));
+        ON_CALL(service_discovery_mock_, OfferService(_)).WillByDefault(Return(score::Result<void>{}));
 
         ON_CALL(skeleton_binding_factory_mock_guard_.factory_mock_, Create(_))
             .WillByDefault(Invoke([this](const auto&) {
                 auto mock = std::make_unique<NiceMock<mock_binding::Skeleton>>();
                 this->skeleton_binding_mock_ = mock.get();
-                ON_CALL(*mock, PrepareOffer(_, _, _)).WillByDefault(Return(score::ResultBlank{}));
+                ON_CALL(*mock, PrepareOffer(_, _, _)).WillByDefault(Return(score::Result<void>{}));
                 return mock;
             }));
     }
@@ -204,7 +204,7 @@ TEST_F(GenericSkeletonEventTest, AllocateAndSendDispatchesToBindingAfterOffer)
 
     // And Given the service is Offered
     EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodsRegistered()).WillRepeatedly(Return(true));
-    EXPECT_CALL(*mock_event_binding_ptr, PrepareOffer()).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(*mock_event_binding_ptr, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
     ASSERT_TRUE(skeleton.OfferService().has_value());
 
     // When calling Allocate()
@@ -216,7 +216,7 @@ TEST_F(GenericSkeletonEventTest, AllocateAndSendDispatchesToBindingAfterOffer)
     ASSERT_TRUE(alloc_result.has_value());
 
     // And When calling Send() with the allocated sample
-    EXPECT_CALL(*mock_event_binding_ptr, Send(_)).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(*mock_event_binding_ptr, Send(_)).WillOnce(Return(score::Result<void>{}));
 
     auto send_result = event->Send(std::move(alloc_result.value()));
 
@@ -251,7 +251,7 @@ TEST_F(GenericSkeletonEventTest, AllocateReturnsErrorWhenBindingFails)
 
     // And Given the service is Offered
     EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodsRegistered()).WillRepeatedly(Return(true));
-    EXPECT_CALL(*mock_event_binding_ptr, PrepareOffer()).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(*mock_event_binding_ptr, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
     ASSERT_TRUE(skeleton.OfferService().has_value());
 
     // Expect the binding to fail allocation
@@ -292,7 +292,7 @@ TEST_F(GenericSkeletonEventTest, SendReturnsErrorWhenBindingFails)
 
     // And Given the service is Offered
     EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodsRegistered()).WillRepeatedly(Return(true));
-    EXPECT_CALL(*mock_event_binding_ptr, PrepareOffer()).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(*mock_event_binding_ptr, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
     ASSERT_TRUE(skeleton.OfferService().has_value());
 
     // Expect the binding to fail sending

--- a/score/mw/com/impl/generic_skeleton_test.cpp
+++ b/score/mw/com/impl/generic_skeleton_test.cpp
@@ -74,7 +74,7 @@ class GenericSkeletonTest : public ::testing::Test
             .WillByDefault(Invoke([this](const auto&) {
                 auto mock = std::make_unique<NiceMock<mock_binding::Skeleton>>();
                 this->skeleton_binding_mock_ = mock.get();
-                ON_CALL(*mock, PrepareOffer(_, _, _)).WillByDefault(Return(score::ResultBlank{}));
+                ON_CALL(*mock, PrepareOffer(_, _, _)).WillByDefault(Return(score::Result<void>{}));
                 return mock;
             }));
     }
@@ -264,8 +264,8 @@ TEST_F(GenericSkeletonTest, OfferServicePropagatesToBindingAndDiscovery)
 
     // Expecting OfferService to trigger binding and discovery
     EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodsRegistered()).WillRepeatedly(Return(true));
-    EXPECT_CALL(*skeleton_binding_mock_, PrepareOffer(_, _, _)).WillOnce(Return(score::ResultBlank{}));
-    EXPECT_CALL(service_discovery_mock_, OfferService(identifier)).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(*skeleton_binding_mock_, PrepareOffer(_, _, _)).WillOnce(Return(score::Result<void>{}));
+    EXPECT_CALL(service_discovery_mock_, OfferService(identifier)).WillOnce(Return(score::Result<void>{}));
 
     // When offering service
     auto result = skeleton.OfferService();
@@ -285,8 +285,8 @@ TEST_F(GenericSkeletonTest, StopOfferServicePropagatesToBindingAndDiscovery)
 
     // And given the service is already Offered
     EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodsRegistered()).WillRepeatedly(Return(true));
-    EXPECT_CALL(*skeleton_binding_mock_, PrepareOffer(_, _, _)).WillOnce(Return(score::ResultBlank{}));
-    EXPECT_CALL(service_discovery_mock_, OfferService(identifier)).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(*skeleton_binding_mock_, PrepareOffer(_, _, _)).WillOnce(Return(score::Result<void>{}));
+    EXPECT_CALL(service_discovery_mock_, OfferService(identifier)).WillOnce(Return(score::Result<void>{}));
     ASSERT_TRUE(skeleton.OfferService().has_value());
 
     // Expecting StopOffer to trigger binding and discovery

--- a/score/mw/com/impl/i_service_discovery.h
+++ b/score/mw/com/impl/i_service_discovery.h
@@ -37,16 +37,16 @@ class IServiceDiscovery
     virtual ~IServiceDiscovery() = default;
     IServiceDiscovery() = default;
 
-    [[nodiscard]] virtual ResultBlank OfferService(InstanceIdentifier) noexcept = 0;
-    [[nodiscard]] virtual ResultBlank StopOfferService(InstanceIdentifier) noexcept = 0;
-    [[nodiscard]] virtual ResultBlank StopOfferService(InstanceIdentifier,
-                                                       QualityTypeSelector quality_type) noexcept = 0;
+    [[nodiscard]] virtual Result<void> OfferService(InstanceIdentifier) noexcept = 0;
+    [[nodiscard]] virtual Result<void> StopOfferService(InstanceIdentifier) noexcept = 0;
+    [[nodiscard]] virtual Result<void> StopOfferService(InstanceIdentifier,
+                                                        QualityTypeSelector quality_type) noexcept = 0;
     virtual Result<FindServiceHandle> StartFindService(FindServiceHandler<HandleType>,
                                                        const InstanceSpecifier) noexcept = 0;
     virtual Result<FindServiceHandle> StartFindService(FindServiceHandler<HandleType>, InstanceIdentifier) noexcept = 0;
     virtual Result<FindServiceHandle> StartFindService(FindServiceHandler<HandleType>,
                                                        const EnrichedInstanceIdentifier) noexcept = 0;
-    [[nodiscard]] virtual ResultBlank StopFindService(const FindServiceHandle) noexcept = 0;
+    [[nodiscard]] virtual Result<void> StopFindService(const FindServiceHandle) noexcept = 0;
     [[nodiscard]] virtual Result<ServiceHandleContainer<HandleType>> FindService(
         InstanceIdentifier instance_identifier) noexcept = 0;
     [[nodiscard]] virtual Result<ServiceHandleContainer<HandleType>> FindService(

--- a/score/mw/com/impl/i_service_discovery_client.h
+++ b/score/mw/com/impl/i_service_discovery_client.h
@@ -31,15 +31,15 @@ class IServiceDiscoveryClient
     virtual ~IServiceDiscoveryClient() noexcept = default;
     IServiceDiscoveryClient() = default;
 
-    [[nodiscard]] virtual ResultBlank OfferService(const InstanceIdentifier instance_identifier) noexcept = 0;
-    [[nodiscard]] virtual ResultBlank StopOfferService(
+    [[nodiscard]] virtual Result<void> OfferService(const InstanceIdentifier instance_identifier) noexcept = 0;
+    [[nodiscard]] virtual Result<void> StopOfferService(
         const InstanceIdentifier instance_identifier,
         const IServiceDiscovery::QualityTypeSelector quality_type_selector) noexcept = 0;
-    [[nodiscard]] virtual ResultBlank StartFindService(
+    [[nodiscard]] virtual Result<void> StartFindService(
         const FindServiceHandle find_service_handle,
         FindServiceHandler<HandleType> handler,
         const EnrichedInstanceIdentifier enriched_instance_identifier) noexcept = 0;
-    [[nodiscard]] virtual ResultBlank StopFindService(const FindServiceHandle find_service_handle) noexcept = 0;
+    [[nodiscard]] virtual Result<void> StopFindService(const FindServiceHandle find_service_handle) noexcept = 0;
     [[nodiscard]] virtual Result<ServiceHandleContainer<HandleType>> FindService(
         const EnrichedInstanceIdentifier enriched_instance_identifier) noexcept = 0;
 

--- a/score/mw/com/impl/methods/proxy_method.h
+++ b/score/mw/com/impl/methods/proxy_method.h
@@ -151,7 +151,7 @@ score::Result<std::tuple<impl::MethodInArgPtr<ArgTypes>...>> AllocateImpl(
 /// This step is important to avoid undefined behaviour (interpreting uninitialized memory) and also to ensure that any
 /// non-trivially constructible types are properly initialized.
 template <typename... ArgTypes>
-ResultBlank InitializeInArgs(ProxyMethodBinding& binding, const std::size_t queue_size)
+Result<void> InitializeInArgs(ProxyMethodBinding& binding, const std::size_t queue_size)
 {
     for (std::size_t queue_index = 0U; queue_index < queue_size; ++queue_index)
     {
@@ -178,7 +178,7 @@ ResultBlank InitializeInArgs(ProxyMethodBinding& binding, const std::size_t queu
 /// This step is important to avoid undefined behaviour (interpreting uninitialized memory) and also to ensure that any
 /// non-trivially constructible types are properly initialized.
 template <typename ReturnType>
-ResultBlank InitializeReturnValue(ProxyMethodBinding& binding, const std::size_t queue_size)
+Result<void> InitializeReturnValue(ProxyMethodBinding& binding, const std::size_t queue_size)
 {
     for (std::size_t queue_index = 0U; queue_index < queue_size; ++queue_index)
     {

--- a/score/mw/com/impl/methods/proxy_method_base.h
+++ b/score/mw/com/impl/methods/proxy_method_base.h
@@ -65,7 +65,7 @@ class ProxyMethodBase
     /// reinitialized on every method call. This potentially would have performance benefits but more importantly this
     /// allows us to support "semi-dynamic" types in which a type dynamically allocates once on construction and the
     /// constructor is then never called again.
-    virtual ResultBlank InitializeInArgsAndReturnValues() = 0;
+    virtual Result<void> InitializeInArgsAndReturnValues() = 0;
 
   protected:
     /// \brief Size of the call-queue is currently fixed to 1! As soon as we are going to support larger call-queues,

--- a/score/mw/com/impl/methods/proxy_method_binding.h
+++ b/score/mw/com/impl/methods/proxy_method_binding.h
@@ -51,8 +51,8 @@ class ProxyMethodBinding
     /// \details The in-arguments and return type storage must have been allocated before calling this method. The
     /// in-arguments must have been filled with the correct data before calling this method.
     /// \param queue_position The call-queue position at which to perform the method call.
-    /// \return ResultBlank indicating success or failure of the method call.
-    virtual score::ResultBlank DoCall(std::size_t queue_position) = 0;
+    /// \return Result<void> indicating success or failure of the method call.
+    virtual score::Result<void> DoCall(std::size_t queue_position) = 0;
 };
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/methods/proxy_method_with_in_args.h
+++ b/score/mw/com/impl/methods/proxy_method_with_in_args.h
@@ -85,7 +85,7 @@ class ProxyMethod<void(ArgTypes...)> final : public ProxyMethodBase
     ProxyMethod(ProxyMethod&&) noexcept;
     ProxyMethod& operator=(ProxyMethod&&) noexcept;
 
-    ResultBlank InitializeInArgsAndReturnValues() override;
+    Result<void> InitializeInArgsAndReturnValues() override;
 
     /// \brief Allocates the necessary storage for the argument values and the return value of a method call.
     /// \return On success, a tuple of MethodInArgPtr for each argument type is returned. On failure, an error code is
@@ -97,13 +97,13 @@ class ProxyMethod<void(ArgTypes...)> final : public ProxyMethodBase
 
     /// \brief This is the copying call-operator of ProxyMethod for a void ReturnType.
     /// \details This call-operator variant takes the argument values as references.
-    score::ResultBlank operator()(const ArgTypes&... args);
+    score::Result<void> operator()(const ArgTypes&... args);
 
     /// \brief This is the zero-copy call-operator of ProxyMethod for a void ReturnType. It only exists if there is at
     /// least one argument.
     /// \details This call-operator variant takes the argument values as MethodInArgPtr, i.e. as pointers to the
     /// argument values, which have been allocated before via Allocate() call.
-    score::ResultBlank operator()(MethodInArgPtr<ArgTypes>... args);
+    score::Result<void> operator()(MethodInArgPtr<ArgTypes>... args);
 
   private:
     /// \brief Compile-time initialized memory::DataTypeSizeInfo for the argument types of this ProxyMethod.
@@ -150,7 +150,7 @@ auto ProxyMethod<void(ArgTypes...)>::operator=(ProxyMethod&& other) noexcept -> 
 }
 
 template <typename... ArgTypes>
-score::ResultBlank ProxyMethod<void(ArgTypes...)>::operator()(const ArgTypes&... args)
+score::Result<void> ProxyMethod<void(ArgTypes...)>::operator()(const ArgTypes&... args)
 {
     auto allocate_result = Allocate();
     if (!allocate_result.has_value())
@@ -170,7 +170,7 @@ score::ResultBlank ProxyMethod<void(ArgTypes...)>::operator()(const ArgTypes&...
 }
 
 template <typename... ArgTypes>
-score::ResultBlank ProxyMethod<void(ArgTypes...)>::operator()(MethodInArgPtr<ArgTypes>... args)
+score::Result<void> ProxyMethod<void(ArgTypes...)>::operator()(MethodInArgPtr<ArgTypes>... args)
 {
     auto queue_position = detail::GetCommonQueuePosition(args...);
     auto call_result = binding_->DoCall(queue_position);
@@ -182,7 +182,7 @@ score::ResultBlank ProxyMethod<void(ArgTypes...)>::operator()(MethodInArgPtr<Arg
 }
 
 template <typename... ArgTypes>
-ResultBlank ProxyMethod<void(ArgTypes...)>::InitializeInArgsAndReturnValues()
+Result<void> ProxyMethod<void(ArgTypes...)>::InitializeInArgsAndReturnValues()
 {
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(binding_ != nullptr);
     const auto init_in_args_result = detail::InitializeInArgs<ArgTypes...>(*binding_, kCallQueueSize);

--- a/score/mw/com/impl/methods/proxy_method_with_in_args_and_return.h
+++ b/score/mw/com/impl/methods/proxy_method_with_in_args_and_return.h
@@ -125,7 +125,7 @@ class ProxyMethod<ReturnType(ArgTypes...)> final : public ProxyMethodBase
     ProxyMethod(ProxyMethod&&) noexcept;
     ProxyMethod& operator=(ProxyMethod&&) noexcept;
 
-    ResultBlank InitializeInArgsAndReturnValues() override;
+    Result<void> InitializeInArgsAndReturnValues() override;
 
     /// \brief Allocates the necessary storage for the argument values and the return value of a method call.
     /// \return On success, a tuple of MethodInArgPtr for each argument type is returned. On failure, an error code is
@@ -247,7 +247,7 @@ score::Result<MethodReturnTypePtr<ReturnType>> ProxyMethod<ReturnType(ArgTypes..
 }
 
 template <typename ReturnType, typename... ArgTypes>
-ResultBlank ProxyMethod<ReturnType(ArgTypes...)>::InitializeInArgsAndReturnValues()
+Result<void> ProxyMethod<ReturnType(ArgTypes...)>::InitializeInArgsAndReturnValues()
 {
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(binding_ != nullptr);
     const auto init_in_args_result = detail::InitializeInArgs<ArgTypes...>(*binding_, kCallQueueSize);

--- a/score/mw/com/impl/methods/proxy_method_with_return_type.h
+++ b/score/mw/com/impl/methods/proxy_method_with_return_type.h
@@ -115,7 +115,7 @@ class ProxyMethod<ReturnType()> final : public ProxyMethodBase
     ProxyMethod(ProxyMethod&&) noexcept;
     ProxyMethod& operator=(ProxyMethod&&) noexcept;
 
-    ResultBlank InitializeInArgsAndReturnValues() override;
+    Result<void> InitializeInArgsAndReturnValues() override;
 
     /// \brief This is the call-operator of ProxyMethod with no arguments for a non-void ReturnType.
     score::Result<MethodReturnTypePtr<ReturnType>> operator()();
@@ -194,7 +194,7 @@ score::Result<MethodReturnTypePtr<ReturnType>> ProxyMethod<ReturnType()>::operat
 }
 
 template <typename ReturnType>
-ResultBlank ProxyMethod<ReturnType()>::InitializeInArgsAndReturnValues()
+Result<void> ProxyMethod<ReturnType()>::InitializeInArgsAndReturnValues()
 {
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(binding_ != nullptr);
     const auto init_return_result = detail::InitializeReturnValue<ReturnType>(*binding_, kCallQueueSize);

--- a/score/mw/com/impl/methods/proxy_method_without_in_args_or_return.cpp
+++ b/score/mw/com/impl/methods/proxy_method_without_in_args_or_return.cpp
@@ -34,7 +34,7 @@ auto ProxyMethod<void()>::operator=(ProxyMethod&& other) noexcept -> ProxyMethod
     return *this;
 }
 
-score::ResultBlank ProxyMethod<void()>::operator()()
+score::Result<void> ProxyMethod<void()>::operator()()
 {
     auto queue_position = detail::DetermineNextAvailableQueueSlot(is_return_type_ptr_active_);
     if (!queue_position.has_value())

--- a/score/mw/com/impl/methods/proxy_method_without_in_args_or_return.h
+++ b/score/mw/com/impl/methods/proxy_method_without_in_args_or_return.h
@@ -86,13 +86,13 @@ class ProxyMethod<void()> final : public ProxyMethodBase
     ProxyMethod(ProxyMethod&&) noexcept;
     ProxyMethod& operator=(ProxyMethod&&) noexcept;
 
-    ResultBlank InitializeInArgsAndReturnValues() override
+    Result<void> InitializeInArgsAndReturnValues() override
     {
         return {};
     }
 
     /// \brief This is the call-operator of ProxyMethod with no arguments and a void ReturnType.
-    score::ResultBlank operator()();
+    score::Result<void> operator()();
 
   private:
     /// \brief Empty optional as in this class template specialization we do not have in-arguments.

--- a/score/mw/com/impl/methods/skeleton_method.h
+++ b/score/mw/com/impl/methods/skeleton_method.h
@@ -109,7 +109,7 @@ class SkeletonMethod<ReturnType(ArgTypes...)> final : public SkeletonMethodBase
     /// method.
     /// \return score::cpp::blank on success and ComErrc code specified by the binding on failiure
     template <typename Callable>
-    ResultBlank RegisterHandler(Callable&& callback);
+    Result<void> RegisterHandler(Callable&& callback);
 
     void UpdateSkeletonReference(SkeletonBase& skeleton_base) noexcept;
 };
@@ -156,7 +156,7 @@ void SkeletonMethod<ReturnType(ArgTypes...)>::UpdateSkeletonReference(SkeletonBa
 
 template <typename ReturnType, typename... ArgTypes>
 template <typename Callable>
-ResultBlank SkeletonMethod<ReturnType(ArgTypes...)>::RegisterHandler(Callable&& callback)
+Result<void> SkeletonMethod<ReturnType(ArgTypes...)>::RegisterHandler(Callable&& callback)
 {
     static_assert(std::is_rvalue_reference_v<decltype(callback)>,
                   "Callbeck provided to register has to be an rvalue reference");

--- a/score/mw/com/impl/methods/skeleton_method_binding.h
+++ b/score/mw/com/impl/methods/skeleton_method_binding.h
@@ -44,7 +44,7 @@ class SkeletonMethodBinding
     SkeletonMethodBinding() = default;
     virtual ~SkeletonMethodBinding() = default;
 
-    virtual ResultBlank RegisterHandler(TypeErasedHandler&& callback) = 0;
+    virtual Result<void> RegisterHandler(TypeErasedHandler&& callback) = 0;
 
     SkeletonMethodBinding(const SkeletonMethodBinding&) = delete;
     SkeletonMethodBinding& operator=(const SkeletonMethodBinding&) & = delete;

--- a/score/mw/com/impl/methods/skeleton_method_test.cpp
+++ b/score/mw/com/impl/methods/skeleton_method_test.cpp
@@ -107,7 +107,7 @@ class SkeletonMethodTypedTest : public ::testing::Test
 
     void SetUp() override
     {
-        ON_CALL(skeleton_method_binding_mock_, RegisterHandler(_)).WillByDefault(Return(ResultBlank{}));
+        ON_CALL(skeleton_method_binding_mock_, RegisterHandler(_)).WillByDefault(Return(Result<void>{}));
     }
     mock_binding::SkeletonMethod skeleton_method_binding_mock_;
 };
@@ -287,7 +287,7 @@ TEST_F(SkeletonMethodThingStuffFixture, DataTransferBetweenTypedAndTypeErasedCal
 
     // Expecting that the register call is dispatched to the binding without an error
     EXPECT_CALL(mock_method_binding_, RegisterHandler(_))
-        .WillOnce(Invoke([this](auto&& type_erased_callable) -> ResultBlank {
+        .WillOnce(Invoke([this](auto&& type_erased_callable) -> Result<void> {
             typeerased_callback_.emplace(std::move(type_erased_callable));
             return {};
         }));
@@ -317,7 +317,7 @@ TEST_F(SkeletonMethodThingVoidFixture, DataTransferBetweenTypedAndTypeErasedCall
 
     // Expecting that the register call is dispatched to the binding without an error
     EXPECT_CALL(mock_method_binding_, RegisterHandler(_))
-        .WillOnce(Invoke([this](auto&& type_erased_callable) -> ResultBlank {
+        .WillOnce(Invoke([this](auto&& type_erased_callable) -> Result<void> {
             typeerased_callback_.emplace(std::move(type_erased_callable));
             return {};
         }));
@@ -345,7 +345,7 @@ TEST_F(SkeletonMethodVoidStuffFixture, DataTransferBetweenTypedAndTypeErasedCall
 
     // Expecting that the register call is dispatched to the binding without an error
     EXPECT_CALL(mock_method_binding_, RegisterHandler(_))
-        .WillOnce(Invoke([this](auto&& type_erased_callable) -> ResultBlank {
+        .WillOnce(Invoke([this](auto&& type_erased_callable) -> Result<void> {
             typeerased_callback_.emplace(std::move(type_erased_callable));
             return {};
         }));
@@ -371,7 +371,7 @@ TEST_F(SkeletonMethodVoidVoidFixture, DataTransferBetweenTypedAndTypeErasedCallb
 
     // Expecting that the register call is dispatched to the binding without an error
     EXPECT_CALL(mock_method_binding_, RegisterHandler(_))
-        .WillOnce(Invoke([this](auto&& type_erased_callable) -> ResultBlank {
+        .WillOnce(Invoke([this](auto&& type_erased_callable) -> Result<void> {
             typeerased_callback_.emplace(std::move(type_erased_callable));
             return {};
         }));

--- a/score/mw/com/impl/mocking/i_proxy_event.h
+++ b/score/mw/com/impl/mocking/i_proxy_event.h
@@ -32,13 +32,13 @@ class IProxyEventBase
     IProxyEventBase() = default;
     virtual ~IProxyEventBase() = default;
 
-    virtual ResultBlank Subscribe(const std::size_t) = 0;
+    virtual Result<void> Subscribe(const std::size_t) = 0;
     virtual void Unsubscribe() = 0;
     virtual SubscriptionState GetSubscriptionState() const = 0;
     virtual std::size_t GetFreeSampleCount() const = 0;
     virtual Result<std::size_t> GetNumNewSamplesAvailable() = 0;
-    virtual ResultBlank SetReceiveHandler(EventReceiveHandler) = 0;
-    virtual ResultBlank UnsetReceiveHandler() = 0;
+    virtual Result<void> SetReceiveHandler(EventReceiveHandler) = 0;
+    virtual Result<void> UnsetReceiveHandler() = 0;
 
   protected:
     IProxyEventBase(const IProxyEventBase&) = default;

--- a/score/mw/com/impl/mocking/i_skeleton_base.h
+++ b/score/mw/com/impl/mocking/i_skeleton_base.h
@@ -26,7 +26,7 @@ class ISkeletonBase
     ISkeletonBase() = default;
     virtual ~ISkeletonBase() = default;
 
-    virtual ResultBlank OfferService() = 0;
+    virtual Result<void> OfferService() = 0;
     virtual void StopOfferService() = 0;
 
   protected:

--- a/score/mw/com/impl/mocking/i_skeleton_event.h
+++ b/score/mw/com/impl/mocking/i_skeleton_event.h
@@ -29,8 +29,8 @@ class ISkeletonEvent
     ISkeletonEvent() = default;
     virtual ~ISkeletonEvent() = default;
 
-    virtual ResultBlank Send(const SampleType&) = 0;
-    virtual ResultBlank Send(SampleAllocateePtr<SampleType>) = 0;
+    virtual Result<void> Send(const SampleType&) = 0;
+    virtual Result<void> Send(SampleAllocateePtr<SampleType>) = 0;
     virtual Result<SampleAllocateePtr<SampleType>> Allocate() = 0;
 
   protected:

--- a/score/mw/com/impl/mocking/i_skeleton_field.h
+++ b/score/mw/com/impl/mocking/i_skeleton_field.h
@@ -29,8 +29,8 @@ class ISkeletonField
     ISkeletonField() = default;
     virtual ~ISkeletonField() = default;
 
-    virtual ResultBlank Update(const SampleType&) = 0;
-    virtual ResultBlank Update(SampleAllocateePtr<SampleType>) = 0;
+    virtual Result<void> Update(const SampleType&) = 0;
+    virtual Result<void> Update(SampleAllocateePtr<SampleType>) = 0;
     virtual Result<SampleAllocateePtr<SampleType>> Allocate() = 0;
 
   protected:

--- a/score/mw/com/impl/mocking/proxy_event_mock.h
+++ b/score/mw/com/impl/mocking/proxy_event_mock.h
@@ -26,13 +26,13 @@ class ProxyEventMock : public IProxyEvent<SampleType>
   public:
     using Callback = typename IProxyEvent<SampleType>::Callback;
 
-    MOCK_METHOD(ResultBlank, Subscribe, (const std::size_t), (override));
+    MOCK_METHOD(Result<void>, Subscribe, (const std::size_t), (override));
     MOCK_METHOD(void, Unsubscribe, (), (override));
     MOCK_METHOD(SubscriptionState, GetSubscriptionState, (), (const, override));
     MOCK_METHOD(std::size_t, GetFreeSampleCount, (), (const, override));
     MOCK_METHOD(Result<std::size_t>, GetNumNewSamplesAvailable, (), (override));
-    MOCK_METHOD(ResultBlank, SetReceiveHandler, (EventReceiveHandler), (override));
-    MOCK_METHOD(ResultBlank, UnsetReceiveHandler, (), (override));
+    MOCK_METHOD(Result<void>, SetReceiveHandler, (EventReceiveHandler), (override));
+    MOCK_METHOD(Result<void>, UnsetReceiveHandler, (), (override));
 
     MOCK_METHOD(Result<std::size_t>, GetNewSamples, (Callback&&, const std::size_t), (override));
 };

--- a/score/mw/com/impl/mocking/proxy_event_mock_test.cpp
+++ b/score/mw/com/impl/mocking/proxy_event_mock_test.cpp
@@ -76,7 +76,7 @@ TYPED_TEST(ProxyEventFieldMockFixture, SubscribeDispatchesToMockAfterInjectingMo
     // Given a ProxyEvent constructed with an empty binding and an injected mock
 
     // Expecting that Subscribe will be called on the mock which returns a valid result
-    EXPECT_CALL(this->proxy_service_element_mock_, Subscribe(kDummyMaxSampleCount)).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(this->proxy_service_element_mock_, Subscribe(kDummyMaxSampleCount)).WillOnce(Return(Result<void>{}));
 
     // When Subscribe is called on the ProxyEvent
     const auto result = this->unit_.Subscribe(kDummyMaxSampleCount);
@@ -183,7 +183,7 @@ TYPED_TEST(ProxyEventFieldMockFixture, SetReceiveHandlerDispatchesToMockAfterInj
 
     // Expecting that SetReceiveHandler will be called on the mock which returns a valid result
 
-    EXPECT_CALL(this->proxy_service_element_mock_, SetReceiveHandler(_)).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(this->proxy_service_element_mock_, SetReceiveHandler(_)).WillOnce(Return(Result<void>{}));
 
     // When SetReceiveHandler is called on the ProxyEvent
     const auto result = this->unit_.SetReceiveHandler([]() {});
@@ -215,7 +215,7 @@ TYPED_TEST(ProxyEventFieldMockFixture, UnsetReceiveHandlerDispatchesToMockAfterI
 
     // Expecting that UnsetReceiveHandler will be called on the mock which returns a valid result
 
-    EXPECT_CALL(this->proxy_service_element_mock_, UnsetReceiveHandler()).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(this->proxy_service_element_mock_, UnsetReceiveHandler()).WillOnce(Return(Result<void>{}));
 
     // When UnsetReceiveHandler is called on the ProxyEvent
     const auto result = this->unit_.UnsetReceiveHandler();

--- a/score/mw/com/impl/mocking/skeleton_base_mock.h
+++ b/score/mw/com/impl/mocking/skeleton_base_mock.h
@@ -23,7 +23,7 @@ namespace score::mw::com::impl
 class SkeletonBaseMock : public ISkeletonBase
 {
   public:
-    MOCK_METHOD(ResultBlank, OfferService, (), (override));
+    MOCK_METHOD(Result<void>, OfferService, (), (override));
     MOCK_METHOD(void, StopOfferService, (), (override));
 };
 

--- a/score/mw/com/impl/mocking/skeleton_base_mock_test.cpp
+++ b/score/mw/com/impl/mocking/skeleton_base_mock_test.cpp
@@ -44,14 +44,14 @@ TEST_F(SkeletonMockFixture, OfferServiceDispatchesToMockAfterInjectingMock)
     // SkeletonBaseMock
 
     // Expecting that OfferService will be called on the mock which returns a valid result
-    EXPECT_CALL(skeleton_mock_, OfferService()).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(skeleton_mock_, OfferService()).WillOnce(Return(Result<void>{}));
 
     // When OfferService is called on the SkeletonBase
     auto result = unit_.OfferService();
 
     // Then the result is valid
     ASSERT_TRUE(result.has_value());
-    EXPECT_EQ(result, ResultBlank{});
+    EXPECT_EQ(result, Result<void>{});
 }
 
 TEST_F(SkeletonMockFixture, OfferServiceReturnsErrorWhenMockReturnsError)

--- a/score/mw/com/impl/mocking/skeleton_event_mock.h
+++ b/score/mw/com/impl/mocking/skeleton_event_mock.h
@@ -24,8 +24,8 @@ template <typename SampleType>
 class SkeletonEventMock : public ISkeletonEvent<SampleType>
 {
   public:
-    MOCK_METHOD(ResultBlank, Send, (const SampleType&), (override));
-    MOCK_METHOD(ResultBlank, Send, (SampleAllocateePtr<SampleType>), (override));
+    MOCK_METHOD(Result<void>, Send, (const SampleType&), (override));
+    MOCK_METHOD(Result<void>, Send, (SampleAllocateePtr<SampleType>), (override));
     MOCK_METHOD(Result<SampleAllocateePtr<SampleType>>, Allocate, (), (override));
 };
 

--- a/score/mw/com/impl/mocking/skeleton_event_mock_test.cpp
+++ b/score/mw/com/impl/mocking/skeleton_event_mock_test.cpp
@@ -80,7 +80,7 @@ TEST_F(SkeletonEventMockFixture, CopySendDispatchesToMockAfterInjectingMock)
     // Given a SkeletonEvent constructed with an empty binding and an injected mock
 
     // Expecting that Send with copy will be called on the mock which returns a valid result
-    EXPECT_CALL(skeleton_event_mock_, Send(kDummyValueToSend)).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(skeleton_event_mock_, Send(kDummyValueToSend)).WillOnce(Return(Result<void>{}));
 
     // When Send with copy is called on the SkeletonEvent
     auto result = unit_.Send(kDummyValueToSend);
@@ -112,9 +112,9 @@ TEST_F(SkeletonEventMockFixture, ZeroCopySendDispatchesToMockAfterInjectingMock)
     // Expecting that zero-copy Send will be called on the mock with a SampleAllocateePtr containing the sent value
     // which returns a valid result
     EXPECT_CALL(skeleton_event_mock_, Send(testing::Matcher<SampleAllocateePtr<TestSampleType>>(_)))
-        .WillOnce(Invoke([](auto sample_allocatee_ptr) noexcept -> ResultBlank {
+        .WillOnce(Invoke([](auto sample_allocatee_ptr) noexcept -> Result<void> {
             EXPECT_EQ(*sample_allocatee_ptr, kDummyValueToSend);
-            return ResultBlank{};
+            return Result<void>{};
         }));
 
     // When zero-copy Send is called on the SkeletonEvent with a SampleAllocateePtr containing a value

--- a/score/mw/com/impl/mocking/skeleton_field_mock.h
+++ b/score/mw/com/impl/mocking/skeleton_field_mock.h
@@ -24,8 +24,8 @@ template <typename SampleType>
 class SkeletonFieldMock : public ISkeletonField<SampleType>
 {
   public:
-    MOCK_METHOD(ResultBlank, Update, (const SampleType&), (override));
-    MOCK_METHOD(ResultBlank, Update, (SampleAllocateePtr<SampleType>), (override));
+    MOCK_METHOD(Result<void>, Update, (const SampleType&), (override));
+    MOCK_METHOD(Result<void>, Update, (SampleAllocateePtr<SampleType>), (override));
     MOCK_METHOD(Result<SampleAllocateePtr<SampleType>>, Allocate, (), (override));
 };
 

--- a/score/mw/com/impl/mocking/skeleton_field_mock_test.cpp
+++ b/score/mw/com/impl/mocking/skeleton_field_mock_test.cpp
@@ -80,7 +80,7 @@ TEST_F(SkeletonFieldMockFixture, CopyUpdateDispatchesToMockAfterInjectingMock)
     // Given a SkeletonField constructed with an empty binding and an injected mock
 
     // Expecting that Update with copy will be called on the mock which returns a valid result
-    EXPECT_CALL(skeleton_field_mock_, Update(kDummyValueToUpdate)).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(skeleton_field_mock_, Update(kDummyValueToUpdate)).WillOnce(Return(Result<void>{}));
 
     // When Update with copy is called on the SkeletonField
     auto result = unit_.Update(kDummyValueToUpdate);
@@ -111,7 +111,7 @@ TEST_F(SkeletonFieldMockFixture, ZeroCopyUpdateDispatchesToMockAfterInjectingMoc
 
     // Expecting that zero-copy Update will be called on the mock which returns a valid result
     EXPECT_CALL(skeleton_field_mock_, Update(testing::Matcher<SampleAllocateePtr<TestSampleType>>(_)))
-        .WillOnce(Return(ResultBlank{}));
+        .WillOnce(Return(Result<void>{}));
 
     // When zero-copy Update is called on the SkeletonField
     auto fake_sample_allocatee_ptr = MakeFakeSampleAllocateePtr(std::make_unique<TestSampleType>());

--- a/score/mw/com/impl/proxy_base.cpp
+++ b/score/mw/com/impl/proxy_base.cpp
@@ -148,7 +148,7 @@ auto ProxyBase::StartFindService(FindServiceHandler<HandleType> handler, Instanc
     return start_find_service_result;
 }
 
-score::ResultBlank ProxyBase::StopFindService(const FindServiceHandle handle) noexcept
+score::Result<void> ProxyBase::StopFindService(const FindServiceHandle handle) noexcept
 {
     const auto stop_find_service_result = Runtime::getInstance().GetServiceDiscovery().StopFindService(handle);
     if (!(stop_find_service_result.has_value()))
@@ -158,12 +158,12 @@ score::ResultBlank ProxyBase::StopFindService(const FindServiceHandle handle) no
     return stop_find_service_result;
 }
 
-ResultBlank ProxyBase::SetupMethods(const std::vector<std::string_view>& enabled_method_names)
+Result<void> ProxyBase::SetupMethods(const std::vector<std::string_view>& enabled_method_names)
 {
     const auto result = proxy_binding_->SetupMethods(enabled_method_names);
     if (!result.has_value())
     {
-        return MakeUnexpected<Blank>(result.error());
+        return MakeUnexpected<void>(result.error());
     }
 
     for (auto& method_key_value_pair : methods_)

--- a/score/mw/com/impl/proxy_base.h
+++ b/score/mw/com/impl/proxy_base.h
@@ -107,7 +107,7 @@ class ProxyBase
      * \param handle The handle returned by StartFindService identifying the find operation to stop.
      * \return A result indicating success or failure of stopping the find operation.
      */
-    static score::ResultBlank StopFindService(const FindServiceHandle handle) noexcept;
+    static score::Result<void> StopFindService(const FindServiceHandle handle) noexcept;
 
     /**
      * \api
@@ -137,7 +137,7 @@ class ProxyBase
         return is_proxy_binding_valid && are_service_element_bindings_valid_;
     }
 
-    ResultBlank SetupMethods(const std::vector<std::string_view>& enabled_method_names);
+    Result<void> SetupMethods(const std::vector<std::string_view>& enabled_method_names);
 
     // Suppress "AUTOSAR C++14 M11-0-1" rule findings. This rule states: "Member data in non-POD class types shall
     // be private.". We need these data elements to exchange this information between the ProxyBase and the

--- a/score/mw/com/impl/proxy_base_test.cpp
+++ b/score/mw/com/impl/proxy_base_test.cpp
@@ -74,7 +74,7 @@ class ProxyBaseFixture : public ::testing::Test
     {
         ON_CALL(runtime_mock_guard_.runtime_mock_, GetServiceDiscovery())
             .WillByDefault(testing::ReturnRef(service_discovery_mock_));
-        ON_CALL(service_discovery_mock_, StopFindService(_)).WillByDefault(Return(ResultBlank{}));
+        ON_CALL(service_discovery_mock_, StopFindService(_)).WillByDefault(Return(Result<void>{}));
     }
 
     ProxyBaseFixture& WithAProxyBaseWithMockBinding(const HandleType& handle_type)
@@ -337,7 +337,7 @@ TEST_F(ProxyBaseStopFindServiceFixture, StopFindServiceWillDispatchToBinding)
 
     // Expecting that StopFindService is called on the Proxy binding with the handle provided to StopFindService
     const FindServiceHandle handle{make_FindServiceHandle(0)};
-    EXPECT_CALL(service_discovery_mock_, StopFindService(handle)).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(service_discovery_mock_, StopFindService(handle)).WillOnce(Return(Result<void>{}));
 
     // When calling StartFindService
     score::cpp::ignore = ProxyBase::StopFindService(handle);
@@ -562,7 +562,7 @@ class DummyProxyMethod : public ProxyMethodBase
 {
   public:
     using ProxyMethodBase::ProxyMethodBase;
-    ResultBlank InitializeInArgsAndReturnValues() override
+    Result<void> InitializeInArgsAndReturnValues() override
     {
         return {};
     }

--- a/score/mw/com/impl/proxy_binding.h
+++ b/score/mw/com/impl/proxy_binding.h
@@ -61,7 +61,7 @@ class ProxyBinding
     /// Unregisters a ProxyEvent binding with its parent proxy
     virtual void UnregisterEventBinding(const std::string_view service_element_name) noexcept = 0;
 
-    virtual ResultBlank SetupMethods(const std::vector<std::string_view>& enabled_method_names) = 0;
+    virtual Result<void> SetupMethods(const std::vector<std::string_view>& enabled_method_names) = 0;
 };
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/proxy_binding_test.cpp
+++ b/score/mw/com/impl/proxy_binding_test.cpp
@@ -31,7 +31,7 @@ class MyProxy final : public ProxyBinding
     }
     void RegisterEventBinding(std::string_view, ProxyEventBindingBase&) noexcept override {}
     void UnregisterEventBinding(std::string_view) noexcept override {}
-    ResultBlank SetupMethods(const std::vector<std::string_view>&) override
+    Result<void> SetupMethods(const std::vector<std::string_view>&) override
     {
         return {};
     }

--- a/score/mw/com/impl/proxy_event_base.cpp
+++ b/score/mw/com/impl/proxy_event_base.cpp
@@ -112,7 +112,7 @@ ProxyEventBase& ProxyEventBase::operator=(ProxyEventBase&&) noexcept = default;
 // which leds to std::terminate().
 // This suppression should be removed after fixing [Ticket-173043](broken_link_j/Ticket-173043)
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-ResultBlank ProxyEventBase::Subscribe(const std::size_t max_sample_count) noexcept
+Result<void> ProxyEventBase::Subscribe(const std::size_t max_sample_count) noexcept
 {
     if (proxy_event_base_mock_ != nullptr)
     {
@@ -213,7 +213,7 @@ Result<std::size_t> ProxyEventBase::GetNumNewSamplesAvailable() const noexcept
     return get_num_new_samples_available_result;
 }
 
-ResultBlank ProxyEventBase::SetReceiveHandler(EventReceiveHandler handler) noexcept
+Result<void> ProxyEventBase::SetReceiveHandler(EventReceiveHandler handler) noexcept
 {
     if (proxy_event_base_mock_ != nullptr)
     {
@@ -246,7 +246,7 @@ ResultBlank ProxyEventBase::SetReceiveHandler(EventReceiveHandler handler) noexc
     return {};
 }
 
-ResultBlank ProxyEventBase::UnsetReceiveHandler() noexcept
+Result<void> ProxyEventBase::UnsetReceiveHandler() noexcept
 {
     if (proxy_event_base_mock_ != nullptr)
     {

--- a/score/mw/com/impl/proxy_event_base.h
+++ b/score/mw/com/impl/proxy_event_base.h
@@ -98,7 +98,7 @@ class ProxyEventBase
      *                          be able to offer to the using application.
      * \return On failure, returns an error code.
      */
-    ResultBlank Subscribe(const std::size_t max_sample_count) noexcept;
+    Result<void> Subscribe(const std::size_t max_sample_count) noexcept;
 
     /**
      * \api
@@ -156,13 +156,13 @@ class ProxyEventBase
      *            already running ReceiveHandler. We also see no use cases for it and won't support it therefore.
      * \param handler user provided handler to be called
      */
-    ResultBlank SetReceiveHandler(EventReceiveHandler handler) noexcept;
+    Result<void> SetReceiveHandler(EventReceiveHandler handler) noexcept;
 
     /**
      * \api
      * \brief Removes any ReceiveHandler registered via SetReceiveHandler.
      */
-    ResultBlank UnsetReceiveHandler() noexcept;
+    Result<void> UnsetReceiveHandler() noexcept;
 
     /**
      * \api

--- a/score/mw/com/impl/proxy_event_base_test.cpp
+++ b/score/mw/com/impl/proxy_event_base_test.cpp
@@ -76,7 +76,7 @@ class ProxyEventBaseFixture : public ::testing::Test
         service_element_ =
             std::make_unique<ServiceElementType>(empty_proxy_, std::move(mock_service_element_binding_ptr), kEventName);
 
-        ON_CALL(*mock_service_element_binding_, SetReceiveHandler(_)).WillByDefault(Return(score::ResultBlank{}));
+        ON_CALL(*mock_service_element_binding_, SetReceiveHandler(_)).WillByDefault(Return(score::Result<void>{}));
     }
 
     DummyProxy empty_proxy_{std::make_unique<mock_binding::Proxy>(),
@@ -361,7 +361,7 @@ class AServiceElement : public ::testing::Test
             std::make_unique<ServiceElementType>(empty_proxy_, std::move(mock_service_element_binding_ptr), kEventName);
         ASSERT_NE(service_element_, nullptr);
 
-        ON_CALL(*mock_service_element_binding_, SetReceiveHandler(_)).WillByDefault(Return(score::ResultBlank{}));
+        ON_CALL(*mock_service_element_binding_, SetReceiveHandler(_)).WillByDefault(Return(score::Result<void>{}));
     }
 
     AServiceElement& WithAReceiveHandler()
@@ -376,9 +376,9 @@ class AServiceElement : public ::testing::Test
     {
         // and given that the receive handler is set by the binding
         ON_CALL(*this->mock_service_element_binding_, SetReceiveHandler(_))
-            .WillByDefault(Invoke([this](std::weak_ptr<ScopedEventReceiveHandler> handler) -> ResultBlank {
+            .WillByDefault(Invoke([this](std::weak_ptr<ScopedEventReceiveHandler> handler) -> Result<void> {
                 event_receive_handler_promise_->set_value(std::move(handler));
-                return ResultBlank{};
+                return Result<void>{};
             }));
 
         return *this;
@@ -430,7 +430,7 @@ TYPED_TEST(AServiceElement, WhenSettingAReceiveHandlerThenItWillDispatchToTheBin
     // Given a Service Element, that is connected to a mock binding
 
     // Expecting that the receive-handler is forwarded to the binding
-    EXPECT_CALL(*this->mock_service_element_binding_, SetReceiveHandler(_)).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(*this->mock_service_element_binding_, SetReceiveHandler(_)).WillOnce(Return(score::Result<void>{}));
 
     // When setting a receive-handler
     score::cpp::ignore = this->service_element_->SetReceiveHandler(EventReceiveHandler{});
@@ -466,7 +466,7 @@ TYPED_TEST(AServiceElement, WhenSettingAReceiveHandlerTwiceThenItWillDispatchToT
     // Expecting that the receive-handler is forwarded to the binding twice
     EXPECT_CALL(*this->mock_service_element_binding_, SetReceiveHandler(_))
         .Times(2)
-        .WillRepeatedly(Return(score::ResultBlank{}));
+        .WillRepeatedly(Return(score::Result<void>{}));
 
     // When setting a receive-handler twice
     score::cpp::ignore = this->service_element_->SetReceiveHandler(EventReceiveHandler{});
@@ -531,7 +531,7 @@ TYPED_TEST(AServiceElement, WhenUnsettingAReceiveHandlerAfterSettingThenItWillDi
     this->WithAReceiveHandler();
 
     // Expecting that the receive-handler is unset
-    EXPECT_CALL(*this->mock_service_element_binding_, UnsetReceiveHandler()).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(*this->mock_service_element_binding_, UnsetReceiveHandler()).WillOnce(Return(score::Result<void>{}));
 
     // and un-setting the receive-handler
     score::cpp::ignore = this->service_element_->UnsetReceiveHandler();
@@ -701,7 +701,7 @@ TYPED_TEST(ProxyEventBaseSubscribeFixture, CallingSubscribeTwiceWithSameMaxSampl
     // Expect that Subscribe is called on the binding only once
     EXPECT_CALL(*this->mock_service_element_binding_, GetSubscriptionState())
         .WillOnce(Return(SubscriptionState::kNotSubscribed));
-    EXPECT_CALL(*this->mock_service_element_binding_, Subscribe(7)).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(*this->mock_service_element_binding_, Subscribe(7)).WillOnce(Return(score::Result<void>{}));
     EXPECT_CALL(*this->mock_service_element_binding_, GetSubscriptionState())
         .WillOnce(Return(SubscriptionState::kSubscriptionPending));
 
@@ -1047,7 +1047,7 @@ TEST(ProxyEventBaseTest, MoveConstructingProxyEventDoesNotCrash)
 
     // Expect that Subscribe is called on the binding only once
     EXPECT_CALL(mock_proxy_event_binding, GetSubscriptionState()).WillOnce(Return(SubscriptionState::kNotSubscribed));
-    EXPECT_CALL(mock_proxy_event_binding, Subscribe(7)).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(mock_proxy_event_binding, Subscribe(7)).WillOnce(Return(score::Result<void>{}));
 
     // When calling subscribe
     const auto subscribe_result = dummy_event_2.Subscribe(7U);
@@ -1077,7 +1077,7 @@ TEST(ProxyEventBaseTest, MoveAssigningProxyEventDoesNotCrash)
 
     // Expect that Subscribe is called on the binding only once
     EXPECT_CALL(mock_proxy_event_binding, GetSubscriptionState()).WillOnce(Return(SubscriptionState::kNotSubscribed));
-    EXPECT_CALL(mock_proxy_event_binding, Subscribe(7)).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(mock_proxy_event_binding, Subscribe(7)).WillOnce(Return(score::Result<void>{}));
 
     // When calling subscribe
     const auto subscribe_result = dummy_event_2.Subscribe(7U);

--- a/score/mw/com/impl/proxy_event_binding_base.h
+++ b/score/mw/com/impl/proxy_event_binding_base.h
@@ -49,7 +49,7 @@ class ProxyEventBindingBase
     ///
     /// \param max_sample_count Specify the maximum number of concurrent samples that this event shall
     ///                         be able to offer to the using application.
-    virtual ResultBlank Subscribe(const std::size_t max_sample_count) noexcept = 0;
+    virtual Result<void> Subscribe(const std::size_t max_sample_count) noexcept = 0;
 
     /// \brief Get the subscription state of this event.
     ///
@@ -68,10 +68,10 @@ class ProxyEventBindingBase
     /// The handler must not throw an exception and it must not terminate.
     ///
     /// \param handler The callback to be called on event reception.
-    virtual ResultBlank SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) noexcept = 0;
+    virtual Result<void> SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) noexcept = 0;
 
     /// \brief Remove any receive handler registered via SetReceiveHandler()
-    virtual ResultBlank UnsetReceiveHandler() noexcept = 0;
+    virtual Result<void> UnsetReceiveHandler() noexcept = 0;
 
     /// \brief Returns the number of new samples a call to GetNewSamples() would currently provide if the
     /// max_sample_count set in the Subscribe call and GetNewSamples call were both infinitely high.

--- a/score/mw/com/impl/proxy_event_binding_base_test.cpp
+++ b/score/mw/com/impl/proxy_event_binding_base_test.cpp
@@ -23,7 +23,7 @@ namespace
 class DummyProxyEventBinding final : public ProxyEventBindingBase
 {
   public:
-    ResultBlank Subscribe(std::size_t) noexcept override
+    Result<void> Subscribe(std::size_t) noexcept override
     {
         return {};
     }
@@ -32,11 +32,11 @@ class DummyProxyEventBinding final : public ProxyEventBindingBase
         return SubscriptionState::kSubscribed;
     }
     void Unsubscribe() noexcept override {}
-    ResultBlank SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler>) noexcept override
+    Result<void> SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler>) noexcept override
     {
         return {};
     }
-    ResultBlank UnsetReceiveHandler() noexcept override
+    Result<void> UnsetReceiveHandler() noexcept override
     {
         return {};
     }

--- a/score/mw/com/impl/proxy_field_base.h
+++ b/score/mw/com/impl/proxy_field_base.h
@@ -58,7 +58,7 @@ class ProxyFieldBase
      *                          be able to offer to the using application.
      * \return On failure, returns an error code.
      */
-    ResultBlank Subscribe(const std::size_t max_sample_count) noexcept
+    Result<void> Subscribe(const std::size_t max_sample_count) noexcept
     {
         return proxy_event_base_dispatch_->Subscribe(max_sample_count);
     }
@@ -127,7 +127,7 @@ class ProxyFieldBase
      *            already running ReceiveHandler. We also see no use cases for it and won't support it therefore.
      * \param handler user provided handler to be called
      */
-    ResultBlank SetReceiveHandler(EventReceiveHandler handler) noexcept
+    Result<void> SetReceiveHandler(EventReceiveHandler handler) noexcept
     {
         return proxy_event_base_dispatch_->SetReceiveHandler(std::move(handler));
     }
@@ -136,7 +136,7 @@ class ProxyFieldBase
      * \api
      * \brief Removes any ReceiveHandler registered via SetReceiveHandler.
      */
-    ResultBlank UnsetReceiveHandler() noexcept
+    Result<void> UnsetReceiveHandler() noexcept
     {
         return proxy_event_base_dispatch_->UnsetReceiveHandler();
     }

--- a/score/mw/com/impl/service_discovery.cpp
+++ b/score/mw/com/impl/service_discovery.cpp
@@ -61,7 +61,7 @@ ServiceDiscovery::~ServiceDiscovery()
 }
 
 auto ServiceDiscovery::OfferService(score::mw::com::impl::InstanceIdentifier instance_identifier) noexcept
-    -> ResultBlank
+    -> Result<void>
 {
     auto& service_discovery_client = GetServiceDiscoveryClient(instance_identifier);
 
@@ -69,13 +69,13 @@ auto ServiceDiscovery::OfferService(score::mw::com::impl::InstanceIdentifier ins
 }
 
 auto ServiceDiscovery::StopOfferService(score::mw::com::impl::InstanceIdentifier instance_identifier) noexcept
-    -> ResultBlank
+    -> Result<void>
 {
     return StopOfferService(instance_identifier, QualityTypeSelector::kBoth);
 }
 
 auto ServiceDiscovery::StopOfferService(score::mw::com::impl::InstanceIdentifier instance_identifier,
-                                        QualityTypeSelector quality_type) noexcept -> ResultBlank
+                                        QualityTypeSelector quality_type) noexcept -> Result<void>
 {
     auto& service_discovery_client = GetServiceDiscoveryClient(instance_identifier);
 
@@ -174,7 +174,7 @@ auto ServiceDiscovery::StartFindService(FindServiceHandler<HandleType> handler,
 }
 
 [[nodiscard]] auto ServiceDiscovery::StopFindService(const FindServiceHandle find_service_handle) noexcept
-    -> ResultBlank
+    -> Result<void>
 {
     // Make a copy of the EnrichedInstanceIdentifiers for which we need to call StopFindService. We make a copy under
     // lock to ensure that the map isn't modified while we're accessing it. However, StopFindService is called on the
@@ -192,7 +192,7 @@ auto ServiceDiscovery::StartFindService(FindServiceHandler<HandleType> handler,
     score::cpp::ignore = handle_to_instances_.erase(find_service_handle);
     lock.unlock();
 
-    ResultBlank result{};
+    Result<void> result{};
     for (const auto& enriched_instance_identifier : enriched_instance_identifiers)
     {
         auto& service_discovery_client =
@@ -310,7 +310,7 @@ auto ServiceDiscovery::GetServiceDiscoveryClient(const InstanceIdentifier& insta
 auto ServiceDiscovery::BindingSpecificStartFindService(
     FindServiceHandle search_handle,
     std::weak_ptr<FindServiceHandler<HandleType>> handler_weak_ptr,
-    const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept -> ResultBlank
+    const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept -> Result<void>
 {
     auto& service_discovery_client = GetServiceDiscoveryClient(enriched_instance_identifier.GetInstanceIdentifier());
 

--- a/score/mw/com/impl/service_discovery.h
+++ b/score/mw/com/impl/service_discovery.h
@@ -44,15 +44,15 @@ class ServiceDiscovery final : public IServiceDiscovery
     ServiceDiscovery& operator=(ServiceDiscovery&&) noexcept = delete;
     ~ServiceDiscovery() override;
 
-    [[nodiscard]] ResultBlank OfferService(InstanceIdentifier) noexcept override;
-    [[nodiscard]] ResultBlank StopOfferService(InstanceIdentifier) noexcept override;
-    [[nodiscard]] ResultBlank StopOfferService(InstanceIdentifier, QualityTypeSelector quality_type) noexcept override;
+    [[nodiscard]] Result<void> OfferService(InstanceIdentifier) noexcept override;
+    [[nodiscard]] Result<void> StopOfferService(InstanceIdentifier) noexcept override;
+    [[nodiscard]] Result<void> StopOfferService(InstanceIdentifier, QualityTypeSelector quality_type) noexcept override;
     Result<FindServiceHandle> StartFindService(FindServiceHandler<HandleType>,
                                                const InstanceSpecifier) noexcept override;
     Result<FindServiceHandle> StartFindService(FindServiceHandler<HandleType>, InstanceIdentifier) noexcept override;
     Result<FindServiceHandle> StartFindService(FindServiceHandler<HandleType>,
                                                const EnrichedInstanceIdentifier) noexcept override;
-    [[nodiscard]] ResultBlank StopFindService(const FindServiceHandle) noexcept override;
+    [[nodiscard]] Result<void> StopFindService(const FindServiceHandle) noexcept override;
     [[nodiscard]] Result<ServiceHandleContainer<HandleType>> FindService(
         InstanceIdentifier instance_identifier) noexcept override;
     [[nodiscard]] Result<ServiceHandleContainer<HandleType>> FindService(
@@ -92,9 +92,9 @@ class ServiceDiscovery final : public IServiceDiscovery
     /// This functionality within this function itself is threadsafe. HOWEVER, the thread safety of the binding specific
     /// StartFindService call depends on the binding itself. For a Lola binding, this function is completely thread
     /// safe.
-    ResultBlank BindingSpecificStartFindService(FindServiceHandle,
-                                                std::weak_ptr<FindServiceHandler<HandleType>> handler_weak_ptr,
-                                                const EnrichedInstanceIdentifier&) noexcept;
+    Result<void> BindingSpecificStartFindService(FindServiceHandle,
+                                                 std::weak_ptr<FindServiceHandler<HandleType>> handler_weak_ptr,
+                                                 const EnrichedInstanceIdentifier&) noexcept;
 
     /// \brief Removes any InstanceIdentifiers which were added to handle_to_instances_ but were never processed since
     /// StartFindService on another binding failed and we returned early.

--- a/score/mw/com/impl/service_discovery_client_mock.h
+++ b/score/mw/com/impl/service_discovery_client_mock.h
@@ -23,16 +23,16 @@ namespace score::mw::com::impl
 class ServiceDiscoveryClientMock : public IServiceDiscoveryClient
 {
   public:
-    MOCK_METHOD(ResultBlank, OfferService, (InstanceIdentifier), (noexcept, override));
-    MOCK_METHOD(ResultBlank,
+    MOCK_METHOD(Result<void>, OfferService, (InstanceIdentifier), (noexcept, override));
+    MOCK_METHOD(Result<void>,
                 StopOfferService,
                 (InstanceIdentifier, IServiceDiscovery::QualityTypeSelector),
                 (noexcept, override));
-    MOCK_METHOD(ResultBlank,
+    MOCK_METHOD(Result<void>,
                 StartFindService,
                 (FindServiceHandle, (FindServiceHandler<HandleType>), EnrichedInstanceIdentifier),
                 (noexcept, override));
-    MOCK_METHOD(ResultBlank, StopFindService, (FindServiceHandle), (noexcept, override));
+    MOCK_METHOD(Result<void>, StopFindService, (FindServiceHandle), (noexcept, override));
     MOCK_METHOD(Result<ServiceHandleContainer<HandleType>>,
                 FindService,
                 (EnrichedInstanceIdentifier),

--- a/score/mw/com/impl/service_discovery_mock.h
+++ b/score/mw/com/impl/service_discovery_mock.h
@@ -31,9 +31,9 @@ namespace score::mw::com::impl
 class ServiceDiscoveryMock : public IServiceDiscovery
 {
   public:
-    MOCK_METHOD(ResultBlank, OfferService, (InstanceIdentifier), (noexcept, override));
-    MOCK_METHOD(ResultBlank, StopOfferService, (InstanceIdentifier), (noexcept, override));
-    MOCK_METHOD(ResultBlank,
+    MOCK_METHOD(Result<void>, OfferService, (InstanceIdentifier), (noexcept, override));
+    MOCK_METHOD(Result<void>, StopOfferService, (InstanceIdentifier), (noexcept, override));
+    MOCK_METHOD(Result<void>,
                 StopOfferService,
                 (InstanceIdentifier, IServiceDiscovery::QualityTypeSelector),
                 (noexcept, override));
@@ -49,7 +49,7 @@ class ServiceDiscoveryMock : public IServiceDiscovery
                 StartFindService,
                 (FindServiceHandler<HandleType>, EnrichedInstanceIdentifier),
                 (noexcept, override));
-    MOCK_METHOD(ResultBlank, StopFindService, (FindServiceHandle), (noexcept, override));
+    MOCK_METHOD(Result<void>, StopFindService, (FindServiceHandle), (noexcept, override));
     MOCK_METHOD(Result<ServiceHandleContainer<HandleType>>, FindService, (InstanceIdentifier), (noexcept, override));
     MOCK_METHOD(Result<ServiceHandleContainer<HandleType>>, FindService, (InstanceSpecifier), (noexcept, override));
 };

--- a/score/mw/com/impl/service_discovery_test.cpp
+++ b/score/mw/com/impl/service_discovery_test.cpp
@@ -88,9 +88,9 @@ class ServiceDiscoveryTest : public Test
 
         ON_CALL(lola_runtime_, GetServiceDiscoveryClient()).WillByDefault(ReturnRef(service_discovery_client_));
 
-        ON_CALL(service_discovery_client_, StartFindService(_, _, _)).WillByDefault(Return(ResultBlank{}));
+        ON_CALL(service_discovery_client_, StartFindService(_, _, _)).WillByDefault(Return(Result<void>{}));
 
-        ON_CALL(service_discovery_client_, StopFindService(_)).WillByDefault(Return(ResultBlank{}));
+        ON_CALL(service_discovery_client_, StopFindService(_)).WillByDefault(Return(Result<void>{}));
     }
 
     ServiceDiscoveryTest& WithAServiceContainingOneInstances() noexcept
@@ -369,11 +369,11 @@ TEST_F(ServiceDiscoveryStartFindServiceInstanceSpecifierFixture,
 
     // Expecting that StartFindService will be called on each instance, with the last one returning an error
     EXPECT_CALL(service_discovery_client_, StartFindService(_, _, config_stores_[0].GetEnrichedInstanceIdentifier()))
-        .WillOnce(DoAll(SaveArg<0>(&handle1), Return(score::ResultBlank{})));
+        .WillOnce(DoAll(SaveArg<0>(&handle1), Return(score::Result<void>{})));
     EXPECT_CALL(service_discovery_client_, StartFindService(_, _, config_stores_[1].GetEnrichedInstanceIdentifier()))
-        .WillOnce(DoAll(SaveArg<0>(&handle2), Return(score::ResultBlank{})));
+        .WillOnce(DoAll(SaveArg<0>(&handle2), Return(score::Result<void>{})));
     EXPECT_CALL(service_discovery_client_, StartFindService(_, _, config_stores_[2].GetEnrichedInstanceIdentifier()))
-        .WillOnce(DoAll(SaveArg<0>(&handle3), Return(score::ResultBlank{})));
+        .WillOnce(DoAll(SaveArg<0>(&handle3), Return(score::Result<void>{})));
     EXPECT_CALL(service_discovery_client_, StartFindService(_, _, config_stores_[3].GetEnrichedInstanceIdentifier()))
         .WillOnce(DoAll(SaveArg<0>(&handle4), Return(Unexpected{ComErrc::kBindingFailure})));
 
@@ -421,7 +421,7 @@ TEST_F(ServiceDiscoveryStartFindServiceInstanceSpecifierFixture,
 
     // Expecting that StartFindService will be called on each instance, with the second one returning an error
     EXPECT_CALL(service_discovery_client_, StartFindService(_, _, config_stores_[0].GetEnrichedInstanceIdentifier()))
-        .WillOnce(DoAll(SaveArg<0>(&handle1), Return(score::ResultBlank{})));
+        .WillOnce(DoAll(SaveArg<0>(&handle1), Return(score::Result<void>{})));
     EXPECT_CALL(service_discovery_client_, StartFindService(_, _, config_stores_[1].GetEnrichedInstanceIdentifier()))
         .WillOnce(DoAll(SaveArg<0>(&handle2), Return(Unexpected{ComErrc::kBindingFailure})));
     EXPECT_CALL(service_discovery_client_, StartFindService(_, _, config_stores_[2].GetEnrichedInstanceIdentifier()))
@@ -444,7 +444,7 @@ TEST_F(ServiceDiscoveryStartFindServiceInstanceSpecifierFixture, StartFindServic
 
     ON_CALL(service_discovery_client_, StartFindService(_, _, _)).WillByDefault([](auto handle, auto handler, auto) {
         handler({}, handle);
-        return ResultBlank{};
+        return Result<void>{};
     });
 
     std::int32_t value{0};
@@ -467,7 +467,7 @@ TEST_F(ServiceDiscoveryStartFindServiceInstanceSpecifierFixture, StartFindServic
         .WillByDefault([this](auto handle, auto handler, auto) {
             score::cpp::ignore = this->unit_->StopFindService(handle);
             handler({}, handle);
-            return ResultBlank{};
+            return Result<void>{};
         });
 
     std::int32_t value{7};
@@ -489,10 +489,10 @@ TEST_F(ServiceDiscoveryStartFindServiceInstanceSpecifierFixture, StartFindServic
 
     FindServiceHandle handle_1{make_FindServiceHandle(0)};
     EXPECT_CALL(service_discovery_client_, StartFindService(_, _, config_stores_[0].GetEnrichedInstanceIdentifier()))
-        .WillOnce(DoAll(SaveArg<0>(&handle_1), Return(ResultBlank{})));
+        .WillOnce(DoAll(SaveArg<0>(&handle_1), Return(Result<void>{})));
     EXPECT_CALL(service_discovery_client_,
                 StartFindService(Eq(ByRef(handle_1)), _, config_stores_[1].GetEnrichedInstanceIdentifier()))
-        .WillOnce(Return(ResultBlank{}));
+        .WillOnce(Return(Result<void>{}));
     EXPECT_CALL(service_discovery_client_, StopFindService(Eq(ByRef(handle_1)))).Times(2);
 
     auto start_result = unit_->StartFindService([](auto, auto) noexcept {}, instance_specifier_);
@@ -511,9 +511,9 @@ TEST_F(ServiceDiscoveryStartFindServiceInstanceSpecifierFixture,
     score::cpp::optional<FindServiceHandle> find_service_handle_1{};
     score::cpp::optional<FindServiceHandle> find_service_handle_2{};
     ON_CALL(service_discovery_client_, StartFindService(_, _, config_stores_[0].GetEnrichedInstanceIdentifier()))
-        .WillByDefault(DoAll(SaveArg<0>(&find_service_handle_1), Return(ResultBlank{})));
+        .WillByDefault(DoAll(SaveArg<0>(&find_service_handle_1), Return(Result<void>{})));
     ON_CALL(service_discovery_client_, StartFindService(_, _, config_stores_[1].GetEnrichedInstanceIdentifier()))
-        .WillByDefault(DoAll(SaveArg<0>(&find_service_handle_2), Return(ResultBlank{})));
+        .WillByDefault(DoAll(SaveArg<0>(&find_service_handle_2), Return(Result<void>{})));
 
     // When calling StartFindService with an InstanceSpecifier and a handler
     auto returned_find_service_handle = unit_->StartFindService([](auto, auto) noexcept {}, instance_specifier_);
@@ -619,7 +619,7 @@ TEST_F(ServiceDiscoveryStartFindServiceInstanceIdentifierFixture, StartFindServi
     ON_CALL(service_discovery_client_, StartFindService(_, _, config_stores_[0].GetEnrichedInstanceIdentifier()))
         .WillByDefault([](auto handle, auto handler, auto) {
             handler({}, handle);
-            return ResultBlank{};
+            return Result<void>{};
         });
 
     bool value{false};
@@ -638,7 +638,7 @@ TEST_F(ServiceDiscoveryStartFindServiceInstanceIdentifierFixture, StartFindServi
 
     FindServiceHandle handle_1{make_FindServiceHandle(0)};
     EXPECT_CALL(service_discovery_client_, StartFindService(_, _, config_stores_[0].GetEnrichedInstanceIdentifier()))
-        .WillOnce(DoAll(SaveArg<0>(&handle_1), Return(ResultBlank{})));
+        .WillOnce(DoAll(SaveArg<0>(&handle_1), Return(Result<void>{})));
     EXPECT_CALL(service_discovery_client_, StopFindService(Eq(ByRef(handle_1))));
 
     auto start_result = unit_->StartFindService([](auto, auto) noexcept {}, config_stores_[0].GetInstanceIdentifier());
@@ -684,10 +684,10 @@ TEST_F(ServiceDiscoveryStopFindServiceFixture, StopFindServiceInvokedIfForgotten
 
     FindServiceHandle handle_1{make_FindServiceHandle(0)};
     EXPECT_CALL(service_discovery_client_, StartFindService(_, _, config_stores_[0].GetEnrichedInstanceIdentifier()))
-        .WillOnce(DoAll(SaveArg<0>(&handle_1), Return(ResultBlank{})));
+        .WillOnce(DoAll(SaveArg<0>(&handle_1), Return(Result<void>{})));
     EXPECT_CALL(service_discovery_client_,
                 StartFindService(handle_1, _, config_stores_[1].GetEnrichedInstanceIdentifier()))
-        .WillOnce(Return(ResultBlank{}));
+        .WillOnce(Return(Result<void>{}));
     EXPECT_CALL(service_discovery_client_, StopFindService(handle_1)).Times(2);
 
     auto start_result = unit_->StartFindService([](auto, auto) noexcept {}, instance_specifier_);
@@ -701,10 +701,10 @@ TEST_F(ServiceDiscoveryStopFindServiceFixture,
 
     FindServiceHandle handle_1{make_FindServiceHandle(0)};
     EXPECT_CALL(service_discovery_client_, StartFindService(_, _, config_stores_[0].GetEnrichedInstanceIdentifier()))
-        .WillOnce(DoAll(SaveArg<0>(&handle_1), Return(ResultBlank{})));
+        .WillOnce(DoAll(SaveArg<0>(&handle_1), Return(Result<void>{})));
     EXPECT_CALL(service_discovery_client_,
                 StartFindService(Eq(ByRef(handle_1)), _, config_stores_[1].GetEnrichedInstanceIdentifier()))
-        .WillOnce(Return(ResultBlank{}));
+        .WillOnce(Return(Result<void>{}));
     EXPECT_CALL(service_discovery_client_, StopFindService(Eq(ByRef(handle_1)))).Times(2);
 
     auto start_result = unit_->StartFindService([](auto, auto) noexcept {}, instance_specifier_);
@@ -719,10 +719,10 @@ TEST_F(ServiceDiscoveryStopFindServiceFixture, StopFindServiceCallsBindingSpecif
 
     FindServiceHandle handle_1{make_FindServiceHandle(0)};
     EXPECT_CALL(service_discovery_client_, StartFindService(_, _, config_stores_[0].GetEnrichedInstanceIdentifier()))
-        .WillOnce(DoAll(SaveArg<0>(&handle_1), Return(ResultBlank{})));
+        .WillOnce(DoAll(SaveArg<0>(&handle_1), Return(Result<void>{})));
     EXPECT_CALL(service_discovery_client_,
                 StartFindService(handle_1, _, config_stores_[1].GetEnrichedInstanceIdentifier()))
-        .WillOnce(Return(ResultBlank{}));
+        .WillOnce(Return(Result<void>{}));
     EXPECT_CALL(service_discovery_client_, StopFindService(Eq(ByRef(handle_1))))
         .Times(2)
         .WillOnce(Return(Unexpected{ComErrc::kBindingFailure}));
@@ -805,7 +805,7 @@ TEST_F(ServiceDiscoveryStopFindServiceFixture, CallingStopFindServiceInHandlerWi
     ON_CALL(service_discovery_client_, StartFindService(_, _, _))
         .WillByDefault(Invoke(WithArgs<1>([handler_promise](auto handler) {
             handler_promise->set_value(std::move(handler));
-            return ResultBlank{};
+            return Result<void>{};
         })));
 
     DestructorNotifier destructor_notifier{};
@@ -849,7 +849,7 @@ TEST_F(ServiceDiscoveryStopFindServiceFixture, CallingStopFindServiceInHandlerWi
     ON_CALL(service_discovery_client_, StartFindService(_, _, _))
         .WillByDefault(Invoke(WithArgs<1>([handler_promise](auto handler) {
             handler_promise->set_value(std::move(handler));
-            return ResultBlank{};
+            return Result<void>{};
         })));
 
     DestructorNotifier destructor_notifier{};
@@ -909,7 +909,7 @@ TEST_F(ServiceDiscoveryStopOfferServiceFixture, StopOfferServiceWithoutQualityTy
     // Expecting that StopOfferService is called on the binding with both quality types
     auto instance_id = config_stores_[0].GetInstanceIdentifier();
     EXPECT_CALL(service_discovery_client_, StopOfferService(instance_id, IServiceDiscovery::QualityTypeSelector::kBoth))
-        .WillOnce(Return(ResultBlank{}));
+        .WillOnce(Return(Result<void>{}));
 
     // When calling StopOfferService without specifying a quality type
     auto result = unit_->StopOfferService(instance_id);
@@ -924,7 +924,8 @@ TEST_F(ServiceDiscoveryStopOfferServiceFixture, StopOfferServiceWithQualityTypeI
     // Expecting that StopOfferService is called on the binding with QM quality type
     auto instance_id = config_stores_[0].GetInstanceIdentifier();
     auto quality_type = IServiceDiscovery::QualityTypeSelector::kAsilQm;
-    EXPECT_CALL(service_discovery_client_, StopOfferService(instance_id, quality_type)).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(service_discovery_client_, StopOfferService(instance_id, quality_type))
+        .WillOnce(Return(Result<void>{}));
 
     // When calling StopOfferService with QM quality type
     auto result = unit_->StopOfferService(instance_id, quality_type);

--- a/score/mw/com/impl/skeleton_base.cpp
+++ b/score/mw/com/impl/skeleton_base.cpp
@@ -160,7 +160,7 @@ SkeletonBase& SkeletonBase::operator=(SkeletonBase&& other) noexcept
     return *this;
 }
 
-score::ResultBlank SkeletonBase::OfferServiceEvents() const noexcept
+score::Result<void> SkeletonBase::OfferServiceEvents() const noexcept
 {
     for (auto& event : events_)
     {
@@ -178,7 +178,7 @@ score::ResultBlank SkeletonBase::OfferServiceEvents() const noexcept
     return {};
 }
 
-score::ResultBlank SkeletonBase::OfferServiceFields() const noexcept
+score::Result<void> SkeletonBase::OfferServiceFields() const noexcept
 {
     for (auto& field : fields_)
     {
@@ -200,7 +200,7 @@ score::ResultBlank SkeletonBase::OfferServiceFields() const noexcept
     return {};
 }
 
-auto SkeletonBase::OfferService() noexcept -> ResultBlank
+auto SkeletonBase::OfferService() noexcept -> Result<void>
 {
     if (skeleton_mock_ != nullptr)
     {

--- a/score/mw/com/impl/skeleton_base.h
+++ b/score/mw/com/impl/skeleton_base.h
@@ -72,7 +72,7 @@ class SkeletonBase
      * \return On failure, returns an error code according to the SW Component Requirements SCR-17434118 and
      * SCR-566325.
      */
-    [[nodiscard]] ResultBlank OfferService() noexcept;
+    [[nodiscard]] Result<void> OfferService() noexcept;
 
     /**
      * \api
@@ -108,8 +108,8 @@ class SkeletonBase
 
     ISkeletonBase* skeleton_mock_;
 
-    [[nodiscard]] score::ResultBlank OfferServiceEvents() const noexcept;
-    [[nodiscard]] score::ResultBlank OfferServiceFields() const noexcept;
+    [[nodiscard]] score::Result<void> OfferServiceEvents() const noexcept;
+    [[nodiscard]] score::Result<void> OfferServiceFields() const noexcept;
 
     FlagOwner service_offered_flag_;
 };

--- a/score/mw/com/impl/skeleton_base_test.cpp
+++ b/score/mw/com/impl/skeleton_base_test.cpp
@@ -549,28 +549,28 @@ TEST_F(SkeletonBaseOfferFixture, ServiceCanBeReOfferedAfterCallingStopOfferServi
         // Expecting that PrepareOffer gets called on the skeleton binding and each event twice
         EXPECT_CALL(*binding_mock, PrepareOffer(_, _, _))
             .Times(2)
-            .WillRepeatedly(Invoke(
-                [&skeleton_offer_count](SkeletonBinding::SkeletonEventBindings&,
-                                        SkeletonBinding::SkeletonFieldBindings&,
-                                        std::optional<SkeletonBinding::RegisterShmObjectTraceCallback>) -> ResultBlank {
-                    skeleton_offer_count++;
-                    return {};
-                }));
+            .WillRepeatedly(Invoke([&skeleton_offer_count](
+                                       SkeletonBinding::SkeletonEventBindings&,
+                                       SkeletonBinding::SkeletonFieldBindings&,
+                                       std::optional<SkeletonBinding::RegisterShmObjectTraceCallback>) -> Result<void> {
+                skeleton_offer_count++;
+                return {};
+            }));
         EXPECT_CALL(*event_binding_mock_1_, PrepareOffer())
             .Times(2)
-            .WillRepeatedly(Invoke([&event_offer_count]() -> ResultBlank {
+            .WillRepeatedly(Invoke([&event_offer_count]() -> Result<void> {
                 event_offer_count++;
                 return {};
             }));
         EXPECT_CALL(*event_binding_mock_2_, PrepareOffer())
             .Times(2)
-            .WillRepeatedly(Invoke([&event_offer_count]() -> ResultBlank {
+            .WillRepeatedly(Invoke([&event_offer_count]() -> Result<void> {
                 event_offer_count++;
                 return {};
             }));
         EXPECT_CALL(*field_binding_mock_, PrepareOffer())
             .Times(2)
-            .WillRepeatedly(Invoke([&event_offer_count]() -> ResultBlank {
+            .WillRepeatedly(Invoke([&event_offer_count]() -> Result<void> {
                 event_offer_count++;
                 return {};
             }));
@@ -663,9 +663,9 @@ class DummyField : public SkeletonFieldBase
     {
         return false;
     };
-    ResultBlank DoDeferredUpdate() noexcept override
+    Result<void> DoDeferredUpdate() noexcept override
     {
-        return ResultBlank{};
+        return Result<void>{};
     };
 
     bool IsSetHandlerRegistered() const noexcept override

--- a/score/mw/com/impl/skeleton_binding.h
+++ b/score/mw/com/impl/skeleton_binding.h
@@ -82,9 +82,9 @@ class SkeletonBinding
     ///  mechanism, it must call this callback for each shm-object it will use.
     ///
     /// \return expects void
-    virtual ResultBlank PrepareOffer(SkeletonEventBindings&,
-                                     SkeletonFieldBindings&,
-                                     std::optional<RegisterShmObjectTraceCallback>) = 0;
+    virtual Result<void> PrepareOffer(SkeletonEventBindings&,
+                                      SkeletonFieldBindings&,
+                                      std::optional<RegisterShmObjectTraceCallback>) = 0;
 
     /**
      * \brief In case there are any binding specifics with regards to service withdrawals, this can be implemented

--- a/score/mw/com/impl/skeleton_binding_test.cpp
+++ b/score/mw/com/impl/skeleton_binding_test.cpp
@@ -23,9 +23,9 @@ namespace
 class MySkeleton final : public SkeletonBinding
 {
   public:
-    ResultBlank PrepareOffer(SkeletonEventBindings&,
-                             SkeletonFieldBindings&,
-                             std::optional<RegisterShmObjectTraceCallback>) noexcept override
+    Result<void> PrepareOffer(SkeletonEventBindings&,
+                              SkeletonFieldBindings&,
+                              std::optional<RegisterShmObjectTraceCallback>) noexcept override
     {
         return {};
     }

--- a/score/mw/com/impl/skeleton_event.h
+++ b/score/mw/com/impl/skeleton_event.h
@@ -100,7 +100,7 @@ class SkeletonEvent : public SkeletonEventBase
      * \param sample_value The event data to be sent to subscribers.
      * \return On failure, returns an error code.
      */
-    ResultBlank Send(const EventType& sample_value) noexcept;
+    Result<void> Send(const EventType& sample_value) noexcept;
 
     /**
      * \api
@@ -110,7 +110,7 @@ class SkeletonEvent : public SkeletonEventBase
      * \param sample The pre-allocated sample pointer containing the event data to be sent.
      * \return On failure, returns an error code.
      */
-    ResultBlank Send(SampleAllocateePtr<EventType> sample) noexcept;
+    Result<void> Send(SampleAllocateePtr<EventType> sample) noexcept;
 
     /**
      * \api
@@ -216,7 +216,7 @@ auto SkeletonEvent<SampleDataType>::operator=(SkeletonEvent&& other) & noexcept 
 }
 
 template <typename SampleDataType>
-ResultBlank SkeletonEvent<SampleDataType>::Send(const EventType& sample_value) noexcept
+Result<void> SkeletonEvent<SampleDataType>::Send(const EventType& sample_value) noexcept
 {
     if (skeleton_event_mock_ != nullptr)
     {
@@ -242,7 +242,7 @@ ResultBlank SkeletonEvent<SampleDataType>::Send(const EventType& sample_value) n
 }
 
 template <typename SampleDataType>
-ResultBlank SkeletonEvent<SampleDataType>::Send(SampleAllocateePtr<EventType> sample) noexcept
+Result<void> SkeletonEvent<SampleDataType>::Send(SampleAllocateePtr<EventType> sample) noexcept
 {
     if (skeleton_event_mock_ != nullptr)
     {

--- a/score/mw/com/impl/skeleton_event_base.h
+++ b/score/mw/com/impl/skeleton_event_base.h
@@ -62,7 +62,7 @@ class SkeletonEventBase
 
     /// \brief Used to indicate that the event shall be available to consumer
     /// Performs binding independent functionality and then dispatches to the binding
-    score::ResultBlank PrepareOffer() noexcept
+    score::Result<void> PrepareOffer() noexcept
     {
         const auto result = binding_->PrepareOffer();
         if (result.has_value())

--- a/score/mw/com/impl/skeleton_event_base_test.cpp
+++ b/score/mw/com/impl/skeleton_event_base_test.cpp
@@ -98,7 +98,7 @@ TEST_F(SkeletonEventBaseFixture, PrepareOfferDispatchesToBinding)
     CreateSkeletonEvent();
 
     // Expecting that PrepareOffer() is called on the binding
-    EXPECT_CALL(*mock_event_binding_, PrepareOffer()).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(*mock_event_binding_, PrepareOffer()).WillOnce(Return(Result<void>{}));
 
     // When offering the event
     const auto result = skeleton_event_->PrepareOffer();
@@ -113,7 +113,7 @@ TEST_F(SkeletonEventBaseFixture, PrepareStopOfferDispatchesToBinding)
     CreateSkeletonEvent();
 
     // Expecting that PrepareOffer() is called on the binding
-    EXPECT_CALL(*mock_event_binding_, PrepareOffer()).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(*mock_event_binding_, PrepareOffer()).WillOnce(Return(Result<void>{}));
 
     // When offering the event
     const auto result = skeleton_event_->PrepareOffer();

--- a/score/mw/com/impl/skeleton_event_binding.h
+++ b/score/mw/com/impl/skeleton_event_binding.h
@@ -51,7 +51,7 @@ class SkeletonEventBindingBase
     virtual ~SkeletonEventBindingBase();
 
     /// \brief Used to indicate that the event shall be available to consumer (e.g. binding specific preparation)
-    virtual ResultBlank PrepareOffer() noexcept = 0;
+    virtual Result<void> PrepareOffer() noexcept = 0;
 
     /// \brief Used to indicate that the event shall no longer be available to consumer (e.g. binding specific
     /// de-initialization)
@@ -78,12 +78,12 @@ class SkeletonEventBinding : public SkeletonEventBindingBase
 
     /// \brief SampleType is allocated by the user and provided to the middleware to send
     /// \return On failure, returns an error code.
-    virtual ResultBlank Send(const SampleType&, score::cpp::optional<SendTraceCallback>) noexcept = 0;
+    virtual Result<void> Send(const SampleType&, score::cpp::optional<SendTraceCallback>) noexcept = 0;
 
     /// \brief SampleType is previously allocated by middleware and provided by the user to indicate that he is finished
     /// filling the provided pointer with live.
     /// \return On failure, returns an error code.
-    virtual ResultBlank Send(SampleAllocateePtr<SampleType>, score::cpp::optional<SendTraceCallback>) noexcept = 0;
+    virtual Result<void> Send(SampleAllocateePtr<SampleType>, score::cpp::optional<SendTraceCallback>) noexcept = 0;
 
     /// \brief Allocates memory for SampleType for the user to fill it. This is especially necessary for Zero-Copy
     /// implementations.

--- a/score/mw/com/impl/skeleton_event_binding_test.cpp
+++ b/score/mw/com/impl/skeleton_event_binding_test.cpp
@@ -27,18 +27,18 @@ template <typename SampleType>
 class MyEvent final : public SkeletonEventBinding<SampleType>
 {
   public:
-    ResultBlank PrepareOffer() noexcept override
+    Result<void> PrepareOffer() noexcept override
     {
         return {};
     }
     void PrepareStopOffer() noexcept override {}
-    ResultBlank Send(
+    Result<void> Send(
         const SampleType&,
         score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>) noexcept override
     {
         return {};
     }
-    ResultBlank Send(
+    Result<void> Send(
         SampleAllocateePtr<SampleType>,
         score::cpp::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>) noexcept override
     {

--- a/score/mw/com/impl/skeleton_event_test.cpp
+++ b/score/mw/com/impl/skeleton_event_test.cpp
@@ -273,7 +273,7 @@ TEST(SkeletonEventSendZeroCopyTest, CallingSendDispatchesToBinding)
 
     // and that Send(SampleAllocateePtr) is called on the event binding with the expected value
     EXPECT_CALL(skeleton_event_binding_mock, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
-        .WillOnce(WithArg<0>(Invoke([](SampleAllocateePtr<TestSampleType> sample_ptr) -> ResultBlank {
+        .WillOnce(WithArg<0>(Invoke([](SampleAllocateePtr<TestSampleType> sample_ptr) -> Result<void> {
             EXPECT_EQ(*sample_ptr, 42);
             return {};
         })));
@@ -368,7 +368,7 @@ TEST(SkeletonEventSendZeroCopyTest, CallingSendWhenBindingFailsReturnsError)
 
     // and that Send(SampleAllocateePtr) is called on the event binding with the expected value
     EXPECT_CALL(skeleton_event_binding_mock, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
-        .WillOnce(WithArg<0>(Invoke([](SampleAllocateePtr<TestSampleType> sample_ptr) -> ResultBlank {
+        .WillOnce(WithArg<0>(Invoke([](SampleAllocateePtr<TestSampleType> sample_ptr) -> Result<void> {
             EXPECT_EQ(*sample_ptr, 42);
             return MakeUnexpected(ComErrc::kInvalidConfiguration);
         })));
@@ -423,7 +423,7 @@ TEST(SkeletonEventTest, CallingSendAfterPrepareOfferDispatchesToBinding)
     EXPECT_CALL(skeleton_event_binding_mock, PrepareOffer());
 
     // and that Send() is called once on the event binding
-    EXPECT_CALL(skeleton_event_binding_mock, Send(test_value, _)).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(skeleton_event_binding_mock, Send(test_value, _)).WillOnce(Return(Result<void>{}));
 
     // Given a skeleton which has a mock skeleton-binding
     MyDummySkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};

--- a/score/mw/com/impl/skeleton_field.h
+++ b/score/mw/com/impl/skeleton_field.h
@@ -86,7 +86,7 @@ class SkeletonField : public SkeletonFieldBase
      * \param sample_value The field data to be sent to subscribers.
      * \return On failure, returns an error code.
      */
-    ResultBlank Update(const FieldType& sample_value) noexcept;
+    Result<void> Update(const FieldType& sample_value) noexcept;
 
     /**
      * \api
@@ -95,7 +95,7 @@ class SkeletonField : public SkeletonFieldBase
      * \param sample The pre-allocated sample pointer containing the field data to be sent.
      * \return On failure, returns an error code.
      */
-    ResultBlank Update(SampleAllocateePtr<FieldType> sample) noexcept;
+    Result<void> Update(SampleAllocateePtr<FieldType> sample) noexcept;
 
     /**
      * \api
@@ -120,7 +120,7 @@ class SkeletonField : public SkeletonFieldBase
     //         void(FieldType& new_value)
     //   - new_value : the value requested by the proxy.
     template <bool ES = EnableSet, typename std::enable_if<ES, int>::type = 0, typename CallableType>
-    ResultBlank RegisterSetHandler(CallableType&& handler)
+    Result<void> RegisterSetHandler(CallableType&& handler)
     {
         static_assert(std::is_invocable_v<CallableType, FieldType&>,
                       "RegisterSetHandler: handler must be callable as void(FieldType& value). "
@@ -151,11 +151,11 @@ class SkeletonField : public SkeletonFieldBase
     {
         return initial_field_value_ != nullptr;
     }
-    ResultBlank DoDeferredUpdate() noexcept override;
+    Result<void> DoDeferredUpdate() noexcept override;
 
     /// \brief FieldType is allocated by the user and provided to the middleware to send. Dispatches to
     /// SkeletonEvent::Send()
-    ResultBlank UpdateImpl(const FieldType& sample_value) noexcept;
+    Result<void> UpdateImpl(const FieldType& sample_value) noexcept;
 
     SkeletonEvent<FieldType>* GetTypedEvent() const noexcept;
 
@@ -347,7 +347,7 @@ auto SkeletonField<SampleDataType, EnableSet, EnableNotifier>::operator=(Skeleto
 /// callback that will update the field value with sample_value which will be called in the first call to
 /// SkeletonFieldBase::PrepareOffer().
 template <typename SampleDataType, bool EnableSet, bool EnableNotifier>
-ResultBlank SkeletonField<SampleDataType, EnableSet, EnableNotifier>::Update(const FieldType& sample_value) noexcept
+Result<void> SkeletonField<SampleDataType, EnableSet, EnableNotifier>::Update(const FieldType& sample_value) noexcept
 {
     if (skeleton_field_mock_ != nullptr)
     {
@@ -357,7 +357,7 @@ ResultBlank SkeletonField<SampleDataType, EnableSet, EnableNotifier>::Update(con
     if (!was_prepare_offer_called_)
     {
         initial_field_value_ = std::make_unique<FieldType>(sample_value);
-        return ResultBlank{};
+        return Result<void>{};
     }
     return UpdateImpl(sample_value);
 }
@@ -365,7 +365,7 @@ ResultBlank SkeletonField<SampleDataType, EnableSet, EnableNotifier>::Update(con
 /// \brief FieldType is previously allocated by middleware and provided by the user to indicate that he is finished
 /// filling the provided pointer with live data. Dispatches to SkeletonEvent::Send()
 template <typename SampleDataType, bool EnableSet, bool EnableNotifier>
-ResultBlank SkeletonField<SampleDataType, EnableSet, EnableNotifier>::Update(
+Result<void> SkeletonField<SampleDataType, EnableSet, EnableNotifier>::Update(
     SampleAllocateePtr<FieldType> sample) noexcept
 {
     if (skeleton_field_mock_ != nullptr)
@@ -405,7 +405,7 @@ template <typename SampleDataType, bool EnableSet, bool EnableNotifier>
 // namespace, or static function with internal linkage, or private member function shall be used.".
 // False-positive, method is used in the base class in PrepareOffer().
 // coverity[autosar_cpp14_a0_1_3_violation : FALSE]
-ResultBlank SkeletonField<SampleDataType, EnableSet, EnableNotifier>::DoDeferredUpdate() noexcept
+Result<void> SkeletonField<SampleDataType, EnableSet, EnableNotifier>::DoDeferredUpdate() noexcept
 {
     SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(
         initial_field_value_ != nullptr,
@@ -418,11 +418,12 @@ ResultBlank SkeletonField<SampleDataType, EnableSet, EnableNotifier>::DoDeferred
 
     // If the Update call succeeded, then we can delete the initial value
     initial_field_value_.reset();
-    return ResultBlank{};
+    return Result<void>{};
 }
 
 template <typename SampleDataType, bool EnableSet, bool EnableNotifier>
-ResultBlank SkeletonField<SampleDataType, EnableSet, EnableNotifier>::UpdateImpl(const FieldType& sample_value) noexcept
+Result<void> SkeletonField<SampleDataType, EnableSet, EnableNotifier>::UpdateImpl(
+    const FieldType& sample_value) noexcept
 {
     return GetTypedEvent()->Send(sample_value);
 }

--- a/score/mw/com/impl/skeleton_field_base.h
+++ b/score/mw/com/impl/skeleton_field_base.h
@@ -56,7 +56,7 @@ class SkeletonFieldBase
     }
 
     /// \brief Used to indicate that the field shall be available to consumer (e.g. binding specific preparation)
-    ResultBlank PrepareOffer() noexcept
+    Result<void> PrepareOffer() noexcept
     {
         // If PrepareOffer() has not been called yet on this field, then we have to set the initial value immediately
         // after calling PrepareOffer() on the binding
@@ -138,7 +138,7 @@ class SkeletonFieldBase
     ///
     /// The existence of the value is a precondition of this function, so IsInitialValueSaved() should be checked before
     /// calling DoDeferredUpdate()
-    virtual ResultBlank DoDeferredUpdate() noexcept = 0;
+    virtual Result<void> DoDeferredUpdate() noexcept = 0;
 };
 
 class SkeletonFieldBaseView

--- a/score/mw/com/impl/skeleton_field_base_test.cpp
+++ b/score/mw/com/impl/skeleton_field_base_test.cpp
@@ -77,7 +77,7 @@ class MyDummyField : public SkeletonFieldBase
         return is_initial_value_saved_;
     }
 
-    ResultBlank DoDeferredUpdate() noexcept override
+    Result<void> DoDeferredUpdate() noexcept override
     {
         was_deferred_update_called_ = true;
         return {};
@@ -95,7 +95,7 @@ class MyDummyField : public SkeletonFieldBase
 class MyDummyFieldFailingDeferredUpdate final : public MyDummyField
 {
   public:
-    ResultBlank DoDeferredUpdate() noexcept override
+    Result<void> DoDeferredUpdate() noexcept override
     {
         return MakeUnexpected(ComErrc::kCommunicationLinkError);
     }
@@ -127,7 +127,7 @@ TEST_F(SkeletonFieldBaseFixture, PrepareOfferDispatchesToBinding)
     CreateSkeletonField();
 
     // Expecting that PrepareOffer() is called on the binding
-    EXPECT_CALL(*mock_event_binding_, PrepareOffer()).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(*mock_event_binding_, PrepareOffer()).WillOnce(Return(Result<void>{}));
 
     // When offering the event
     const auto result = skeleton_field_->PrepareOffer();
@@ -142,7 +142,7 @@ TEST_F(SkeletonFieldBaseFixture, PrepareStopOfferDispatchesToBinding)
     CreateSkeletonField();
 
     // Expecting that PrepareOffer() is called on the binding
-    EXPECT_CALL(*mock_event_binding_, PrepareOffer()).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(*mock_event_binding_, PrepareOffer()).WillOnce(Return(Result<void>{}));
 
     // and expecting that PrepareStopOffer() is called on the binding
     EXPECT_CALL(*mock_event_binding_, PrepareStopOffer());
@@ -161,7 +161,7 @@ TEST_F(SkeletonFieldBaseFixture, PrepareOfferCallsInitialUpdateCallback)
     CreateSkeletonField();
 
     // Expecting that PrepareOffer() is called on the binding
-    EXPECT_CALL(*mock_event_binding_, PrepareOffer()).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(*mock_event_binding_, PrepareOffer()).WillOnce(Return(Result<void>{}));
 
     // When offering the event
     EXPECT_FALSE(skeleton_field_->was_deferred_update_called_);
@@ -233,7 +233,7 @@ TEST(SkeletonFieldBaseTest, PrepareOfferPropagatesErrorFromInitialValueUpdateCal
     ASSERT_NE(mock_event_binding, nullptr);
 
     // Expecting that PrepareOffer() is called on the binding
-    EXPECT_CALL(*mock_event_binding, PrepareOffer()).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(*mock_event_binding, PrepareOffer()).WillOnce(Return(Result<void>{}));
 
     // When offering the event
     const auto result = skeleton_field.PrepareOffer();

--- a/score/mw/com/impl/skeleton_field_test.cpp
+++ b/score/mw/com/impl/skeleton_field_test.cpp
@@ -139,11 +139,11 @@ TEST(SkeletonFieldCopyUpdateTest, CallingUpdateBeforeOfferServiceDefersCallToOff
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
 
     // and that PrepareOffer() will be called on the event binding
-    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called on the event binding with the initial value and returns an empty result
     EXPECT_CALL(skeleton_field_binding_mock, Send(initial_value, _))
-        .WillOnce(InvokeWithoutArgs([&is_send_called_on_binding]() noexcept -> ResultBlank {
+        .WillOnce(InvokeWithoutArgs([&is_send_called_on_binding]() noexcept -> Result<void> {
             is_send_called_on_binding = true;
             return {};
         }));
@@ -197,7 +197,7 @@ TEST(SkeletonFieldCopyUpdateTest, CallingUpdateBeforeOfferServicePropagatesBindi
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
 
     // and that PrepareOffer() will be called on the event binding
-    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called on the event binding with the initial value and returns an error
     EXPECT_CALL(skeleton_field_binding_mock, Send(initial_value, _))
@@ -253,13 +253,13 @@ TEST(SkeletonFieldCopyUpdateTest, CallingUpdateAfterOfferServiceDispatchesToBind
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
 
     // and that PrepareOffer() will be called on the event binding
-    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called on the event binding with the initial value and returns an empty result
-    EXPECT_CALL(skeleton_field_binding_mock, Send(initial_value, _)).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(skeleton_field_binding_mock, Send(initial_value, _)).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called a second time on the event binding with the updated value and returns an empty result
-    EXPECT_CALL(skeleton_field_binding_mock, Send(updated_value, _)).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(skeleton_field_binding_mock, Send(updated_value, _)).WillOnce(Return(score::Result<void>{}));
 
     // Given a skeleton created based on a Lola binding
     MyDummySkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
@@ -309,10 +309,10 @@ TEST(SkeletonFieldCopyUpdateTest, CallingUpdateAfterOfferServicePropagatesBindin
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
 
     // and that PrepareOffer() will be called on the event binding
-    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called on the event binding with the initial value and returns an empty result
-    EXPECT_CALL(skeleton_field_binding_mock, Send(initial_value, _)).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(skeleton_field_binding_mock, Send(initial_value, _)).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called a second time on the event binding with the updated value and returns an error
     EXPECT_CALL(skeleton_field_binding_mock, Send(updated_value, _))
@@ -396,7 +396,7 @@ TEST(SkeletonFieldAllocateTest, CallingAllocateAfterPrepareOfferDispatchesToBind
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
 
     // and that PrepareOffer() will be called on the event binding
-    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called on the event binding with the initial value
     EXPECT_CALL(skeleton_field_binding_mock, Send(initial_value, _));
@@ -451,7 +451,7 @@ TEST(SkeletonFieldAllocateTest, CallingAllocateAfterPrepareOfferFailsWhenBinding
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
 
     // and that PrepareOffer() will be called on the event binding
-    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called on the event binding with the initial value
     EXPECT_CALL(skeleton_field_binding_mock, Send(initial_value, _));
@@ -508,7 +508,7 @@ TEST(SkeletonFieldZeroCopyUpdateTest, CallingZeroCopyUpdateAfterOfferServiceDisp
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
 
     // and that PrepareOffer() will be called on the event binding
-    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called on the event binding with the initial value
     EXPECT_CALL(skeleton_field_binding_mock, Send(initial_value, _));
@@ -519,7 +519,7 @@ TEST(SkeletonFieldZeroCopyUpdateTest, CallingZeroCopyUpdateAfterOfferServiceDisp
 
     // and Send will be called a second time on the event binding with a new value which returns an empty result
     EXPECT_CALL(skeleton_field_binding_mock, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
-        .WillOnce(WithArg<0>(Invoke([new_value](SampleAllocateePtr<TestSampleType> sample_ptr) -> ResultBlank {
+        .WillOnce(WithArg<0>(Invoke([new_value](SampleAllocateePtr<TestSampleType> sample_ptr) -> Result<void> {
             EXPECT_EQ(*sample_ptr, new_value);
             return {};
         })));
@@ -583,7 +583,7 @@ TEST(SkeletonFieldZeroCopyUpdateTest, CallingZeroCopyUpdateAfterOfferServiceProp
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
 
     // and that PrepareOffer() will be called on the event binding
-    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called on the event binding with the initial value
     EXPECT_CALL(skeleton_field_binding_mock, Send(initial_value, _));
@@ -594,7 +594,7 @@ TEST(SkeletonFieldZeroCopyUpdateTest, CallingZeroCopyUpdateAfterOfferServiceProp
 
     // and Send will be called a second time on the event binding with a new value which returns an error
     EXPECT_CALL(skeleton_field_binding_mock, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
-        .WillOnce(WithArg<0>(Invoke([new_value](SampleAllocateePtr<TestSampleType> sample_ptr) -> ResultBlank {
+        .WillOnce(WithArg<0>(Invoke([new_value](SampleAllocateePtr<TestSampleType> sample_ptr) -> Result<void> {
             EXPECT_EQ(*sample_ptr, new_value);
             return MakeUnexpected(ComErrc::kInvalidBindingInformation);
         })));
@@ -656,7 +656,7 @@ TEST(SkeletonFieldInitialValueFixture, LatestFieldValueWillBeSetOnPrepareOffer)
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
 
     // and that PrepareOffer() will be called on the event binding
-    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called only once on the event binding with the latest value
     EXPECT_CALL(skeleton_field_binding_mock, Send(latest_value, _));
@@ -736,7 +736,7 @@ TEST(SkeletonFieldInitialValueFixture, MoveConstructingFieldBeforePrepareOfferWi
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
 
     // and that PrepareOffer() will be called on the event binding
-    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called on the event binding with the initial value
     EXPECT_CALL(skeleton_field_binding_mock, Send(initial_value, _));
@@ -780,7 +780,7 @@ TEST(SkeletonFieldInitialValueFixture, MoveAssigningFieldBeforePrepareOfferWillK
     EXPECT_CALL(skeleton_field_binding_mock, GetBindingType()).WillOnce(Return(BindingType::kLoLa));
 
     // and that PrepareOffer() will be called on the event binding
-    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::ResultBlank{}));
+    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called on the event binding with the initial value from the moved-from field
     EXPECT_CALL(skeleton_field_binding_mock, Send(initial_value, _));
@@ -1019,7 +1019,7 @@ TEST(SkeletonFieldSetHandlerTest, RegisterSetHandlerForwardsToMethodBinding)
         .WillOnce(Return(ByMove(nullptr)));
 
     // The method binding's RegisterHandler must be called exactly once and returns success.
-    EXPECT_CALL(method_binding_mock, RegisterHandler(_)).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(method_binding_mock, RegisterHandler(_)).WillOnce(Return(Result<void>{}));
 
     // Given a setter-capable skeleton
     MySetterSkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
@@ -1140,11 +1140,11 @@ TEST(SkeletonFieldSetHandlerTest, PrepareOfferSucceedsAfterRegisterSetHandler)
         .WillOnce(Return(ByMove(nullptr)));
 
     // The binding's RegisterHandler returns success
-    EXPECT_CALL(method_binding_mock, RegisterHandler(_)).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(method_binding_mock, RegisterHandler(_)).WillOnce(Return(Result<void>{}));
 
     // PrepareOffer on the event binding and the initial-value Send must succeed
-    EXPECT_CALL(event_binding, PrepareOffer()).WillOnce(Return(ResultBlank{}));
-    EXPECT_CALL(event_binding, Send(initial_value, _)).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(event_binding, PrepareOffer()).WillOnce(Return(Result<void>{}));
+    EXPECT_CALL(event_binding, Send(initial_value, _)).WillOnce(Return(Result<void>{}));
 
     MySetterSkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
 
@@ -1184,8 +1184,8 @@ TEST(SkeletonFieldSetHandlerTest, PrepareOfferSucceedsWithoutHandlerWhenEnableSe
                 CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName))
         .WillOnce(Return(ByMove(std::move(event_binding_ptr))));
 
-    EXPECT_CALL(event_binding, PrepareOffer()).WillOnce(Return(ResultBlank{}));
-    EXPECT_CALL(event_binding, Send(initial_value, _)).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(event_binding, PrepareOffer()).WillOnce(Return(Result<void>{}));
+    EXPECT_CALL(event_binding, Send(initial_value, _)).WillOnce(Return(Result<void>{}));
 
     // A non-setter skeleton (EnableSet=false)
     MyDummySkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
@@ -1227,10 +1227,10 @@ TEST(SkeletonFieldSetHandlerTest, RegisterSetHandlerAcceptsAnyCallable)
 class CapturingSkeletonMethodBinding : public SkeletonMethodBinding
 {
   public:
-    ResultBlank RegisterHandler(TypeErasedHandler&& cb) override
+    Result<void> RegisterHandler(TypeErasedHandler&& cb) override
     {
         captured_handler_ = std::move(cb);
-        return ResultBlank{};
+        return Result<void>{};
     }
 
     TypeErasedHandler captured_handler_{};
@@ -1259,10 +1259,10 @@ TEST(SkeletonFieldSetHandlerTest, UserCallbackIsInvokedByWrappedHandler)
         .WillOnce(Return(ByMove(std::move(event_binding_ptr))));
 
     // PrepareOffer and the deferred Send for the initial value
-    EXPECT_CALL(event_binding, PrepareOffer()).WillOnce(Return(ResultBlank{}));
-    EXPECT_CALL(event_binding, Send(TestSampleType{1U}, _)).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(event_binding, PrepareOffer()).WillOnce(Return(Result<void>{}));
+    EXPECT_CALL(event_binding, Send(TestSampleType{1U}, _)).WillOnce(Return(Result<void>{}));
     // The wrapped handler also calls Update(incoming_value) → Send on the event binding
-    EXPECT_CALL(event_binding, Send(incoming_value, _)).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(event_binding, Send(incoming_value, _)).WillOnce(Return(Result<void>{}));
 
     // Use a capturing binding so that we can invoke the type-erased handler later
     auto capturing_binding = std::make_unique<CapturingSkeletonMethodBinding>();
@@ -1328,10 +1328,10 @@ TEST(SkeletonFieldSetHandlerTest, UserCallbackCanModifyValueInPlace)
                 CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName))
         .WillOnce(Return(ByMove(std::move(event_binding_ptr))));
 
-    EXPECT_CALL(event_binding, PrepareOffer()).WillOnce(Return(ResultBlank{}));
-    EXPECT_CALL(event_binding, Send(TestSampleType{1U}, _)).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(event_binding, PrepareOffer()).WillOnce(Return(Result<void>{}));
+    EXPECT_CALL(event_binding, Send(TestSampleType{1U}, _)).WillOnce(Return(Result<void>{}));
     // The modified value (20) must be the one forwarded to the event binding
-    EXPECT_CALL(event_binding, Send(modified_value, _)).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(event_binding, Send(modified_value, _)).WillOnce(Return(Result<void>{}));
 
     auto capturing_binding = std::make_unique<CapturingSkeletonMethodBinding>();
     auto& capturing_binding_ref = *capturing_binding;
@@ -1391,8 +1391,8 @@ TEST(SkeletonFieldSetHandlerTest, WrappedHandlerLogsWhenUpdateFails)
                 CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName))
         .WillOnce(Return(ByMove(std::move(event_binding_ptr))));
 
-    EXPECT_CALL(event_binding, PrepareOffer()).WillOnce(Return(ResultBlank{}));
-    EXPECT_CALL(event_binding, Send(TestSampleType{1U}, _)).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(event_binding, PrepareOffer()).WillOnce(Return(Result<void>{}));
+    EXPECT_CALL(event_binding, Send(TestSampleType{1U}, _)).WillOnce(Return(Result<void>{}));
     // Simulate Update() failure when the wrapped handler is invoked by the proxy
     EXPECT_CALL(event_binding, Send(incoming_value, _))
         .WillOnce(Return(MakeUnexpected(ComErrc::kCommunicationLinkError)));
@@ -1453,8 +1453,8 @@ TEST(SkeletonFieldSetHandlerTest, IsSetHandlerRegisteredFlagIsSetAfterRegistrati
                 CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName))
         .WillOnce(Return(ByMove(std::move(event_binding_ptr))));
 
-    EXPECT_CALL(event_binding, PrepareOffer()).WillOnce(Return(ResultBlank{}));
-    EXPECT_CALL(event_binding, Send(initial_value, _)).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(event_binding, PrepareOffer()).WillOnce(Return(Result<void>{}));
+    EXPECT_CALL(event_binding, Send(initial_value, _)).WillOnce(Return(Result<void>{}));
 
     mock_binding::SkeletonMethod method_binding_mock{};
     SkeletonMethodBindingFactoryMockGuard method_binding_factory_guard{};
@@ -1462,7 +1462,7 @@ TEST(SkeletonFieldSetHandlerTest, IsSetHandlerRegisteredFlagIsSetAfterRegistrati
         .WillOnce(Return(ByMove(std::make_unique<mock_binding::SkeletonMethodFacade>(method_binding_mock))));
     EXPECT_CALL(method_binding_factory_guard.factory_mock_, Create(kInstanceIdWithLolaBinding, _, _, MethodType::kGet))
         .WillOnce(Return(ByMove(nullptr)));
-    EXPECT_CALL(method_binding_mock, RegisterHandler(_)).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(method_binding_mock, RegisterHandler(_)).WillOnce(Return(Result<void>{}));
 
     MySetterSkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
 
@@ -1507,9 +1507,9 @@ TEST(SkeletonFieldSetHandlerTest, SecondRegisterSetHandlerReplacesHandler)
                 CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName))
         .WillOnce(Return(ByMove(std::move(event_binding_ptr))));
 
-    EXPECT_CALL(event_binding, PrepareOffer()).WillOnce(Return(ResultBlank{}));
-    EXPECT_CALL(event_binding, Send(TestSampleType{1U}, _)).WillOnce(Return(ResultBlank{}));
-    EXPECT_CALL(event_binding, Send(incoming_value, _)).WillOnce(Return(ResultBlank{}));
+    EXPECT_CALL(event_binding, PrepareOffer()).WillOnce(Return(Result<void>{}));
+    EXPECT_CALL(event_binding, Send(TestSampleType{1U}, _)).WillOnce(Return(Result<void>{}));
+    EXPECT_CALL(event_binding, Send(incoming_value, _)).WillOnce(Return(Result<void>{}));
 
     // The method binding is called twice (once per RegisterSetHandler)
     auto capturing_binding = std::make_unique<CapturingSkeletonMethodBinding>();

--- a/score/mw/com/impl/tracing/common_event_tracing.cpp
+++ b/score/mw/com/impl/tracing/common_event_tracing.cpp
@@ -42,11 +42,11 @@ std::string_view GetInstanceSpecifier(const InstanceIdentifier& instance_identif
 
 }  // namespace
 
-ResultBlank TraceData(const ServiceElementInstanceIdentifierView service_element_instance_identifier_view,
-                      const TracingRuntime::TracePointType trace_point,
-                      const BindingType binding_type,
-                      const std::pair<const void*, std::size_t>& local_data_chunk,
-                      const score::cpp::optional<TracingRuntime::TracePointDataId> trace_point_data_id) noexcept
+Result<void> TraceData(const ServiceElementInstanceIdentifierView service_element_instance_identifier_view,
+                       const TracingRuntime::TracePointType trace_point,
+                       const BindingType binding_type,
+                       const std::pair<const void*, std::size_t>& local_data_chunk,
+                       const score::cpp::optional<TracingRuntime::TracePointDataId> trace_point_data_id) noexcept
 {
     auto* const tracing_runtime = impl::Runtime::getInstance().GetTracingRuntime();
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(tracing_runtime != nullptr);
@@ -58,13 +58,13 @@ ResultBlank TraceData(const ServiceElementInstanceIdentifierView service_element
                                   local_data_chunk.second);
 }
 
-ResultBlank TraceShmData(const BindingType binding_type,
-                         const ServiceElementTracingData service_element_tracing_data,
-                         const ServiceElementInstanceIdentifierView service_element_instance_identifier_view,
-                         const TracingRuntime::TracePointType trace_point,
-                         TracingRuntime::TracePointDataId trace_point_data_id,
-                         TypeErasedSamplePtr sample_ptr,
-                         const std::pair<const void*, std::size_t>& data_chunk) noexcept
+Result<void> TraceShmData(const BindingType binding_type,
+                          const ServiceElementTracingData service_element_tracing_data,
+                          const ServiceElementInstanceIdentifierView service_element_instance_identifier_view,
+                          const TracingRuntime::TracePointType trace_point,
+                          TracingRuntime::TracePointDataId trace_point_data_id,
+                          TypeErasedSamplePtr sample_ptr,
+                          const std::pair<const void*, std::size_t>& data_chunk) noexcept
 {
     auto* const tracing_runtime = impl::Runtime::getInstance().GetTracingRuntime();
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(tracing_runtime != nullptr);

--- a/score/mw/com/impl/tracing/common_event_tracing.h
+++ b/score/mw/com/impl/tracing/common_event_tracing.h
@@ -35,19 +35,19 @@ std::pair<const void*, std::size_t> ConvertToFatPointer(const T& input_value)
     return {data_ptr, data_size};
 }
 
-ResultBlank TraceData(const ServiceElementInstanceIdentifierView service_element_instance_identifier_view,
-                      const TracingRuntime::TracePointType trace_point,
-                      const BindingType binding_type,
-                      const std::pair<const void*, std::size_t>& local_data_chunk = {nullptr, 0U},
-                      const score::cpp::optional<TracingRuntime::TracePointDataId> trace_point_data_id = {}) noexcept;
+Result<void> TraceData(const ServiceElementInstanceIdentifierView service_element_instance_identifier_view,
+                       const TracingRuntime::TracePointType trace_point,
+                       const BindingType binding_type,
+                       const std::pair<const void*, std::size_t>& local_data_chunk = {nullptr, 0U},
+                       const score::cpp::optional<TracingRuntime::TracePointDataId> trace_point_data_id = {}) noexcept;
 
-ResultBlank TraceShmData(const BindingType binding_type,
-                         const ServiceElementTracingData service_element_tracing_data,
-                         const ServiceElementInstanceIdentifierView service_element_instance_identifier_view,
-                         const TracingRuntime::TracePointType trace_point,
-                         TracingRuntime::TracePointDataId trace_point_data_id,
-                         TypeErasedSamplePtr sample_ptr,
-                         const std::pair<const void*, std::size_t>& data_chunk) noexcept;
+Result<void> TraceShmData(const BindingType binding_type,
+                          const ServiceElementTracingData service_element_tracing_data,
+                          const ServiceElementInstanceIdentifierView service_element_instance_identifier_view,
+                          const TracingRuntime::TracePointType trace_point,
+                          TracingRuntime::TracePointDataId trace_point_data_id,
+                          TypeErasedSamplePtr sample_ptr,
+                          const std::pair<const void*, std::size_t>& data_chunk) noexcept;
 
 ServiceElementInstanceIdentifierView GetServiceElementInstanceIdentifierView(
     const InstanceIdentifier& instance_identifier,

--- a/score/mw/com/impl/tracing/common_event_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/common_event_tracing_test.cpp
@@ -99,7 +99,7 @@ using CommonEventTracingLocalTraceDataFixture = CommonEventTracingFixture;
 TEST_F(CommonEventTracingLocalTraceDataFixture, CallingTraceDataWillReturnSuccessIfBindingReturnsSuccess)
 {
     // Expecting that TraceData will be called on the tracing runtime binding which returns a valid result
-    ON_CALL(tracing_runtime_mock_, Trace(_, _, _, _, _, _)).WillByDefault(Return(ResultBlank{}));
+    ON_CALL(tracing_runtime_mock_, Trace(_, _, _, _, _, _)).WillByDefault(Return(Result<void>{}));
 
     // When calling TraceData with local data chunk
     const auto trace_data_result = TraceData(service_element_instance_identifier_view_,
@@ -169,7 +169,7 @@ using CommonEventTracingShmTraceDataFixture = CommonEventTracingFixture;
 TEST_F(CommonEventTracingShmTraceDataFixture, CallingTraceDataWillReturnSuccess)
 {
     // Expecting that TraceShmData will be called on the tracing runtime binding which returns a valid result
-    ON_CALL(tracing_runtime_mock_, Trace(_, _, _, _, _, _, _, _)).WillByDefault(Return(ResultBlank{}));
+    ON_CALL(tracing_runtime_mock_, Trace(_, _, _, _, _, _, _, _)).WillByDefault(Return(Result<void>{}));
 
     // When calling TraceShmData with a shm data chunk
     const auto trace_shm_data_result = TraceShmData(binding_type_,

--- a/score/mw/com/impl/tracing/i_tracing_runtime.h
+++ b/score/mw/com/impl/tracing/i_tracing_runtime.h
@@ -60,21 +60,21 @@ class ITracingRuntime
         BindingType binding_type,
         ServiceElementInstanceIdentifierView service_element_instance_identifier_view) noexcept = 0;
 
-    virtual ResultBlank Trace(const BindingType binding_type,
-                              const ServiceElementTracingData service_element_tracing_data,
-                              const ServiceElementInstanceIdentifierView service_element_instance_identifier,
-                              const TracePointType trace_point_type,
-                              const TracePointDataId trace_point_data_id,
-                              TypeErasedSamplePtr sample_ptr,
-                              const void* const shm_data_ptr,
-                              const std::size_t shm_data_size) noexcept = 0;
+    virtual Result<void> Trace(const BindingType binding_type,
+                               const ServiceElementTracingData service_element_tracing_data,
+                               const ServiceElementInstanceIdentifierView service_element_instance_identifier,
+                               const TracePointType trace_point_type,
+                               const TracePointDataId trace_point_data_id,
+                               TypeErasedSamplePtr sample_ptr,
+                               const void* const shm_data_ptr,
+                               const std::size_t shm_data_size) noexcept = 0;
 
-    virtual ResultBlank Trace(const BindingType binding_type,
-                              const ServiceElementInstanceIdentifierView service_element_instance_identifier,
-                              const TracePointType trace_point_type,
-                              const score::cpp::optional<TracePointDataId> trace_point_data_id,
-                              const void* const local_data_ptr,
-                              const std::size_t local_data_size) noexcept = 0;
+    virtual Result<void> Trace(const BindingType binding_type,
+                               const ServiceElementInstanceIdentifierView service_element_instance_identifier,
+                               const TracePointType trace_point_type,
+                               const score::cpp::optional<TracePointDataId> trace_point_data_id,
+                               const void* const local_data_ptr,
+                               const std::size_t local_data_size) noexcept = 0;
 
     virtual IBindingTracingRuntime& GetBindingTracingRuntime(const BindingType binding_type) const noexcept = 0;
 

--- a/score/mw/com/impl/tracing/proxy_event_tracing.cpp
+++ b/score/mw/com/impl/tracing/proxy_event_tracing.cpp
@@ -32,7 +32,7 @@ namespace score::mw::com::impl::tracing
 namespace
 {
 
-void UpdateTracingDataFromTraceResult(ResultBlank trace_result,
+void UpdateTracingDataFromTraceResult(Result<void> trace_result,
                                       ProxyEventTracingData& proxy_event_tracing_data,
                                       bool& proxy_event_trace_point) noexcept
 {

--- a/score/mw/com/impl/tracing/skeleton_event_tracing.cpp
+++ b/score/mw/com/impl/tracing/skeleton_event_tracing.cpp
@@ -35,7 +35,7 @@ namespace score::mw::com::impl::tracing
 namespace detail_skeleton_event_tracing
 {
 
-void UpdateTracingDataFromTraceResult(const ResultBlank trace_result,
+void UpdateTracingDataFromTraceResult(const Result<void> trace_result,
                                       SkeletonEventTracingData& skeleton_event_tracing_data,
                                       bool& skeleton_event_trace_point) noexcept
 {

--- a/score/mw/com/impl/tracing/skeleton_event_tracing.h
+++ b/score/mw/com/impl/tracing/skeleton_event_tracing.h
@@ -141,7 +141,7 @@ TypeErasedSamplePtr CreateTypeErasedSamplePtr(impl::SampleAllocateePtr<SampleTyp
     return std::visit(visitor, binding_ptr_variant);
 }
 
-void UpdateTracingDataFromTraceResult(const ResultBlank trace_result,
+void UpdateTracingDataFromTraceResult(const Result<void> trace_result,
                                       SkeletonEventTracingData& skeleton_event_tracing_data,
                                       bool& skeleton_event_trace_point) noexcept;
 

--- a/score/mw/com/impl/tracing/skeleton_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/skeleton_tracing_test.cpp
@@ -72,7 +72,7 @@ class MyDummyField : public SkeletonFieldBase
         return true;
     }
 
-    ResultBlank DoDeferredUpdate() noexcept override
+    Result<void> DoDeferredUpdate() noexcept override
     {
         return {};
     }

--- a/score/mw/com/impl/tracing/test/proxy_event_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/test/proxy_event_tracing_test.cpp
@@ -102,7 +102,7 @@ class ProxyEventTracingFixture : public ::testing::Test
         // Expecting that a ProxyEvent binding is created
         ExpectProxyServiceElementBindingCreation(proxy_service_element_binding_factory_mock_guard_);
 
-        ON_CALL(*mock_proxy_event_binding_, SetReceiveHandler(_)).WillByDefault(Return(score::ResultBlank{}));
+        ON_CALL(*mock_proxy_event_binding_, SetReceiveHandler(_)).WillByDefault(Return(score::Result<void>{}));
     }
 
     void CreateProxy()
@@ -473,7 +473,7 @@ TYPED_TEST(ProxyEventTracingSubscribeFixture, SubscribeCallsAreTracedWhenEnabled
                       _,
                       _))
         .WillOnce(WithArgs<4, 5>(
-            Invoke([max_sample_count](const void* local_data_ptr, std::size_t local_data_size) -> ResultBlank {
+            Invoke([max_sample_count](const void* local_data_ptr, std::size_t local_data_size) -> Result<void> {
                 EXPECT_EQ(local_data_size, sizeof(std::size_t));
                 const auto actual_max_sample_count_ptr = static_cast<const std::size_t*>(local_data_ptr);
                 EXPECT_EQ(max_sample_count, *actual_max_sample_count_ptr);
@@ -543,7 +543,7 @@ TYPED_TEST(ProxyEventTracingSubscribeFixture,
                       _,
                       _))
         .WillOnce(WithArgs<4, 5>(
-            Invoke([max_sample_count](const void* local_data_ptr, std::size_t local_data_size) -> ResultBlank {
+            Invoke([max_sample_count](const void* local_data_ptr, std::size_t local_data_size) -> Result<void> {
                 EXPECT_EQ(local_data_size, sizeof(std::size_t));
                 const auto actual_max_sample_count_ptr = static_cast<const std::size_t*>(local_data_ptr);
                 EXPECT_EQ(max_sample_count, *actual_max_sample_count_ptr);
@@ -621,7 +621,7 @@ TYPED_TEST(ProxyEventTracingSubscribeFixture,
                       _,
                       _))
         .WillOnce(WithArgs<4, 5>(
-            Invoke([max_sample_count](const void* local_data_ptr, std::size_t local_data_size) -> ResultBlank {
+            Invoke([max_sample_count](const void* local_data_ptr, std::size_t local_data_size) -> Result<void> {
                 EXPECT_EQ(local_data_size, sizeof(std::size_t));
                 const auto actual_max_sample_count_ptr = static_cast<const std::size_t*>(local_data_ptr);
                 EXPECT_EQ(max_sample_count, *actual_max_sample_count_ptr);
@@ -736,7 +736,7 @@ TYPED_TEST(ProxyEventTracingUnsubscribeFixture, UnsubscribeCallsAreTracedWhenEna
                       score::cpp::optional<tracing::ITracingRuntime::TracePointDataId>{},
                       nullptr,
                       0U))
-        .WillOnce(Return(ResultBlank{}));
+        .WillOnce(Return(Result<void>{}));
 
     // and that GetBindingType is called on the proxy event binding
     EXPECT_CALL(*this->mock_proxy_event_binding_, GetBindingType()).WillOnce(Return(BindingType::kLoLa));
@@ -972,7 +972,7 @@ TYPED_TEST(ProxyEventTracingSetReceiveHandlerFixture, SetReceiveHandlerCallsAreT
                       score::cpp::optional<tracing::ITracingRuntime::TracePointDataId>{},
                       nullptr,
                       0U))
-        .WillOnce(Return(ResultBlank{}));
+        .WillOnce(Return(Result<void>{}));
 
     // and that GetBindingType is called on the proxy event binding
     EXPECT_CALL(*this->mock_proxy_event_binding_, GetBindingType()).WillOnce(Return(BindingType::kLoLa));
@@ -1186,7 +1186,7 @@ TYPED_TEST(ProxyEventTracingReceiveHandlerCallbackFixture, ReceiveHandlerCallbac
     std::weak_ptr<ScopedEventReceiveHandler> scoped_event_receive_handler_weak_ptr{};
     EXPECT_CALL(*this->mock_proxy_event_binding_, SetReceiveHandler(_))
         .WillOnce(Invoke(
-            [&scoped_event_receive_handler_weak_ptr](std::weak_ptr<ScopedEventReceiveHandler> handler) -> ResultBlank {
+            [&scoped_event_receive_handler_weak_ptr](std::weak_ptr<ScopedEventReceiveHandler> handler) -> Result<void> {
                 scoped_event_receive_handler_weak_ptr = std::move(handler);
                 return {};
             }));
@@ -1254,7 +1254,7 @@ TYPED_TEST(ProxyEventTracingReceiveHandlerCallbackFixture,
     std::weak_ptr<ScopedEventReceiveHandler> scoped_event_receive_handler_weak_ptr{};
     EXPECT_CALL(*this->mock_proxy_event_binding_, SetReceiveHandler(_))
         .WillOnce(Invoke(
-            [&scoped_event_receive_handler_weak_ptr](std::weak_ptr<ScopedEventReceiveHandler> handler) -> ResultBlank {
+            [&scoped_event_receive_handler_weak_ptr](std::weak_ptr<ScopedEventReceiveHandler> handler) -> Result<void> {
                 scoped_event_receive_handler_weak_ptr = std::move(handler);
                 return {};
             }));
@@ -1330,7 +1330,7 @@ TYPED_TEST(ProxyEventTracingReceiveHandlerCallbackFixture,
     std::weak_ptr<ScopedEventReceiveHandler> scoped_event_receive_handler_weak_ptr{};
     EXPECT_CALL(*this->mock_proxy_event_binding_, SetReceiveHandler(_))
         .WillOnce(Invoke(
-            [&scoped_event_receive_handler_weak_ptr](std::weak_ptr<ScopedEventReceiveHandler> handler) -> ResultBlank {
+            [&scoped_event_receive_handler_weak_ptr](std::weak_ptr<ScopedEventReceiveHandler> handler) -> Result<void> {
                 scoped_event_receive_handler_weak_ptr = std::move(handler);
                 return {};
             }));
@@ -1400,7 +1400,7 @@ TYPED_TEST(ProxyEventTracingReceiveHandlerCallbackFixture, ReceiveHandlerCallbac
     std::weak_ptr<ScopedEventReceiveHandler> scoped_event_receive_handler_weak_ptr{};
     EXPECT_CALL(*this->mock_proxy_event_binding_, SetReceiveHandler(_))
         .WillOnce(Invoke(
-            [&scoped_event_receive_handler_weak_ptr](std::weak_ptr<ScopedEventReceiveHandler> handler) -> ResultBlank {
+            [&scoped_event_receive_handler_weak_ptr](std::weak_ptr<ScopedEventReceiveHandler> handler) -> Result<void> {
                 scoped_event_receive_handler_weak_ptr = std::move(handler);
                 return {};
             }));

--- a/score/mw/com/impl/tracing/test/skeleton_event_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/test/skeleton_event_tracing_test.cpp
@@ -284,7 +284,7 @@ TEST_F(SkeletonEventTracingSendFixture, SendCallsAreTracedWhenEnabled)
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(sample_data, _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -301,7 +301,7 @@ TEST_F(SkeletonEventTracingSendFixture, SendCallsAreTracedWhenEnabled)
                       _,
                       _,
                       _))
-        .WillOnce(WithArgs<6, 7>(Invoke([&sample_data](const void* data_ptr, std::size_t data_size) -> ResultBlank {
+        .WillOnce(WithArgs<6, 7>(Invoke([&sample_data](const void* data_ptr, std::size_t data_size) -> Result<void> {
             EXPECT_EQ(data_size, sizeof(TestSampleType));
             const auto actual_data_ptr = static_cast<const TestSampleType*>(data_ptr);
             EXPECT_EQ(*actual_data_ptr, sample_data);
@@ -371,7 +371,7 @@ TEST_F(SkeletonEventTracingSendFixture, SendTracePointShouldBeDisabledAfterTrace
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(sample_data, _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -461,7 +461,7 @@ TEST_F(SkeletonEventTracingSendFixture, SendTracePointShouldBeDisabledAfterTrace
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(sample_data, _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -546,7 +546,7 @@ TEST_F(SkeletonEventTracingSendFixture, SendCallsAreNotTracedWhenDisabled)
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(sample_data, _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -595,7 +595,7 @@ TEST_F(SkeletonEventTracingSendFixture, SendCallsAreNotTracedWhenTracingFilterCo
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(sample_data, _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -647,7 +647,7 @@ TEST_F(SkeletonEventTracingSendFixture, SendCallsAreNotTracedWhenTracingRuntimeC
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(sample_data, _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -719,7 +719,7 @@ TEST_F(SkeletonEventTracingSendWithAllocateFixture, SendCallsAreTracedWhenEnable
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -736,7 +736,7 @@ TEST_F(SkeletonEventTracingSendWithAllocateFixture, SendCallsAreTracedWhenEnable
                       _,
                       _,
                       _))
-        .WillOnce(WithArgs<6, 7>(Invoke([&sample_data](const void* data_ptr, std::size_t data_size) -> ResultBlank {
+        .WillOnce(WithArgs<6, 7>(Invoke([&sample_data](const void* data_ptr, std::size_t data_size) -> Result<void> {
             EXPECT_EQ(data_size, sizeof(TestSampleType));
             const auto actual_data_ptr = static_cast<const TestSampleType*>(data_ptr);
             EXPECT_EQ(*actual_data_ptr, sample_data);
@@ -817,7 +817,7 @@ TEST_F(SkeletonEventTracingSendWithAllocateFixture,
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -918,7 +918,7 @@ TEST_F(SkeletonEventTracingSendWithAllocateFixture,
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -1013,7 +1013,7 @@ TEST_F(SkeletonEventTracingSendWithAllocateFixture, SendCallsAreNotTracedWhenDis
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -1072,7 +1072,7 @@ TEST_F(SkeletonEventTracingSendWithAllocateFixture, SendCallsAreNotTracedWhenTra
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -1134,7 +1134,7 @@ TEST_F(SkeletonEventTracingSendWithAllocateFixture, SendCallsAreNotTracedWhenTra
     EXPECT_CALL(*mock_skeleton_event_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));

--- a/score/mw/com/impl/tracing/test/skeleton_field_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/test/skeleton_field_tracing_test.cpp
@@ -291,7 +291,7 @@ TEST_F(SkeletonFieldTracingSendFixture, SendCallsAreTracedWhenEnabled)
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(sample_data, _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -308,7 +308,7 @@ TEST_F(SkeletonFieldTracingSendFixture, SendCallsAreTracedWhenEnabled)
                       _,
                       _,
                       _))
-        .WillOnce(WithArgs<6, 7>(Invoke([&sample_data](const void* data_ptr, std::size_t data_size) -> ResultBlank {
+        .WillOnce(WithArgs<6, 7>(Invoke([&sample_data](const void* data_ptr, std::size_t data_size) -> Result<void> {
             EXPECT_EQ(data_size, sizeof(TestSampleType));
             const auto actual_data_ptr = static_cast<const TestSampleType*>(data_ptr);
             EXPECT_EQ(*actual_data_ptr, sample_data);
@@ -381,7 +381,7 @@ TEST_F(SkeletonFieldTracingSendFixture, SendTracePointShouldBeDisabledAfterTrace
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(sample_data, _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -474,7 +474,7 @@ TEST_F(SkeletonFieldTracingSendFixture, SendTracePointShouldBeDisabledAfterTrace
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(sample_data, _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -562,7 +562,7 @@ TEST_F(SkeletonFieldTracingSendFixture, SendCallsAreNotTracedWhenDisabled)
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(sample_data, _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -614,7 +614,7 @@ TEST_F(SkeletonFieldTracingSendFixture, SendCallsAreNotTracedWhenTracingFilterCo
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(sample_data, _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -669,7 +669,7 @@ TEST_F(SkeletonFieldTracingSendFixture, SendCallsAreNotTracedWhenTracingRuntimeC
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(sample_data, _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -744,7 +744,7 @@ TEST_F(SkeletonFieldTracingSendWithAllocateFixture, SendCallsAreTracedWhenEnable
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -762,7 +762,7 @@ TEST_F(SkeletonFieldTracingSendWithAllocateFixture, SendCallsAreTracedWhenEnable
                       _,
                       _,
                       _))
-        .WillOnce(WithArgs<6, 7>(Invoke([&sample_data](const void* data_ptr, std::size_t data_size) -> ResultBlank {
+        .WillOnce(WithArgs<6, 7>(Invoke([&sample_data](const void* data_ptr, std::size_t data_size) -> Result<void> {
             EXPECT_EQ(data_size, sizeof(TestSampleType));
             const auto actual_data_ptr = static_cast<const TestSampleType*>(data_ptr);
             EXPECT_EQ(*actual_data_ptr, sample_data);
@@ -853,7 +853,7 @@ TEST_F(SkeletonFieldTracingSendWithAllocateFixture,
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -965,7 +965,7 @@ TEST_F(SkeletonFieldTracingSendWithAllocateFixture,
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -1071,7 +1071,7 @@ TEST_F(SkeletonFieldTracingSendWithAllocateFixture, SendCallsAreNotTracedWhenDis
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -1140,7 +1140,7 @@ TEST_F(SkeletonFieldTracingSendWithAllocateFixture, SendCallsAreNotTracedWhenTra
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));
@@ -1212,7 +1212,7 @@ TEST_F(SkeletonFieldTracingSendWithAllocateFixture, SendCallsAreNotTracedWhenTra
     EXPECT_CALL(*mock_skeleton_field_binding_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
         .WillOnce(WithArgs<1>(Invoke(
             [&send_trace_callback_result](score::cpp::optional<SkeletonEventBinding<TestSampleType>::SendTraceCallback>
-                                              provided_send_trace_callback) -> ResultBlank {
+                                              provided_send_trace_callback) -> Result<void> {
                 send_trace_callback_result = std::move(provided_send_trace_callback);
                 return {};
             })));

--- a/score/mw/com/impl/tracing/test/skeleton_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/test/skeleton_tracing_test.cpp
@@ -198,7 +198,7 @@ TEST_F(SkeletonBaseRegisterShmTracingFixture, RegisterShmObjectIsTracedIfTracing
     EXPECT_CALL(*binding_mock_, PrepareOffer(_, _, _))
         .WillOnce(WithArg<2>(Invoke([&register_shm_object_trace_callback_result](
                                         std::optional<SkeletonBinding::RegisterShmObjectTraceCallback>
-                                            provided_register_shm_object_trace_callback_result) -> ResultBlank {
+                                            provided_register_shm_object_trace_callback_result) -> Result<void> {
             register_shm_object_trace_callback_result = std::move(provided_register_shm_object_trace_callback_result);
             return {};
         })));
@@ -260,7 +260,7 @@ TEST_F(SkeletonBaseRegisterShmTracingFixture, RegisterShmObjectIsNotTracedIfTrac
     EXPECT_CALL(*binding_mock_, PrepareOffer(_, _, _))
         .WillOnce(WithArg<2>(Invoke([&register_shm_object_trace_callback_result](
                                         std::optional<SkeletonBinding::RegisterShmObjectTraceCallback>
-                                            provided_register_shm_object_trace_callback_result) -> ResultBlank {
+                                            provided_register_shm_object_trace_callback_result) -> Result<void> {
             register_shm_object_trace_callback_result = std::move(provided_register_shm_object_trace_callback_result);
             return {};
         })));
@@ -327,7 +327,7 @@ TEST_F(SkeletonBaseUnregisterShmTracingFixture, UnregisterShmObjectIsTracedIfTra
     EXPECT_CALL(*binding_mock_, PrepareStopOffer(_))
         .WillOnce(Invoke([&unregister_shm_object_trace_callback_result](
                              score::cpp::optional<SkeletonBinding::UnregisterShmObjectTraceCallback>
-                                 provided_unregister_shm_object_trace_callback_result) -> ResultBlank {
+                                 provided_unregister_shm_object_trace_callback_result) -> Result<void> {
             unregister_shm_object_trace_callback_result =
                 std::move(provided_unregister_shm_object_trace_callback_result);
             return {};
@@ -387,7 +387,7 @@ TEST_F(SkeletonBaseUnregisterShmTracingFixture, UnregisterShmObjectIsNotTracedIf
     EXPECT_CALL(*binding_mock_, PrepareStopOffer(_))
         .WillOnce(Invoke([&unregister_shm_object_trace_callback_result](
                              score::cpp::optional<SkeletonBinding::UnregisterShmObjectTraceCallback>
-                                 provided_unregister_shm_object_trace_callback_result) -> ResultBlank {
+                                 provided_unregister_shm_object_trace_callback_result) -> Result<void> {
             unregister_shm_object_trace_callback_result =
                 std::move(provided_unregister_shm_object_trace_callback_result);
             return {};
@@ -448,7 +448,7 @@ TEST_F(SkeletonBaseUnregisterShmTracingFixture, UnregisterShmObjectIsTracedOnDes
     // object trace call
     EXPECT_CALL(*binding_mock_, PrepareStopOffer(_))
         .WillOnce(Invoke([](score::cpp::optional<SkeletonBinding::UnregisterShmObjectTraceCallback>
-                                provided_unregister_shm_object_trace_callback_result) -> ResultBlank {
+                                provided_unregister_shm_object_trace_callback_result) -> Result<void> {
             // Expect that the unregister shm object tracing callback is not empty
             EXPECT_TRUE(provided_unregister_shm_object_trace_callback_result.has_value());
 
@@ -505,7 +505,7 @@ TEST_F(SkeletonBaseUnregisterShmTracingFixture,
     // object trace call
     EXPECT_CALL(*binding_mock_, PrepareStopOffer(_))
         .WillOnce(Invoke([](score::cpp::optional<SkeletonBinding::UnregisterShmObjectTraceCallback>
-                                provided_unregister_shm_object_trace_callback_result) -> ResultBlank {
+                                provided_unregister_shm_object_trace_callback_result) -> Result<void> {
             // Expect that the unregister shm object tracing callback is empty
             EXPECT_FALSE(provided_unregister_shm_object_trace_callback_result.has_value());
             return {};

--- a/score/mw/com/impl/tracing/tracing_runtime.cpp
+++ b/score/mw/com/impl/tracing/tracing_runtime.cpp
@@ -250,7 +250,7 @@ ServiceElementTracingData TracingRuntime::RegisterServiceElement(const BindingTy
     return binding_runtime.RegisterServiceElement(number_of_ipc_tracing_slots);
 }
 
-ResultBlank TracingRuntime::ProcessTraceCallResult(
+Result<void> TracingRuntime::ProcessTraceCallResult(
     const ServiceElementInstanceIdentifierView& service_element_instance_identifier,
     const analysis::tracing::TraceResult& trace_call_result,
     IBindingTracingRuntime& binding_tracing_runtime) noexcept
@@ -504,14 +504,14 @@ Result<analysis::tracing::ShmObjectHandle> TracingRuntime::GetRegisteredShmObjec
 // throwing std::bad_optional_access which leds to std::terminate(). This suppression should be removed after fixing
 // [Ticket-173043](broken_link_j/Ticket-173043)
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-ResultBlank TracingRuntime::Trace(const BindingType binding_type,
-                                  const ServiceElementTracingData service_element_tracing_data,
-                                  const ServiceElementInstanceIdentifierView service_element_instance_identifier,
-                                  const TracePointType trace_point_type,
-                                  const TracePointDataId trace_point_data_id,
-                                  TypeErasedSamplePtr sample_ptr,
-                                  const void* const shm_data_ptr,
-                                  const std::size_t shm_data_size) noexcept
+Result<void> TracingRuntime::Trace(const BindingType binding_type,
+                                   const ServiceElementTracingData service_element_tracing_data,
+                                   const ServiceElementInstanceIdentifierView service_element_instance_identifier,
+                                   const TracePointType trace_point_type,
+                                   const TracePointDataId trace_point_data_id,
+                                   TypeErasedSamplePtr sample_ptr,
+                                   const void* const shm_data_ptr,
+                                   const std::size_t shm_data_size) noexcept
 {
     if (!atomic_state_.is_tracing_enabled)
     {
@@ -599,12 +599,12 @@ ResultBlank TracingRuntime::Trace(const BindingType binding_type,
     return ProcessTraceCallResult(service_element_instance_identifier, trace_result, binding_runtime);
 }
 
-ResultBlank TracingRuntime::Trace(const BindingType binding_type,
-                                  const ServiceElementInstanceIdentifierView service_element_instance_identifier,
-                                  const TracePointType trace_point_type,
-                                  const score::cpp::optional<TracePointDataId> trace_point_data_id,
-                                  const void* const local_data_ptr,
-                                  const std::size_t local_data_size) noexcept
+Result<void> TracingRuntime::Trace(const BindingType binding_type,
+                                   const ServiceElementInstanceIdentifierView service_element_instance_identifier,
+                                   const TracePointType trace_point_type,
+                                   const score::cpp::optional<TracePointDataId> trace_point_data_id,
+                                   const void* const local_data_ptr,
+                                   const std::size_t local_data_size) noexcept
 {
     if (!atomic_state_.is_tracing_enabled)
     {

--- a/score/mw/com/impl/tracing/tracing_runtime.h
+++ b/score/mw/com/impl/tracing/tracing_runtime.h
@@ -131,14 +131,14 @@ class TracingRuntime : public ITracingRuntime
     /// \param shm_data_size size of the data, where shm_data_ptr points to
     /// \return blank in case of success, else either an error with code TraceErrorDisableAllTracePoints or
     ///         TraceErrorDisableTracePointInstance
-    ResultBlank Trace(const BindingType binding_type,
-                      const ServiceElementTracingData service_element_tracing_data,
-                      const ServiceElementInstanceIdentifierView service_element_instance_identifier,
-                      const TracePointType trace_point_type,
-                      const TracePointDataId trace_point_data_id,
-                      TypeErasedSamplePtr sample_ptr,
-                      const void* const shm_data_ptr,
-                      const std::size_t shm_data_size) noexcept override;
+    Result<void> Trace(const BindingType binding_type,
+                       const ServiceElementTracingData service_element_tracing_data,
+                       const ServiceElementInstanceIdentifierView service_element_instance_identifier,
+                       const TracePointType trace_point_type,
+                       const TracePointDataId trace_point_data_id,
+                       TypeErasedSamplePtr sample_ptr,
+                       const void* const shm_data_ptr,
+                       const std::size_t shm_data_size) noexcept override;
 
     /// \brief Trace call for data residing locally (not in shared-memory) being synchronously copied for tracing.
     /// \param binding_type identification of binding, which does the call.
@@ -151,12 +151,12 @@ class TracingRuntime : public ITracingRuntime
     /// \param local_data_size size of the data, where local_data_ptr points to
     /// \return blank in case of success, else either an error with code TraceErrorDisableAllTracePoints or
     ///         TraceErrorDisableTracePointInstance
-    ResultBlank Trace(const BindingType binding_type,
-                      const ServiceElementInstanceIdentifierView service_element_instance_identifier,
-                      const TracePointType trace_point_type,
-                      const score::cpp::optional<TracePointDataId> trace_point_data_id,
-                      const void* const local_data_ptr,
-                      const std::size_t local_data_size) noexcept override;
+    Result<void> Trace(const BindingType binding_type,
+                       const ServiceElementInstanceIdentifierView service_element_instance_identifier,
+                       const TracePointType trace_point_type,
+                       const score::cpp::optional<TracePointDataId> trace_point_data_id,
+                       const void* const local_data_ptr,
+                       const std::size_t local_data_size) noexcept override;
 
     IBindingTracingRuntime& GetBindingTracingRuntime(const BindingType binding_type) const noexcept override;
 
@@ -167,9 +167,9 @@ class TracingRuntime : public ITracingRuntime
     ///        to many consecutive recoverable errors. Will be called after each call to Trace with the given result.
     /// \param trace_call_result result of last call to Generic Trace API trace method.
     /// \return Result to be forwarded to the caller of Trace()
-    ResultBlank ProcessTraceCallResult(const ServiceElementInstanceIdentifierView& service_element_instance_identifier,
-                                       const analysis::tracing::TraceResult& trace_call_result,
-                                       IBindingTracingRuntime& binding_tracing_runtime) noexcept;
+    Result<void> ProcessTraceCallResult(const ServiceElementInstanceIdentifierView& service_element_instance_identifier,
+                                        const analysis::tracing::TraceResult& trace_call_result,
+                                        IBindingTracingRuntime& binding_tracing_runtime) noexcept;
 
     Result<analysis::tracing::ShmObjectHandle> GetRegisteredShmObject(
         IBindingTracingRuntime& binding_runtime,

--- a/score/mw/com/impl/tracing/tracing_runtime_mock.h
+++ b/score/mw/com/impl/tracing/tracing_runtime_mock.h
@@ -33,7 +33,7 @@ class TracingRuntimeMock : public ITracingRuntime
                 (noexcept, override));
     MOCK_METHOD(void, UnregisterShmObject, (BindingType, ServiceElementInstanceIdentifierView), (noexcept, override));
 
-    MOCK_METHOD(ResultBlank,
+    MOCK_METHOD(Result<void>,
                 Trace,
                 (BindingType,
                  ServiceElementTracingData service_element_tracing_data,
@@ -44,7 +44,7 @@ class TracingRuntimeMock : public ITracingRuntime
                  const void*,
                  std::size_t),
                 (noexcept, override));
-    MOCK_METHOD(ResultBlank,
+    MOCK_METHOD(Result<void>,
                 Trace,
                 (BindingType,
                  ServiceElementInstanceIdentifierView,

--- a/score/mw/com/impl/tracing/tracing_runtime_test.cpp
+++ b/score/mw/com/impl/tracing/tracing_runtime_test.cpp
@@ -159,7 +159,7 @@ TEST(TracingRuntime, TracingRuntimeTraceWillReceivePointerToConstShmData)
     using ShmPointerType = const void*;
 
     // Check that ShmPointerType is the type that is passed to TracingRuntime::Trace
-    constexpr auto trace_shm_signature = static_cast<score::ResultBlank (
+    constexpr auto trace_shm_signature = static_cast<score::Result<void> (
         score::mw::com::impl::tracing::TracingRuntime::*)(BindingType,
                                                           ServiceElementInstanceIdentifierView,
                                                           ITracingRuntime::TracePointType,

--- a/score/mw/com/impl/traits_test.cpp
+++ b/score/mw/com/impl/traits_test.cpp
@@ -126,7 +126,7 @@ class ProxyCreationFixture : public ::testing::Test
             .WillByDefault(Return(ByMove(std::move(proxy_method_binding_mock_ptr))));
 
         // By default that the proxy_binding can successfully call SetupMethods
-        ON_CALL(proxy_binding_mock_, SetupMethods(_)).WillByDefault(Return(score::ResultBlank{}));
+        ON_CALL(proxy_binding_mock_, SetupMethods(_)).WillByDefault(Return(score::Result<void>{}));
 
         // By default the runtime configuration resolves instance identifiers
         resolved_instance_identifiers_.push_back(identifier_with_valid_binding_);
@@ -502,9 +502,9 @@ class SkeletonCreationFixture : public ::testing::Test
         ON_CALL(skeleton_binding_mock_, VerifyAllMethodsRegistered()).WillByDefault(Return(true));
 
         // By default the skeleton and service element bindings will report that offer service preparation succeeded
-        ON_CALL(skeleton_binding_mock_, PrepareOffer(_, _, _)).WillByDefault(Return(score::ResultBlank{}));
-        ON_CALL(skeleton_event_binding_mock_, PrepareOffer()).WillByDefault(Return(score::ResultBlank{}));
-        ON_CALL(skeleton_field_binding_mock_, PrepareOffer()).WillByDefault(Return(score::ResultBlank{}));
+        ON_CALL(skeleton_binding_mock_, PrepareOffer(_, _, _)).WillByDefault(Return(score::Result<void>{}));
+        ON_CALL(skeleton_event_binding_mock_, PrepareOffer()).WillByDefault(Return(score::Result<void>{}));
+        ON_CALL(skeleton_field_binding_mock_, PrepareOffer()).WillByDefault(Return(score::Result<void>{}));
     }
 
     std::vector<InstanceIdentifier> resolved_instance_identifiers_{};
@@ -814,7 +814,7 @@ TEST_F(GeneratedSkeletonCreationInstanceIdentifierTestFixture, CanInterpretAsSke
         .WillOnce(
             Invoke([](SkeletonBinding::SkeletonEventBindings& events,
                       SkeletonBinding::SkeletonFieldBindings& fields,
-                      std::optional<SkeletonBinding::RegisterShmObjectTraceCallback> trace_callback) -> ResultBlank {
+                      std::optional<SkeletonBinding::RegisterShmObjectTraceCallback> trace_callback) -> Result<void> {
                 EXPECT_EQ(events.size(), 1);
                 const auto& event_it = events.begin();
                 EXPECT_EQ(event_it->first, kEventName);
@@ -884,9 +884,9 @@ class GeneratedSkeletonStopOfferServiceRaiiFixture : public SkeletonCreationFixt
         ON_CALL(skeleton_binding_mock_2_, VerifyAllMethodsRegistered()).WillByDefault(Return(true));
 
         // By default the skeleton and service element bindings will report that offer service preparation succeeded
-        ON_CALL(skeleton_binding_mock_2_, PrepareOffer(_, _, _)).WillByDefault(Return(score::ResultBlank{}));
-        ON_CALL(skeleton_event_binding_mock_2_, PrepareOffer()).WillByDefault(Return(score::ResultBlank{}));
-        ON_CALL(skeleton_field_binding_mock_2_, PrepareOffer()).WillByDefault(Return(score::ResultBlank{}));
+        ON_CALL(skeleton_binding_mock_2_, PrepareOffer(_, _, _)).WillByDefault(Return(score::Result<void>{}));
+        ON_CALL(skeleton_event_binding_mock_2_, PrepareOffer()).WillByDefault(Return(score::Result<void>{}));
+        ON_CALL(skeleton_field_binding_mock_2_, PrepareOffer()).WillByDefault(Return(score::Result<void>{}));
     }
 
     MySkeleton CreateService()

--- a/score/mw/com/requirements/component_requirements/component_requirements_ipc.trlc
+++ b/score/mw/com/requirements/component_requirements/component_requirements_ipc.trlc
@@ -165,7 +165,7 @@ section "com" {
             ScoreReq.CompReq SkeletonOfferService {
                 description = '''The {{mw::com}}/{{LoLa}} shall provide an {{OfferService}} method as part of the {{Skeleton}} class to offer a service to applications.
 
-                {{{bmw::ResultBlank Skeleton::OfferService() noexcept;}}}
+                {{{bmw::Result<void> Skeleton::OfferService() noexcept;}}}
 
                 Behaviour: is described in Behaviour of OfferService.
 
@@ -251,7 +251,7 @@ section "com" {
 
                     * on success, a {{SampleAllocateePtr}} constructed from {{EventType}} (See SampleAllocateePtr).
 
-                    * on failure, a {{bmw::ResultBlank}}, which contains a {{bmw::result::Error}}containing the value {{ComErrc::kNotOffered}} if Skeleton OfferService has not been called or the service offering has been withdrawn with a call to Skeleton StopOfferService.'''
+                    * on failure, a {{bmw::Result<void>}}, which contains a {{bmw::result::Error}}containing the value {{ComErrc::kNotOffered}} if Skeleton OfferService has not been called or the service offering has been withdrawn with a call to Skeleton StopOfferService.'''
                     safety = ScoreReq.Asil.B
                     derived_from = [Communication.EventType@1, Communication.ZeroCopy@1]
                     version = 1
@@ -261,7 +261,7 @@ section "com" {
                 ScoreReq.CompReq SkeletonEventClassSend {
                     description = '''The {{SkeletonEvent}} class shall contain a public method:
 
-                    {{{ bmw::ResultBlank SkeletonEvent::Send(const EventType &value) noexcept;}}}
+                    {{{ bmw::Result<void> SkeletonEvent::Send(const EventType &value) noexcept;}}}
 
                     Arguments:
 
@@ -269,7 +269,7 @@ section "com" {
 
                     Behaviour: is described in Behaviour of Update/Send with Copy.
 
-                    Return value: {{bmw::ResultBlank}}{{bmw::result::Error}}returned  which contains a  containing the value {{ComErrc::kNotOffered}} if Skeleton OfferService has not been called or the service offering has been withdrawn with a call to Skeleton StopOfferService.'''
+                    Return value: {{bmw::Result<void>}}{{bmw::result::Error}}returned  which contains a  containing the value {{ComErrc::kNotOffered}} if Skeleton OfferService has not been called or the service offering has been withdrawn with a call to Skeleton StopOfferService.'''
                     safety = ScoreReq.Asil.B
                     derived_from = [Communication.StatelessCommunication@1]
                     version = 1
@@ -279,7 +279,7 @@ section "com" {
                 ScoreReq.CompReq SkeletonEventClassZeroCopySend {
                     description = '''The {{SkeletonEvent}} class shall contain a public method:
 
-                    {{{bmw::ResultBlank SkeletonEvent::Send(bmw::mw::com::SampleAllocateePtr<EventType> data) noexcept;}}}
+                    {{{bmw::Result<void> SkeletonEvent::Send(bmw::mw::com::SampleAllocateePtr<EventType> data) noexcept;}}}
 
                     Arguments:
 
@@ -287,7 +287,7 @@ section "com" {
 
                     Behaviour: is described in Behaviour of Zero-copy Update/Send.
 
-                    Return value: {{bmw::ResultBlank}}{{bmw::result::Error}}returned  which contains a  containing the value {{ComErrc::kNotOffered}} if Skeleton OfferService has not been called or the service offering has been withdrawn with a call to Skeleton StopOfferService'''
+                    Return value: {{bmw::Result<void>}}{{bmw::result::Error}}returned  which contains a  containing the value {{ComErrc::kNotOffered}} if Skeleton OfferService has not been called or the service offering has been withdrawn with a call to Skeleton StopOfferService'''
                     safety = ScoreReq.Asil.B
                     derived_from = [Communication.ZeroCopy@1]
                     version = 1
@@ -352,7 +352,7 @@ section "com" {
 
                     * on success, a {{SampleAllocateePtr<FieldType>}} (See SampleAllocateePtr).
 
-                    *  on failure, a {{bmw::ResultBlank}}, which contains a {{bmw::result::Error}}containing the value {{ComErrc::kNotOffered}} if Skeleton OfferService has not been called or the service offering has been withdrawn with a call to Skeleton StopOfferService.'''
+                    *  on failure, a {{bmw::Result<void>}}, which contains a {{bmw::result::Error}}containing the value {{ComErrc::kNotOffered}} if Skeleton OfferService has not been called or the service offering has been withdrawn with a call to Skeleton StopOfferService.'''
                     safety = ScoreReq.Asil.B
                     derived_from = [Communication.ServiceInstance@1, Communication.ZeroCopy@1]
                     version = 1
@@ -362,7 +362,7 @@ section "com" {
                 ScoreReq.CompReq SkeletonFieldClassUpdate {
                     description = '''The {{SkeletonField}} class shall contain a public method:
 
-                    {{{ bmw::ResultBlank SkeletonField::Update(const FieldType &value) noexcept;}}}
+                    {{{ bmw::Result<void> SkeletonField::Update(const FieldType &value) noexcept;}}}
 
                     Arguments:
 
@@ -378,7 +378,7 @@ section "com" {
                 ScoreReq.CompReq SkeletonFieldClassZeroCopyUpdate {
                     description = '''The {{SkeletonField}} class shall contain a public method:
 
-                    {{{bmw::ResultBlank SkeletonField::Update(mw::com::SampleAllocateePtr<FieldType> data) noexcept;}}}
+                    {{{bmw::Result<void> SkeletonField::Update(mw::com::SampleAllocateePtr<FieldType> data) noexcept;}}}
 
                     Arguments:
 
@@ -577,7 +577,7 @@ section "com" {
             ScoreReq.CompReq ProxyStopFindService {
                 description = '''The {{Proxy}} class shall contain a public method:
 
-                {{static bmw::ResultBlank Proxy::StopFindService(bmw::mw::com::FindServiceHandle handle) noexcept}}
+                {{static bmw::Result<void> Proxy::StopFindService(bmw::mw::com::FindServiceHandle handle) noexcept}}
 
                 Arguments:
 
@@ -658,7 +658,7 @@ section "com" {
                 ScoreReq.CompReq ProxyEventSubscribe {
                     description = '''The {{ProxyEvent}} class shall provide a public method:
 
-                    {{{bmw::ResultBlank ProxyEvent::Subscribe(std::size\_t max\_sample\_count) noexcept}}}
+                    {{{bmw::Result<void> ProxyEvent::Subscribe(std::size\_t max\_sample\_count) noexcept}}}
 
                     Behaviour is described in default-cursor Behaviour of Subscribe.
 
@@ -696,7 +696,7 @@ section "com" {
                 ScoreReq.CompReq ProxyEventSetSubscriptionStateChangeHandler {
                     description = '''The {{ProxyEvent}} class shall provide a public method:
 
-                    {{{bmw::ResultBlank ProxyEvent::SetSubscriptionStateChangeHandler(SubscriptionStateChangeHandler subscription\_state\_change\_handler) noexcept; }}}
+                    {{{bmw::Result<void> ProxyEvent::SetSubscriptionStateChangeHandler(SubscriptionStateChangeHandler subscription\_state\_change\_handler) noexcept; }}}
 
                     Arguments:
 
@@ -753,7 +753,7 @@ section "com" {
                     description = '''The {{ProxyEvent}}
                      shall provide a public method:
 
-                    {{{bmw::ResultBlank ProxyEvent::SetReceiveHandler(mw::com::EventReceiveHandler handler) noexcept;}}}
+                    {{{bmw::Result<void> ProxyEvent::SetReceiveHandler(mw::com::EventReceiveHandler handler) noexcept;}}}
 
                     Arguments:
 
@@ -772,7 +772,7 @@ section "com" {
                     description = '''The {{ProxyEvent}}
                      shall provide a public method:
 
-                    {{{bmw::ResultBlank ProxyEvent::UnsetReceiveHandler() noexcept}}}
+                    {{{bmw::Result<void> ProxyEvent::UnsetReceiveHandler() noexcept}}}
 
                     Behaviour is described in Behaviour of UnsetReceiveHandler.
 
@@ -864,7 +864,7 @@ section "com" {
                 ScoreReq.CompReq ProxyFieldSubscribe {
                     description = '''The {{ProxyField}} class shall provide a public method:
 
-                    {{{ bmw::ResultBlank ProxyField::Subscribe(std::size\_t max\_sample\_count) noexcept; }}}
+                    {{{ bmw::Result<void> ProxyField::Subscribe(std::size\_t max\_sample\_count) noexcept; }}}
 
                     Behaviour is described in Behaviour of Subscribe.
 
@@ -903,7 +903,7 @@ section "com" {
                     description = '''The {{ProxyField}}
                      class shall provide a public method:
 
-                    {{{bmw::ResultBlank ProxyField::SetSubscriptionStateChangeHandler(SubscriptionStateChangeHandler subscription\_state\_change\_handler) noexcept; }}}
+                    {{{bmw::Result<void> ProxyField::SetSubscriptionStateChangeHandler(SubscriptionStateChangeHandler subscription\_state\_change\_handler) noexcept; }}}
 
                     Arguments:
 
@@ -961,7 +961,7 @@ section "com" {
                     description = '''The {{ProxyField}}
                      shall provide a public method:
 
-                    {{{bmw::ResultBlank ProxyField::SetReceiveHandler(mw::com::EventReceiveHandler handler) noexcept;}}}
+                    {{{bmw::Result<void> ProxyField::SetReceiveHandler(mw::com::EventReceiveHandler handler) noexcept;}}}
 
                     Arguments:
 
@@ -980,7 +980,7 @@ section "com" {
                     description = '''The {{ProxyField}}
                      shall provide a public method:
 
-                    {{{bmw::ResultBlank ProxyField::UnsetReceiveHandler() noexcept}}}
+                    {{{bmw::Result<void> ProxyField::UnsetReceiveHandler() noexcept}}}
 
                     Behaviour is described in progress-cursor Behaviour of UnsetReceiveHandler.
 
@@ -1211,7 +1211,7 @@ section "com" {
             ScoreReq.CompReq GenericProxyStopFindService {
                 description = '''The {{GenericProxy}} class shall contain a public method:
 
-                {{static bmw::ResultBlank GenericProxy::StopFindService(mw::com::FindServiceHandle handle) noexcept}}
+                {{static bmw::Result<void> GenericProxy::StopFindService(mw::com::FindServiceHandle handle) noexcept}}
 
                 Arguments:
 
@@ -1219,7 +1219,7 @@ section "com" {
 
                 Behaviour: Stops the asynchronous search for available services, which has been started by either GenericProxy StartFindService with InstanceIdentifier or GenericProxy StartFindService with InstanceSpecifier. After the call has returned no further calls to the user provided FindServiceHandler takes place.
 
-                Return values: returned {{bmw::ResultBlank}}, which contains a {{bmw::result::Error}} containing the value {{ComErrc::kInvalidHandle}}, in case the given handle hasn't been returned by a corresponding {{StartFindService}} call on the same class or is a handle for a search, which has already been stopped.'''
+                Return values: returned {{bmw::Result<void>}}, which contains a {{bmw::result::Error}} containing the value {{ComErrc::kInvalidHandle}}, in case the given handle hasn't been returned by a corresponding {{StartFindService}} call on the same class or is a handle for a search, which has already been stopped.'''
                 safety = ScoreReq.Asil.B
                 derived_from = [Communication.ServiceDiscovery@1, Communication.SafeCommunication@1]
                 version = 1
@@ -1330,7 +1330,7 @@ section "com" {
                     description = '''A {{GenericProxyEvent}}
                      class shall provide a public method:
 
-                    {{{bmw::ResultBlank GenericProxyEvent::Subscribe(std::size\_t max\_sample\_count) noexcept}}}
+                    {{{bmw::Result<void> GenericProxyEvent::Subscribe(std::size\_t max\_sample\_count) noexcept}}}
 
                     Behaviour is described in Behaviour of Subscribe.
 
@@ -1370,7 +1370,7 @@ section "com" {
 
                      class shall provide a public method:
 
-                    {{{bmw::ResultBlank GenericProxyEvent::SetSubscriptionStateChangeHandler(SubscriptionStateChangeHandler subscription\_state\_change\_handler) noexcept; }}}
+                    {{{bmw::Result<void> GenericProxyEvent::SetSubscriptionStateChangeHandler(SubscriptionStateChangeHandler subscription\_state\_change\_handler) noexcept; }}}
 
                     Arguments:
 
@@ -1426,7 +1426,7 @@ section "com" {
                 ScoreReq.CompReq GenericProxyEventSetReceiveHandler {
                     description = '''The {{GenericProxyEvent}} shall provide a public method:
 
-                    {{{bmw::ResultBlank GenericProxyEvent::SetReceiveHandler(mw::com::EventReceiveHandler handler) noexcept;}}}
+                    {{{bmw::Result<void> GenericProxyEvent::SetReceiveHandler(mw::com::EventReceiveHandler handler) noexcept;}}}
 
                     Arguments:
 
@@ -1444,7 +1444,7 @@ section "com" {
                 ScoreReq.CompReq GenericProxyEventUnsetReceiveHandler {
                     description = '''The {{GenericProxyEvent}} shall provide a public method:
 
-                    {{{bmw::ResultBlank GenericProxyEvent::UnsetReceiveHandler() noexcept}}}
+                    {{{bmw::Result<void> GenericProxyEvent::UnsetReceiveHandler() noexcept}}}
 
                     Behaviour is described in Behaviour of UnsetReceiveHandler.
 
@@ -2723,7 +2723,7 @@ section "com" {
 
         /* broken_link_c/issue/20002443 */
         ScoreReq.CompReq ReturnCodeForBindingFailures {
-            description = '''Any signature in the public API that has the possiblity of returning an error code (e.g. bmw::Result, bmw::ResultBlank) is allowed to return{{bmw::result::ErrorCode}}{{mw::com::ComErrorDomain}} and the value is set to {{kBindingFailure}}, when any failure occurs in the binding. a  where the error domain is set to '''
+            description = '''Any signature in the public API that has the possiblity of returning an error code (e.g. bmw::Result, bmw::Result<void>) is allowed to return{{bmw::result::ErrorCode}}{{mw::com::ComErrorDomain}} and the value is set to {{kBindingFailure}}, when any failure occurs in the binding. a  where the error domain is set to '''
             safety = ScoreReq.Asil.B
             derived_from = [Communication.ErrorHandling@1]
             version = 1

--- a/score/mw/com/requirements/component_requirements/component_requirements_ipc_fields.trlc
+++ b/score/mw/com/requirements/component_requirements/component_requirements_ipc_fields.trlc
@@ -116,7 +116,7 @@ section "com" {
         }
 
         ScoreReq.CompReq RegisterSetHandlerSignature {
-            description=""" The signature of the `RegisterSetHandler` method shall be: `score::ResultBlank RegisterSetHandler(SetHandlerType)`"""
+            description=""" The signature of the `RegisterSetHandler` method shall be: `score::Result<void> RegisterSetHandler(SetHandlerType)`"""
             derived_from = [Communication.Field@1]
             version = 1
         }

--- a/score/mw/com/test/common_test_resources/common_service.h
+++ b/score/mw/com/test/common_test_resources/common_service.h
@@ -56,7 +56,7 @@ class Service
         return score::Result<Service>(Service(std::move(service_result.value())));
     }
 
-    [[nodiscard]] ResultBlank OfferService(const std::int32_t test_value)
+    [[nodiscard]] Result<void> OfferService(const std::int32_t test_value)
     {
         std::cout << "Start offering service, with value " << test_value << "\n";
         const auto update_result = lola_service_.test_field.Update(test_value);

--- a/score/mw/com/test/common_test_resources/consumer_resources.h
+++ b/score/mw/com/test/common_test_resources/consumer_resources.h
@@ -64,10 +64,10 @@ Result<FindServiceHandle> StartFindService(const std::string_view message_prefix
 }
 
 template <typename ProxyEventInterface>
-ResultBlank SubscribeProxyEvent(const std::string_view message_prefix,
-                                ProxyEventInterface& proxy_event,
-                                std::size_t max_sample_count,
-                                CheckPointControl& check_point_control)
+Result<void> SubscribeProxyEvent(const std::string_view message_prefix,
+                                 ProxyEventInterface& proxy_event,
+                                 std::size_t max_sample_count,
+                                 CheckPointControl& check_point_control)
 {
     const auto subscribe_result = proxy_event.Subscribe(max_sample_count);
     if (!(subscribe_result.has_value()))
@@ -81,10 +81,10 @@ ResultBlank SubscribeProxyEvent(const std::string_view message_prefix,
 }
 
 template <typename ProxyEventInterface>
-ResultBlank SetBasicNotifierReceiveHandler(const std::string_view message_prefix,
-                                           ProxyEventInterface& proxy_event,
-                                           concurrency::Notification& event_received,
-                                           CheckPointControl& check_point_control)
+Result<void> SetBasicNotifierReceiveHandler(const std::string_view message_prefix,
+                                            ProxyEventInterface& proxy_event,
+                                            concurrency::Notification& event_received,
+                                            CheckPointControl& check_point_control)
 {
     const auto set_receive_handler_result = proxy_event.SetReceiveHandler([&event_received, message_prefix] {
         std::cerr << message_prefix << ": Event receive handler called" << std::endl;

--- a/score/mw/com/test/common_test_resources/generic_trace_api_test_resources.cpp
+++ b/score/mw/com/test/common_test_resources/generic_trace_api_test_resources.cpp
@@ -51,19 +51,19 @@ void SetupGenericTraceApiMocking(GenericTraceApiMockContext& context) noexcept
     ON_CALL(context.generic_trace_api_mock, RegisterShmObject(trace_client_id, An<const std::string&>()))
         .WillByDefault(Return(RegisterSharedMemoryObjectResult{shm_object_handle}));
     ON_CALL(context.generic_trace_api_mock, UnregisterShmObject(trace_client_id, _))
-        .WillByDefault(Return(ResultBlank{}));
+        .WillByDefault(Return(Result<void>{}));
     ON_CALL(context.generic_trace_api_mock, RegisterTraceDoneCB(trace_client_id, _))
         .WillByDefault(Invoke([&context](TraceClientId, TraceDoneCallBackType callback) {
             context.stored_trace_done_cb = std::move(callback);
-            return score::ResultBlank{};
+            return score::Result<void>{};
         }));
     ON_CALL(context.generic_trace_api_mock, Trace(trace_client_id, _, An<ShmDataChunkList&>(), _))
         .WillByDefault(Invoke(
             [&context](TraceClientId, const MetaInfoVariants::Type&, ShmDataChunkList&, TraceContextId context_id) {
                 context.last_trace_context_id = context_id;
-                return score::ResultBlank{};
+                return score::Result<void>{};
             }));
-    ON_CALL(context.generic_trace_api_mock, Trace(trace_client_id, _, _)).WillByDefault(Return(score::ResultBlank{}));
+    ON_CALL(context.generic_trace_api_mock, Trace(trace_client_id, _, _)).WillByDefault(Return(score::Result<void>{}));
 
     score::memory::shared::SharedMemoryFactory::SetTypedMemoryProvider(context.typed_memory_mock);
     // Our mock-function for AllocateNamedTypedMemory does the same thing the normal/not-typed-mem allocation does.

--- a/score/mw/com/test/common_test_resources/provider_resources.h
+++ b/score/mw/com/test/common_test_resources/provider_resources.h
@@ -56,9 +56,9 @@ Result<SkeletonInterface> CreateSkeleton(const std::string_view message_prefix,
 }
 
 template <typename SkeletonInterface>
-ResultBlank OfferService(const std::string_view message_prefix,
-                         SkeletonInterface& skeleton,
-                         CheckPointControl& check_point_control) noexcept
+Result<void> OfferService(const std::string_view message_prefix,
+                          SkeletonInterface& skeleton,
+                          CheckPointControl& check_point_control) noexcept
 {
     const auto offer_service_result = skeleton.OfferService();
     std::cerr << message_prefix << ": After Skeleton Offered." << std::endl;

--- a/score/mw/com/test/methods/methods_test_resources/method_consumer.h
+++ b/score/mw/com/test/methods/methods_test_resources/method_consumer.h
@@ -145,7 +145,7 @@ bool MethodConsumer<Proxy>::CallMethodWithInArgsOnly(const std::int32_t input_ar
 {
     auto& proxy = proxy_container_.GetProxy();
 
-    auto call_result = [&proxy, copy_mode, input_argument_a, input_argument_b]() -> ResultBlank {
+    auto call_result = [&proxy, copy_mode, input_argument_a, input_argument_b]() -> Result<void> {
         SCORE_LANGUAGE_FUTURECPP_ASSERT(copy_mode == CopyMode::WITH_COPY || copy_mode == CopyMode::ZERO_COPY);
         if (copy_mode == CopyMode::ZERO_COPY)
         {

--- a/score/mw/com/test/methods/non_trivial_constructors/consumer.cpp
+++ b/score/mw/com/test/methods/non_trivial_constructors/consumer.cpp
@@ -68,7 +68,7 @@ bool CallMethodWithInArgsAndReturn(NonTrivialConstructorProxy& proxy)
 
 bool CallMethodWithInArgsOnly(NonTrivialConstructorProxy& proxy)
 {
-    auto call_result = [&proxy]() -> ResultBlank {
+    auto call_result = [&proxy]() -> Result<void> {
         std::cout << "\n=== Test: with_in_args_only (zero-copy) ===" << std::endl;
         auto allocated_args_result = proxy.with_in_args_only.Allocate();
         if (!allocated_args_result.has_value())


### PR DESCRIPTION
Use `Result<void>` directly, as `ResultBlank` and `Blank` aliases will be removed.