### PR TITLE
Komal/safety analysis traceability

### DIFF
--- a/score/mw/com/dependability/safety_analysis/root_causes/in_memory_configuration_wrong_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/in_memory_configuration_wrong_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("In-Memory configuration wrong", "Communication.InMemoryConfigurationWrong")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/BUILD
@@ -14,6 +14,7 @@
 filegroup(
     name = "root_causes_proxy",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "//score/mw/com/dependability/safety_analysis/root_causes/proxy/call_method:call_method_fta",
         "//score/mw/com/dependability/safety_analysis/root_causes/proxy/construction:construction_fta",
         "//score/mw/com/dependability/safety_analysis/root_causes/proxy/find_service:service_not_found_fta",

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/BUILD
@@ -14,7 +14,6 @@
 filegroup(
     name = "root_causes_proxy",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "//score/mw/com/dependability/safety_analysis/root_causes/proxy/call_method:call_method_fta",
         "//score/mw/com/dependability/safety_analysis/root_causes/proxy/construction:construction_fta",
         "//score/mw/com/dependability/safety_analysis/root_causes/proxy/find_service:service_not_found_fta",
@@ -27,6 +26,7 @@ filegroup(
         "//score/mw/com/dependability/safety_analysis/root_causes/proxy/subscribe_for_an_event:subscribe_to_wrong_event_fta",
         "//score/mw/com/dependability/safety_analysis/root_causes/proxy/subscribe_for_an_event:subscribe_with_wrong_max_sample_count_fta",
         "//score/mw/com/dependability/safety_analysis/root_causes/proxy/unsubscribe_for_an_event:does_not_unsubscribe_fta",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/call_method/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/call_method/BUILD
@@ -14,6 +14,7 @@
 filegroup(
     name = "call_method_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "call_blocks_fta.puml",
         "wrong_in_args_provided_fta.puml",
         "wrong_results_used_fta.puml",

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/call_method/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/call_method/BUILD
@@ -14,10 +14,10 @@
 filegroup(
     name = "call_method_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "call_blocks_fta.puml",
         "wrong_in_args_provided_fta.puml",
         "wrong_results_used_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/call_method/call_blocks_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/call_method/call_blocks_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Method Call blocks", "Communication.CallBlocks")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/call_method/wrong_in_args_provided_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/call_method/wrong_in_args_provided_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Wrong input arguments provided", "Communication.WrongInArgsProvided")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/call_method/wrong_results_used_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/call_method/wrong_results_used_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Wrong call result used", "Communication.WrongResultsUsed")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/construction/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/construction/BUILD
@@ -14,6 +14,7 @@
 filegroup(
     name = "construction_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "service_is_found_but_does_not_exist_fta.puml",
     ],
     visibility = ["//visibility:public"],

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/construction/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/construction/BUILD
@@ -14,8 +14,8 @@
 filegroup(
     name = "construction_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "service_is_found_but_does_not_exist_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/construction/service_is_found_but_does_not_exist_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/construction/service_is_found_but_does_not_exist_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Service is found, but does not exist", "Communication.ServiceIsFoundButDoesNotExist")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/find_service/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/find_service/BUILD
@@ -14,6 +14,7 @@
 filegroup(
     name = "service_not_found_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "service_not_found_fta.puml",
     ],
     visibility = ["//visibility:public"],
@@ -22,6 +23,7 @@ filegroup(
 filegroup(
     name = "wrong_service_found_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "wrong_service_found_fta.puml",
     ],
     visibility = ["//visibility:public"],

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/find_service/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/find_service/BUILD
@@ -14,8 +14,8 @@
 filegroup(
     name = "service_not_found_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "service_not_found_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )
@@ -23,8 +23,8 @@ filegroup(
 filegroup(
     name = "wrong_service_found_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "wrong_service_found_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/find_service/service_not_found_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/find_service/service_not_found_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Service not found", "Communication.ServiceNotFound")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/find_service/wrong_service_found_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/find_service/wrong_service_found_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Wrong service found", "Communication.WrongServiceFound")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/generic_proxy/generic_proxy_event/getsamplesize_from_generic_proxy_event/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/generic_proxy/generic_proxy_event/getsamplesize_from_generic_proxy_event/BUILD
@@ -14,6 +14,7 @@
 filegroup(
     name = "the_size_returned_is_bigger_then_the_actual_value_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "the_size_returned_is_bigger_then_actual_value_fta.puml",
     ],
     visibility = ["//visibility:public"],

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/generic_proxy/generic_proxy_event/getsamplesize_from_generic_proxy_event/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/generic_proxy/generic_proxy_event/getsamplesize_from_generic_proxy_event/BUILD
@@ -14,8 +14,8 @@
 filegroup(
     name = "the_size_returned_is_bigger_then_the_actual_value_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "the_size_returned_is_bigger_then_actual_value_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/generic_proxy/generic_proxy_event/getsamplesize_from_generic_proxy_event/the_size_returned_is_bigger_then_actual_value_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/generic_proxy/generic_proxy_event/getsamplesize_from_generic_proxy_event/the_size_returned_is_bigger_then_actual_value_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("The size returned is bigger / smaller then the actual value", "Communication.TheSizeReturnedIsBiggerThenTheActualValue")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/generic_proxy/getting_access_to_generic_proxy_events/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/generic_proxy/getting_access_to_generic_proxy_events/BUILD
@@ -14,6 +14,7 @@
 filegroup(
     name = "map_containing_nonexistent_events_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "map_containing_nonexistent_events_fta.puml",
     ],
     visibility = ["//visibility:public"],

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/generic_proxy/getting_access_to_generic_proxy_events/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/generic_proxy/getting_access_to_generic_proxy_events/BUILD
@@ -14,8 +14,8 @@
 filegroup(
     name = "map_containing_nonexistent_events_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "map_containing_nonexistent_events_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/generic_proxy/getting_access_to_generic_proxy_events/map_containing_nonexistent_events_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/generic_proxy/getting_access_to_generic_proxy_events/map_containing_nonexistent_events_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Map containing non-existent events", "Communication.MapContainingNonexistentEvents")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/get_new_samples_on_an_event/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/get_new_samples_on_an_event/BUILD
@@ -14,6 +14,7 @@
 filegroup(
     name = "callback_invoked_with_wrong_data_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "callback_invoked_with_wrong_data_fta.puml",
     ],
     visibility = ["//visibility:public"],
@@ -22,6 +23,7 @@ filegroup(
 filegroup(
     name = "callback_not_invoked_despite_samples_available_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "callback_not_invoked_despite_samples_available_fta.puml",
     ],
     visibility = ["//visibility:public"],

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/get_new_samples_on_an_event/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/get_new_samples_on_an_event/BUILD
@@ -14,8 +14,8 @@
 filegroup(
     name = "callback_invoked_with_wrong_data_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "callback_invoked_with_wrong_data_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )
@@ -23,8 +23,8 @@ filegroup(
 filegroup(
     name = "callback_not_invoked_despite_samples_available_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "callback_not_invoked_despite_samples_available_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/get_new_samples_on_an_event/callback_invoked_with_wrong_data_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/get_new_samples_on_an_event/callback_invoked_with_wrong_data_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Callback invoked with wrong data", "Communication.CallbackInvokedWithWrongData")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/get_new_samples_on_an_event/callback_not_invoked_despite_samples_available_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/get_new_samples_on_an_event/callback_not_invoked_despite_samples_available_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Callback not invoked, despite samples available", "Communication.CallbackNotInvokedDespiteSamplesAvailable")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/start_find_service_construction/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/start_find_service_construction/BUILD
@@ -14,6 +14,7 @@
 filegroup(
     name = "start_find_service_callback_is_redundantly_called_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "start_find_service_callback_is_redundantly_called_fta.puml",
     ],
     visibility = ["//visibility:public"],

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/start_find_service_construction/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/start_find_service_construction/BUILD
@@ -14,8 +14,8 @@
 filegroup(
     name = "start_find_service_callback_is_redundantly_called_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "start_find_service_callback_is_redundantly_called_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/start_find_service_construction/start_find_service_callback_is_redundantly_called_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/start_find_service_construction/start_find_service_callback_is_redundantly_called_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("StartFindService callback is called unexpectedly", "Communication.StartFindServiceCallbackCalledUnexpectedly")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/subscribe_for_an_event/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/subscribe_for_an_event/BUILD
@@ -14,6 +14,7 @@
 filegroup(
     name = "subscribe_to_wrong_event_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "subscribe_to_wrong_event_fta.puml",
     ],
     visibility = ["//visibility:public"],
@@ -22,6 +23,7 @@ filegroup(
 filegroup(
     name = "subscribe_with_wrong_max_sample_count_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "subscribe_with_wrong_max_sample_count_fta.puml",
     ],
     visibility = ["//visibility:public"],

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/subscribe_for_an_event/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/subscribe_for_an_event/BUILD
@@ -14,8 +14,8 @@
 filegroup(
     name = "subscribe_to_wrong_event_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "subscribe_to_wrong_event_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )
@@ -23,8 +23,8 @@ filegroup(
 filegroup(
     name = "subscribe_with_wrong_max_sample_count_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "subscribe_with_wrong_max_sample_count_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/subscribe_for_an_event/subscribe_to_wrong_event_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/subscribe_for_an_event/subscribe_to_wrong_event_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Subscribe to Wrong Event or Field", "Communication.SubscribeToWrongEvent")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/subscribe_for_an_event/subscribe_with_wrong_max_sample_count_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/subscribe_for_an_event/subscribe_with_wrong_max_sample_count_fta.puml
@@ -12,7 +12,7 @@
 ' *******************************************************************************
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Subscribe with wrong max. sample count", "Communication.SubscribeWithWrongMaxSampleCount")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/unsubscribe_for_an_event/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/unsubscribe_for_an_event/BUILD
@@ -14,6 +14,7 @@
 filegroup(
     name = "does_not_unsubscribe_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "does_not_unsubscribe_fta.puml",
     ],
     visibility = ["//visibility:public"],

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/unsubscribe_for_an_event/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/unsubscribe_for_an_event/BUILD
@@ -14,8 +14,8 @@
 filegroup(
     name = "does_not_unsubscribe_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "does_not_unsubscribe_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/com/dependability/safety_analysis/root_causes/proxy/unsubscribe_for_an_event/does_not_unsubscribe_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/proxy/unsubscribe_for_an_event/does_not_unsubscribe_fta.puml
@@ -12,7 +12,7 @@
 ' *******************************************************************************
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Does not unsubscribe", "Communication.DoesNotUnsubscribe")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/BUILD
@@ -14,6 +14,7 @@
 filegroup(
     name = "root_causes_skeleton",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "//score/mw/com/dependability/safety_analysis/root_causes/skeleton/allocate_an_event_or_field:allocate_in_wrong_memory_fta",
         "//score/mw/com/dependability/safety_analysis/root_causes/skeleton/allocate_an_event_or_field:to_few_memory_allocated_fta",
         "//score/mw/com/dependability/safety_analysis/root_causes/skeleton/creation:creation_of_skeleton_not_possible_fta",

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/BUILD
@@ -14,7 +14,6 @@
 filegroup(
     name = "root_causes_skeleton",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "//score/mw/com/dependability/safety_analysis/root_causes/skeleton/allocate_an_event_or_field:allocate_in_wrong_memory_fta",
         "//score/mw/com/dependability/safety_analysis/root_causes/skeleton/allocate_an_event_or_field:to_few_memory_allocated_fta",
         "//score/mw/com/dependability/safety_analysis/root_causes/skeleton/creation:creation_of_skeleton_not_possible_fta",
@@ -35,6 +34,7 @@ filegroup(
         "//score/mw/com/dependability/safety_analysis/root_causes/skeleton/send_an_event_or_field:sends_to_wrong_consumer_fta",
         "//score/mw/com/dependability/safety_analysis/root_causes/skeleton/stop_offer_a_service:only_partially_stop_offer_fta",
         "//score/mw/com/dependability/safety_analysis/root_causes/skeleton/stop_offer_a_service:stop_offer_on_wrong_ids_fta",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/allocate_an_event_or_field/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/allocate_an_event_or_field/BUILD
@@ -14,6 +14,7 @@
 filegroup(
     name = "allocate_in_wrong_memory_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "allocate_in_wrong_memory_fta.puml",
     ],
     visibility = ["//visibility:public"],
@@ -22,6 +23,7 @@ filegroup(
 filegroup(
     name = "to_few_memory_allocated_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "to_few_memory_allocated_fta.puml",
     ],
     visibility = ["//visibility:public"],

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/allocate_an_event_or_field/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/allocate_an_event_or_field/BUILD
@@ -14,8 +14,8 @@
 filegroup(
     name = "allocate_in_wrong_memory_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "allocate_in_wrong_memory_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )
@@ -23,8 +23,8 @@ filegroup(
 filegroup(
     name = "to_few_memory_allocated_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "to_few_memory_allocated_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/allocate_an_event_or_field/allocate_in_wrong_memory_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/allocate_an_event_or_field/allocate_in_wrong_memory_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Allocate in Wrong Memory", "Communication.MemoryAllocatedInWrongSection")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/allocate_an_event_or_field/to_few_memory_allocated_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/allocate_an_event_or_field/to_few_memory_allocated_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("To few memory allocated", "Communication.TooFewMemoryAllocated")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/creation/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/creation/BUILD
@@ -14,6 +14,7 @@
 filegroup(
     name = "creation_of_skeleton_not_possible_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "creation_of_skeleton_not_possible_fta.puml",
     ],
     visibility = ["//visibility:public"],

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/creation/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/creation/BUILD
@@ -14,8 +14,8 @@
 filegroup(
     name = "creation_of_skeleton_not_possible_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "creation_of_skeleton_not_possible_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/creation/creation_of_skeleton_not_possible_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/creation/creation_of_skeleton_not_possible_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Creation of Skeleton not possible", "Communication.CreationOfSkeletonNotPossible")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/destruction/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/destruction/BUILD
@@ -14,6 +14,7 @@
 filegroup(
     name = "no_resources_freed_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "no_resources_freed_fta.puml",
     ],
     visibility = ["//visibility:public"],
@@ -22,6 +23,7 @@ filegroup(
 filegroup(
     name = "wrong_resources_freed_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "wrong_resources_freed_fta.puml",
     ],
     visibility = ["//visibility:public"],

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/destruction/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/destruction/BUILD
@@ -14,8 +14,8 @@
 filegroup(
     name = "no_resources_freed_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "no_resources_freed_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )
@@ -23,8 +23,8 @@ filegroup(
 filegroup(
     name = "wrong_resources_freed_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "wrong_resources_freed_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/destruction/no_resources_freed_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/destruction/no_resources_freed_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("No resources freed", "Communication.NoResourcesFreed")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/destruction/wrong_resources_freed_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/destruction/wrong_resources_freed_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Wrong resources freed", "Communication.WrongResourcesFreed")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/handle_method_call/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/handle_method_call/BUILD
@@ -14,6 +14,7 @@
 filegroup(
     name = "wrong_in_args_used_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "wrong_in_args_used_fta.puml",
     ],
     visibility = ["//visibility:public"],
@@ -22,6 +23,7 @@ filegroup(
 filegroup(
     name = "wrong_method_called_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "wrong_method_called_fta.puml",
     ],
     visibility = ["//visibility:public"],
@@ -30,6 +32,7 @@ filegroup(
 filegroup(
     name = "wrong_results_provided_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "wrong_results_provided_fta.puml",
     ],
     visibility = ["//visibility:public"],

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/handle_method_call/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/handle_method_call/BUILD
@@ -14,8 +14,8 @@
 filegroup(
     name = "wrong_in_args_used_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "wrong_in_args_used_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )
@@ -23,8 +23,8 @@ filegroup(
 filegroup(
     name = "wrong_method_called_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "wrong_method_called_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )
@@ -32,8 +32,8 @@ filegroup(
 filegroup(
     name = "wrong_results_provided_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "wrong_results_provided_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/handle_method_call/wrong_in_args_used_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/handle_method_call/wrong_in_args_used_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Wrong input arguments used", "Communication.WrongInArgsUsed")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/handle_method_call/wrong_method_called_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/handle_method_call/wrong_method_called_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Wrong method called", "Communication.WrongMethodCalled")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/handle_method_call/wrong_results_provided_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/handle_method_call/wrong_results_provided_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Wrong call result provided", "Communication.WrongResultsProvided")
 $OrGate("Gate1", "TopEvent")

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/offer_a_service/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/offer_a_service/BUILD
@@ -14,6 +14,7 @@
 filegroup(
     name = "only_partially_offered_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "only_partially_offered_fta.puml",
     ],
     visibility = ["//visibility:public"],
@@ -22,6 +23,7 @@ filegroup(
 filegroup(
     name = "service_offered_under_wrong_id_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "service_offered_under_wrong_id_fta.puml",
     ],
     visibility = ["//visibility:public"],
@@ -30,6 +32,7 @@ filegroup(
 filegroup(
     name = "skeleton_not_offered_without_initial_field_value_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "skeleton_not_offered_without_initial_fieled_value_fta.puml",
     ],
     visibility = ["//visibility:public"],
@@ -38,6 +41,7 @@ filegroup(
 filegroup(
     name = "skeleton_offered_wrong_binding_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "skeleton_offered_wrong_binding_fta.puml",
     ],
     visibility = ["//visibility:public"],
@@ -46,6 +50,7 @@ filegroup(
 filegroup(
     name = "skeleton_not_offered_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "skeleton_not_offered_fta.puml",
     ],
     visibility = ["//visibility:public"],
@@ -54,6 +59,7 @@ filegroup(
 filegroup(
     name = "offers_already_offered_service_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "offers_already_offered_service_fta.puml",
     ],
     visibility = ["//visibility:public"],

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/offer_a_service/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/offer_a_service/BUILD
@@ -14,8 +14,8 @@
 filegroup(
     name = "only_partially_offered_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "only_partially_offered_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )
@@ -23,8 +23,8 @@ filegroup(
 filegroup(
     name = "service_offered_under_wrong_id_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "service_offered_under_wrong_id_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )
@@ -32,8 +32,8 @@ filegroup(
 filegroup(
     name = "skeleton_not_offered_without_initial_field_value_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "skeleton_not_offered_without_initial_fieled_value_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )
@@ -41,8 +41,8 @@ filegroup(
 filegroup(
     name = "skeleton_offered_wrong_binding_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "skeleton_offered_wrong_binding_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )
@@ -50,8 +50,8 @@ filegroup(
 filegroup(
     name = "skeleton_not_offered_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "skeleton_not_offered_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )
@@ -59,8 +59,8 @@ filegroup(
 filegroup(
     name = "offers_already_offered_service_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "offers_already_offered_service_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/offer_a_service/offers_already_offered_service_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/offer_a_service/offers_already_offered_service_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Offers already offered service", "Communication.OffersAlreadyOfferedService")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/offer_a_service/only_partially_offered_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/offer_a_service/only_partially_offered_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Only partially offered", "Communication.ServiceOnlyPartiallyOffered")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/offer_a_service/service_offered_under_wrong_id_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/offer_a_service/service_offered_under_wrong_id_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Service is offered under wrong IDs", "Communication.ServiceOfferedUnderWrongIds")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/offer_a_service/skeleton_not_offered_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/offer_a_service/skeleton_not_offered_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Skeleton Not offered", "Communication.ServiceNotOffered")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/offer_a_service/skeleton_not_offered_without_initial_fieled_value_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/offer_a_service/skeleton_not_offered_without_initial_fieled_value_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Skeleton is offered without initial field values", "Communication.ServiceOfferedWithoutInitialFieldValue")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/offer_a_service/skeleton_offered_wrong_binding_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/offer_a_service/skeleton_offered_wrong_binding_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Skeleton offered on wrong binding", "Communication.ServiceOfferedOnWrongBinding")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/send_an_event_or_field/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/send_an_event_or_field/BUILD
@@ -14,6 +14,7 @@
 filegroup(
     name = "changes_user_data_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "changes_user_data_fta.puml",
     ],
     visibility = ["//visibility:public"],
@@ -22,6 +23,7 @@ filegroup(
 filegroup(
     name = "does_not_free_resources_after_usage_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "does_not_free_resources_after_usage_fta.puml",
     ],
     visibility = ["//visibility:public"],
@@ -30,6 +32,7 @@ filegroup(
 filegroup(
     name = "only_partially_notifies_user_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "only_partially_notifies_user_fta.puml",
     ],
     visibility = ["//visibility:public"],
@@ -38,6 +41,7 @@ filegroup(
 filegroup(
     name = "sends_to_wrong_consumer_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "sends_to_wrong_consumer_fta.puml",
     ],
     visibility = ["//visibility:public"],

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/send_an_event_or_field/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/send_an_event_or_field/BUILD
@@ -14,8 +14,8 @@
 filegroup(
     name = "changes_user_data_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "changes_user_data_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )
@@ -23,8 +23,8 @@ filegroup(
 filegroup(
     name = "does_not_free_resources_after_usage_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "does_not_free_resources_after_usage_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )
@@ -32,8 +32,8 @@ filegroup(
 filegroup(
     name = "only_partially_notifies_user_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "only_partially_notifies_user_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )
@@ -41,8 +41,8 @@ filegroup(
 filegroup(
     name = "sends_to_wrong_consumer_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "sends_to_wrong_consumer_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/send_an_event_or_field/changes_user_data_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/send_an_event_or_field/changes_user_data_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Changes User-Data", "Communication.SendingEventChangesUserData")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/send_an_event_or_field/does_not_free_resources_after_usage_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/send_an_event_or_field/does_not_free_resources_after_usage_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Does not free Resources after usage", "Communication.SendingEventDoesNotFreeResources")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/send_an_event_or_field/only_partially_notifies_user_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/send_an_event_or_field/only_partially_notifies_user_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Only partially notifies user", "Communication.SendingEventOnlyPartiallyNotifiesConsumer")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/send_an_event_or_field/sends_to_wrong_consumer_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/send_an_event_or_field/sends_to_wrong_consumer_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Sends to wrong consumer", "Communication.SendingEventSendsToWrongConsumer")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/stop_offer_a_service/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/stop_offer_a_service/BUILD
@@ -14,6 +14,7 @@
 filegroup(
     name = "only_partially_stop_offer_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "only_partially_stop_offer_fta.puml",
     ],
     visibility = ["//visibility:public"],
@@ -22,6 +23,7 @@ filegroup(
 filegroup(
     name = "stop_offer_on_wrong_ids_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "stop_offer_on_wrong_ids_fta.puml",
     ],
     visibility = ["//visibility:public"],

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/stop_offer_a_service/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/stop_offer_a_service/BUILD
@@ -14,8 +14,8 @@
 filegroup(
     name = "only_partially_stop_offer_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "only_partially_stop_offer_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )
@@ -23,8 +23,8 @@ filegroup(
 filegroup(
     name = "stop_offer_on_wrong_ids_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "stop_offer_on_wrong_ids_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/stop_offer_a_service/only_partially_stop_offer_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/stop_offer_a_service/only_partially_stop_offer_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Only Partially Stop Offer", "Communication.ServiceOnlyPartiallyStopOffered")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/skeleton/stop_offer_a_service/stop_offer_on_wrong_ids_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/skeleton/stop_offer_a_service/stop_offer_on_wrong_ids_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Stop Offer on wrong IDS", "Communication.ServiceStopOfferingWrongIds")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/BUILD
@@ -14,6 +14,7 @@
 filegroup(
     name = "smart_pointer_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "//score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/method_signature_element_ptr:method_signature_element_ptr_fta",
         "//score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/sample_ptr_sample_allocate_ptr",
     ],

--- a/score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/BUILD
@@ -14,9 +14,9 @@
 filegroup(
     name = "smart_pointer_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "//score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/method_signature_element_ptr:method_signature_element_ptr_fta",
         "//score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/sample_ptr_sample_allocate_ptr",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/method_signature_element_ptr/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/method_signature_element_ptr/BUILD
@@ -14,6 +14,7 @@
 filegroup(
     name = "method_signature_element_ptr_fta",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "failure_freeing_resources_on_destruction_fta.puml",
         "points_to_wrong_data_fta.puml",
     ],

--- a/score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/method_signature_element_ptr/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/method_signature_element_ptr/BUILD
@@ -14,9 +14,9 @@
 filegroup(
     name = "method_signature_element_ptr_fta",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "failure_freeing_resources_on_destruction_fta.puml",
         "points_to_wrong_data_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/method_signature_element_ptr/failure_freeing_resources_on_destruction_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/method_signature_element_ptr/failure_freeing_resources_on_destruction_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Failure freeing resources on destruction", "Communication.MethodSignatureElementPtrFailsToFree")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/method_signature_element_ptr/points_to_wrong_data_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/method_signature_element_ptr/points_to_wrong_data_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Points to wrong data", "Communication.MethodSignatureElementPtrWrongTarget")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/sample_ptr_sample_allocate_ptr/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/sample_ptr_sample_allocate_ptr/BUILD
@@ -14,6 +14,7 @@
 filegroup(
     name = "sample_ptr_sample_allocate_ptr",
     srcs = [
+        "@score_tooling//plantuml:fta_metamodel",
         "does_not_free_resources_on_destruction_fta.puml",
         "returns_wrong_data_fta.puml",
     ],

--- a/score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/sample_ptr_sample_allocate_ptr/BUILD
+++ b/score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/sample_ptr_sample_allocate_ptr/BUILD
@@ -14,9 +14,9 @@
 filegroup(
     name = "sample_ptr_sample_allocate_ptr",
     srcs = [
-        "@score_tooling//plantuml:fta_metamodel",
         "does_not_free_resources_on_destruction_fta.puml",
         "returns_wrong_data_fta.puml",
+        "@score_tooling//plantuml:fta_metamodel",
     ],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/sample_ptr_sample_allocate_ptr/does_not_free_resources_on_destruction_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/sample_ptr_sample_allocate_ptr/does_not_free_resources_on_destruction_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Does not free resources on destruction", "Communication.DoesNotFreeResourcesOnDestruction")
 

--- a/score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/sample_ptr_sample_allocate_ptr/returns_wrong_data_fta.puml
+++ b/score/mw/com/dependability/safety_analysis/root_causes/smart_pointer/sample_ptr_sample_allocate_ptr/returns_wrong_data_fta.puml
@@ -13,7 +13,7 @@
 
 @startuml
 
-!include ../../../../../../../../third_party/traceability/doc/sample_library/safety_analysis/fta_metamodel.puml
+!include fta_metamodel.puml
 
 $TopEvent("Returns wrong data", "Communication.ReturnsWrongData")
 


### PR DESCRIPTION
Apply buildifier formatting to safety analysis root_causes BUILD files to fix CI format test failure.

Changes:

Add 39 PUML files for safety analysis root causes (proxy, skeleton, smart_pointer)
Add 21 BUILD files with filegroup definitions
Format BUILD files per buildifier canonical format
Files Changed: 60 files (39 PUML + 21 BUILD)

