### PR TITLE
lola/proxy: Fix data-race in Method registration

### DIFF
--- a/score/mw/com/impl/bindings/lola/proxy.cpp
+++ b/score/mw/com/impl/bindings/lola/proxy.cpp
@@ -475,6 +475,7 @@ void Proxy::ServiceAvailabilityChangeHandler(const bool is_service_available)
     // dispatching to message passing and allows more specific error handling / logging).
     if (offered_state_machine_.GetCurrentState() == OfferedStateMachine::State::STOP_OFFERED)
     {
+        std::lock_guard lock{proxy_method_registration_mutex_};
         for (auto& proxy_method : proxy_methods_)
         {
             proxy_method.second.get().MarkUnsubscribed();
@@ -510,6 +511,7 @@ void Proxy::ServiceAvailabilityChangeHandler(const bool is_service_available)
         }
         else
         {
+            std::lock_guard lock{proxy_method_registration_mutex_};
             for (auto& proxy_method : proxy_methods_)
             {
                 proxy_method.second.get().MarkSubscribed();
@@ -632,17 +634,21 @@ score::ResultBlank Proxy::SetupMethods(const std::vector<std::string_view>& enab
 
     const auto& lola_service_type_deployment = GetLoLaServiceTypeDeployment(handle_);
     const auto& lola_service_instance_deployment = GetLoLaInstanceDeployment(handle_);
-    for (const auto& [field_name, field_instance_deployment] : lola_service_instance_deployment.fields_)
     {
-        const auto field_id = GetServiceElementId<ServiceElementType::FIELD>(lola_service_type_deployment, field_name);
+        std::lock_guard lock{proxy_method_registration_mutex_};
+        for (const auto& [field_name, field_instance_deployment] : lola_service_instance_deployment.fields_)
+        {
+            const auto field_id =
+                GetServiceElementId<ServiceElementType::FIELD>(lola_service_type_deployment, field_name);
 
-        if (kUseGetIfAvailable && proxy_methods_.count({field_id, MethodType::kGet}) != 0U)
-        {
-            enabled_method_data.push_back({{field_id, MethodType::kGet}, kFieldMethodQueueSize});
-        }
-        if (kUseSetIfAvailable && proxy_methods_.count({field_id, MethodType::kSet}) != 0U)
-        {
-            enabled_method_data.push_back({{field_id, MethodType::kSet}, kFieldMethodQueueSize});
+            if (kUseGetIfAvailable && proxy_methods_.count({field_id, MethodType::kGet}) != 0U)
+            {
+                enabled_method_data.push_back({{field_id, MethodType::kGet}, kFieldMethodQueueSize});
+            }
+            if (kUseSetIfAvailable && proxy_methods_.count({field_id, MethodType::kSet}) != 0U)
+            {
+                enabled_method_data.push_back({{field_id, MethodType::kSet}, kFieldMethodQueueSize});
+            }
         }
     }
     // This check has be done after looping over the fields to add the field methods to the enabled method data because,
@@ -710,6 +716,7 @@ score::ResultBlank Proxy::SetupMethods(const std::vector<std::string_view>& enab
         quality_type_, skeleton_instance_identifier, proxy_instance_identifier_, GetSourcePid());
     if (subscription_result.has_value())
     {
+        std::lock_guard lock{proxy_method_registration_mutex_};
         for (auto& proxy_method : proxy_methods_)
         {
             proxy_method.second.get().MarkSubscribed();
@@ -868,6 +875,7 @@ pid_t Proxy::GetSourcePid() const noexcept
 
 void Proxy::RegisterMethod(const UniqueMethodIdentifier method_id, ProxyMethod& proxy_method) noexcept
 {
+    std::lock_guard lock{proxy_method_registration_mutex_};
     const auto [ignorable, was_inserted] = proxy_methods_.insert({method_id, proxy_method});
     score::cpp::ignore = ignorable;
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(was_inserted, "Method IDs must be unique!");

--- a/score/mw/com/impl/bindings/lola/proxy.h
+++ b/score/mw/com/impl/bindings/lola/proxy.h
@@ -238,6 +238,10 @@ class Proxy : public ProxyBinding
     std::optional<memory::shared::LockFile> service_instance_usage_marker_file_;
     std::unique_ptr<score::memory::shared::FlockMutexAndLock<score::memory::shared::SharedFlockMutex>>
         service_instance_usage_flock_mutex_and_lock_;
+    /// Mutex which synchronises registration of Proxy methods via Proxy::RegisterMethod with the
+    /// FindServiceHandler in find_service_guard_ which will call ServiceAvailabilityChangeHandler iterating over
+    /// proxy_methods_.
+    std::mutex proxy_method_registration_mutex_;
     std::unordered_map<score::mw::com::impl::lola::UniqueMethodIdentifier, std::reference_wrapper<ProxyMethod>>
         proxy_methods_;
     MethodData* method_data_;


### PR DESCRIPTION
The race only occours when the find-service callback fires (on a service-discovery thread) at the exact moment RegisterMethod or SetupMethods is modifying/reading proxy_methods_ on the other thread. Thus, causing a data race.