### PR TITLE
mw::com: Migrate from boolean enablers to struct Tags to enable Get/Set/Notify functionality in Fields.

### DIFF
--- a/score/mw/com/design/events_fields/README.md
+++ b/score/mw/com/design/events_fields/README.md
@@ -52,6 +52,35 @@ normally registers itself at its parent skeleton in its event-collection. This i
 the field use case as in this case the `impl::SkeletonField<SampleType>` has already registered itself in its parents
 field-collection!
 
+### Field capability tags
+
+A field is declared with its `SampleType` plus a pack of marker tags from `field_tags.h`. Any combination of
+`WithGetter`, `WithSetter` and `WithNotifier` is allowed, and the tags decide which methods the user actually sees:
+`WithGetter` enables `Get()`, `WithSetter` enables `Set()`, and `WithNotifier` enables the notifier methods
+(`Subscribe()`, `Unsubscribe()`, `GetSubscriptionState()`, `GetNumNewSamplesAvailable()`, `GetNewSamples()`,
+`GetFreeSampleCount()`, `SetReceiveHandler()`, `UnsetReceiveHandler()`, `SetSubscriptionStateChangeHandler()` and
+`UnsetSubscriptionStateChangeHandler()`). The gating happens at compile time via SFINAE, so calling e.g. `Subscribe()`
+on a field that was not declared with `WithNotifier` does not compile.
+
+The notifier is a pure consumer-side concept. It only controls
+whether the proxy can subscribe and receive event-style notifications when the provider updates the value, and says
+nothing about the provider side. This follows `ara::com`, where the notifier is essentially "the event part" of a field
+(see AUTOSAR's [Explanation of ara::com API](https://www.autosar.org/fileadmin/standards/R24-11/AP/AUTOSAR_AP_EXP_ARAComAPI.pdf),
+chapter "Fields").
+
+The same asymmetry shows up in how each side builds the field's event dispatch:
+
+- On the skeleton side, value handling does not depend on the tags. `impl::SkeletonField` always creates its
+  `skeleton_event_dispatch_`, and `Update()`/`Allocate()` are always present. I.e. the provider can always set the
+  initial value and push new values later, whether or not a notifier was configured.
+- On the proxy side, the event dispatch (`proxy_event_dispatch_`) is only created when `WithNotifier` is set. Without it
+  the member stays `nullptr` and the notifier methods are removed at compile time.
+
+The only combination we actually enforce is a `static_assert` on both `impl::ProxyField` and `impl::SkeletonField`: a
+field must have at least one of `WithGetter` or `WithNotifier`. Without one of them the consumer has no way to observe
+the value, which makes the field useless. We deliberately do not require a setter, since a read-only field is perfectly normal and the provider always sets the
+value itself via `Update()` with no explicit tag needed.
+
 ## Event related datastructures in LoLa binding
 
 Here we provide insight, how event communication is realized within our `LoLa` (shared memory based) binding. The

--- a/score/mw/com/impl/BUILD
+++ b/score/mw/com/impl/BUILD
@@ -747,6 +747,14 @@ cc_library(
     visibility = ["//score/mw/com:__subpackages__"],
 )
 
+cc_unit_test(
+    name = "field_tags_test",
+    srcs = ["field_tags_test.cpp"],
+    deps = [
+        ":field_tags",
+    ],
+)
+
 cc_library(
     name = "service_element_type",
     srcs = ["service_element_type.cpp"],

--- a/score/mw/com/impl/BUILD
+++ b/score/mw/com/impl/BUILD
@@ -265,6 +265,7 @@ cc_library(
         "//score/mw/com:__subpackages__",
     ],
     deps = [
+        ":field_tags",
         ":method_type",
         ":skeleton_event",
         ":skeleton_field_base",
@@ -289,6 +290,7 @@ cc_library(
         "//score/mw/com:__subpackages__",
     ],
     deps = [
+        ":field_tags",
         ":flag_owner",
         ":proxy_base",
         ":proxy_event",
@@ -328,6 +330,7 @@ cc_library(
         "//score/mw/com:__subpackages__",
     ],
     deps = [
+        ":field_tags",
         ":method_type",
         ":proxy_event",
         ":proxy_event_binding",
@@ -730,6 +733,15 @@ cc_library(
     name = "method_type",
     srcs = ["method_type.cpp"],
     hdrs = ["method_type.h"],
+    features = COMPILER_WARNING_FEATURES,
+    tags = ["FFI"],
+    visibility = ["//score/mw/com:__subpackages__"],
+)
+
+cc_library(
+    name = "field_tags",
+    srcs = ["field_tags.cpp"],
+    hdrs = ["field_tags.h"],
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     visibility = ["//score/mw/com:__subpackages__"],

--- a/score/mw/com/impl/field_tags.cpp
+++ b/score/mw/com/impl/field_tags.cpp
@@ -1,0 +1,13 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/impl/field_tags.h"

--- a/score/mw/com/impl/field_tags.h
+++ b/score/mw/com/impl/field_tags.h
@@ -1,0 +1,69 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_IMPL_FIELD_TAGS_H
+#define SCORE_MW_COM_IMPL_FIELD_TAGS_H
+
+#include <type_traits>
+
+namespace score::mw::com::impl
+{
+
+/// \brief Tag types used on ProxyField/SkeletonField level to accomplish SFINAE gating of various signatures,
+/// which depend on the availability of Get/Set/Notifier.
+struct WithGetter
+{
+};
+
+struct WithSetter
+{
+};
+
+struct WithNotifier
+{
+};
+
+template <typename TargetType, typename... Tags>
+struct contains_type : std::disjunction<std::is_same<TargetType, Tags>...>
+{
+};
+
+/// \brief Gates a member function on whether a capability tag was declared for this field.
+///
+/// Two things have to be true for the overload to work:
+///   - \c RequiredTag is somewhere(order does not matter) in \c EnabledTags.
+///   - \c FieldType == \c ClassFieldType (see below)
+///
+/// The second condition (\c FieldType == \c ClassFieldType) is a SFINAE workaround: \c FieldType
+/// must be a deduced local parameter of the member function template (defaulting to \c ClassFieldType)
+/// so the check stays dependent and the compiler does not harderr at class instantiation time.
+///
+/// In practice you use it like this inside \c Foo<FieldType, Tags...>:
+/// \code
+///   template <typename F = FieldType,
+///             std::enable_if_t<is_tag_enabled<F, FieldType, WithSetter, Tags...>::value, int> = 0>
+///   void Set(F value);
+/// \endcode
+///
+/// \tparam FieldType       Local deduced copy of the field type, must default to \c ClassFieldType.
+/// \tparam ClassFieldType  The actual field type the enclosing class was instantiated with.
+/// \tparam RequiredTag     The tag that must be present (e.g. \c WithSetter, \c WithGetter).
+/// \tparam EnabledTags     All tags the field was declared with.
+template <typename FieldType, typename ClassFieldType, typename RequiredTag, typename... EnabledTags>
+struct is_tag_enabled
+    : std::conjunction<contains_type<RequiredTag, EnabledTags...>, std::is_same<FieldType, ClassFieldType>>
+{
+};
+
+}  // namespace score::mw::com::impl
+
+#endif  // SCORE_MW_COM_IMPL_FIELD_TAGS_H

--- a/score/mw/com/impl/field_tags_test.cpp
+++ b/score/mw/com/impl/field_tags_test.cpp
@@ -1,0 +1,89 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/impl/field_tags.h"
+
+#include <gtest/gtest.h>
+
+namespace score::mw::com::impl
+{
+namespace
+{
+
+TEST(ContainsTypeTest, ReturnsTrueWhenTargetTypeIsInPack)
+{
+    // Given a tag pack containing the target type (at any position)
+    // When checking contains_type
+    // Then the result is true
+    static_assert(contains_type<WithGetter, WithGetter>::value);
+    static_assert(contains_type<WithSetter, WithSetter>::value);
+    static_assert(contains_type<WithNotifier, WithNotifier>::value);
+    static_assert(contains_type<WithGetter, WithGetter, WithSetter>::value);
+    static_assert(contains_type<WithGetter, WithGetter, WithSetter, WithNotifier>::value);
+    static_assert(contains_type<WithSetter, WithGetter, WithSetter, WithNotifier>::value);
+    static_assert(contains_type<WithNotifier, WithGetter, WithSetter, WithNotifier>::value);
+}
+
+TEST(ContainsTypeTest, ReturnsFalseWhenPackIsEmpty)
+{
+    // Given an empty tag pack
+    // When checking contains_type for any target type
+    // Then the result is false
+    static_assert(!contains_type<WithGetter>::value);
+    static_assert(!contains_type<WithSetter>::value);
+    static_assert(!contains_type<WithNotifier>::value);
+}
+
+TEST(ContainsTypeTest, ReturnsFalseWhenTargetTypeIsAbsentFromPack)
+{
+    // Given a tag pack that does not contain the target type
+    // When checking contains_type
+    // Then the result is false
+    static_assert(!contains_type<WithGetter, WithSetter>::value);
+    static_assert(!contains_type<WithGetter, WithSetter, WithNotifier>::value);
+    static_assert(!contains_type<WithSetter, WithGetter, WithNotifier>::value);
+    static_assert(!contains_type<WithNotifier, WithGetter, WithSetter>::value);
+}
+
+TEST(IsTagEnabledTest, ReturnsTrueWhenFieldTypesMatchAndTargetTagIsInPack)
+{
+    // Given FieldType == ClassFieldType and the target tag in the pack
+    // When checking is_tag_enabled
+    // Then the result is true
+    using FieldType = int;
+    static_assert(is_tag_enabled<FieldType, FieldType, WithGetter, WithGetter>::value);
+    static_assert(is_tag_enabled<FieldType, FieldType, WithSetter, WithGetter, WithSetter>::value);
+    static_assert(is_tag_enabled<FieldType, FieldType, WithNotifier, WithGetter, WithSetter, WithNotifier>::value);
+}
+
+TEST(IsTagEnabledTest, ReturnsFalseWhenFieldTypesDoNotMatch)
+{
+    // Given FieldType != ClassFieldType.
+    // When checking is_tag_enabled
+    // Then the result is false even if the target tag is in the pack
+    static_assert(!is_tag_enabled<int, double, WithGetter, WithGetter>::value);
+    static_assert(!is_tag_enabled<int, double, WithNotifier, WithGetter, WithSetter, WithNotifier>::value);
+}
+
+TEST(IsTagEnabledTest, ReturnsFalseWhenTargetTagIsAbsentFromPack)
+{
+    // Given FieldType == ClassFieldType but the target tag is not in the pack
+    // When checking is_tag_enabled
+    // Then the result is false
+    using FieldType = int;
+    static_assert(!is_tag_enabled<FieldType, FieldType, WithGetter, WithSetter>::value);
+    static_assert(!is_tag_enabled<FieldType, FieldType, WithGetter, WithSetter, WithNotifier>::value);
+    static_assert(!is_tag_enabled<FieldType, FieldType, WithGetter>::value);
+}
+
+}  // namespace
+}  // namespace score::mw::com::impl

--- a/score/mw/com/impl/generic_proxy_event.cpp
+++ b/score/mw/com/impl/generic_proxy_event.cpp
@@ -21,9 +21,9 @@ namespace score::mw::com::impl
 
 GenericProxyEvent::GenericProxyEvent(ProxyBase& base, const std::string_view event_name)
     : ProxyEventBase{base,
+                     event_name,
                      ProxyBaseView{base}.GetBinding(),
-                     GenericProxyEventBindingFactory::Create(base, event_name),
-                     event_name}
+                     GenericProxyEventBindingFactory::Create(base, event_name)}
 {
     ProxyBaseView proxy_base_view{base};
     if (!binding_base_)
@@ -34,9 +34,9 @@ GenericProxyEvent::GenericProxyEvent(ProxyBase& base, const std::string_view eve
 }
 
 GenericProxyEvent::GenericProxyEvent(ProxyBase& base,
-                                     std::unique_ptr<GenericProxyEventBinding> proxy_binding,
-                                     const std::string_view event_name)
-    : ProxyEventBase{base, ProxyBaseView{base}.GetBinding(), std::move(proxy_binding), event_name}
+                                     const std::string_view event_name,
+                                     std::unique_ptr<GenericProxyEventBinding> proxy_binding)
+    : ProxyEventBase{base, event_name, ProxyBaseView{base}.GetBinding(), std::move(proxy_binding)}
 {
     ProxyBaseView proxy_base_view{base};
     if (!binding_base_)

--- a/score/mw/com/impl/generic_proxy_event.h
+++ b/score/mw/com/impl/generic_proxy_event.h
@@ -47,8 +47,8 @@ class GenericProxyEvent : public ProxyEventBase
     ///
     /// \param proxy_binding The binding that shall be associated with this proxy.
     explicit GenericProxyEvent(ProxyBase& base,
-                               std::unique_ptr<GenericProxyEventBinding> proxy_binding,
-                               const std::string_view event_name);
+                               const std::string_view event_name,
+                               std::unique_ptr<GenericProxyEventBinding> proxy_binding);
 
     /// \brief Constructs a ProxyEvent by querying the base proxie's ProxyBinding for the respective ProxyEventBinding.
     ///

--- a/score/mw/com/impl/generic_proxy_event_test.cpp
+++ b/score/mw/com/impl/generic_proxy_event_test.cpp
@@ -87,7 +87,7 @@ TEST(GenericProxyEventTest, SamplePtrsToSlotDataAreConst)
     ProxyBase empty_proxy(std::make_unique<mock_binding::Proxy>(),
                           make_HandleType(make_InstanceIdentifier(kEmptyInstanceDeployment, kEmptyTypeDeployment)));
     GenericProxyEvent proxy_event{
-        empty_proxy, std::unique_ptr<GenericProxyEventBinding>{std::move(mock_proxy_event_ptr)}, kEventName};
+        empty_proxy, kEventName, std::unique_ptr<GenericProxyEventBinding>{std::move(mock_proxy_event_ptr)}};
 
     EXPECT_CALL(mock_proxy_event, Subscribe(max_num_samples));
     EXPECT_CALL(mock_proxy_event, GetNewSamples(_, _));
@@ -120,7 +120,7 @@ TEST(GenericProxyEventDeathTest, DieOnProxyDestructionWhileHoldingSamplePtrs)
     ProxyBase empty_proxy(std::make_unique<mock_binding::Proxy>(),
                           make_HandleType(make_InstanceIdentifier(kEmptyInstanceDeployment, kEmptyTypeDeployment)));
     auto proxy_event = std::make_unique<GenericProxyEvent>(
-        empty_proxy, std::unique_ptr<GenericProxyEventBinding>{std::move(mock_proxy_event_ptr)}, kEventName);
+        empty_proxy, kEventName, std::unique_ptr<GenericProxyEventBinding>{std::move(mock_proxy_event_ptr)});
 
     EXPECT_CALL(mock_proxy_event, Subscribe(max_num_samples));
     EXPECT_CALL(mock_proxy_event, GetNewSamples(_, _));
@@ -158,7 +158,7 @@ TEST(GenericProxyEventGetSampleSizeTest, GetSampleSizeDispatchesToBinding)
     ProxyBase empty_proxy(std::make_unique<mock_binding::Proxy>(),
                           make_HandleType(make_InstanceIdentifier(kEmptyInstanceDeployment, kEmptyTypeDeployment)));
     GenericProxyEvent proxy_event{
-        empty_proxy, std::unique_ptr<GenericProxyEventBinding>{std::move(mock_proxy_event_ptr)}, kEventName};
+        empty_proxy, kEventName, std::unique_ptr<GenericProxyEventBinding>{std::move(mock_proxy_event_ptr)}};
 
     // Expect that GetSampleSize is called once on the binding
     EXPECT_CALL(mock_proxy_event, GetSampleSize()).WillOnce(Return(expected_sample_size));
@@ -186,7 +186,7 @@ TEST(GenericProxyEventHasSerializedFormatTest, HasSerializedFormatDispatchesToBi
     ProxyBase empty_proxy(std::make_unique<mock_binding::Proxy>(),
                           make_HandleType(make_InstanceIdentifier(kEmptyInstanceDeployment, kEmptyTypeDeployment)));
     GenericProxyEvent proxy_event{
-        empty_proxy, std::unique_ptr<GenericProxyEventBinding>{std::move(mock_proxy_event_ptr)}, kEventName};
+        empty_proxy, kEventName, std::unique_ptr<GenericProxyEventBinding>{std::move(mock_proxy_event_ptr)}};
 
     // Expect that HasSerializedFormat is called once on the binding
     EXPECT_CALL(mock_proxy_event, HasSerializedFormat()).WillOnce(Return(expected_has_serialized_format));
@@ -217,7 +217,7 @@ TEST(GenericProxyEventGetNewSamplesTest, GetNewSamplesContainsCorrectReceiverSig
     ProxyBase empty_proxy(std::make_unique<mock_binding::Proxy>(),
                           make_HandleType(make_InstanceIdentifier(kEmptyInstanceDeployment, kEmptyTypeDeployment)));
     GenericProxyEvent proxy_event{
-        empty_proxy, std::unique_ptr<GenericProxyEventBinding>{std::move(mock_proxy_event_ptr)}, kEventName};
+        empty_proxy, kEventName, std::unique_ptr<GenericProxyEventBinding>{std::move(mock_proxy_event_ptr)}};
 
     // Expect that GetNewSamples is called once on the binding
     EXPECT_CALL(mock_proxy_event, GetNewSamples(_, _))

--- a/score/mw/com/impl/method_type.h
+++ b/score/mw/com/impl/method_type.h
@@ -19,26 +19,6 @@
 namespace score::mw::com::impl
 {
 
-namespace detail
-{
-
-/// \brief Tag types used on ProxyField/SkeletonField level to accomplish overload-resolution for various signatures,
-/// which depend on the availability of Get/Set/Notifier.
-struct EnableBothTag
-{
-};
-struct EnableGetOnlyTag
-{
-};
-struct EnableSetOnlyTag
-{
-};
-struct EnableNeitherTag
-{
-};
-
-}  // namespace detail
-
 /// \brief Enum used to differentiate between regular service methods and field Get/Set methods.
 enum class MethodType : std::uint8_t
 {

--- a/score/mw/com/impl/methods/proxy_method_base.h
+++ b/score/mw/com/impl/methods/proxy_method_base.h
@@ -32,8 +32,8 @@ class ProxyMethodBase
 {
   public:
     ProxyMethodBase(ProxyBase& proxy_base,
-                    std::unique_ptr<ProxyMethodBinding> proxy_method_binding,
                     std::string_view method_name,
+                    std::unique_ptr<ProxyMethodBinding> proxy_method_binding,
                     MethodType method_type = MethodType::kMethod) noexcept
         : proxy_base_{proxy_base},
           method_name_{method_name},

--- a/score/mw/com/impl/methods/proxy_method_test.cpp
+++ b/score/mw/com/impl/methods/proxy_method_test.cpp
@@ -88,7 +88,7 @@ class ProxyMethodTestFixture : public ::testing::Test
     ProxyMethodTestFixture& GivenAValidProxyMethod()
     {
         unit_ = std::make_unique<ProxyServiceMethodType>(
-            proxy_base_, std::make_unique<mock_binding::ProxyMethodFacade>(proxy_method_binding_mock_), kMethodName);
+            proxy_base_, kMethodName, std::make_unique<mock_binding::ProxyMethodFacade>(proxy_method_binding_mock_));
         return *this;
     }
 
@@ -160,8 +160,8 @@ TYPED_TEST(ProxyMethodAllArgCombinationsTestFixture, Construction)
     // Then the ProxyMethod can be constructed
     using ProxyMethodType = ProxyMethod<TypeParam>;
     ProxyMethodType{this->proxy_base_,
-                    std::make_unique<mock_binding::ProxyMethodFacade>(this->proxy_method_binding_mock_),
-                    kMethodName};
+                    kMethodName,
+                    std::make_unique<mock_binding::ProxyMethodFacade>(this->proxy_method_binding_mock_)};
 }
 
 TYPED_TEST(ProxyMethodAllArgCombinationsTestFixture, WhenMoveConstructingProxyMethodUpdateMethodIsCalled)
@@ -171,8 +171,8 @@ TYPED_TEST(ProxyMethodAllArgCombinationsTestFixture, WhenMoveConstructingProxyMe
     // Given a proxy method
     auto proxy_method =
         ProxyMethodType{this->proxy_base_,
-                        std::make_unique<mock_binding::ProxyMethodFacade>(this->proxy_method_binding_mock_),
-                        kMethodName};
+                        kMethodName,
+                        std::make_unique<mock_binding::ProxyMethodFacade>(this->proxy_method_binding_mock_)};
 
     // When movie-constructing this method
     auto moved_method{std::move(proxy_method)};
@@ -190,15 +190,15 @@ TYPED_TEST(ProxyMethodAllArgCombinationsTestFixture, WhenMoveAssigningProxyMetho
     // Given a proxy method
     auto proxy_method =
         ProxyMethodType{this->proxy_base_,
-                        std::make_unique<mock_binding::ProxyMethodFacade>(this->proxy_method_binding_mock_),
-                        kMethodName};
+                        kMethodName,
+                        std::make_unique<mock_binding::ProxyMethodFacade>(this->proxy_method_binding_mock_)};
 
     ProxyBase other_proxy_base = {std::make_unique<mock_binding::Proxy>(), this->config_store_.GetHandle()};
 
     auto other_proxy_method =
         ProxyMethodType{other_proxy_base,
-                        std::make_unique<mock_binding::ProxyMethodFacade>(this->proxy_method_binding_mock_),
-                        "this_method_will_be_overwritten_soon"};
+                        "this_method_will_be_overwritten_soon",
+                        std::make_unique<mock_binding::ProxyMethodFacade>(this->proxy_method_binding_mock_)};
 
     // When move-assigning this method
     other_proxy_method = std::move(proxy_method);
@@ -218,8 +218,8 @@ TYPED_TEST(ProxyMethodAllArgCombinationsTestFixture,
     // Given a proxy method
     auto proxy_method =
         ProxyMethodType{this->proxy_base_,
-                        std::make_unique<mock_binding::ProxyMethodFacade>(this->proxy_method_binding_mock_),
-                        kMethodName};
+                        kMethodName,
+                        std::make_unique<mock_binding::ProxyMethodFacade>(this->proxy_method_binding_mock_)};
 
     auto same_method_ptr = &proxy_method;
     // When move-assigning this method to itself
@@ -263,7 +263,7 @@ TYPED_TEST(ProxyMethodAllArgCombinationsTestFixture, InvalidBindingInConstructor
     using ProxyMethodType = ProxyMethod<TypeParam>;
 
     // When a proxy method is created with an invalid binding
-    auto proxy_method = std::make_unique<ProxyMethodType>(this->proxy_base_, nullptr, kMethodName);
+    auto proxy_method = std::make_unique<ProxyMethodType>(this->proxy_base_, kMethodName, nullptr);
 
     // Then calling AreBindingsValid returns false
     EXPECT_FALSE(ProxyBaseView{this->proxy_base_}.AreBindingsValid());

--- a/score/mw/com/impl/methods/proxy_method_with_in_args.h
+++ b/score/mw/com/impl/methods/proxy_method_with_in_args.h
@@ -52,18 +52,18 @@ class ProxyMethod<void(ArgTypes...)> final : public ProxyMethodBase
   public:
     ProxyMethod(ProxyBase& proxy_base, std::string_view method_name) noexcept
         : ProxyMethod(proxy_base,
+                      method_name,
                       ProxyMethodBindingFactory<void(ArgTypes...)>::Create(proxy_base.GetHandle(),
                                                                            ProxyBaseView{proxy_base}.GetBinding(),
                                                                            method_name,
-                                                                           MethodType::kMethod),
-                      method_name)
+                                                                           MethodType::kMethod))
     {
     }
 
     ProxyMethod(ProxyBase& proxy_base,
-                std::unique_ptr<ProxyMethodBinding> proxy_method_binding,
-                std::string_view method_name) noexcept
-        : ProxyMethodBase(proxy_base, std::move(proxy_method_binding), method_name, MethodType::kMethod),
+                std::string_view method_name,
+                std::unique_ptr<ProxyMethodBinding> proxy_method_binding) noexcept
+        : ProxyMethodBase(proxy_base, method_name, std::move(proxy_method_binding), MethodType::kMethod),
           are_in_arg_ptrs_active_(kCallQueueSize)
     {
         auto proxy_base_view = ProxyBaseView{proxy_base};

--- a/score/mw/com/impl/methods/proxy_method_with_in_args_and_return.h
+++ b/score/mw/com/impl/methods/proxy_method_with_in_args_and_return.h
@@ -40,7 +40,7 @@
 namespace score::mw::com::impl
 {
 
-template <typename, bool, bool, bool>
+template <typename, typename...>
 class ProxyField;
 
 /// \brief Partial specialization of ProxyMethod for function signatures with arguments and non-void return
@@ -55,15 +55,10 @@ class ProxyMethod<ReturnType(ArgTypes...)> final : public ProxyMethodBase
     // coverity[autosar_cpp14_a11_3_1_violation]
     friend class ProxyMethodView;
 
-    /// gtodo: check this.
-    friend class ProxyField<ReturnType, false, false, false>;
-    friend class ProxyField<ReturnType, false, false, true>;
-    friend class ProxyField<ReturnType, false, true, false>;
-    friend class ProxyField<ReturnType, false, true, true>;
-    friend class ProxyField<ReturnType, true, false, false>;
-    friend class ProxyField<ReturnType, true, false, true>;
-    friend class ProxyField<ReturnType, true, true, false>;
-    friend class ProxyField<ReturnType, true, true, true>;
+    // ProxyField needs to instantiate ProxyMethod via the private FieldOnlyConstructorEnabler tag.
+    // coverity[autosar_cpp14_a11_3_1_violation]
+    template <typename, typename...>
+    friend class ProxyField;
 
     struct FieldOnlyConstructorEnabler
     {

--- a/score/mw/com/impl/methods/proxy_method_with_in_args_and_return.h
+++ b/score/mw/com/impl/methods/proxy_method_with_in_args_and_return.h
@@ -68,11 +68,11 @@ class ProxyMethod<ReturnType(ArgTypes...)> final : public ProxyMethodBase
     ProxyMethod(ProxyBase& proxy_base, std::string_view method_name) noexcept
         : ProxyMethodBase(
               proxy_base,
+              method_name,
               ProxyMethodBindingFactory<ReturnType(ArgTypes...)>::Create(proxy_base.GetHandle(),
                                                                          ProxyBaseView{proxy_base}.GetBinding(),
                                                                          method_name,
                                                                          MethodType::kMethod),
-              method_name,
               MethodType::kMethod),
           are_in_arg_ptrs_active_(kCallQueueSize)
     {
@@ -86,9 +86,9 @@ class ProxyMethod<ReturnType(ArgTypes...)> final : public ProxyMethodBase
     }
 
     ProxyMethod(ProxyBase& proxy_base,
-                std::unique_ptr<ProxyMethodBinding> proxy_method_binding,
-                std::string_view method_name) noexcept
-        : ProxyMethodBase(proxy_base, std::move(proxy_method_binding), method_name, MethodType::kMethod),
+                std::string_view method_name,
+                std::unique_ptr<ProxyMethodBinding> proxy_method_binding) noexcept
+        : ProxyMethodBase(proxy_base, method_name, std::move(proxy_method_binding), MethodType::kMethod),
           are_in_arg_ptrs_active_(kCallQueueSize)
     {
         auto proxy_base_view = ProxyBaseView{proxy_base};
@@ -101,10 +101,10 @@ class ProxyMethod<ReturnType(ArgTypes...)> final : public ProxyMethodBase
     }
 
     ProxyMethod(ProxyBase& proxy_base,
-                std::unique_ptr<ProxyMethodBinding> proxy_method_binding,
                 std::string_view method_name,
+                std::unique_ptr<ProxyMethodBinding> proxy_method_binding,
                 FieldOnlyConstructorEnabler) noexcept
-        : ProxyMethodBase(proxy_base, std::move(proxy_method_binding), method_name, MethodType::kSet),
+        : ProxyMethodBase(proxy_base, method_name, std::move(proxy_method_binding), MethodType::kSet),
           are_in_arg_ptrs_active_(kCallQueueSize)
     {
         auto proxy_base_view = ProxyBaseView{proxy_base};

--- a/score/mw/com/impl/methods/proxy_method_with_in_args_and_return.h
+++ b/score/mw/com/impl/methods/proxy_method_with_in_args_and_return.h
@@ -55,10 +55,15 @@ class ProxyMethod<ReturnType(ArgTypes...)> final : public ProxyMethodBase
     // coverity[autosar_cpp14_a11_3_1_violation]
     friend class ProxyMethodView;
 
-    friend class ProxyField<ReturnType, true, true, true>;
-    friend class ProxyField<ReturnType, true, true, false>;
+    /// gtodo: check this.
+    friend class ProxyField<ReturnType, false, false, false>;
+    friend class ProxyField<ReturnType, false, false, true>;
     friend class ProxyField<ReturnType, false, true, false>;
     friend class ProxyField<ReturnType, false, true, true>;
+    friend class ProxyField<ReturnType, true, false, false>;
+    friend class ProxyField<ReturnType, true, false, true>;
+    friend class ProxyField<ReturnType, true, true, false>;
+    friend class ProxyField<ReturnType, true, true, true>;
 
     struct FieldOnlyConstructorEnabler
     {

--- a/score/mw/com/impl/methods/proxy_method_with_return_type.h
+++ b/score/mw/com/impl/methods/proxy_method_with_return_type.h
@@ -49,6 +49,13 @@ class ProxyMethod<ReturnType()> final : public ProxyMethodBase
     // This enables us to hide unnecessary internals from the end-user.
     // coverity[autosar_cpp14_a11_3_1_violation]
     friend class ProxyMethodView;
+    friend class ProxyField<ReturnType, false, false, false>;
+    friend class ProxyField<ReturnType, false, false, true>;
+    friend class ProxyField<ReturnType, false, true, false>;
+    friend class ProxyField<ReturnType, false, true, true>;
+    friend class ProxyField<ReturnType, true, false, false>;
+    friend class ProxyField<ReturnType, true, false, true>;
+    friend class ProxyField<ReturnType, true, true, false>;
     friend class ProxyField<ReturnType, true, true, true>;
     friend class ProxyField<ReturnType, true, false, false>;
     friend class ProxyField<ReturnType, true, true, false>;

--- a/score/mw/com/impl/methods/proxy_method_with_return_type.h
+++ b/score/mw/com/impl/methods/proxy_method_with_return_type.h
@@ -61,11 +61,11 @@ class ProxyMethod<ReturnType()> final : public ProxyMethodBase
   public:
     ProxyMethod(ProxyBase& proxy_base, std::string_view method_name) noexcept
         : ProxyMethodBase(proxy_base,
+                          method_name,
                           ProxyMethodBindingFactory<ReturnType()>::Create(proxy_base.GetHandle(),
                                                                           ProxyBaseView{proxy_base}.GetBinding(),
                                                                           method_name,
                                                                           MethodType::kMethod),
-                          method_name,
                           MethodType::kMethod)
     {
         auto proxy_base_view = ProxyBaseView{proxy_base};
@@ -78,9 +78,9 @@ class ProxyMethod<ReturnType()> final : public ProxyMethodBase
     }
 
     ProxyMethod(ProxyBase& proxy_base,
-                std::unique_ptr<ProxyMethodBinding> proxy_method_binding,
-                std::string_view method_name) noexcept
-        : ProxyMethodBase(proxy_base, std::move(proxy_method_binding), method_name, MethodType::kMethod)
+                std::string_view method_name,
+                std::unique_ptr<ProxyMethodBinding> proxy_method_binding) noexcept
+        : ProxyMethodBase(proxy_base, method_name, std::move(proxy_method_binding), MethodType::kMethod)
     {
         auto proxy_base_view = ProxyBaseView{proxy_base};
         proxy_base_view.RegisterMethod(method_name_, *this);
@@ -92,10 +92,10 @@ class ProxyMethod<ReturnType()> final : public ProxyMethodBase
     }
 
     ProxyMethod(ProxyBase& proxy_base,
-                std::unique_ptr<ProxyMethodBinding> proxy_method_binding,
                 std::string_view method_name,
+                std::unique_ptr<ProxyMethodBinding> proxy_method_binding,
                 FieldOnlyConstructorEnabler) noexcept
-        : ProxyMethodBase(proxy_base, std::move(proxy_method_binding), method_name, MethodType::kGet)
+        : ProxyMethodBase(proxy_base, method_name, std::move(proxy_method_binding), MethodType::kGet)
     {
         auto proxy_base_view = ProxyBaseView{proxy_base};
         if (binding_ == nullptr)

--- a/score/mw/com/impl/methods/proxy_method_with_return_type.h
+++ b/score/mw/com/impl/methods/proxy_method_with_return_type.h
@@ -36,7 +36,7 @@
 namespace score::mw::com::impl
 {
 
-template <typename, bool, bool, bool>
+template <typename, typename...>
 class ProxyField;
 
 /// \brief Partial specialization of ProxyMethod for function signatures with no arguments and non-void return
@@ -49,17 +49,11 @@ class ProxyMethod<ReturnType()> final : public ProxyMethodBase
     // This enables us to hide unnecessary internals from the end-user.
     // coverity[autosar_cpp14_a11_3_1_violation]
     friend class ProxyMethodView;
-    friend class ProxyField<ReturnType, false, false, false>;
-    friend class ProxyField<ReturnType, false, false, true>;
-    friend class ProxyField<ReturnType, false, true, false>;
-    friend class ProxyField<ReturnType, false, true, true>;
-    friend class ProxyField<ReturnType, true, false, false>;
-    friend class ProxyField<ReturnType, true, false, true>;
-    friend class ProxyField<ReturnType, true, true, false>;
-    friend class ProxyField<ReturnType, true, true, true>;
-    friend class ProxyField<ReturnType, true, false, false>;
-    friend class ProxyField<ReturnType, true, true, false>;
-    friend class ProxyField<ReturnType, true, false, true>;
+
+    // ProxyField needs to instantiate ProxyMethod via the private FieldOnlyConstructorEnabler tag.
+    // coverity[autosar_cpp14_a11_3_1_violation]
+    template <typename, typename...>
+    friend class ProxyField;
 
     struct FieldOnlyConstructorEnabler
     {

--- a/score/mw/com/impl/methods/proxy_method_without_in_args_or_return.h
+++ b/score/mw/com/impl/methods/proxy_method_without_in_args_or_return.h
@@ -46,11 +46,11 @@ class ProxyMethod<void()> final : public ProxyMethodBase
   public:
     ProxyMethod(ProxyBase& proxy_base, std::string_view method_name) noexcept
         : ProxyMethodBase(proxy_base,
+                          method_name,
                           ProxyMethodBindingFactory<void()>::Create(proxy_base.GetHandle(),
                                                                     ProxyBaseView{proxy_base}.GetBinding(),
                                                                     method_name,
                                                                     MethodType::kMethod),
-                          method_name,
                           MethodType::kMethod)
     {
         auto proxy_base_view = ProxyBaseView{proxy_base};
@@ -63,9 +63,9 @@ class ProxyMethod<void()> final : public ProxyMethodBase
     }
 
     ProxyMethod(ProxyBase& proxy_base,
-                std::unique_ptr<ProxyMethodBinding> proxy_method_binding,
-                std::string_view method_name) noexcept
-        : ProxyMethodBase(proxy_base, std::move(proxy_method_binding), method_name, MethodType::kMethod)
+                std::string_view method_name,
+                std::unique_ptr<ProxyMethodBinding> proxy_method_binding) noexcept
+        : ProxyMethodBase(proxy_base, method_name, std::move(proxy_method_binding), MethodType::kMethod)
     {
         auto proxy_base_view = ProxyBaseView{proxy_base};
         proxy_base_view.RegisterMethod(method_name_, *this);

--- a/score/mw/com/impl/methods/skeleton_method.h
+++ b/score/mw/com/impl/methods/skeleton_method.h
@@ -31,7 +31,7 @@
 namespace score::mw::com::impl
 {
 
-template <typename, bool, bool>
+template <typename, typename...>
 class SkeletonField;
 
 template <typename Signature>
@@ -53,7 +53,7 @@ class SkeletonMethod<ReturnType(ArgTypes...)> final : public SkeletonMethodBase
     static_assert(return_value_is_not_a_pointer,
                   "Return value can not be a pointer, since we can not put them in shared memory.");
 
-    template <typename, bool, bool>
+    template <typename, typename...>
     // coverity[autosar_cpp14_a11_3_1_violation]
     friend class SkeletonField;
 

--- a/score/mw/com/impl/mocking/proxy_event_mock_test.cpp
+++ b/score/mw/com/impl/mocking/proxy_event_mock_test.cpp
@@ -66,7 +66,7 @@ struct ProxyEventStruct
 
 struct ProxyFieldStruct
 {
-    using ProxyEventField = ProxyField<TestSampleType>;
+    using ProxyEventField = ProxyField<TestSampleType, WithGetter, WithSetter, WithNotifier>;
     using ProxyEventFieldMock = ProxyEventMock<TestSampleType>;
 };
 

--- a/score/mw/com/impl/mocking/proxy_event_mock_test.cpp
+++ b/score/mw/com/impl/mocking/proxy_event_mock_test.cpp
@@ -54,8 +54,8 @@ class ProxyEventFieldMockFixture : public ::testing::Test
     ProxyEventFieldMock proxy_service_element_mock_{};
     ProxyBase proxy_base_{nullptr, MakeFakeHandle(1U)};
     ProxyEventField unit_{proxy_base_,
-                          std::unique_ptr<ProxyEventBinding<TestSampleType>>{nullptr},
-                          kDummyEventFieldName};
+                          kDummyEventFieldName,
+                          std::unique_ptr<ProxyEventBinding<TestSampleType>>{nullptr}};
 };
 
 struct ProxyEventStruct

--- a/score/mw/com/impl/mocking/proxy_wrapper_class_test_view_test.cpp
+++ b/score/mw/com/impl/mocking/proxy_wrapper_class_test_view_test.cpp
@@ -54,7 +54,8 @@ class MyInterface : public InterfaceTrait::Base
 
     typename InterfaceTrait::template Event<TestEventType> some_event{*this, kEventName};
     typename InterfaceTrait::template Event<TestEventType2> some_event_2{*this, kEventName2};
-    typename InterfaceTrait::template Field<TestFieldType> some_field{*this, kFieldName};
+    typename InterfaceTrait::template Field<TestFieldType, WithGetter, WithNotifier, WithSetter> some_field{*this,
+                                                                                                            kFieldName};
 };
 using MyProxy = AsProxy<MyInterface>;
 
@@ -244,7 +245,8 @@ class FieldOnlyInterface : public InterfaceTrait::Base
   public:
     using InterfaceTrait::Base::Base;
 
-    typename InterfaceTrait::template Field<TestFieldType> some_field{*this, kFieldName};
+    typename InterfaceTrait::template Field<TestFieldType, WithGetter, WithNotifier, WithSetter> some_field{*this,
+                                                                                                            kFieldName};
 };
 using FieldOnlyProxy = AsProxy<FieldOnlyInterface>;
 

--- a/score/mw/com/impl/mocking/skeleton_field_mock.h
+++ b/score/mw/com/impl/mocking/skeleton_field_mock.h
@@ -20,7 +20,7 @@
 namespace score::mw::com::impl
 {
 
-template <typename SampleType>
+template <typename SampleType, typename... Tags>
 class SkeletonFieldMock : public ISkeletonField<SampleType>
 {
   public:

--- a/score/mw/com/impl/mocking/skeleton_field_mock_test.cpp
+++ b/score/mw/com/impl/mocking/skeleton_field_mock_test.cpp
@@ -41,7 +41,7 @@ class SkeletonFieldMockFixture : public ::testing::Test
 
     SkeletonFieldMock<TestSampleType> skeleton_field_mock_{};
     SkeletonBase skeleton_base_{nullptr, MakeFakeInstanceIdentifier(1U)};
-    SkeletonField<TestSampleType> unit_{skeleton_base_, kDummyFieldName, nullptr};
+    SkeletonField<TestSampleType, WithGetter, WithNotifier, WithSetter> unit_{skeleton_base_, kDummyFieldName, nullptr};
 };
 
 TEST_F(SkeletonFieldMockFixture, AllocateDispatchesToMockAfterInjectingMock)

--- a/score/mw/com/impl/mocking/skeleton_wrapper_class_test_view.h
+++ b/score/mw/com/impl/mocking/skeleton_wrapper_class_test_view.h
@@ -52,14 +52,14 @@ class NamedSkeletonEventMock
     SkeletonEventMock<EventType> mock;
 };
 
-template <typename FieldType>
+template <typename FieldType, typename... Tags>
 class NamedSkeletonFieldMock
 {
   public:
     NamedSkeletonFieldMock(const std::string_view field_name_in) : field_name{field_name_in}, mock{} {}
 
     std::string_view field_name;
-    SkeletonFieldMock<FieldType> mock;
+    SkeletonFieldMock<FieldType, Tags...> mock;
 };
 
 template <typename SkeletonWrapperClass>
@@ -85,10 +85,10 @@ class SkeletonWrapperClassTestView
     /// @param event_mocks A tuple containing a NamedEventMock per event in the interface.
     /// @param field_mocks A tuple containing a NamedFieldMock per event in the interface.
     /// @return SkeletonWrapperClass containing mocked skeleton and mocked events / fields.
-    template <typename... EventTypes, typename... FieldTypes>
+    template <typename... EventTypes, typename... FieldTypes, typename... Tags>
     static SkeletonWrapperClass Create(SkeletonBaseMock& skeleton_mock,
                                        std::tuple<NamedSkeletonEventMock<EventTypes>...>& event_mocks,
-                                       std::tuple<NamedSkeletonFieldMock<FieldTypes>...>& field_mocks)
+                                       std::tuple<NamedSkeletonFieldMock<FieldTypes, Tags...>...>& field_mocks)
     {
         // Create service element binding factory guards which inject mocks into the binding factories. We rely on the
         // default behaviour that calls to Create on the factories will return nullptrs. This is required since the real
@@ -117,9 +117,9 @@ class SkeletonWrapperClassTestView
     }
 
     /// @brief Test-only Create call which can be used when an interface does not contain any events.
-    template <typename... FieldTypes>
+    template <typename... FieldTypes, typename... Tags>
     static SkeletonWrapperClass Create(SkeletonBaseMock& skeleton_mock,
-                                       std::tuple<NamedSkeletonFieldMock<FieldTypes>...>& field_mocks)
+                                       std::tuple<NamedSkeletonFieldMock<FieldTypes, Tags...>...>& field_mocks)
     {
         // Since empty_event_mocks is passed to Create as a non-const reference, when this function returns, the
         // reference to empty_event_mocks will be dangling. However, since its empty, the tuple and its contents are not
@@ -156,19 +156,20 @@ class SkeletonWrapperClassTestView
         typed_event->InjectMock(mock);
     }
 
-    template <typename SampleType>
-    static void InjectFieldMock(SkeletonFieldBase& field_base, SkeletonFieldMock<SampleType>& mock)
+    template <typename SampleType, typename... Tags>
+    static void InjectFieldMock(SkeletonFieldBase& field_base, SkeletonFieldMock<SampleType, Tags...>& mock)
     {
-        auto* typed_field = dynamic_cast<SkeletonField<SampleType>*>(&field_base);
+        auto* typed_field = dynamic_cast<SkeletonField<SampleType, Tags...>*>(&field_base);
         SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(typed_field != nullptr,
                                                           "field_base should always be a fully typed SkeletonField");
         typed_field->InjectMock(mock);
     }
 
-    template <typename... EventTypes, typename... FieldTypes>
+    template <typename... EventTypes, typename... FieldTypes, typename... Tags>
     static void InjectEventAndFieldMocks(SkeletonWrapperClass& skeleton,
                                          std::tuple<NamedSkeletonEventMock<EventTypes>...>& event_mocks,
-                                         std::tuple<NamedSkeletonFieldMock<FieldTypes>...>& field_mocks)
+                                         std::tuple<NamedSkeletonFieldMock<FieldTypes, Tags...>...>& field_mocks)
+
     {
         auto& events = SkeletonBaseView{skeleton}.GetEvents();
         auto& fields = SkeletonBaseView{skeleton}.GetFields();

--- a/score/mw/com/impl/mocking/skeleton_wrapper_class_test_view_test.cpp
+++ b/score/mw/com/impl/mocking/skeleton_wrapper_class_test_view_test.cpp
@@ -59,7 +59,8 @@ class MyInterface : public InterfaceTrait::Base
 
     typename InterfaceTrait::template Event<TestEventType> some_event{*this, kEventName};
     typename InterfaceTrait::template Event<TestEventType2> some_event_2{*this, kEventName2};
-    typename InterfaceTrait::template Field<TestFieldType> some_field{*this, kFieldName};
+    typename InterfaceTrait::template Field<TestFieldType, WithGetter, WithNotifier, WithSetter> some_field{*this,
+                                                                                                            kFieldName};
 };
 using MySkeleton = AsSkeleton<MyInterface>;
 
@@ -235,7 +236,7 @@ TEST_F(SkeletonWrapperTestClassCreateFixture, CreatingMockSkeletonWithAllEventsA
     SkeletonBaseMock skeleton_mock{};
     std::tuple<NamedSkeletonEventMock<TestEventType>, NamedSkeletonEventMock<TestEventType2>> events_tuple{kEventName,
                                                                                                            kEventName2};
-    std::tuple<NamedSkeletonFieldMock<TestFieldType>> fields_tuple{kFieldName};
+    std::tuple<NamedSkeletonFieldMock<TestFieldType, WithGetter, WithNotifier, WithSetter>> fields_tuple{kFieldName};
 
     // When creating a mocked skeleton
     auto skeleton = SkeletonWrapperClassTestView<MySkeleton>::Create(skeleton_mock, events_tuple, fields_tuple);
@@ -249,7 +250,7 @@ TEST_F(SkeletonWrapperTestClassCreateFixture, CallingFunctionsOnMockSkeletonDisp
     SkeletonBaseMock skeleton_mock{};
     std::tuple<NamedSkeletonEventMock<TestEventType>, NamedSkeletonEventMock<TestEventType2>> events_tuple{kEventName,
                                                                                                            kEventName2};
-    std::tuple<NamedSkeletonFieldMock<TestFieldType>> fields_tuple{kFieldName};
+    std::tuple<NamedSkeletonFieldMock<TestFieldType, WithGetter, WithNotifier, WithSetter>> fields_tuple{kFieldName};
 
     // and a mocked skeleton
     auto skeleton = SkeletonWrapperClassTestView<MySkeleton>::Create(skeleton_mock, events_tuple, fields_tuple);
@@ -320,7 +321,8 @@ class FieldOnlyInterface : public InterfaceTrait::Base
   public:
     using InterfaceTrait::Base::Base;
 
-    typename InterfaceTrait::template Field<TestFieldType> some_field{*this, kFieldName};
+    typename InterfaceTrait::template Field<TestFieldType, WithGetter, WithNotifier, WithSetter> some_field{*this,
+                                                                                                            kFieldName};
 };
 using FieldOnlySkeleton = AsSkeleton<FieldOnlyInterface>;
 
@@ -329,7 +331,7 @@ TEST_F(SkeletonWrapperTestClassFieldsOnlyCreateFixture, CreatingMockSkeletonWith
 {
     // Given a SkeletonBaseMock and a mock per Field
     SkeletonBaseMock skeleton_mock{};
-    std::tuple<NamedSkeletonFieldMock<TestFieldType>> fields_tuple{kFieldName};
+    std::tuple<NamedSkeletonFieldMock<TestFieldType, WithGetter, WithNotifier, WithSetter>> fields_tuple{kFieldName};
 
     // When creating a mocked skeleton
     auto skeleton = SkeletonWrapperClassTestView<FieldOnlySkeleton>::Create(skeleton_mock, fields_tuple);
@@ -341,7 +343,7 @@ TEST_F(SkeletonWrapperTestClassFieldsOnlyCreateFixture, CallingFunctionsOnMockSk
 {
     // Given a SkeletonBaseMock and a mock per Field
     SkeletonBaseMock skeleton_mock{};
-    std::tuple<NamedSkeletonFieldMock<TestFieldType>> fields_tuple{kFieldName};
+    std::tuple<NamedSkeletonFieldMock<TestFieldType, WithGetter, WithNotifier, WithSetter>> fields_tuple{kFieldName};
 
     // and given a mocked skeleton was created
     auto skeleton = SkeletonWrapperClassTestView<FieldOnlySkeleton>::Create(skeleton_mock, fields_tuple);

--- a/score/mw/com/impl/mocking/skeleton_wrapper_class_test_view_test.cpp
+++ b/score/mw/com/impl/mocking/skeleton_wrapper_class_test_view_test.cpp
@@ -13,6 +13,7 @@
 #include "score/mw/com/impl/mocking/skeleton_wrapper_class_test_view.h"
 
 #include "score/mw/com/impl/com_error.h"
+#include "score/mw/com/impl/field_tags.h"
 #include "score/mw/com/impl/instance_identifier.h"
 #include "score/mw/com/impl/instance_specifier.h"
 #include "score/mw/com/impl/mocking/skeleton_base_mock.h"

--- a/score/mw/com/impl/proxy_base.cpp
+++ b/score/mw/com/impl/proxy_base.cpp
@@ -186,7 +186,7 @@ void ProxyBase::Deinitialize()
     }
     for (auto& field : fields_)
     {
-        field.second.get().Unsubscribe();
+        ProxyFieldBaseView{field.second.get()}.Unsubscribe();
     }
     if (proxy_binding_ != nullptr)
     {

--- a/score/mw/com/impl/proxy_base_test.cpp
+++ b/score/mw/com/impl/proxy_base_test.cpp
@@ -593,27 +593,27 @@ class ProxyBaseServiceElementReferencesFixture : public ::testing::Test
     MyProxy proxy_{std::make_unique<mock_binding::ProxyFacade>(proxy_binding_mock_), handle_};
 
     ProxyEventBase event_0_{proxy_,
+                            event_name_0_,
                             &proxy_binding_mock_,
-                            std::make_unique<mock_binding::ProxyEventBase>(),
-                            event_name_0_};
+                            std::make_unique<mock_binding::ProxyEventBase>()};
     ProxyEventBase event_1_{proxy_,
+                            event_name_1_,
                             &proxy_binding_mock_,
-                            std::make_unique<mock_binding::ProxyEventBase>(),
-                            event_name_1_};
+                            std::make_unique<mock_binding::ProxyEventBase>()};
 
     ProxyEventBase field_event_dispatch_0_{proxy_,
+                                           field_name_0_,
                                            &proxy_binding_mock_,
-                                           std::make_unique<mock_binding::ProxyEventBase>(),
-                                           field_name_0_};
+                                           std::make_unique<mock_binding::ProxyEventBase>()};
     ProxyEventBase field_event_dispatch_1_{proxy_,
+                                           field_name_1_,
                                            &proxy_binding_mock_,
-                                           std::make_unique<mock_binding::ProxyEventBase>(),
-                                           field_name_1_};
-    ProxyFieldBase field_0_{proxy_, &field_event_dispatch_0_, field_name_0_};
-    ProxyFieldBase field_1_{proxy_, &field_event_dispatch_1_, field_name_1_};
+                                           std::make_unique<mock_binding::ProxyEventBase>()};
+    ProxyFieldBase field_0_{proxy_, field_name_0_, &field_event_dispatch_0_};
+    ProxyFieldBase field_1_{proxy_, field_name_1_, &field_event_dispatch_1_};
 
-    DummyProxyMethod method_0_{proxy_, std::make_unique<mock_binding::ProxyMethod>(), method_name_0_};
-    DummyProxyMethod method_1_{proxy_, std::make_unique<mock_binding::ProxyMethod>(), method_name_1_};
+    DummyProxyMethod method_0_{proxy_, method_name_0_, std::make_unique<mock_binding::ProxyMethod>()};
+    DummyProxyMethod method_1_{proxy_, method_name_1_, std::make_unique<mock_binding::ProxyMethod>()};
 };
 
 TEST_F(ProxyBaseServiceElementReferencesFixture, RegisteringServiceElementStoresReferenceInMap)
@@ -707,11 +707,11 @@ TEST_F(ProxyBaseServiceElementReferencesFixture, MoveAssigningUpdatesReferencesT
 
     // and given that an Event, Field and Method were registered on the second proxy
     ProxyEventBase event{
-        proxy_2, &proxy_binding_mock, std::make_unique<mock_binding::ProxyEventBase>(), other_event_name};
+        proxy_2, other_event_name, &proxy_binding_mock, std::make_unique<mock_binding::ProxyEventBase>()};
     ProxyEventBase field_event_dispatch{
-        proxy_2, &proxy_binding_mock, std::make_unique<mock_binding::ProxyEventBase>(), other_field_name};
-    ProxyFieldBase field{proxy_2, &field_event_dispatch, other_field_name};
-    DummyProxyMethod method{proxy_2, std::make_unique<mock_binding::ProxyMethod>(), other_method_name};
+        proxy_2, other_field_name, &proxy_binding_mock, std::make_unique<mock_binding::ProxyEventBase>()};
+    ProxyFieldBase field{proxy_2, other_field_name, &field_event_dispatch};
+    DummyProxyMethod method{proxy_2, other_method_name, std::make_unique<mock_binding::ProxyMethod>()};
     ProxyBaseView{proxy_2}.RegisterEvent(other_event_name, event);
     ProxyBaseView{proxy_2}.RegisterField(other_field_name, field);
     ProxyBaseView{proxy_2}.RegisterMethod(other_method_name, method);

--- a/score/mw/com/impl/proxy_event.h
+++ b/score/mw/com/impl/proxy_event.h
@@ -80,8 +80,8 @@ class ProxyEvent final : public ProxyEventBase
     ///
     /// \param proxy_binding The binding that shall be associated with this proxy.
     ProxyEvent(ProxyBase& base,
-               std::unique_ptr<ProxyEventBinding<SampleType>> proxy_event_binding,
-               const std::string_view event_name);
+               const std::string_view event_name,
+               std::unique_ptr<ProxyEventBinding<SampleType>> proxy_event_binding);
 
     /// \brief Constructor that allows to set the binding directly.
     ///
@@ -89,8 +89,8 @@ class ProxyEvent final : public ProxyEventBase
     ///
     /// \param proxy_binding The binding that shall be associated with this proxy.
     ProxyEvent(ProxyBase& base,
-               std::unique_ptr<ProxyEventBinding<SampleType>> proxy_binding,
                const std::string_view event_name,
+               std::unique_ptr<ProxyEventBinding<SampleType>> proxy_binding,
                FieldOnlyConstructorEnabler);
 
     /// \brief Constructs a ProxyEvent by querying the base proxie's ProxyBinding for the respective ProxyEventBinding.
@@ -143,9 +143,9 @@ class ProxyEvent final : public ProxyEventBase
 
 template <typename SampleType>
 ProxyEvent<SampleType>::ProxyEvent(ProxyBase& base,
-                                   std::unique_ptr<ProxyEventBinding<SampleType>> proxy_event_binding,
-                                   const std::string_view event_name)
-    : ProxyEventBase{base, ProxyBaseView{base}.GetBinding(), std::move(proxy_event_binding), event_name},
+                                   const std::string_view event_name,
+                                   std::unique_ptr<ProxyEventBinding<SampleType>> proxy_event_binding)
+    : ProxyEventBase{base, event_name, ProxyBaseView{base}.GetBinding(), std::move(proxy_event_binding)},
       proxy_event_mock_{nullptr}
 {
     ProxyBaseView proxy_base_view{base};
@@ -158,7 +158,7 @@ ProxyEvent<SampleType>::ProxyEvent(ProxyBase& base,
 
 template <typename SampleType>
 ProxyEvent<SampleType>::ProxyEvent(ProxyBase& base, const std::string_view event_name)
-    : ProxyEvent{base, ProxyEventBindingFactory<SampleType>::Create(base, event_name), event_name}
+    : ProxyEvent{base, event_name, ProxyEventBindingFactory<SampleType>::Create(base, event_name)}
 {
     if (GetTypedEventBinding() != nullptr)
     {
@@ -171,10 +171,10 @@ ProxyEvent<SampleType>::ProxyEvent(ProxyBase& base, const std::string_view event
 
 template <typename SampleType>
 ProxyEvent<SampleType>::ProxyEvent(ProxyBase& base,
-                                   std::unique_ptr<ProxyEventBinding<SampleType>> proxy_binding,
                                    const std::string_view event_name,
+                                   std::unique_ptr<ProxyEventBinding<SampleType>> proxy_binding,
                                    FieldOnlyConstructorEnabler)
-    : ProxyEvent{base, std::move(proxy_binding), event_name}
+    : ProxyEvent{base, event_name, std::move(proxy_binding)}
 {
     // This is the specific ctor that is used by ProxyField for its "dispatch event" composite. Therefore, we do not
     // register the event in the ProxyBase's event map, since registration in the correct field map is done by

--- a/score/mw/com/impl/proxy_event.h
+++ b/score/mw/com/impl/proxy_event.h
@@ -40,7 +40,7 @@ namespace score::mw::com::impl
 // False Positive: this is a normal forward declaration.
 // Which is used to avoid cyclic dependency with proxy_field.h
 // coverity[autosar_cpp14_m3_2_3_violation]
-template <typename, bool, bool, bool>
+template <typename, typename...>
 class ProxyField;
 
 /// \brief This is the user-visible class of an event that is part of a proxy. It contains ProxyEvent functionality that
@@ -62,7 +62,7 @@ class ProxyEvent final : public ProxyEventBase
     // Design decission: ProxyField uses composition pattern to reuse code from ProxyEvent. These two classes also have
     // shared private APIs which necessitates the use of the friend keyword.
     // coverity[autosar_cpp14_a11_3_1_violation]
-    template <typename, bool, bool, bool>
+    template <typename, typename...>
     friend class ProxyField;
 
     // Empty struct that is used to make the second constructor only accessible to ProxyField (as it is a friend).

--- a/score/mw/com/impl/proxy_event_base.cpp
+++ b/score/mw/com/impl/proxy_event_base.cpp
@@ -78,9 +78,9 @@ class EventBindingRegistrationGuard final
 // This is false positive. Function is declared only once.
 // coverity[autosar_cpp14_a3_1_1_violation]
 ProxyEventBase::ProxyEventBase(ProxyBase& proxy_base,
+                               std::string_view event_name,
                                ProxyBinding* proxy_binding_ptr,
-                               std::unique_ptr<ProxyEventBindingBase> proxy_event_binding,
-                               std::string_view event_name) noexcept
+                               std::unique_ptr<ProxyEventBindingBase> proxy_event_binding) noexcept
     : binding_base_{std::move(proxy_event_binding)},
       proxy_base_(proxy_base),
       event_name_{event_name},

--- a/score/mw/com/impl/proxy_event_base.h
+++ b/score/mw/com/impl/proxy_event_base.h
@@ -61,9 +61,9 @@ class ProxyEventBase
     /// \param proxy_event_binding The binding that shall be associated with this proxy event.
     /// \param event_name Event name of the event.
     ProxyEventBase(ProxyBase& proxy_base,
+                   std::string_view event_name,
                    ProxyBinding* proxy_binding_ptr,
-                   std::unique_ptr<ProxyEventBindingBase> proxy_event_binding,
-                   std::string_view event_name) noexcept;
+                   std::unique_ptr<ProxyEventBindingBase> proxy_event_binding) noexcept;
 
     /// \brief A ProxyEventBase shall not be copyable
     ProxyEventBase(const ProxyEventBase&) = delete;

--- a/score/mw/com/impl/proxy_event_base_test.cpp
+++ b/score/mw/com/impl/proxy_event_base_test.cpp
@@ -74,7 +74,7 @@ class ProxyEventBaseFixture : public ::testing::Test
         mock_service_element_binding_ = mock_service_element_binding_ptr.get();
 
         service_element_ =
-            std::make_unique<ServiceElementType>(empty_proxy_, std::move(mock_service_element_binding_ptr), kEventName);
+            std::make_unique<ServiceElementType>(empty_proxy_, kEventName, std::move(mock_service_element_binding_ptr));
 
         ON_CALL(*mock_service_element_binding_, SetReceiveHandler(_)).WillByDefault(Return(score::Result<void>{}));
         ON_CALL(*mock_service_element_binding_, Subscribe(_)).WillByDefault(Return(score::Result<void>{}));
@@ -166,7 +166,7 @@ TYPED_TEST(ProxyEventBaseCreationFixture, CreatingServiceElementWithValidEventBi
 
     // When creating a ProxyEvent with a valid binding
     auto service_element = std::make_unique<typename ProxyEventBaseCreationFixture<TypeParam>::ServiceElementType>(
-        dummy_proxy, std::move(valid_proxy_event_binding), kEventName);
+        dummy_proxy, kEventName, std::move(valid_proxy_event_binding));
 
     // Then the proxy should report that all bindings are valid
     EXPECT_TRUE(dummy_proxy.AreBindingsValid());
@@ -181,8 +181,8 @@ TYPED_TEST(ProxyEventBaseCreationFixture, CreatingServiceElementWithInvalidEvent
     // When creating a ProxyEvent with an invalid binding
     auto service_element = std::make_unique<typename ProxyEventBaseCreationFixture<TypeParam>::ServiceElementType>(
         dummy_proxy,
-        std::unique_ptr<typename ProxyEventBaseCreationFixture<TypeParam>::MockServiceElementType>(nullptr),
-        kEventName);
+        kEventName,
+        std::unique_ptr<typename ProxyEventBaseCreationFixture<TypeParam>::MockServiceElementType>(nullptr));
 
     // Then the proxy should report that all bindings are not valid
     EXPECT_FALSE(dummy_proxy.AreBindingsValid());
@@ -199,7 +199,7 @@ TYPED_TEST(ProxyEventBaseCreationFixture, CreatingServiceElementWithInvalidProxy
 
     // When creating a ProxyEvent with a valid binding
     auto service_element = std::make_unique<typename ProxyEventBaseCreationFixture<TypeParam>::ServiceElementType>(
-        dummy_proxy, std::move(valid_proxy_event_binding), kEventName);
+        dummy_proxy, kEventName, std::move(valid_proxy_event_binding));
 
     // Then the proxy should report that all bindings are not valid
     EXPECT_FALSE(dummy_proxy.AreBindingsValid());
@@ -225,7 +225,7 @@ TYPED_TEST(ProxyEventBaseCreationFixture,
 
     // When creating a ProxyEvent with a valid binding
     auto service_element = std::make_unique<typename ProxyEventBaseCreationFixture<TypeParam>::ServiceElementType>(
-        dummy_proxy, std::move(valid_proxy_event_binding), kEventName);
+        dummy_proxy, kEventName, std::move(valid_proxy_event_binding));
 }
 
 TYPED_TEST(ProxyEventBaseCreationFixture,
@@ -246,8 +246,8 @@ TYPED_TEST(ProxyEventBaseCreationFixture,
     // When creating a ProxyEvent with an invalid binding
     auto service_element = std::make_unique<typename ProxyEventBaseCreationFixture<TypeParam>::ServiceElementType>(
         dummy_proxy,
-        std::unique_ptr<typename ProxyEventBaseCreationFixture<TypeParam>::MockServiceElementType>(nullptr),
-        kEventName);
+        kEventName,
+        std::unique_ptr<typename ProxyEventBaseCreationFixture<TypeParam>::MockServiceElementType>(nullptr));
 }
 
 TYPED_TEST(ProxyEventBaseUnsubscribeFixture, CallingUnsubscribeWhileSubscribedCallsUnsubscribeOnBinding)
@@ -392,7 +392,7 @@ class AServiceElement : public ::testing::Test
         mock_service_element_binding_ = mock_service_element_binding_ptr.get();
 
         service_element_ =
-            std::make_unique<ServiceElementType>(empty_proxy_, std::move(mock_service_element_binding_ptr), kEventName);
+            std::make_unique<ServiceElementType>(empty_proxy_, kEventName, std::move(mock_service_element_binding_ptr));
         ASSERT_NE(service_element_, nullptr);
 
         ON_CALL(*mock_service_element_binding_, SetReceiveHandler(_)).WillByDefault(Return(score::Result<void>{}));
@@ -1074,7 +1074,7 @@ TEST(ProxyEventBaseTest, MoveConstructingProxyEventDoesNotCrash)
 
     // Given a Service Element, that is connected to a mock binding
     ProxyEventBase dummy_event{
-        empty_proxy, ProxyBaseView{empty_proxy}.GetBinding(), std::move(mock_proxy_event_binding_ptr), kEventName};
+        empty_proxy, kEventName, ProxyBaseView{empty_proxy}.GetBinding(), std::move(mock_proxy_event_binding_ptr)};
 
     // And a new Service Element is created with the move constructor
     ProxyEventBase dummy_event_2{std::move(dummy_event)};
@@ -1100,13 +1100,13 @@ TEST(ProxyEventBaseTest, MoveAssigningProxyEventDoesNotCrash)
 
     // Given a Service Element, that is connected to a mock binding
     ProxyEventBase dummy_event{
-        empty_proxy, ProxyBaseView{empty_proxy}.GetBinding(), std::move(mock_proxy_event_binding_ptr), kEventName};
+        empty_proxy, kEventName, ProxyBaseView{empty_proxy}.GetBinding(), std::move(mock_proxy_event_binding_ptr)};
 
     // And a new Service Element is created and move assigned
     ProxyEventBase dummy_event_2{empty_proxy,
+                                 kEventName2,
                                  ProxyBaseView{empty_proxy}.GetBinding(),
-                                 std::make_unique<StrictMock<mock_binding::ProxyEventBase>>(),
-                                 kEventName2};
+                                 std::make_unique<StrictMock<mock_binding::ProxyEventBase>>()};
     dummy_event_2 = std::move(dummy_event);
 
     // Expect that Subscribe is called on the binding only once
@@ -1130,7 +1130,7 @@ TEST(ProxyEventBaseTest, SetSubscriptionStateChangeHandlerWorks)
 
     // Given a Service Element, that is connected to a mock binding
     ProxyEventBase dummy_event{
-        empty_proxy, ProxyBaseView{empty_proxy}.GetBinding(), std::move(mock_proxy_event_binding_ptr), kEventName};
+        empty_proxy, kEventName, ProxyBaseView{empty_proxy}.GetBinding(), std::move(mock_proxy_event_binding_ptr)};
 
     // Expect that SetSubscriptionStateChangeHandler is called
     EXPECT_CALL(mock_proxy_event_binding, SetSubscriptionStateChangeHandler).WillOnce(Return(score::Result<void>{}));
@@ -1152,7 +1152,7 @@ TEST(ProxyEventBaseTest, UnsetSubscriptionStateChangeHandlerWorks)
 
     // Given a Service Element, that is connected to a mock binding
     ProxyEventBase dummy_event{
-        empty_proxy, ProxyBaseView{empty_proxy}.GetBinding(), std::move(mock_proxy_event_binding_ptr), kEventName};
+        empty_proxy, kEventName, ProxyBaseView{empty_proxy}.GetBinding(), std::move(mock_proxy_event_binding_ptr)};
 
     // Expect that UnsetSubscriptionStateChangeHandler is called
     EXPECT_CALL(mock_proxy_event_binding, UnsetSubscriptionStateChangeHandler).WillOnce(Return(score::Result<void>{}));

--- a/score/mw/com/impl/proxy_event_base_test.cpp
+++ b/score/mw/com/impl/proxy_event_base_test.cpp
@@ -100,7 +100,7 @@ struct GenericProxyEventStruct
 
 struct ProxyFieldStruct
 {
-    using ServiceElementType = ProxyField<TestEventOrFieldType>;
+    using ServiceElementType = ProxyField<TestEventOrFieldType, WithGetter, WithNotifier, WithSetter>;
     using MockServiceElementType = mock_binding::ProxyEvent<TestEventOrFieldType>;
 };
 

--- a/score/mw/com/impl/proxy_event_test.cpp
+++ b/score/mw/com/impl/proxy_event_test.cpp
@@ -106,7 +106,7 @@ class ProxyEventFixture : public ::testing::Test
                        make_HandleType(make_InstanceIdentifier(kEmptyInstanceDeployment, kEmptyTypeDeployment))},
           mock_proxy_event_ptr_{std::make_unique<MockProxyEventType>()},
           mock_proxy_event_{*mock_proxy_event_ptr_},
-          proxy_event_{empty_proxy_, std::move(mock_proxy_event_ptr_), kEventName}
+          proxy_event_{empty_proxy_, kEventName, std::move(mock_proxy_event_ptr_)}
     {
         ON_CALL(mock_proxy_event_, Subscribe(_)).WillByDefault(Return(score::Result<void>{}));
     }
@@ -319,7 +319,7 @@ TYPED_TEST(ProxyEventFixture, CanConstructUnboundProxy)
 
     // When creating an unbound proxy event (note we need a different event name here as the fixture already uses the
     // first)
-    ProxyEvent<typename Base::SampleType> proxy_event{this->empty_proxy_, nullptr, kEventName2};
+    ProxyEvent<typename Base::SampleType> proxy_event{this->empty_proxy_, kEventName2, nullptr};
     // Nothing bad happens
 }
 
@@ -464,7 +464,7 @@ TEST(ProxyEventTest, SamplePtrsToSlotDataAreConst)
     ProxyBase empty_proxy(std::make_unique<mock_binding::Proxy>(),
                           make_HandleType(make_InstanceIdentifier(kEmptyInstanceDeployment, kEmptyTypeDeployment)));
     ProxyEvent<SampleType> proxy{
-        empty_proxy, std::unique_ptr<ProxyEventBinding<SampleType>>{std::move(mock_proxy_ptr)}, kEventName};
+        empty_proxy, kEventName, std::unique_ptr<ProxyEventBinding<SampleType>>{std::move(mock_proxy_ptr)}};
 
     EXPECT_CALL(mock_proxy, Subscribe(max_num_samples));
     EXPECT_CALL(mock_proxy, GetNewSamples(_, _));
@@ -497,7 +497,7 @@ TEST(ProxyEventDeathTest, DieOnProxyDestructionWhileHoldingSamplePtrs)
     ProxyBase empty_proxy(std::make_unique<mock_binding::Proxy>(),
                           make_HandleType(make_InstanceIdentifier(kEmptyInstanceDeployment, kEmptyTypeDeployment)));
     auto proxy = std::make_unique<ProxyEvent<SampleType>>(
-        empty_proxy, std::unique_ptr<ProxyEventBinding<SampleType>>{std::move(mock_proxy_ptr)}, kEventName);
+        empty_proxy, kEventName, std::unique_ptr<ProxyEventBinding<SampleType>>{std::move(mock_proxy_ptr)});
 
     EXPECT_CALL(mock_proxy, Subscribe(max_num_samples));
     EXPECT_CALL(mock_proxy, GetNewSamples(_, _));
@@ -559,7 +559,7 @@ TEST_F(ProxyEventMoveAssignmentTest, MoveAssignmentTransfersBindingFromSourceToD
     auto second_binding_facade = std::make_unique<mock_binding::ProxyEventFacade<SampleType>>(second_binding_mock);
 
     // Given two registered ProxyEvents, each with their own binding mock
-    ProxyEventType second_event{empty_proxy_, std::move(second_binding_facade), kEventName2};
+    ProxyEventType second_event{empty_proxy_, kEventName2, std::move(second_binding_facade)};
     ProxyBaseView{empty_proxy_}.RegisterEvent(kEventName, proxy_event_);
     ProxyBaseView{empty_proxy_}.RegisterEvent(kEventName2, second_event);
 

--- a/score/mw/com/impl/proxy_event_test.cpp
+++ b/score/mw/com/impl/proxy_event_test.cpp
@@ -83,7 +83,7 @@ struct GenericProxyEventStruct
 struct ProxyFieldStruct
 {
     using SampleType = TestSampleType;
-    using ProxyEventType = ProxyField<TestSampleType>;
+    using ProxyEventType = ProxyField<TestSampleType, WithGetter, WithNotifier, WithSetter>;
     using MockProxyEventType = NiceMock<mock_binding::ProxyEvent<TestSampleType>>;
 };
 

--- a/score/mw/com/impl/proxy_field.h
+++ b/score/mw/com/impl/proxy_field.h
@@ -13,6 +13,7 @@
 #ifndef SCORE_MW_COM_IMPL_PROXY_FIELD_H
 #define SCORE_MW_COM_IMPL_PROXY_FIELD_H
 
+#include "score/mw/com/impl/field_tags.h"
 #include "score/mw/com/impl/methods/proxy_method_with_in_args_and_return.h"
 #include "score/mw/com/impl/methods/proxy_method_with_return_type.h"
 #include "score/mw/com/impl/plumbing/proxy_field_binding_factory.h"
@@ -38,140 +39,105 @@ namespace score::mw::com::impl
 // Suppress "AUTOSAR C++14 M3-2-3" rule finding. This rule states: "An identifier with external linkage shall have
 // exactly one definition". This a forward class declaration.
 // coverity[autosar_cpp14_m3_2_3_violation]
-template <typename FieldType>
+template <typename FieldType, typename... Tags>
 class ProxyFieldAttorney;
 
 /// \brief This is the user-visible class of a field that is part of a proxy. It delegates all functionality to
 /// ProxyEvent.
 ///
-/// \tparam SampleDataType Type of data that is transferred by the event.
-/// \tparam EnableGet Whether the get method shall be enabled for this field. If true, a Get() method will be available.
-/// \tparam EnableSet Whether the set method shall be enabled for this field. If true, a Set() method will be available.
-/// \tparam EnableNotifier Whether the notifier functionality shall be enabled for this field. Whether this has an
-/// effect, depends on the binding that is used. The LoLa/shm-binding ignores this template parameter.
-template <typename SampleDataType,
-          const bool EnableGet = false,
-          const bool EnableSet = false,
-          const bool EnableNotifier = false>
+/// \tparam SampleDataType Type of data carried by the field.
+/// \tparam Tags Pack of marker tags from field_tags.h. Any combination of WithGetter, WithSetter, WithNotifier is
+///         supported, subject to the static_assert below: at least one of WithGetter or WithNotifier must be
+///         present (otherwise the value is invisible to consumers). WithGetter enables Get(), WithSetter enables
+///         Set(), WithNotifier enables the notifier methods Subscribe(), Unsubscribe(), GetSubscriptionState(),
+///         GetFreeSampleCount(), GetNumNewSamplesAvailable(), SetReceiveHandler(), UnsetReceiveHandler(),
+///         GetNewSamples().
+template <typename SampleDataType, typename... Tags>
 class ProxyField final : public ProxyFieldBase
 {
+
+    // A ProxyField must enable WithGetter or WithNotifier. A field with only WithSetter (or no tags at all)
+    // gives the consumer no way to observe the value it can write, making the field useless.
+    static_assert(
+        contains_type<WithNotifier, Tags...>::value || contains_type<WithGetter, Tags...>::value,
+        "A field must either have WithGetter or WithNotifier enabled otherwise, there is no way for the consumer to "
+        "receive the field values.");
+
     // Suppress "AUTOSAR C++14 A11-3-1", The rule declares: "Friend declarations shall not be used".
     // Design decision: The "*Attorney" class is a helper, which sets the internal state of this class accessing
     // private members and used for testing purposes only.
     // coverity[autosar_cpp14_a11_3_1_violation]
-    friend class ProxyFieldAttorney<SampleDataType>;
+    friend class ProxyFieldAttorney<SampleDataType, Tags...>;
 
   public:
     using FieldType = SampleDataType;
 
-    /// Constructor that allows to set the binding directly (both EnableGet and EnableSet are true).
-    ///
-    /// This is used for testing only. Allows for directly setting the bindings, and usually the mock binding is used
-    /// here.
+    /// \brief Testing ctor that delegates to the production ctor that accepts mock bindings directly, this can only be
+    /// used in test code.
+    /// \details The template tags do not gate this overload; they continue to control which parts of the public
+    ///          API (Get, Set, Subscribe, ...) are available on the resulting object. The event binding parameter
+    ///          is required (non default) to disambiguate this overload from the production ctor.
+    /// \param proxy_base Parent proxy that owns this field's registration.
+    /// \param field_name Field's name as it appears in the deployment.
+    /// \param event_binding Mock event binding. Must be provided (use nullptr if no event binding is needed).
+    /// \param set_method_binding Optional mock Set-method binding. If nullptr, no ProxyMethod is built for Set
+    ///        (same MarkServiceElementBindingInvalid avoidance as get_method_binding).
+    /// \param get_method_binding Optional mock Get-method binding. If nullptr, no ProxyMethod is built for Get;
+    ///        this avoids the ProxyMethod ctor calling ProxyBaseView::MarkServiceElementBindingInvalid() on the
+    ///        parent, which would otherwise make AreBindingsValid() return false during proxy construction.
     ProxyField(ProxyBase& proxy_base,
                const std::string_view field_name,
                std::unique_ptr<ProxyEventBinding<FieldType>> event_binding,
-               std::unique_ptr<ProxyMethodBinding> get_method_binding = nullptr,
                std::unique_ptr<ProxyMethodBinding> set_method_binding = nullptr,
-               detail::EnableBothTag = {})
-        : ProxyField{
-              proxy_base,
-              field_name,
-              std::make_unique<ProxyEvent<FieldType>>(proxy_base, field_name, std::move(event_binding)),
-              // If a binding is not provided, then we don't create the method. This ensures that the ProxyMethod
-              // doesn't report that the binding is invalid (via proxy_base_view.MarkServiceElementBindingInvalid())
-              get_method_binding == nullptr ? nullptr
-                                            : std::make_unique<ProxyMethod<FieldType()>>(
-                                                  proxy_base,
-                                                  field_name,
-                                                  std::move(get_method_binding),
-                                                  typename ProxyMethod<FieldType()>::FieldOnlyConstructorEnabler{}),
-              set_method_binding == nullptr
-                  ? nullptr
-                  : std::make_unique<ProxyMethod<FieldType(FieldType)>>(
-                        proxy_base,
-                        field_name,
-                        std::move(set_method_binding),
-                        typename ProxyMethod<FieldType(FieldType)>::FieldOnlyConstructorEnabler{})}
+               std::unique_ptr<ProxyMethodBinding> get_method_binding = nullptr)
+        : ProxyField{proxy_base,
+                     field_name,
+                     std::make_unique<ProxyEvent<FieldType>>(proxy_base, field_name, std::move(event_binding)),
+                     set_method_binding == nullptr
+                         ? nullptr
+                         : std::make_unique<ProxyMethod<FieldType(FieldType)>>(
+                               proxy_base,
+                               field_name,
+                               std::move(set_method_binding),
+                               typename ProxyMethod<FieldType(FieldType)>::FieldOnlyConstructorEnabler{}),
+                     get_method_binding == nullptr
+                         ? nullptr
+                         : std::make_unique<ProxyMethod<FieldType()>>(
+                               proxy_base,
+                               field_name,
+                               std::move(get_method_binding),
+                               typename ProxyMethod<FieldType()>::FieldOnlyConstructorEnabler{})}
     {
     }
 
-    /// \brief Constructs a ProxyField (both EnableGet and EnableSet are true). Normal ctor that is used in production
-    /// code.
-    template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<EG && ES>>
-    ProxyField(ProxyBase& proxy_base, const std::string_view field_name, detail::EnableBothTag = {})
+    /// \brief Production ctor used by the end users.
+    /// \details The Make*IfEnabled helpers consult the tag pack at compile time and return nullptr when their
+    ///          corresponding tag is absent, so the same body produces the correct dispatch for every valid
+    ///          tag combination. The class-level static_assert ensures that at least one of WithGetter or
+    ///          WithNotifier is present.
+    /// \param proxy_base Parent proxy that owns this field's registration.
+    /// \param field_name Field's name as it appears in the deployment.
+    ProxyField(ProxyBase& proxy_base, const std::string_view field_name)
         : ProxyField{proxy_base,
                      field_name,
-                     std::make_unique<ProxyEvent<FieldType>>(
-                         proxy_base,
-                         field_name,
-                         ProxyFieldBindingFactory<FieldType>::CreateEventBinding(proxy_base, field_name),
-                         typename ProxyEvent<FieldType>::FieldOnlyConstructorEnabler{}),
-                     std::make_unique<ProxyMethod<FieldType()>>(
-                         proxy_base,
-                         field_name,
-                         ProxyFieldBindingFactory<FieldType>::CreateGetMethodBinding(proxy_base, field_name),
-                         typename ProxyMethod<FieldType()>::FieldOnlyConstructorEnabler{}),
-                     std::make_unique<ProxyMethod<FieldType(FieldType)>>(
-                         proxy_base,
-                         field_name,
-                         ProxyFieldBindingFactory<FieldType>::CreateSetMethodBinding(proxy_base, field_name),
-                         typename ProxyMethod<FieldType(FieldType)>::FieldOnlyConstructorEnabler{})}
+                     MakeEventDispatchIfEnabled(proxy_base, field_name),
+                     MakeSetMethodDispatchIfEnabled(proxy_base, field_name),
+                     MakeGetMethodDispatchIfEnabled(proxy_base, field_name)}
     {
-    }
-
-    /// \brief Constructs a ProxyField (only EnableGet is true). Normal ctor that is used in production code.
-    template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<EG && !ES>>
-    ProxyField(ProxyBase& proxy_base, const std::string_view field_name, detail::EnableGetOnlyTag = {})
-        : ProxyField{proxy_base,
-                     field_name,
-                     std::make_unique<ProxyEvent<FieldType>>(
-                         proxy_base,
-                         field_name,
-                         ProxyFieldBindingFactory<FieldType>::CreateEventBinding(proxy_base, field_name),
-                         typename ProxyEvent<FieldType>::FieldOnlyConstructorEnabler{}),
-                     std::make_unique<ProxyMethod<FieldType()>>(
-                         proxy_base,
-                         field_name,
-                         ProxyFieldBindingFactory<FieldType>::CreateGetMethodBinding(proxy_base, field_name),
-                         typename ProxyMethod<FieldType()>::FieldOnlyConstructorEnabler{}),
-                     nullptr}
-    {
-    }
-
-    /// \brief Constructs a ProxyField (only EnableSet is true). Normal ctor that is used in production code.
-    template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<!EG && ES>>
-    ProxyField(ProxyBase& proxy_base, const std::string_view field_name, detail::EnableSetOnlyTag = {})
-        : ProxyField{proxy_base,
-                     field_name,
-                     std::make_unique<ProxyEvent<FieldType>>(
-                         proxy_base,
-                         field_name,
-                         ProxyFieldBindingFactory<FieldType>::CreateEventBinding(proxy_base, field_name),
-                         typename ProxyEvent<FieldType>::FieldOnlyConstructorEnabler{}),
-                     nullptr,
-                     std::make_unique<ProxyMethod<FieldType(FieldType)>>(
-                         proxy_base,
-                         field_name,
-                         ProxyFieldBindingFactory<FieldType>::CreateSetMethodBinding(proxy_base, field_name),
-                         typename ProxyMethod<FieldType(FieldType)>::FieldOnlyConstructorEnabler{})}
-    {
-    }
-
-    /// \brief Constructs a ProxyField (both EnableGet and EnableSet are false). Normal ctor that is used in production
-    /// code.
-    template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<!EG && !ES>>
-    ProxyField(ProxyBase& proxy_base, const std::string_view field_name, detail::EnableNeitherTag = {})
-        : ProxyField{proxy_base,
-                     field_name,
-                     std::make_unique<ProxyEvent<FieldType>>(
-                         proxy_base,
-                         field_name,
-                         ProxyFieldBindingFactory<FieldType>::CreateEventBinding(proxy_base, field_name),
-                         typename ProxyEvent<FieldType>::FieldOnlyConstructorEnabler{}),
-                     nullptr,
-                     nullptr}
-    {
+        // Each Make*IfEnabled must have produced a non-null dispatch when the
+        // corresponding tag is in the pack.
+        if constexpr (kHasNotifier)
+        {
+            SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(proxy_event_dispatch_ != nullptr);
+        }
+        if constexpr (kHasSetter)
+        {
+            SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(proxy_method_set_dispatch_ != nullptr);
+        }
+        if constexpr (kHasGetter)
+        {
+            SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(proxy_method_get_dispatch_ != nullptr);
+        }
     }
 
     /// \brief A ProxyField shall not be copyable
@@ -188,84 +154,290 @@ class ProxyField final : public ProxyFieldBase
      * \api
      * \brief Receive pending data from the field.
      * \details The user needs to provide a callable that fulfills the following signature:
-     *          void F(SamplePtr<const FieldType>) noexcept. This callback will be called for each sample
+     *          void(SamplePtr<const FieldType>) noexcept. This callback will be called for each sample
      *          that is available at the time of the call. Notice that the number of callback calls cannot
      *          exceed std::min(GetFreeSampleCount(), max_num_samples) times.
-     * \tparam F Callable with the signature void(SamplePtr<const FieldType>) noexcept
+     * \tparam ReceiverType Callable with the signature void(SamplePtr<const FieldType>) noexcept
      * \param receiver Callable with the appropriate signature. GetNewSamples will take ownership
      *                 of this callable.
      * \param max_num_samples Maximum number of samples to return via the given callable.
      * \return Number of samples that were handed over to the callable or an error.
      */
-    template <typename F>
-    Result<std::size_t> GetNewSamples(F&& receiver, const std::size_t max_num_samples) noexcept
+    template <typename ReceiverType,
+              typename T = SampleDataType,
+              typename = std::enable_if_t<is_tag_enabled<T, SampleDataType, WithNotifier, Tags...>::value>>
+    Result<std::size_t> GetNewSamples(ReceiverType&& receiver, const std::size_t max_num_samples) noexcept
     {
-        return proxy_event_dispatch_->GetNewSamples(std::forward<F>(receiver), max_num_samples);
+        return proxy_event_dispatch_->GetNewSamples(std::forward<ReceiverType>(receiver), max_num_samples);
     }
 
-    template <typename T = SampleDataType, typename = std::enable_if_t<EnableGet && std::is_same_v<T, SampleDataType>>>
+    /**
+     * \api
+     * \brief Subscribe to the field.
+     * \param max_sample_count Specify the maximum number of concurrent samples that this event shall
+     *                          be able to offer to the using application.
+     * \return On failure, returns an error code.
+     */
+    template <typename T = SampleDataType,
+              typename = std::enable_if_t<is_tag_enabled<T, SampleDataType, WithNotifier, Tags...>::value>>
+    Result<void> Subscribe(const std::size_t max_sample_count) noexcept
+    {
+        return ProxyFieldBase::Subscribe(max_sample_count);
+    }
+
+    /**
+     * \api
+     * \brief End subscription to a field and release needed resources.
+     * \details It is illegal to call this method while data is still held by the application in the form of SamplePtr.
+     *          Doing so will result in undefined behavior. After a call to this method, the field behaves as if it had
+     *          just been constructed.
+     */
+    template <typename T = SampleDataType,
+              typename = std::enable_if_t<is_tag_enabled<T, SampleDataType, WithNotifier, Tags...>::value>>
+    void Unsubscribe() noexcept
+    {
+        ProxyFieldBase::Unsubscribe();
+    }
+
+    /**
+     * \api
+     * \brief Get the subscription state of this field.
+     * \details This method can always be called regardless of the state of the field.
+     * \return Subscription state of the field.
+     */
+    template <typename T = SampleDataType,
+              typename = std::enable_if_t<is_tag_enabled<T, SampleDataType, WithNotifier, Tags...>::value>>
+    SubscriptionState GetSubscriptionState() noexcept
+    {
+        return ProxyFieldBase::GetSubscriptionState();
+    }
+
+    /**
+     * \api
+     * \brief Get the number of samples that can still be received by the user of this field.
+     * \details If this returns 0, the user first has to drop at least one SamplePtr before it is possible to receive
+     *          data via GetNewSamples again. If there is no subscription for this field, the returned value is
+     *          unspecified.
+     * \return Number of samples that can still be received.
+     */
+    template <typename T = SampleDataType,
+              typename = std::enable_if_t<is_tag_enabled<T, SampleDataType, WithNotifier, Tags...>::value>>
+    std::size_t GetFreeSampleCount() noexcept
+    {
+        return ProxyFieldBase::GetFreeSampleCount();
+    }
+
+    /**
+     * \api
+     * \brief Returns the number of new samples a call to GetNewSamples() (given parameter max_num_samples
+     *        doesn't restrict it) would currently provide.
+     * \details This is a proprietary extension to the official ara::com API. It is useful in resource sensitive
+     *          setups, where the user wants to work in polling mode only without registered async receive-handlers.
+     *          For further details see //score/mw/com/design/extensions/README.md.
+     * \return Either 0 if no new samples are available (and GetNewSamples() wouldn't return any) or N, where 1 <= N <=
+     *         actual new samples. I.e. an implementation is allowed to report a lower number than actual new samples,
+     *         which would be provided by a call to GetNewSamples().
+     */
+    template <typename T = SampleDataType,
+              typename = std::enable_if_t<is_tag_enabled<T, SampleDataType, WithNotifier, Tags...>::value>>
+    Result<std::size_t> GetNumNewSamplesAvailable() noexcept
+    {
+        return ProxyFieldBase::GetNumNewSamplesAvailable();
+    }
+
+    /**
+     * \api
+     * \brief Sets the handler to be called, whenever a new field value has been received.
+     * \details Generally a ReceiveHandler has no restrictions on what mw::com API it is allowed to call.
+     *          It is especially allowed to call all public APIs of the Field instance on which it had been
+     *          set/registered as long as it obeys the general requirement, that API calls on a Proxy/Proxy field are
+     *          thread safe/can't be called concurrently.
+     * \attention This function MUST NOT be called from the context of a ReceiveHandler registered for this field!
+     *            It makes semantically not really sense to register a "new" ReceiveHandler from the context of an
+     *            already running ReceiveHandler. We also see no use cases for it and won't support it therefore.
+     * \param handler user provided handler to be called
+     */
+    template <typename T = SampleDataType,
+              typename = std::enable_if_t<is_tag_enabled<T, SampleDataType, WithNotifier, Tags...>::value>>
+    Result<void> SetReceiveHandler(EventReceiveHandler handler) noexcept
+    {
+        return ProxyFieldBase::SetReceiveHandler(std::move(handler));
+    }
+
+    /**
+     * \api
+     * \brief Unsets/Unregisters a SubscriptionStateChangeHandler for this field. After this method returns, it is
+     *        guaranteed, that the previously registered handler is neither active nor will be called anymore.
+     */
+    template <typename T = SampleDataType,
+              typename = std::enable_if_t<is_tag_enabled<T, SampleDataType, WithNotifier, Tags...>::value>>
+    Result<void> UnsetSubscriptionStateChangeHandler() noexcept
+    {
+        return ProxyFieldBase::UnsetSubscriptionStateChangeHandler();
+    }
+
+    /**
+     * \api
+     * \brief Sets/Registers a SubscriptionStateChangeHandler for this event. This handler will be called whenever the
+     * subscription state of this event changes.
+     * \note An already set/registered SubscriptionStateChangeHandler will be silently overridden.
+     * \param handler
+     */
+    template <typename T = SampleDataType,
+              typename = std::enable_if_t<is_tag_enabled<T, SampleDataType, WithNotifier, Tags...>::value>>
+    Result<void> SetSubscriptionStateChangeHandler(SubscriptionStateChangeHandler handler) noexcept
+    {
+        return ProxyFieldBase::SetSubscriptionStateChangeHandler(std::move(handler));
+    }
+
+    /**
+     * \api
+     * \brief Removes any ReceiveHandler registered via SetReceiveHandler.
+     */
+    template <typename T = SampleDataType,
+              typename = std::enable_if_t<is_tag_enabled<T, SampleDataType, WithNotifier, Tags...>::value>>
+    Result<void> UnsetReceiveHandler() noexcept
+    {
+        return ProxyFieldBase::UnsetReceiveHandler();
+    }
+
+    /**
+     * \api
+     * \brief Get the current value of the field.
+     * \details This method is only available when the field is created with the WithGetter tag
+     */
+    template <typename T = SampleDataType,
+              typename = std::enable_if_t<is_tag_enabled<T, SampleDataType, WithGetter, Tags...>::value>>
     score::Result<MethodReturnTypePtr<T>> Get() noexcept
     {
         return proxy_method_get_dispatch_->operator()();
     }
 
-    template <typename T = SampleDataType, typename = std::enable_if_t<EnableSet && std::is_same_v<T, SampleDataType>>>
+    /**
+     * \api
+     * \brief Set a new value to the field.
+     * \details This method is only available when the field is created with the WithSetter tag
+     */
+    template <typename T = SampleDataType,
+              typename = std::enable_if_t<is_tag_enabled<T, SampleDataType, WithSetter, Tags...>::value>>
     score::Result<MethodReturnTypePtr<T>> Set(const SampleDataType& new_field_value) noexcept
     {
         return proxy_method_set_dispatch_->operator()(new_field_value);
     }
 
+    template <typename T = SampleDataType,
+              typename = std::enable_if_t<is_tag_enabled<T, SampleDataType, WithNotifier, Tags...>::value>>
     void InjectMock(IProxyEvent<FieldType>& proxy_event_mock)
     {
         proxy_event_dispatch_->InjectMock(proxy_event_mock);
     }
 
   private:
+    static constexpr bool kHasNotifier = contains_type<WithNotifier, Tags...>::value;
+    static constexpr bool kHasSetter = contains_type<WithSetter, Tags...>::value;
+    static constexpr bool kHasGetter = contains_type<WithGetter, Tags...>::value;
+
+    /// \brief Builds the proxy event dispatch via the binding factory when WithNotifier is enabled.
+    /// \return A valid ProxyEvent dispatch when WithNotifier is in the tag pack, nullptr otherwise.
+    static std::unique_ptr<ProxyEvent<FieldType>> MakeEventDispatchIfEnabled(ProxyBase& proxy_base,
+                                                                             const std::string_view field_name)
+    {
+        if constexpr (kHasNotifier)
+        {
+            return std::make_unique<ProxyEvent<FieldType>>(
+                proxy_base,
+                field_name,
+                ProxyFieldBindingFactory<FieldType>::CreateEventBinding(proxy_base, field_name),
+                typename ProxyEvent<FieldType>::FieldOnlyConstructorEnabler{});
+        }
+        else
+        {
+            return nullptr;
+        }
+    }
+
+    /// \brief Builds the Set-method dispatch via the binding factory when WithSetter is enabled.
+    /// \return A valid ProxyMethod dispatch when WithSetter is in the tag pack, nullptr otherwise.
+    static std::unique_ptr<ProxyMethod<FieldType(FieldType)>> MakeSetMethodDispatchIfEnabled(
+        ProxyBase& proxy_base,
+        const std::string_view field_name)
+    {
+        if constexpr (kHasSetter)
+        {
+            return std::make_unique<ProxyMethod<FieldType(FieldType)>>(
+                proxy_base,
+                field_name,
+                ProxyFieldBindingFactory<FieldType>::CreateSetMethodBinding(proxy_base, field_name),
+                typename ProxyMethod<FieldType(FieldType)>::FieldOnlyConstructorEnabler{});
+        }
+        else
+        {
+            return nullptr;
+        }
+    }
+
+    /// \brief Builds the Get-method dispatch via the binding factory when WithGetter is enabled.
+    /// \return A valid ProxyMethod dispatch when WithGetter is in the tag pack, nullptr otherwise.
+    static std::unique_ptr<ProxyMethod<FieldType()>> MakeGetMethodDispatchIfEnabled(ProxyBase& proxy_base,
+                                                                                    const std::string_view field_name)
+    {
+        if constexpr (kHasGetter)
+        {
+            return std::make_unique<ProxyMethod<FieldType()>>(
+                proxy_base,
+                field_name,
+                ProxyFieldBindingFactory<FieldType>::CreateGetMethodBinding(proxy_base, field_name),
+                typename ProxyMethod<FieldType()>::FieldOnlyConstructorEnabler{});
+        }
+        else
+        {
+            return nullptr;
+        }
+    }
+
     ProxyField(ProxyBase& proxy_base,
                const std::string_view field_name,
                std::unique_ptr<ProxyEvent<FieldType>> proxy_event_dispatch,
-               std::unique_ptr<ProxyMethod<FieldType()>> proxy_method_get_dispatch,
-               std::unique_ptr<ProxyMethod<FieldType(FieldType)>> proxy_method_set_dispatch)
+               std::unique_ptr<ProxyMethod<FieldType(FieldType)>> proxy_method_set_dispatch,
+               std::unique_ptr<ProxyMethod<FieldType()>> proxy_method_get_dispatch)
         : ProxyFieldBase{proxy_base, field_name, proxy_event_dispatch.get()},
           proxy_event_dispatch_{std::move(proxy_event_dispatch)},
-          proxy_method_get_dispatch_{std::move(proxy_method_get_dispatch)},
-          proxy_method_set_dispatch_{std::move(proxy_method_set_dispatch)}
+          proxy_method_set_dispatch_{std::move(proxy_method_set_dispatch)},
+          proxy_method_get_dispatch_{std::move(proxy_method_get_dispatch)}
     {
-        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(proxy_event_dispatch_ != nullptr);
-
         ProxyBaseView proxy_base_view{proxy_base};
         proxy_base_view.RegisterField(field_name, *this);
     }
 
     std::unique_ptr<ProxyEvent<FieldType>> proxy_event_dispatch_;
 
-    std::unique_ptr<ProxyMethod<FieldType()>> proxy_method_get_dispatch_;
     std::unique_ptr<ProxyMethod<FieldType(FieldType)>> proxy_method_set_dispatch_;
+    std::unique_ptr<ProxyMethod<FieldType()>> proxy_method_get_dispatch_;
 
     static_assert(std::is_same_v<decltype(proxy_event_dispatch_), std::unique_ptr<ProxyEvent<FieldType>>>,
                   "proxy_event_dispatch_ needs to be a unique_ptr since we pass a pointer to it to ProxyFieldBase, so "
                   "we must ensure that it doesn't move when the ProxyField is moved to avoid dangling references. ");
 };
 
-template <typename FieldType, const bool EnableGet, const bool EnableSet, const bool EnableNotifier>
-ProxyField<FieldType, EnableGet, EnableSet, EnableNotifier>::ProxyField(ProxyField&& other) noexcept
+template <typename SampleDataType, typename... Tags>
+ProxyField<SampleDataType, Tags...>::ProxyField(ProxyField&& other) noexcept
     : ProxyFieldBase(std::move(static_cast<ProxyFieldBase&&>(other))),
       proxy_event_dispatch_(std::move(other.proxy_event_dispatch_)),
-      proxy_method_get_dispatch_(std::move(other.proxy_method_get_dispatch_)),
-      proxy_method_set_dispatch_(std::move(other.proxy_method_set_dispatch_))
+      proxy_method_set_dispatch_(std::move(other.proxy_method_set_dispatch_)),
+      proxy_method_get_dispatch_(std::move(other.proxy_method_get_dispatch_))
 {
     ProxyBaseView proxy_base_view{proxy_base_.get()};
     proxy_base_view.UpdateField(field_name_, *this);
 }
 
-template <typename FieldType, const bool EnableGet, const bool EnableSet, const bool EnableNotifier>
+template <typename SampleDataType, typename... Tags>
 // Suppress "AUTOSAR C++14 A6-2-1" rule violation. The rule states "Move and copy assignment operators shall either move
 // or respectively copy base classes and data members of a class, without any side effects."
 // Rationale: The parent proxy stores a reference to the ProxyEvent. The address that is pointed to must be
 // updated when the ProxyField is moved. Therefore, side effects are required.
 // coverity[autosar_cpp14_a6_2_1_violation]
-auto ProxyField<FieldType, EnableGet, EnableSet, EnableNotifier>::operator=(ProxyField&& other) & noexcept
-    -> ProxyField<FieldType, EnableGet, EnableSet, EnableNotifier>&
+auto ProxyField<SampleDataType, Tags...>::operator=(ProxyField&& other) & noexcept
+    -> ProxyField<SampleDataType, Tags...>&
 {
     if (this != &other)
     {
@@ -274,8 +446,8 @@ auto ProxyField<FieldType, EnableGet, EnableSet, EnableNotifier>::operator=(Prox
         ProxyBaseView proxy_base_view{proxy_base_.get()};
         proxy_base_view.UpdateField(field_name_, *this);
         proxy_event_dispatch_ = std::move(other.proxy_event_dispatch_);
-        proxy_method_get_dispatch_ = std::move(other.proxy_method_get_dispatch_);
         proxy_method_set_dispatch_ = std::move(other.proxy_method_set_dispatch_);
+        proxy_method_get_dispatch_ = std::move(other.proxy_method_get_dispatch_);
     }
     return *this;
 }

--- a/score/mw/com/impl/proxy_field.h
+++ b/score/mw/com/impl/proxy_field.h
@@ -16,7 +16,6 @@
 #include "score/mw/com/impl/methods/proxy_method_with_in_args_and_return.h"
 #include "score/mw/com/impl/methods/proxy_method_with_return_type.h"
 #include "score/mw/com/impl/plumbing/proxy_field_binding_factory.h"
-#include "score/mw/com/impl/plumbing/sample_ptr.h"
 #include "score/mw/com/impl/proxy_event.h"
 #include "score/mw/com/impl/proxy_event_binding.h"
 #include "score/mw/com/impl/proxy_field_base.h"
@@ -69,83 +68,31 @@ class ProxyField final : public ProxyFieldBase
     ///
     /// This is used for testing only. Allows for directly setting the bindings, and usually the mock binding is used
     /// here.
-    template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<EG && ES>>
     ProxyField(ProxyBase& proxy_base,
                const std::string_view field_name,
                std::unique_ptr<ProxyEventBinding<FieldType>> event_binding,
-               std::unique_ptr<ProxyMethodBinding> get_method_binding,
-               std::unique_ptr<ProxyMethodBinding> set_method_binding,
+               std::unique_ptr<ProxyMethodBinding> get_method_binding = nullptr,
+               std::unique_ptr<ProxyMethodBinding> set_method_binding = nullptr,
                detail::EnableBothTag = {})
-        : ProxyField{proxy_base,
-                     field_name,
-                     std::make_unique<ProxyEvent<FieldType>>(proxy_base, field_name, std::move(event_binding)),
-                     std::make_unique<ProxyMethod<FieldType()>>(
-                         proxy_base,
-                         field_name,
-                         std::move(get_method_binding),
-                         typename ProxyMethod<FieldType()>::FieldOnlyConstructorEnabler{}),
-                     std::make_unique<ProxyMethod<FieldType(FieldType)>>(
-                         proxy_base,
-                         field_name,
-                         std::move(set_method_binding),
-                         typename ProxyMethod<FieldType(FieldType)>::FieldOnlyConstructorEnabler{})}
-    {
-    }
-
-    /// Constructor that allows to set the binding directly (only EnableGet is true).
-    ///
-    /// This is used for testing only. Allows for directly setting the bindings, and usually the mock binding is used
-    /// here.
-    template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<EG && !ES>>
-    ProxyField(ProxyBase& proxy_base,
-               const std::string_view field_name,
-               std::unique_ptr<ProxyEventBinding<FieldType>> event_binding,
-               std::unique_ptr<ProxyMethodBinding> get_method_binding,
-               detail::EnableGetOnlyTag = {})
-        : ProxyField{proxy_base,
-                     field_name,
-                     std::make_unique<ProxyEvent<FieldType>>(proxy_base, field_name, std::move(event_binding)),
-                     std::make_unique<ProxyMethod<FieldType()>>(
-                         proxy_base,
-                         field_name,
-                         std::move(get_method_binding),
-                         typename ProxyMethod<FieldType()>::FieldOnlyConstructorEnabler{})}
-    {
-    }
-
-    /// Constructor that allows to set the binding directly (only EnableSet is true).
-    ///
-    /// This is used for testing only. Allows for directly setting the bindings, and usually the mock binding is used
-    /// here.
-    template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<!EG && ES>>
-    ProxyField(ProxyBase& proxy_base,
-               const std::string_view field_name,
-               std::unique_ptr<ProxyEventBinding<FieldType>> event_binding,
-               std::unique_ptr<ProxyMethodBinding> set_method_binding,
-               detail::EnableSetOnlyTag = {})
-        : ProxyField{proxy_base,
-                     field_name,
-                     std::make_unique<ProxyEvent<FieldType>>(proxy_base, field_name, std::move(event_binding)),
-                     std::make_unique<ProxyMethod<FieldType(FieldType)>>(
-                         proxy_base,
-                         field_name,
-                         std::move(set_method_binding),
-                         typename ProxyMethod<FieldType(FieldType)>::FieldOnlyConstructorEnabler{})}
-    {
-    }
-
-    /// Constructor that allows to set the binding directly (both EnableGet and EnableSet are false).
-    ///
-    /// This is used for testing only. Allows for directly setting the bindings, and usually the mock binding is used
-    /// here.
-    template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<!EG && !ES>>
-    ProxyField(ProxyBase& proxy_base,
-               const std::string_view field_name,
-               std::unique_ptr<ProxyEventBinding<FieldType>> event_binding,
-               detail::EnableNeitherTag = {})
-        : ProxyField{proxy_base,
-                     field_name,
-                     std::make_unique<ProxyEvent<FieldType>>(proxy_base, field_name, std::move(event_binding))}
+        : ProxyField{
+              proxy_base,
+              field_name,
+              std::make_unique<ProxyEvent<FieldType>>(proxy_base, field_name, std::move(event_binding)),
+              // If a binding is not provided, then we don't create the method. This ensures that the ProxyMethod
+              // doesn't report that the binding is invalid (via proxy_base_view.MarkServiceElementBindingInvalid())
+              get_method_binding == nullptr ? nullptr
+                                            : std::make_unique<ProxyMethod<FieldType()>>(
+                                                  proxy_base,
+                                                  field_name,
+                                                  std::move(get_method_binding),
+                                                  typename ProxyMethod<FieldType()>::FieldOnlyConstructorEnabler{}),
+              set_method_binding == nullptr
+                  ? nullptr
+                  : std::make_unique<ProxyMethod<FieldType(FieldType)>>(
+                        proxy_base,
+                        field_name,
+                        std::move(set_method_binding),
+                        typename ProxyMethod<FieldType(FieldType)>::FieldOnlyConstructorEnabler{})}
     {
     }
 
@@ -187,7 +134,8 @@ class ProxyField final : public ProxyFieldBase
                          proxy_base,
                          field_name,
                          ProxyFieldBindingFactory<FieldType>::CreateGetMethodBinding(proxy_base, field_name),
-                         typename ProxyMethod<FieldType()>::FieldOnlyConstructorEnabler{})}
+                         typename ProxyMethod<FieldType()>::FieldOnlyConstructorEnabler{}),
+                     nullptr}
     {
     }
 
@@ -201,6 +149,7 @@ class ProxyField final : public ProxyFieldBase
                          field_name,
                          ProxyFieldBindingFactory<FieldType>::CreateEventBinding(proxy_base, field_name),
                          typename ProxyEvent<FieldType>::FieldOnlyConstructorEnabler{}),
+                     nullptr,
                      std::make_unique<ProxyMethod<FieldType(FieldType)>>(
                          proxy_base,
                          field_name,
@@ -219,7 +168,9 @@ class ProxyField final : public ProxyFieldBase
                          proxy_base,
                          field_name,
                          ProxyFieldBindingFactory<FieldType>::CreateEventBinding(proxy_base, field_name),
-                         typename ProxyEvent<FieldType>::FieldOnlyConstructorEnabler{})}
+                         typename ProxyEvent<FieldType>::FieldOnlyConstructorEnabler{}),
+                     nullptr,
+                     nullptr}
     {
     }
 
@@ -270,8 +221,6 @@ class ProxyField final : public ProxyFieldBase
     }
 
   private:
-    /// \brief Private constructor overload for when both EnableGet and EnableSet are true.
-    template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<EG && ES>>
     ProxyField(ProxyBase& proxy_base,
                const std::string_view field_name,
                std::unique_ptr<ProxyEvent<FieldType>> proxy_event_dispatch,
@@ -288,63 +237,10 @@ class ProxyField final : public ProxyFieldBase
         proxy_base_view.RegisterField(field_name, *this);
     }
 
-    /// \brief Private constructor overload for when only EnableGet is true.
-    template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<EG && !ES>>
-    ProxyField(ProxyBase& proxy_base,
-               const std::string_view field_name,
-               std::unique_ptr<ProxyEvent<FieldType>> proxy_event_dispatch,
-               std::unique_ptr<ProxyMethod<FieldType()>> proxy_method_get_dispatch)
-        : ProxyFieldBase{proxy_base, field_name, proxy_event_dispatch.get()},
-          proxy_event_dispatch_{std::move(proxy_event_dispatch)},
-          proxy_method_get_dispatch_{std::move(proxy_method_get_dispatch)}
-    {
-        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(proxy_event_dispatch_ != nullptr);
-
-        ProxyBaseView proxy_base_view{proxy_base};
-        proxy_base_view.RegisterField(field_name, *this);
-    }
-
-    /// \brief Private constructor overload for when only EnableSet is true.
-    template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<!EG && ES>>
-    ProxyField(ProxyBase& proxy_base,
-               const std::string_view field_name,
-               std::unique_ptr<ProxyEvent<FieldType>> proxy_event_dispatch,
-               std::unique_ptr<ProxyMethod<FieldType(FieldType)>> proxy_method_set_dispatch)
-        : ProxyFieldBase{proxy_base, field_name, proxy_event_dispatch.get()},
-          proxy_event_dispatch_{std::move(proxy_event_dispatch)},
-          proxy_method_set_dispatch_{std::move(proxy_method_set_dispatch)}
-    {
-        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(proxy_event_dispatch_ != nullptr);
-
-        ProxyBaseView proxy_base_view{proxy_base};
-        proxy_base_view.RegisterField(field_name, *this);
-    }
-
-    /// \brief Private constructor overload for when both EnableGet and EnableSet are false.
-    template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<!EG && !ES>>
-    ProxyField(ProxyBase& proxy_base,
-               const std::string_view field_name,
-               std::unique_ptr<ProxyEvent<FieldType>> proxy_event_dispatch)
-        : ProxyFieldBase{proxy_base, field_name, proxy_event_dispatch.get()},
-          proxy_event_dispatch_{std::move(proxy_event_dispatch)}
-    {
-        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(proxy_event_dispatch_ != nullptr);
-
-        ProxyBaseView proxy_base_view{proxy_base};
-        proxy_base_view.RegisterField(field_name, *this);
-    }
-
     std::unique_ptr<ProxyEvent<FieldType>> proxy_event_dispatch_;
 
-    struct empty
-    {
-    };
-
-    using ProxyGetMethodType = std::conditional_t<EnableGet, std::unique_ptr<ProxyMethod<FieldType()>>, empty>;
-    using ProxySetMethodType = std::conditional_t<EnableSet, std::unique_ptr<ProxyMethod<FieldType(FieldType)>>, empty>;
-
-    ProxyGetMethodType proxy_method_get_dispatch_;
-    ProxySetMethodType proxy_method_set_dispatch_;
+    std::unique_ptr<ProxyMethod<FieldType()>> proxy_method_get_dispatch_;
+    std::unique_ptr<ProxyMethod<FieldType(FieldType)>> proxy_method_set_dispatch_;
 
     static_assert(std::is_same_v<decltype(proxy_event_dispatch_), std::unique_ptr<ProxyEvent<FieldType>>>,
                   "proxy_event_dispatch_ needs to be a unique_ptr since we pass a pointer to it to ProxyFieldBase, so "

--- a/score/mw/com/impl/proxy_field.h
+++ b/score/mw/com/impl/proxy_field.h
@@ -71,24 +71,24 @@ class ProxyField final : public ProxyFieldBase
     /// here.
     template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<EG && ES>>
     ProxyField(ProxyBase& proxy_base,
+               const std::string_view field_name,
                std::unique_ptr<ProxyEventBinding<FieldType>> event_binding,
                std::unique_ptr<ProxyMethodBinding> get_method_binding,
                std::unique_ptr<ProxyMethodBinding> set_method_binding,
-               const std::string_view field_name,
                detail::EnableBothTag = {})
         : ProxyField{proxy_base,
-                     std::make_unique<ProxyEvent<FieldType>>(proxy_base, std::move(event_binding), field_name),
+                     field_name,
+                     std::make_unique<ProxyEvent<FieldType>>(proxy_base, field_name, std::move(event_binding)),
                      std::make_unique<ProxyMethod<FieldType()>>(
                          proxy_base,
-                         std::move(get_method_binding),
                          field_name,
+                         std::move(get_method_binding),
                          typename ProxyMethod<FieldType()>::FieldOnlyConstructorEnabler{}),
                      std::make_unique<ProxyMethod<FieldType(FieldType)>>(
                          proxy_base,
-                         std::move(set_method_binding),
                          field_name,
-                         typename ProxyMethod<FieldType(FieldType)>::FieldOnlyConstructorEnabler{}),
-                     field_name}
+                         std::move(set_method_binding),
+                         typename ProxyMethod<FieldType(FieldType)>::FieldOnlyConstructorEnabler{})}
     {
     }
 
@@ -98,18 +98,18 @@ class ProxyField final : public ProxyFieldBase
     /// here.
     template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<EG && !ES>>
     ProxyField(ProxyBase& proxy_base,
+               const std::string_view field_name,
                std::unique_ptr<ProxyEventBinding<FieldType>> event_binding,
                std::unique_ptr<ProxyMethodBinding> get_method_binding,
-               const std::string_view field_name,
                detail::EnableGetOnlyTag = {})
         : ProxyField{proxy_base,
-                     std::make_unique<ProxyEvent<FieldType>>(proxy_base, std::move(event_binding), field_name),
+                     field_name,
+                     std::make_unique<ProxyEvent<FieldType>>(proxy_base, field_name, std::move(event_binding)),
                      std::make_unique<ProxyMethod<FieldType()>>(
                          proxy_base,
-                         std::move(get_method_binding),
                          field_name,
-                         typename ProxyMethod<FieldType()>::FieldOnlyConstructorEnabler{}),
-                     field_name}
+                         std::move(get_method_binding),
+                         typename ProxyMethod<FieldType()>::FieldOnlyConstructorEnabler{})}
     {
     }
 
@@ -119,18 +119,18 @@ class ProxyField final : public ProxyFieldBase
     /// here.
     template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<!EG && ES>>
     ProxyField(ProxyBase& proxy_base,
+               const std::string_view field_name,
                std::unique_ptr<ProxyEventBinding<FieldType>> event_binding,
                std::unique_ptr<ProxyMethodBinding> set_method_binding,
-               const std::string_view field_name,
                detail::EnableSetOnlyTag = {})
         : ProxyField{proxy_base,
-                     std::make_unique<ProxyEvent<FieldType>>(proxy_base, std::move(event_binding), field_name),
+                     field_name,
+                     std::make_unique<ProxyEvent<FieldType>>(proxy_base, field_name, std::move(event_binding)),
                      std::make_unique<ProxyMethod<FieldType(FieldType)>>(
                          proxy_base,
-                         std::move(set_method_binding),
                          field_name,
-                         typename ProxyMethod<FieldType(FieldType)>::FieldOnlyConstructorEnabler{}),
-                     field_name}
+                         std::move(set_method_binding),
+                         typename ProxyMethod<FieldType(FieldType)>::FieldOnlyConstructorEnabler{})}
     {
     }
 
@@ -140,12 +140,12 @@ class ProxyField final : public ProxyFieldBase
     /// here.
     template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<!EG && !ES>>
     ProxyField(ProxyBase& proxy_base,
-               std::unique_ptr<ProxyEventBinding<FieldType>> event_binding,
                const std::string_view field_name,
+               std::unique_ptr<ProxyEventBinding<FieldType>> event_binding,
                detail::EnableNeitherTag = {})
         : ProxyField{proxy_base,
-                     std::make_unique<ProxyEvent<FieldType>>(proxy_base, std::move(event_binding), field_name),
-                     field_name}
+                     field_name,
+                     std::make_unique<ProxyEvent<FieldType>>(proxy_base, field_name, std::move(event_binding))}
     {
     }
 
@@ -154,22 +154,22 @@ class ProxyField final : public ProxyFieldBase
     template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<EG && ES>>
     ProxyField(ProxyBase& proxy_base, const std::string_view field_name, detail::EnableBothTag = {})
         : ProxyField{proxy_base,
+                     field_name,
                      std::make_unique<ProxyEvent<FieldType>>(
                          proxy_base,
-                         ProxyFieldBindingFactory<FieldType>::CreateEventBinding(proxy_base, field_name),
                          field_name,
+                         ProxyFieldBindingFactory<FieldType>::CreateEventBinding(proxy_base, field_name),
                          typename ProxyEvent<FieldType>::FieldOnlyConstructorEnabler{}),
                      std::make_unique<ProxyMethod<FieldType()>>(
                          proxy_base,
-                         ProxyFieldBindingFactory<FieldType>::CreateGetMethodBinding(proxy_base, field_name),
                          field_name,
+                         ProxyFieldBindingFactory<FieldType>::CreateGetMethodBinding(proxy_base, field_name),
                          typename ProxyMethod<FieldType()>::FieldOnlyConstructorEnabler{}),
                      std::make_unique<ProxyMethod<FieldType(FieldType)>>(
                          proxy_base,
-                         ProxyFieldBindingFactory<FieldType>::CreateSetMethodBinding(proxy_base, field_name),
                          field_name,
-                         typename ProxyMethod<FieldType(FieldType)>::FieldOnlyConstructorEnabler{}),
-                     field_name}
+                         ProxyFieldBindingFactory<FieldType>::CreateSetMethodBinding(proxy_base, field_name),
+                         typename ProxyMethod<FieldType(FieldType)>::FieldOnlyConstructorEnabler{})}
     {
     }
 
@@ -177,17 +177,17 @@ class ProxyField final : public ProxyFieldBase
     template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<EG && !ES>>
     ProxyField(ProxyBase& proxy_base, const std::string_view field_name, detail::EnableGetOnlyTag = {})
         : ProxyField{proxy_base,
+                     field_name,
                      std::make_unique<ProxyEvent<FieldType>>(
                          proxy_base,
-                         ProxyFieldBindingFactory<FieldType>::CreateEventBinding(proxy_base, field_name),
                          field_name,
+                         ProxyFieldBindingFactory<FieldType>::CreateEventBinding(proxy_base, field_name),
                          typename ProxyEvent<FieldType>::FieldOnlyConstructorEnabler{}),
                      std::make_unique<ProxyMethod<FieldType()>>(
                          proxy_base,
-                         ProxyFieldBindingFactory<FieldType>::CreateGetMethodBinding(proxy_base, field_name),
                          field_name,
-                         typename ProxyMethod<FieldType()>::FieldOnlyConstructorEnabler{}),
-                     field_name}
+                         ProxyFieldBindingFactory<FieldType>::CreateGetMethodBinding(proxy_base, field_name),
+                         typename ProxyMethod<FieldType()>::FieldOnlyConstructorEnabler{})}
     {
     }
 
@@ -195,17 +195,17 @@ class ProxyField final : public ProxyFieldBase
     template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<!EG && ES>>
     ProxyField(ProxyBase& proxy_base, const std::string_view field_name, detail::EnableSetOnlyTag = {})
         : ProxyField{proxy_base,
+                     field_name,
                      std::make_unique<ProxyEvent<FieldType>>(
                          proxy_base,
-                         ProxyFieldBindingFactory<FieldType>::CreateEventBinding(proxy_base, field_name),
                          field_name,
+                         ProxyFieldBindingFactory<FieldType>::CreateEventBinding(proxy_base, field_name),
                          typename ProxyEvent<FieldType>::FieldOnlyConstructorEnabler{}),
                      std::make_unique<ProxyMethod<FieldType(FieldType)>>(
                          proxy_base,
-                         ProxyFieldBindingFactory<FieldType>::CreateSetMethodBinding(proxy_base, field_name),
                          field_name,
-                         typename ProxyMethod<FieldType(FieldType)>::FieldOnlyConstructorEnabler{}),
-                     field_name}
+                         ProxyFieldBindingFactory<FieldType>::CreateSetMethodBinding(proxy_base, field_name),
+                         typename ProxyMethod<FieldType(FieldType)>::FieldOnlyConstructorEnabler{})}
     {
     }
 
@@ -214,12 +214,12 @@ class ProxyField final : public ProxyFieldBase
     template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<!EG && !ES>>
     ProxyField(ProxyBase& proxy_base, const std::string_view field_name, detail::EnableNeitherTag = {})
         : ProxyField{proxy_base,
+                     field_name,
                      std::make_unique<ProxyEvent<FieldType>>(
                          proxy_base,
-                         ProxyFieldBindingFactory<FieldType>::CreateEventBinding(proxy_base, field_name),
                          field_name,
-                         typename ProxyEvent<FieldType>::FieldOnlyConstructorEnabler{}),
-                     field_name}
+                         ProxyFieldBindingFactory<FieldType>::CreateEventBinding(proxy_base, field_name),
+                         typename ProxyEvent<FieldType>::FieldOnlyConstructorEnabler{})}
     {
     }
 
@@ -273,11 +273,11 @@ class ProxyField final : public ProxyFieldBase
     /// \brief Private constructor overload for when both EnableGet and EnableSet are true.
     template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<EG && ES>>
     ProxyField(ProxyBase& proxy_base,
+               const std::string_view field_name,
                std::unique_ptr<ProxyEvent<FieldType>> proxy_event_dispatch,
                std::unique_ptr<ProxyMethod<FieldType()>> proxy_method_get_dispatch,
-               std::unique_ptr<ProxyMethod<FieldType(FieldType)>> proxy_method_set_dispatch,
-               const std::string_view field_name)
-        : ProxyFieldBase{proxy_base, proxy_event_dispatch.get(), field_name},
+               std::unique_ptr<ProxyMethod<FieldType(FieldType)>> proxy_method_set_dispatch)
+        : ProxyFieldBase{proxy_base, field_name, proxy_event_dispatch.get()},
           proxy_event_dispatch_{std::move(proxy_event_dispatch)},
           proxy_method_get_dispatch_{std::move(proxy_method_get_dispatch)},
           proxy_method_set_dispatch_{std::move(proxy_method_set_dispatch)}
@@ -291,10 +291,10 @@ class ProxyField final : public ProxyFieldBase
     /// \brief Private constructor overload for when only EnableGet is true.
     template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<EG && !ES>>
     ProxyField(ProxyBase& proxy_base,
+               const std::string_view field_name,
                std::unique_ptr<ProxyEvent<FieldType>> proxy_event_dispatch,
-               std::unique_ptr<ProxyMethod<FieldType()>> proxy_method_get_dispatch,
-               const std::string_view field_name)
-        : ProxyFieldBase{proxy_base, proxy_event_dispatch.get(), field_name},
+               std::unique_ptr<ProxyMethod<FieldType()>> proxy_method_get_dispatch)
+        : ProxyFieldBase{proxy_base, field_name, proxy_event_dispatch.get()},
           proxy_event_dispatch_{std::move(proxy_event_dispatch)},
           proxy_method_get_dispatch_{std::move(proxy_method_get_dispatch)}
     {
@@ -307,10 +307,10 @@ class ProxyField final : public ProxyFieldBase
     /// \brief Private constructor overload for when only EnableSet is true.
     template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<!EG && ES>>
     ProxyField(ProxyBase& proxy_base,
+               const std::string_view field_name,
                std::unique_ptr<ProxyEvent<FieldType>> proxy_event_dispatch,
-               std::unique_ptr<ProxyMethod<FieldType(FieldType)>> proxy_method_set_dispatch,
-               const std::string_view field_name)
-        : ProxyFieldBase{proxy_base, proxy_event_dispatch.get(), field_name},
+               std::unique_ptr<ProxyMethod<FieldType(FieldType)>> proxy_method_set_dispatch)
+        : ProxyFieldBase{proxy_base, field_name, proxy_event_dispatch.get()},
           proxy_event_dispatch_{std::move(proxy_event_dispatch)},
           proxy_method_set_dispatch_{std::move(proxy_method_set_dispatch)}
     {
@@ -323,9 +323,9 @@ class ProxyField final : public ProxyFieldBase
     /// \brief Private constructor overload for when both EnableGet and EnableSet are false.
     template <bool EG = EnableGet, bool ES = EnableSet, typename = std::enable_if_t<!EG && !ES>>
     ProxyField(ProxyBase& proxy_base,
-               std::unique_ptr<ProxyEvent<FieldType>> proxy_event_dispatch,
-               const std::string_view field_name)
-        : ProxyFieldBase{proxy_base, proxy_event_dispatch.get(), field_name},
+               const std::string_view field_name,
+               std::unique_ptr<ProxyEvent<FieldType>> proxy_event_dispatch)
+        : ProxyFieldBase{proxy_base, field_name, proxy_event_dispatch.get()},
           proxy_event_dispatch_{std::move(proxy_event_dispatch)}
     {
         SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(proxy_event_dispatch_ != nullptr);

--- a/score/mw/com/impl/proxy_field_base.h
+++ b/score/mw/com/impl/proxy_field_base.h
@@ -30,7 +30,7 @@ namespace score::mw::com::impl
 class ProxyFieldBase
 {
   public:
-    ProxyFieldBase(ProxyBase& proxy_base, ProxyEventBase* proxy_event_base_dispatch, std::string_view field_name)
+    ProxyFieldBase(ProxyBase& proxy_base, std::string_view field_name, ProxyEventBase* proxy_event_base_dispatch)
         : proxy_base_{proxy_base}, proxy_event_base_dispatch_{proxy_event_base_dispatch}, field_name_{field_name}
     {
         SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(proxy_event_base_dispatch != nullptr);

--- a/score/mw/com/impl/proxy_field_base.h
+++ b/score/mw/com/impl/proxy_field_base.h
@@ -27,8 +27,16 @@
 namespace score::mw::com::impl
 {
 
+class ProxyBase;
+class ProxyFieldBaseView;
+
 class ProxyFieldBase
 {
+    // Suppress "AUTOSAR C++14 A11-3-1", The rule states: "Friend declarations shall not be used".
+    // Design decision. This class provides a view to the private members of this class.
+    // coverity[autosar_cpp14_a11_3_1_violation]
+    friend class ProxyFieldBaseView;
+
   public:
     ProxyFieldBase(ProxyBase& proxy_base, std::string_view field_name, ProxyEventBase* proxy_event_base_dispatch)
         : proxy_base_{proxy_base}, proxy_event_base_dispatch_{proxy_event_base_dispatch}, field_name_{field_name}
@@ -52,121 +60,100 @@ class ProxyFieldBase
     }
 
     /**
-     * \api
-     * \brief Subscribe to the field.
-     * \param max_sample_count Specify the maximum number of concurrent samples that this event shall
-     *                          be able to offer to the using application.
-     * \return On failure, returns an error code.
+     * \name Tag-gated interface
+     *
+     * These methods are protected rather than public because the derived \c ProxyField class
+     * template decides which of them are exposed to the end user, based on the capability tags
+     * (\c WithGetter, \c WithSetter, \c WithNotifier) the field was declared with.  Keeping them
+     * protected here prevents direct access while still letting the derived class forward them
+     * selectively — only when the matching tag is present.
      */
+    /// \{
+  protected:
     Result<void> Subscribe(const std::size_t max_sample_count) noexcept
     {
+        SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(proxy_event_base_dispatch_ != nullptr);
         return proxy_event_base_dispatch_->Subscribe(max_sample_count);
     }
 
-    /**
-     * \api
-     * \brief Get the subscription state of this field.
-     * \details This method can always be called regardless of the state of the field.
-     * \return Subscription state of the field.
-     */
     SubscriptionState GetSubscriptionState() noexcept
     {
+        SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(proxy_event_base_dispatch_ != nullptr);
         return proxy_event_base_dispatch_->GetSubscriptionState();
     }
 
-    /**
-     * \api
-     * \brief End subscription to a field and release needed resources.
-     * \details It is illegal to call this method while data is still held by the application in the form of SamplePtr.
-     *          Doing so will result in undefined behavior. After a call to this method, the field behaves as if it had
-     *          just been constructed.
-     */
     void Unsubscribe() noexcept
     {
+        SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(proxy_event_base_dispatch_ != nullptr);
         proxy_event_base_dispatch_->Unsubscribe();
     }
 
-    /**
-     * \api
-     * \brief Sets/Registers a SubscriptionStateChangeHandler for this event. This handler will be called whenever the
-     * subscription state of this event changes.
-     * \note An already set/registered SubscriptionStateChangeHandler will be silently overridden.
-     * \param handler
-     */
     Result<void> SetSubscriptionStateChangeHandler(SubscriptionStateChangeHandler handler) noexcept
     {
+        SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(proxy_event_base_dispatch_ != nullptr);
         return proxy_event_base_dispatch_->SetSubscriptionStateChangeHandler(std::move(handler));
     }
 
-    /**
-     * \api
-     * \brief Unsets/Unregisters a SubscriptionStateChangeHandler for this field. After this method returns, it is
-     *        guaranteed, that the previously registered handler is neither active nor will be called anymore.
-     */
     Result<void> UnsetSubscriptionStateChangeHandler() noexcept
     {
+        SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(proxy_event_base_dispatch_ != nullptr);
         return proxy_event_base_dispatch_->UnsetSubscriptionStateChangeHandler();
     }
 
-    /**
-     * \api
-     * \brief Get the number of samples that can still be received by the user of this field.
-     * \details If this returns 0, the user first has to drop at least one SamplePtr before it is possible to receive
-     *          data via GetNewSamples again. If there is no subscription for this field, the returned value is
-     *          unspecified.
-     * \return Number of samples that can still be received.
-     */
     std::size_t GetFreeSampleCount() noexcept
     {
+        SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(proxy_event_base_dispatch_ != nullptr);
         return proxy_event_base_dispatch_->GetFreeSampleCount();
     }
 
-    /**
-     * \api
-     * \brief Returns the number of new samples a call to GetNewSamples() (given parameter max_num_samples
-     *        doesn't restrict it) would currently provide.
-     * \details This is a proprietary extension to the official ara::com API. It is useful in resource sensitive
-     *          setups, where the user wants to work in polling mode only without registered async receive-handlers.
-     *          For further details see //score/mw/com/design/extensions/README.md.
-     * \return Either 0 if no new samples are available (and GetNewSamples() wouldn't return any) or N, where 1 <= N <=
-     *         actual new samples. I.e. an implementation is allowed to report a lower number than actual new samples,
-     *         which would be provided by a call to GetNewSamples().
-     */
     Result<std::size_t> GetNumNewSamplesAvailable() noexcept
     {
+        SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(proxy_event_base_dispatch_ != nullptr);
         return proxy_event_base_dispatch_->GetNumNewSamplesAvailable();
     }
 
-    /**
-     * \api
-     * \brief Sets the handler to be called, whenever a new field value has been received.
-     * \details Generally a ReceiveHandler has no restrictions on what mw::com API it is allowed to call.
-     *          It is especially allowed to call all public APIs of the Field instance on which it had been
-     *          set/registered as long as it obeys the general requirement, that API calls on a Proxy/Proxy field are
-     *          thread safe/can't be called concurrently.
-     * \attention This function MUST NOT be called from the context of a ReceiveHandler registered for this field!
-     *            It makes semantically not really sense to register a "new" ReceiveHandler from the context of an
-     *            already running ReceiveHandler. We also see no use cases for it and won't support it therefore.
-     * \param handler user provided handler to be called
-     */
     Result<void> SetReceiveHandler(EventReceiveHandler handler) noexcept
     {
+        SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(proxy_event_base_dispatch_ != nullptr);
         return proxy_event_base_dispatch_->SetReceiveHandler(std::move(handler));
     }
 
-    /**
-     * \api
-     * \brief Removes any ReceiveHandler registered via SetReceiveHandler.
-     */
     Result<void> UnsetReceiveHandler() noexcept
     {
+        SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(proxy_event_base_dispatch_ != nullptr);
         return proxy_event_base_dispatch_->UnsetReceiveHandler();
     }
+    /// \}
 
-  protected:
     std::reference_wrapper<ProxyBase> proxy_base_;
     ProxyEventBase* proxy_event_base_dispatch_;
     std::string_view field_name_;
+};
+
+/// \brief Controlled access to ProxyFieldBase internals for use within the impl namespace.
+///
+/// ProxyBase needs to call certain ProxyFieldBase methods (e.g. \c Unsubscribe) during its own
+/// lifecycle, but those methods must not be reachable by end users of the public API because the ProxyField which
+/// inherits from this class decides which functions are exposed to the user based on its template params. Broadly,
+/// making ProxyBase a \c friend directly would give it unrestricted access to everything private.  This view class is
+/// the middle ground. It is the only \c friend of ProxyFieldBase and selectively re-exposes just the methods that
+/// ProxyBase actually needs.  End users never see it because it lives in the \c impl namespace.
+class ProxyFieldBaseView
+{
+  public:
+    explicit ProxyFieldBaseView(ProxyFieldBase& base) noexcept : base_{base} {}
+
+    void Unsubscribe() noexcept
+    {
+        // if the WithNotifier tag is not set, proxy_event_base_dispatch_ will be nullptr.
+        if (base_.proxy_event_base_dispatch_ != nullptr)
+        {
+            base_.Unsubscribe();
+        }
+    }
+
+  private:
+    ProxyFieldBase& base_;
 };
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/proxy_field_base.h
+++ b/score/mw/com/impl/proxy_field_base.h
@@ -38,10 +38,10 @@ class ProxyFieldBase
     friend class ProxyFieldBaseView;
 
   public:
+    /// \param proxy_event_base_dispatch May be nullptr when the field's tag pack does not include WithNotifier.
     ProxyFieldBase(ProxyBase& proxy_base, std::string_view field_name, ProxyEventBase* proxy_event_base_dispatch)
         : proxy_base_{proxy_base}, proxy_event_base_dispatch_{proxy_event_base_dispatch}, field_name_{field_name}
     {
-        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(proxy_event_base_dispatch != nullptr);
     }
 
     /// \brief A ProxyFieldBase shall not be copyable

--- a/score/mw/com/impl/proxy_field_test.cpp
+++ b/score/mw/com/impl/proxy_field_test.cpp
@@ -37,6 +37,153 @@ using namespace ::testing;
 
 using TestSampleType = std::uint8_t;
 
+namespace
+{
+// SFINAE detection traits used to verify that the notifier API surfafce is gated on the WithNotifier tag.
+// Each trait checks whether the corresponding member call is well-formed on the field type.
+
+template <typename, typename = void>
+struct has_subscribe : std::false_type
+{
+};
+template <typename T>
+struct has_subscribe<T, std::void_t<decltype(std::declval<T&>().Subscribe(std::declval<std::size_t>()))>>
+    : std::true_type
+{
+};
+
+template <typename, typename = void>
+struct has_unsubscribe : std::false_type
+{
+};
+template <typename T>
+struct has_unsubscribe<T, std::void_t<decltype(std::declval<T&>().Unsubscribe())>> : std::true_type
+{
+};
+
+template <typename, typename = void>
+struct has_get_subscription_state : std::false_type
+{
+};
+template <typename T>
+struct has_get_subscription_state<T, std::void_t<decltype(std::declval<T&>().GetSubscriptionState())>> : std::true_type
+{
+};
+
+template <typename, typename = void>
+struct has_set_subscription_state_change_handler : std::false_type
+{
+};
+template <typename T>
+struct has_set_subscription_state_change_handler<
+    T,
+    std::void_t<decltype(std::declval<T&>().SetSubscriptionStateChangeHandler(
+        std::declval<SubscriptionStateChangeHandler>()))>> : std::true_type
+{
+};
+
+template <typename, typename = void>
+struct has_unset_subscription_state_change_handler : std::false_type
+{
+};
+template <typename T>
+struct has_unset_subscription_state_change_handler<
+    T,
+    std::void_t<decltype(std::declval<T&>().UnsetSubscriptionStateChangeHandler())>> : std::true_type
+{
+};
+
+template <typename, typename = void>
+struct has_get_free_sample_count : std::false_type
+{
+};
+template <typename T>
+struct has_get_free_sample_count<T, std::void_t<decltype(std::declval<T&>().GetFreeSampleCount())>> : std::true_type
+{
+};
+
+template <typename, typename = void>
+struct has_get_num_new_samples_available : std::false_type
+{
+};
+template <typename T>
+struct has_get_num_new_samples_available<T, std::void_t<decltype(std::declval<T&>().GetNumNewSamplesAvailable())>>
+    : std::true_type
+{
+};
+
+template <typename, typename = void>
+struct has_set_receive_handler : std::false_type
+{
+};
+template <typename T>
+struct has_set_receive_handler<
+    T,
+    std::void_t<decltype(std::declval<T&>().SetReceiveHandler(std::declval<EventReceiveHandler>()))>> : std::true_type
+{
+};
+
+template <typename, typename = void>
+struct has_unset_receive_handler : std::false_type
+{
+};
+template <typename T>
+struct has_unset_receive_handler<T, std::void_t<decltype(std::declval<T&>().UnsetReceiveHandler())>> : std::true_type
+{
+};
+
+struct DummySampleReceiver
+{
+    template <typename SamplePtrT>
+    void operator()(SamplePtrT) noexcept
+    {
+    }
+};
+
+template <typename, typename = void>
+struct has_get_new_samples : std::false_type
+{
+};
+template <typename T>
+struct has_get_new_samples<T,
+                           std::void_t<decltype(std::declval<T&>().GetNewSamples(std::declval<DummySampleReceiver>(),
+                                                                                 std::declval<std::size_t>()))>>
+    : std::true_type
+{
+};
+
+template <typename, typename = void>
+struct has_inject_mock : std::false_type
+{
+};
+template <typename T>
+struct has_inject_mock<
+    T,
+    std::void_t<decltype(std::declval<T&>().InjectMock(std::declval<IProxyEvent<typename T::FieldType>&>()))>>
+    : std::true_type
+{
+};
+
+template <typename, typename = void>
+struct has_get : std::false_type
+{
+};
+template <typename T>
+struct has_get<T, std::void_t<decltype(std::declval<T&>().Get())>> : std::true_type
+{
+};
+
+template <typename, typename = void>
+struct has_set : std::false_type
+{
+};
+template <typename T>
+struct has_set<T, std::void_t<decltype(std::declval<T&>().Set(std::declval<typename T::FieldType&>()))>>
+    : std::true_type
+{
+};
+}  // namespace
+
 TEST(ProxyFieldTest, NotCopyable)
 {
     RecordProperty("Verifies", "SCR-17397027");
@@ -86,6 +233,80 @@ TEST(ProxyFieldTest, ProxyFieldContainsPublicFieldType)
     static_assert(std::is_same<typename ProxyField<CustomFieldType, WithGetter, WithNotifier, WithSetter>::FieldType,
                                CustomFieldType>::value,
                   "Incorrect FieldType.");
+}
+
+TEST(ProxyFieldNotifierGatingTest, NotifierApiExistsWhenWithNotifierTagIsPresent)
+{
+    // Given a ProxyField with the WithNotifier tag
+    // When checking the notifier API
+    // Then all notifier-related members should be present
+    using NotifierField = ProxyField<TestSampleType, WithNotifier>;
+    static_assert(has_subscribe<NotifierField>::value);
+    static_assert(has_unsubscribe<NotifierField>::value);
+    static_assert(has_set_subscription_state_change_handler<NotifierField>::value);
+    static_assert(has_unset_subscription_state_change_handler<NotifierField>::value);
+    static_assert(has_get_subscription_state<NotifierField>::value);
+    static_assert(has_get_free_sample_count<NotifierField>::value);
+    static_assert(has_get_num_new_samples_available<NotifierField>::value);
+    static_assert(has_set_receive_handler<NotifierField>::value);
+    static_assert(has_unset_receive_handler<NotifierField>::value);
+    static_assert(has_get_new_samples<NotifierField>::value);
+    static_assert(has_inject_mock<NotifierField>::value);
+}
+
+TEST(ProxyFieldNotifierGatingTest, NotifierApiIsAbsentWhenWithNotifierTagIsMissing)
+{
+    // Given a ProxyField without the WithNotifier tag
+    // When checking the notifier API
+    // Then all notifier-related members should be absent
+    using GetterOnlyField = ProxyField<TestSampleType, WithGetter>;
+    static_assert(!has_subscribe<GetterOnlyField>::value);
+    static_assert(!has_unsubscribe<GetterOnlyField>::value);
+    static_assert(!has_set_subscription_state_change_handler<GetterOnlyField>::value);
+    static_assert(!has_unset_subscription_state_change_handler<GetterOnlyField>::value);
+    static_assert(!has_get_subscription_state<GetterOnlyField>::value);
+    static_assert(!has_get_free_sample_count<GetterOnlyField>::value);
+    static_assert(!has_get_num_new_samples_available<GetterOnlyField>::value);
+    static_assert(!has_set_receive_handler<GetterOnlyField>::value);
+    static_assert(!has_unset_receive_handler<GetterOnlyField>::value);
+    static_assert(!has_get_new_samples<GetterOnlyField>::value);
+    static_assert(!has_inject_mock<GetterOnlyField>::value);
+}
+
+TEST(ProxyFieldGetterGatingTest, GetExistsWhenWithGetterTagIsPresent)
+{
+    // Given a ProxyField with the WithGetter tag
+    // When checking Get
+    // Then Get should be present
+    using GetterField = ProxyField<TestSampleType, WithGetter>;
+    static_assert(has_get<GetterField>::value);
+}
+
+TEST(ProxyFieldGetterGatingTest, GetIsAbsentWhenWithGetterTagIsMissing)
+{
+    // Given a ProxyField without the WithGetter tag
+    // When checking Get
+    // Then Get should be absent
+    using NotifierOnlyField = ProxyField<TestSampleType, WithNotifier>;
+    static_assert(!has_get<NotifierOnlyField>::value);
+}
+
+TEST(ProxyFieldSetterGatingTest, SetExistsWhenWithSetterTagIsPresent)
+{
+    // Given a ProxyField with the WithSetter tag
+    // When checking Set
+    // Then Set should be present
+    using SetterField = ProxyField<TestSampleType, WithGetter, WithSetter>;
+    static_assert(has_set<SetterField>::value);
+}
+
+TEST(ProxyFieldSetterGatingTest, SetIsAbsentWhenWithSetterTagIsMissing)
+{
+    // Given a ProxyField without the WithSetter tag
+    // When checking Set
+    // Then Set should be absent
+    using GetterOnlyField = ProxyField<TestSampleType, WithGetter>;
+    static_assert(!has_set<GetterOnlyField>::value);
 }
 
 }  // namespace

--- a/score/mw/com/impl/proxy_field_test.cpp
+++ b/score/mw/com/impl/proxy_field_test.cpp
@@ -45,14 +45,18 @@ TEST(ProxyFieldTest, NotCopyable)
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
-    static_assert(!std::is_copy_constructible<ProxyField<TestSampleType>>::value, "Is wrongly copyable");
-    static_assert(!std::is_copy_assignable<ProxyField<TestSampleType>>::value, "Is wrongly copyable");
+    static_assert(!std::is_copy_constructible<ProxyField<TestSampleType, WithGetter, WithNotifier, WithSetter>>::value,
+                  "Is wrongly copyable");
+    static_assert(!std::is_copy_assignable<ProxyField<TestSampleType, WithGetter, WithNotifier, WithSetter>>::value,
+                  "Is wrongly copyable");
 }
 
 TEST(ProxyFieldTest, IsMoveable)
 {
-    static_assert(std::is_move_constructible<ProxyField<TestSampleType>>::value, "Is not move constructible");
-    static_assert(std::is_move_assignable<ProxyField<TestSampleType>>::value, "Is not move assignable");
+    static_assert(std::is_move_constructible<ProxyField<TestSampleType, WithGetter, WithSetter>>::value,
+                  "Is not move constructible");
+    static_assert(std::is_move_assignable<ProxyField<TestSampleType, WithGetter, WithSetter>>::value,
+                  "Is not move assignable");
 }
 
 TEST(ProxyFieldTest, ClassTypeDependsOnFieldDataType)
@@ -63,8 +67,8 @@ TEST(ProxyFieldTest, ClassTypeDependsOnFieldDataType)
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
-    using FirstProxyFieldType = ProxyField<bool>;
-    using SecondProxyFieldType = ProxyField<std::uint16_t>;
+    using FirstProxyFieldType = ProxyField<bool, WithGetter, WithNotifier, WithSetter>;
+    using SecondProxyFieldType = ProxyField<std::uint16_t, WithGetter, WithNotifier, WithSetter>;
     static_assert(!std::is_same_v<FirstProxyFieldType, SecondProxyFieldType>,
                   "Class type does not depend on field data type");
 }
@@ -79,7 +83,8 @@ TEST(ProxyFieldTest, ProxyFieldContainsPublicFieldType)
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     using CustomFieldType = std::uint16_t;
-    static_assert(std::is_same<typename ProxyField<CustomFieldType>::FieldType, CustomFieldType>::value,
+    static_assert(std::is_same<typename ProxyField<CustomFieldType, WithGetter, WithNotifier, WithSetter>::FieldType,
+                               CustomFieldType>::value,
                   "Incorrect FieldType.");
 }
 

--- a/score/mw/com/impl/skeleton_base_test.cpp
+++ b/score/mw/com/impl/skeleton_base_test.cpp
@@ -63,7 +63,8 @@ class MyDummySkeleton final : public SkeletonBase
     SkeletonEvent<TestSampleType> dummy_event{*this, kDummyEventName};
     SkeletonEvent<TestSampleType> dummy_event2{*this, kDummyEventName2};
 
-    SkeletonField<TestSampleType> dummy_field{*this, kDummyFieldName};
+    // Explicity not having WithGetter/Setter tags since Get/Set functionality is tested in skeleton_field_test.cpp..
+    SkeletonField<TestSampleType, WithNotifier> dummy_field{*this, kDummyFieldName};
 };
 
 mock_binding::Skeleton* GetMockBinding(MyDummySkeleton& skeleton) noexcept

--- a/score/mw/com/impl/skeleton_event.h
+++ b/score/mw/com/impl/skeleton_event.h
@@ -36,7 +36,7 @@ namespace score::mw::com::impl
 
 // False Positive: this is a normal forward declaration.
 // coverity[autosar_cpp14_m3_2_3_violation]
-template <typename SampleDataType, const bool EnableSet, const bool EnableNotifier>
+template <typename SampleDataType, typename... Tags>
 class SkeletonField;
 
 template <typename SampleDataType>
@@ -51,7 +51,7 @@ class SkeletonEvent : public SkeletonEventBase
     // SkeletonField uses composition pattern to reuse code from SkeletonEvent. These two classes also have shared
     // private APIs which necessitates the use of the friend keyword.
     // coverity[autosar_cpp14_a11_3_1_violation]
-    template <typename T, bool ES, bool EN>
+    template <typename T, typename... Ts>
     friend class SkeletonField;
 
     // Empty struct that is used to make the second constructor only accessible to SkeletonEvent and SkeletonField (as

--- a/score/mw/com/impl/skeleton_field.h
+++ b/score/mw/com/impl/skeleton_field.h
@@ -13,6 +13,7 @@
 #ifndef SCORE_MW_COM_IMPL_SKELETON_FIELD_H
 #define SCORE_MW_COM_IMPL_SKELETON_FIELD_H
 
+#include "score/mw/com/impl/field_tags.h"
 #include "score/mw/com/impl/method_type.h"
 #include "score/mw/com/impl/methods/skeleton_method.h"
 #include "score/mw/com/impl/plumbing/sample_allocatee_ptr.h"
@@ -35,37 +36,58 @@
 namespace score::mw::com::impl
 {
 
-template <typename SampleDataType, const bool EnableSet = false, const bool EnableNotifier = false>
+template <typename SampleDataType, typename... Tags>
 class SkeletonField : public SkeletonFieldBase
 {
+    // SkeletonField must enable WithGetter or WithNotifier. Without one the consumer has no way to
+    // observe the value, so the field is useless. WithSetter alone does not count.
+    static_assert(
+        contains_type<WithNotifier, Tags...>::value || contains_type<WithGetter, Tags...>::value,
+        "A field must either have WithGetter or WithNotifier enabled otherwise, there is no way for the consumer to "
+        "receive the field values.");
+
   public:
     using FieldType = SampleDataType;
 
-    /// \brief Constructs a SkeletonField with setter enabled. Normal ctor used in production code.
-    ///
-    /// \param parent Skeleton that contains this field.
-    /// \param field_name Field name of the field.
-    /// \param detail::EnableSetOnlyTag This parameter is only used for constructor overload disambiguation and
-    /// has no semantic meaning. The tag disambiguates the setter-enabled ctor from the no-setter ctor, as
-    /// otherwise both would have the same signature.
-    template <bool ES = EnableSet, typename = std::enable_if_t<ES>>
-    SkeletonField(SkeletonBase& parent, const std::string_view field_name, detail::EnableSetOnlyTag = {});
-
-    /// \brief Constructs a SkeletonField with no setter. Normal ctor used in production code.
-    ///
-    /// \param parent Skeleton that contains this field.
-    /// \param field_name Field name of the field.
-    /// \param detail::EnableNeitherTag This parameter is only used for constructor overload disambiguation and
-    /// has no semantic meaning.
-    template <bool ES = EnableSet, typename = std::enable_if_t<!ES>>
-    SkeletonField(SkeletonBase& parent, const std::string_view field_name, detail::EnableNeitherTag = {});
-
-    /// Constructor that allows to set the binding directly.
-    ///
-    /// This is used only used for testing.
+    /// \brief Testing ctor that delegates to the production ctor that accepts mock bindings directly, this can only be
+    /// used in test code.
+    /// \param skeleton_base Parent skeleton that owns this field's registration.
+    /// \param field_name Field's name as it appears in the deployment.
+    /// \param binding Mock event binding.
     SkeletonField(SkeletonBase& skeleton_base,
                   const std::string_view field_name,
-                  std::unique_ptr<SkeletonEventBinding<FieldType>> binding);
+                  std::unique_ptr<SkeletonEventBinding<FieldType>> binding)
+        : SkeletonField{skeleton_base,
+                        field_name,
+                        std::make_unique<SkeletonEvent<FieldType>>(skeleton_base, field_name, std::move(binding)),
+                        nullptr,
+                        nullptr}
+    {
+    }
+
+    /// \brief Production ctor used by end users.
+    /// \details The MakeGetMethodIfEnabled / MakeSetMethodIfEnabled helpers consult the tag pack at compile time
+    ///          and return nullptr when their corresponding tag is absent.
+    /// \param parent Parent skeleton that owns this field's registration.
+    /// \param field_name Field's name as it appears in the deployment.
+    SkeletonField(SkeletonBase& parent, const std::string_view field_name)
+        : SkeletonField{parent,
+                        field_name,
+                        MakeSkeletonEvent(parent, field_name),
+                        MakeSetMethodIfEnabled(parent, field_name),
+                        MakeGetMethodIfEnabled(parent, field_name)}
+    {
+        // Each Make*IfEnabled must have produced a non-null dispatch when
+        // the corresponding tag is in the pack.
+        if constexpr (kHasGetter)
+        {
+            SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(get_method_ != nullptr);
+        }
+        if constexpr (kHasSetter)
+        {
+            SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(set_method_ != nullptr);
+        }
+    }
 
     ~SkeletonField() override = default;
 
@@ -112,15 +134,17 @@ class SkeletonField : public SkeletonFieldBase
         skeleton_field_mock_ = &skeleton_field_mock;
     }
 
-    // SFINAE-gated: only exists when EnableSet == true
-    //
-    // \ brief Registers a handler that is invoked by the middleware whenever a proxy calls the field setter.
-    //
-    // \tparam CallableType Any callable (std::function, score::cpp::callback, lambda, ...) with the signature:
-    //         void(FieldType& new_value)
-    //   - new_value : the value requested by the proxy. This value will be modified in place by the registered handler
-    //   and the new value will be used to update the field.
-    template <bool ES = EnableSet, std::enable_if_t<ES, int> = 0, typename CallableType>
+    /// \brief Registers a handler invoked by the middleware whenever a proxy calls the field setter.
+    /// \details Only available when the tag pack includes WithSetter (SFINAE-gated).
+    ///
+    /// \tparam CallableType Any callable (std::function, score::cpp::callback, lambda, ...) with the signature
+    ///         void(FieldType& new_value), where new_value is the proxy-requested value at entry and the
+    ///         accepted value at exit.
+    /// \param handler User callback to install.
+    /// \return void on success otherwise the error code reported by the binding.
+    template <typename CallableType,
+              typename U = SampleDataType,
+              typename = std::enable_if_t<is_tag_enabled<U, SampleDataType, WithSetter, Tags...>::value>>
     Result<void> RegisterSetHandler(CallableType&& set_handler)
     {
         static_assert(std::is_invocable_v<CallableType, FieldType&>,
@@ -172,13 +196,6 @@ class SkeletonField : public SkeletonFieldBase
     using SetMethodSignature = FieldType(FieldType);
     using GetMethodSignature = FieldType();
 
-    /// \brief Private delegating constructor used by the no-setter public ctor and testing ctor.
-    SkeletonField(SkeletonBase& parent,
-                  std::unique_ptr<SkeletonEvent<FieldType>> skeleton_event_dispatch,
-                  std::unique_ptr<SkeletonMethod<SetMethodSignature>> skeleton_set_method_dispatch,
-                  std::unique_ptr<SkeletonMethod<GetMethodSignature>> skeleton_get_method_dispatch,
-                  const std::string_view field_name);
-
     [[nodiscard]] bool IsInitialValueSaved() const noexcept override
     {
         return initial_field_value_ != nullptr;
@@ -193,12 +210,73 @@ class SkeletonField : public SkeletonFieldBase
 
     [[nodiscard]] bool IsSetHandlerMissing() const noexcept override
     {
-        if constexpr (!EnableSet)
+        if constexpr (!kHasSetter)
         {
             return false;
         }
         return !is_set_handler_registered_;
     }
+
+    static constexpr bool kHasGetter = contains_type<WithGetter, Tags...>::value;
+    static constexpr bool kHasSetter = contains_type<WithSetter, Tags...>::value;
+
+    static std::unique_ptr<SkeletonEvent<FieldType>> MakeSkeletonEvent(SkeletonBase& parent,
+                                                                       const std::string_view field_name)
+    {
+        // No kHasNotifier: the SkeletonEvent is always built because it provides Update/Allocate.
+        return std::make_unique<SkeletonEvent<FieldType>>(
+            parent,
+            field_name,
+            SkeletonFieldBindingFactory<SampleDataType>::CreateEventBinding(
+                SkeletonBaseView{parent}.GetAssociatedInstanceIdentifier(), parent, field_name),
+            typename SkeletonEvent<FieldType>::FieldOnlyConstructorEnabler{});
+    }
+
+    /// \brief Builds the Get-method dispatch when WithGetter is enabled.
+    /// \return A valid SkeletonMethod dispatch when WithGetter is in the tag pack, nullptr otherwise.
+    static std::unique_ptr<SkeletonMethod<GetMethodSignature>> MakeGetMethodIfEnabled(SkeletonBase& parent,
+                                                                                      const std::string_view field_name)
+    {
+        if constexpr (kHasGetter)
+        {
+            return std::make_unique<SkeletonMethod<GetMethodSignature>>(
+                parent,
+                field_name,
+                ::score::mw::com::impl::MethodType::kGet,
+                typename SkeletonMethod<GetMethodSignature>::FieldOnlyConstructorEnabler{});
+        }
+        else
+        {
+            return nullptr;
+        }
+    }
+
+    /// \brief Builds the Set-method dispatch when WithSetter is enabled.
+    /// \return A valid SkeletonMethod dispatch when WithSetter is in the tag pack, nullptr otherwise.
+    static std::unique_ptr<SkeletonMethod<SetMethodSignature>> MakeSetMethodIfEnabled(SkeletonBase& parent,
+                                                                                      const std::string_view field_name)
+    {
+        if constexpr (kHasSetter)
+        {
+            return std::make_unique<SkeletonMethod<SetMethodSignature>>(
+                parent,
+                field_name,
+                ::score::mw::com::impl::MethodType::kSet,
+                typename SkeletonMethod<SetMethodSignature>::FieldOnlyConstructorEnabler{});
+        }
+        else
+        {
+            return nullptr;
+        }
+    }
+
+    /// \brief Single private delegating constructor. Both the production and test ctors funnel through here with
+    ///        appropriate dispatches (real ones from the Make*IfEnabled helpers, or nullptr).
+    SkeletonField(SkeletonBase& parent,
+                  const std::string_view field_name,
+                  std::unique_ptr<SkeletonEvent<FieldType>> skeleton_event_dispatch,
+                  std::unique_ptr<SkeletonMethod<SetMethodSignature>> skeleton_set_method_dispatch,
+                  std::unique_ptr<SkeletonMethod<GetMethodSignature>> skeleton_get_method_dispatch);
 
     std::unique_ptr<FieldType> initial_field_value_;
     ISkeletonField<FieldType>* skeleton_field_mock_;
@@ -210,79 +288,13 @@ class SkeletonField : public SkeletonFieldBase
     std::unique_ptr<SkeletonMethod<GetMethodSignature>> get_method_;
 };
 
-/// \brief Public ctor — EnableSet=true: delegates to the private ctor that also creates the set method.
-template <typename SampleDataType, bool EnableSet, bool EnableNotifier>
-template <bool ES, typename>
-SkeletonField<SampleDataType, EnableSet, EnableNotifier>::SkeletonField(SkeletonBase& parent,
-                                                                        const std::string_view field_name,
-                                                                        detail::EnableSetOnlyTag)
-    : SkeletonField{
-          parent,
-          std::make_unique<SkeletonEvent<FieldType>>(parent,
-                                                     field_name,
-                                                     SkeletonFieldBindingFactory<SampleDataType>::CreateEventBinding(
-                                                         SkeletonBaseView{parent}.GetAssociatedInstanceIdentifier(),
-                                                         parent,
-                                                         field_name),
-                                                     typename SkeletonEvent<FieldType>::FieldOnlyConstructorEnabler{}),
-          std::make_unique<SkeletonMethod<SetMethodSignature>>(
-              parent,
-              field_name,
-              ::score::mw::com::impl::MethodType::kSet,
-              typename SkeletonMethod<SetMethodSignature>::FieldOnlyConstructorEnabler{}),
-          // TODO: Move get_method_ initialization into the delegating constructors (like set_method_) once the
-          // Get handler is implemented.
-          std::make_unique<SkeletonMethod<GetMethodSignature>>(
-              parent,
-              field_name,
-              ::score::mw::com::impl::MethodType::kGet,
-              typename SkeletonMethod<GetMethodSignature>::FieldOnlyConstructorEnabler{}),
-          field_name}
-{
-}
-
-/// \brief Public ctor — EnableSet=false: delegates to the private ctor with no set method.
-template <typename SampleDataType, bool EnableSet, bool EnableNotifier>
-template <bool ES, typename>
-SkeletonField<SampleDataType, EnableSet, EnableNotifier>::SkeletonField(SkeletonBase& parent,
-                                                                        const std::string_view field_name,
-                                                                        detail::EnableNeitherTag)
-    : SkeletonField{
-          parent,
-          std::make_unique<SkeletonEvent<FieldType>>(parent,
-                                                     field_name,
-                                                     SkeletonFieldBindingFactory<SampleDataType>::CreateEventBinding(
-                                                         SkeletonBaseView{parent}.GetAssociatedInstanceIdentifier(),
-                                                         parent,
-                                                         field_name),
-                                                     typename SkeletonEvent<FieldType>::FieldOnlyConstructorEnabler{}),
-          nullptr,
-          nullptr,
-          field_name}
-{
-}
-
-/// \brief Testing ctor: binding is provided directly (used with mock bindings in tests).
-template <typename SampleDataType, bool EnableSet, bool EnableNotifier>
-SkeletonField<SampleDataType, EnableSet, EnableNotifier>::SkeletonField(
-    SkeletonBase& skeleton_base,
-    const std::string_view field_name,
-    std::unique_ptr<SkeletonEventBinding<FieldType>> binding)
-    : SkeletonField{skeleton_base,
-                    std::make_unique<SkeletonEvent<FieldType>>(skeleton_base, field_name, std::move(binding)),
-                    nullptr,
-                    nullptr,
-                    field_name}
-{
-}
-
-template <typename SampleDataType, bool EnableSet, bool EnableNotifier>
-SkeletonField<SampleDataType, EnableSet, EnableNotifier>::SkeletonField(
+template <typename SampleDataType, typename... Tags>
+SkeletonField<SampleDataType, Tags...>::SkeletonField(
     SkeletonBase& parent,
+    const std::string_view field_name,
     std::unique_ptr<SkeletonEvent<FieldType>> skeleton_event_dispatch,
     std::unique_ptr<SkeletonMethod<SetMethodSignature>> skeleton_set_method_dispatch,
-    std::unique_ptr<SkeletonMethod<GetMethodSignature>> skeleton_get_method_dispatch,
-    const std::string_view field_name)
+    std::unique_ptr<SkeletonMethod<GetMethodSignature>> skeleton_get_method_dispatch)
     : SkeletonFieldBase{parent, field_name, std::move(skeleton_event_dispatch)},
       initial_field_value_{nullptr},
       skeleton_field_mock_{nullptr},
@@ -294,8 +306,8 @@ SkeletonField<SampleDataType, EnableSet, EnableNotifier>::SkeletonField(
     skeleton_base_view.RegisterField(field_name, *this);
 }
 
-template <typename SampleDataType, bool EnableSet, bool EnableNotifier>
-SkeletonField<SampleDataType, EnableSet, EnableNotifier>::SkeletonField(SkeletonField&& other) noexcept
+template <typename SampleDataType, typename... Tags>
+SkeletonField<SampleDataType, Tags...>::SkeletonField(SkeletonField&& other) noexcept
     : SkeletonFieldBase(static_cast<SkeletonFieldBase&&>(other)),
       // known llvm bug (https://github.com/llvm/llvm-project/issues/63202)
       // This usage is safe because the previous line only moves the base class portion via static_cast.
@@ -312,9 +324,9 @@ SkeletonField<SampleDataType, EnableSet, EnableNotifier>::SkeletonField(Skeleton
     skeleton_base_view.UpdateField(field_name_, *this);
 }
 
-template <typename SampleDataType, bool EnableSet, bool EnableNotifier>
-auto SkeletonField<SampleDataType, EnableSet, EnableNotifier>::operator=(SkeletonField&& other) & noexcept
-    -> SkeletonField<SampleDataType, EnableSet, EnableNotifier>&
+template <typename SampleDataType, typename... Tags>
+auto SkeletonField<SampleDataType, Tags...>::operator=(SkeletonField&& other) & noexcept
+    -> SkeletonField<SampleDataType, Tags...>&
 {
     if (this != &other)
     {
@@ -338,8 +350,8 @@ auto SkeletonField<SampleDataType, EnableSet, EnableNotifier>::operator=(Skeleto
 /// field cannot be set until the Skeleton has been set up via Skeleton::OfferService(). Therefore, we create a
 /// callback that will update the field value with sample_value which will be called in the first call to
 /// SkeletonFieldBase::PrepareOffer().
-template <typename SampleDataType, bool EnableSet, bool EnableNotifier>
-Result<void> SkeletonField<SampleDataType, EnableSet, EnableNotifier>::Update(const FieldType& sample_value) noexcept
+template <typename SampleDataType, typename... Tags>
+Result<void> SkeletonField<SampleDataType, Tags...>::Update(const FieldType& sample_value) noexcept
 {
     if (skeleton_field_mock_ != nullptr)
     {
@@ -356,9 +368,8 @@ Result<void> SkeletonField<SampleDataType, EnableSet, EnableNotifier>::Update(co
 
 /// \brief FieldType is previously allocated by middleware and provided by the user to indicate that he is finished
 /// filling the provided pointer with live data. Dispatches to SkeletonEvent::Send()
-template <typename SampleDataType, bool EnableSet, bool EnableNotifier>
-Result<void> SkeletonField<SampleDataType, EnableSet, EnableNotifier>::Update(
-    SampleAllocateePtr<FieldType> sample) noexcept
+template <typename SampleDataType, typename... Tags>
+Result<void> SkeletonField<SampleDataType, Tags...>::Update(SampleAllocateePtr<FieldType> sample) noexcept
 {
     if (skeleton_field_mock_ != nullptr)
     {
@@ -373,8 +384,8 @@ Result<void> SkeletonField<SampleDataType, EnableSet, EnableNotifier>::Update(
 ///
 /// This function cannot be currently called to set the initial value of a field as the shared memory must be first
 /// set up in the Skeleton::PrepareOffer() before the user can obtain / use a SampleAllocateePtr.
-template <typename SampleDataType, bool EnableSet, bool EnableNotifier>
-Result<SampleAllocateePtr<SampleDataType>> SkeletonField<SampleDataType, EnableSet, EnableNotifier>::Allocate() noexcept
+template <typename SampleDataType, typename... Tags>
+Result<SampleAllocateePtr<SampleDataType>> SkeletonField<SampleDataType, Tags...>::Allocate() noexcept
 {
     if (skeleton_field_mock_ != nullptr)
     {
@@ -392,12 +403,12 @@ Result<SampleAllocateePtr<SampleDataType>> SkeletonField<SampleDataType, EnableS
     return GetTypedEvent()->Allocate();
 }
 
-template <typename SampleDataType, bool EnableSet, bool EnableNotifier>
+template <typename SampleDataType, typename... Tags>
 // Suppress "AUTOSAR C++14 A0-1-3" rule finding. This rule states: "Every function defined in an anonymous
 // namespace, or static function with internal linkage, or private member function shall be used.".
 // False-positive, method is used in the base class in PrepareOffer().
 // coverity[autosar_cpp14_a0_1_3_violation : FALSE]
-Result<void> SkeletonField<SampleDataType, EnableSet, EnableNotifier>::DoDeferredUpdate() noexcept
+Result<void> SkeletonField<SampleDataType, Tags...>::DoDeferredUpdate() noexcept
 {
     SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(
         initial_field_value_ != nullptr,
@@ -413,16 +424,14 @@ Result<void> SkeletonField<SampleDataType, EnableSet, EnableNotifier>::DoDeferre
     return Result<void>{};
 }
 
-template <typename SampleDataType, bool EnableSet, bool EnableNotifier>
-Result<void> SkeletonField<SampleDataType, EnableSet, EnableNotifier>::UpdateImpl(
-    const FieldType& sample_value) noexcept
+template <typename SampleDataType, typename... Tags>
+Result<void> SkeletonField<SampleDataType, Tags...>::UpdateImpl(const FieldType& sample_value) noexcept
 {
     return GetTypedEvent()->Send(sample_value);
 }
 
-template <typename SampleDataType, bool EnableSet, bool EnableNotifier>
-auto SkeletonField<SampleDataType, EnableSet, EnableNotifier>::GetTypedEvent() const noexcept
-    -> SkeletonEvent<SampleDataType>*
+template <typename SampleDataType, typename... Tags>
+auto SkeletonField<SampleDataType, Tags...>::GetTypedEvent() const noexcept -> SkeletonEvent<SampleDataType>*
 {
     auto* const typed_event = dynamic_cast<SkeletonEvent<FieldType>*>(skeleton_event_dispatch_.get());
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(typed_event != nullptr, "Downcast to SkeletonEvent<FieldType> failed!");

--- a/score/mw/com/impl/skeleton_field_test.cpp
+++ b/score/mw/com/impl/skeleton_field_test.cpp
@@ -36,6 +36,19 @@ namespace
 
 using TestSampleType = std::uint8_t;
 
+// SFINAE helper to check if RegisterSetHandler is available with "WithSetter" tag.
+template <typename, typename = void>
+struct has_register_set_handler : std::false_type
+{
+};
+template <typename T>
+struct has_register_set_handler<T,
+                                std::void_t<decltype(std::declval<T&>().RegisterSetHandler(
+                                    std::declval<score::cpp::callback<void(typename T::FieldType&)>>()))>>
+    : std::true_type
+{
+};
+
 using SkeletonEventTracingData = tracing::SkeletonEventTracingData;
 
 using ::testing::_;
@@ -66,7 +79,8 @@ class MyDummySkeleton : public SkeletonBase
   public:
     using SkeletonBase::SkeletonBase;
 
-    SkeletonField<TestSampleType> my_dummy_field_{*this, kFieldName};
+    // WithSetter is intentionally absent here since setter-related behaviour is tested via MySetterSkeleton below.
+    SkeletonField<TestSampleType, WithGetter, WithNotifier> my_dummy_field_{*this, kFieldName};
 };
 
 class SkeletonFieldTestFixture : public ::testing::Test
@@ -135,14 +149,20 @@ TEST(SkeletonFieldTest, NotCopyable)
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
-    static_assert(!std::is_copy_constructible<SkeletonField<TestSampleType>>::value, "Is wrongly copyable");
-    static_assert(!std::is_copy_assignable<SkeletonField<TestSampleType>>::value, "Is wrongly copyable");
+    static_assert(
+        !std::is_copy_constructible<SkeletonField<TestSampleType, WithGetter, WithNotifier, WithSetter>>::value,
+        "Is wrongly copyable");
+    static_assert(!std::is_copy_assignable<SkeletonField<TestSampleType, WithGetter, WithNotifier, WithSetter>>::value,
+                  "Is wrongly copyable");
 }
 
 TEST(SkeletonFieldTest, IsMoveable)
 {
-    static_assert(std::is_move_constructible<SkeletonField<TestSampleType>>::value, "Is not move constructible");
-    static_assert(std::is_move_assignable<SkeletonField<TestSampleType>>::value, "Is not move assignable");
+    static_assert(
+        std::is_move_constructible<SkeletonField<TestSampleType, WithGetter, WithNotifier, WithSetter>>::value,
+        "Is not move constructible");
+    static_assert(std::is_move_assignable<SkeletonField<TestSampleType, WithGetter, WithNotifier, WithSetter>>::value,
+                  "Is not move assignable");
 }
 
 TEST(SkeletonFieldTest, ClassTypeDependsOnFieldDataType)
@@ -168,7 +188,8 @@ TEST(SkeletonFieldTest, SkeletonFieldContainsPublicSampleType)
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
-    static_assert(std::is_same<typename SkeletonField<TestSampleType>::FieldType, TestSampleType>::value,
+    static_assert(std::is_same<typename SkeletonField<TestSampleType, WithGetter, WithNotifier, WithSetter>::FieldType,
+                               TestSampleType>::value,
                   "Incorrect FieldType.");
 }
 
@@ -677,6 +698,13 @@ TEST(SkeletonFieldInitialValueTest, MoveAssigningFieldBeforePrepareOfferWillKeep
     ON_CALL(runtime_mock_guard.runtime_mock_, GetTracingFilterConfig()).WillByDefault(Return(nullptr));
 
     SkeletonFieldBindingFactoryMockGuard<TestSampleType> skeleton_field_binding_factory_mock_guard{};
+    SkeletonMethodBindingFactoryMockGuard skeleton_method_binding_factory_mock_guard{};
+
+    mock_binding::SkeletonMethod skeleton_method_mock{};
+    ON_CALL(skeleton_method_binding_factory_mock_guard.factory_mock_, Create(_, _, _, _))
+        .WillByDefault(InvokeWithoutArgs([&skeleton_method_mock]() {
+            return std::make_unique<mock_binding::SkeletonMethodFacade>(skeleton_method_mock);
+        }));
 
     // Expecting that a SkeletonField binding is created
     auto skeleton_field_binding_mock_ptr = std::make_unique<mock_binding::SkeletonEvent<TestSampleType>>();
@@ -832,32 +860,31 @@ TEST_F(SkeletonFieldDeathTest, UpdateWithInvalidFieldNameTriggersTermination)
     EXPECT_DEATH(SkeletonBaseView{unit}.UpdateField("non_existing_test_field_name", field);, ".*");
 }
 
-// Helper skeleton that holds an EnableSet=true field (setter-capable field)
+// Helper skeleton that holds a SkeletonField with all three tags.
 class MySetterSkeleton : public SkeletonBase
 {
   public:
     using SkeletonBase::SkeletonBase;
 
-    SkeletonField<TestSampleType, /*EnableSet=*/true> my_setter_field_{*this, kFieldName};
+    SkeletonField<TestSampleType, WithGetter, WithSetter, WithNotifier> my_setter_field_{*this, kFieldName};
 };
 
-TEST(SkeletonFieldSetHandlerTypeTraitsTest, RegisterSetHandlerOnlyExistsWhenEnableSetIsTrue)
+TEST(SkeletonFieldSetHandlerTypeTraitsTest, RegisterSetHandlerOnlyExistsWhenWithSetterTagPresent)
 {
     RecordProperty("Description",
-                   "RegisterSetHandler() shall only exist on SkeletonField<T, EnableSet=true>. "
-                   "Verify via has_member detection that it is absent when EnableSet=false.");
+                   "RegisterSetHandler() shall only exist on SkeletonField specializations whose tag pack "
+                   "contains WithSetter. Verify via SFINAE detection that it is absent without WithSetter.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
-    // RegisterSetHandler should be callable on EnableSet=true
-    static_assert(std::is_same_v<SkeletonField<TestSampleType, true>::FieldType, TestSampleType>,
-                  "Setter-capable field must expose FieldType");
+    using SetterField = SkeletonField<TestSampleType, WithSetter, WithNotifier, WithGetter>;
+    using NoSetterField = SkeletonField<TestSampleType, WithNotifier, WithGetter>;
 
-    // EnableSet=false field must not expose SetHandlerType at the member function level. We verify
-    // indirectly that the EnableSet template parameter distinguishes the types.
-    static_assert(!std::is_same_v<SkeletonField<TestSampleType, false>, SkeletonField<TestSampleType, true>>,
-                  "EnableSet=false and EnableSet=true fields must be different types");
+    static_assert(has_register_set_handler<SetterField>::value,
+                  "RegisterSetHandler must exist on a SkeletonField with WithSetter in the tag pack");
+    static_assert(!has_register_set_handler<NoSetterField>::value,
+                  "RegisterSetHandler must be SFINAE-removed on a SkeletonField without WithSetter");
 }
 
 using SkeletonFieldSetHandlerTest = SkeletonFieldTestFixture;
@@ -930,7 +957,7 @@ TEST_F(SkeletonFieldSetHandlerTest, PrepareOfferSucceedsAfterRegisterSetHandler)
     EXPECT_TRUE(result.has_value());
 }
 
-TEST_F(SkeletonFieldSetHandlerTest, PrepareOfferSucceedsWithoutHandlerWhenEnableSetIsFalse)
+TEST_F(SkeletonFieldSetHandlerTest, PrepareOfferSucceedsWithoutHandlerWhenWithSetterTagIsAbsent)
 {
     // Given a skeleton containing a field without a setter enabled
     MyDummySkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};

--- a/score/mw/com/impl/test/proxy_resources.h
+++ b/score/mw/com/impl/test/proxy_resources.h
@@ -24,11 +24,11 @@
 namespace score::mw::com::impl
 {
 
-template <typename FieldType>
+template <typename FieldType, typename... Tags>
 class ProxyFieldAttorney
 {
   public:
-    ProxyFieldAttorney(ProxyField<FieldType>& proxy_field) noexcept : proxy_field_{proxy_field} {}
+    ProxyFieldAttorney(ProxyField<FieldType, Tags...>& proxy_field) noexcept : proxy_field_{proxy_field} {}
 
     ProxyEvent<FieldType>& GetProxyEvent() noexcept
     {
@@ -37,7 +37,7 @@ class ProxyFieldAttorney
     }
 
   private:
-    ProxyField<FieldType>& proxy_field_;
+    ProxyField<FieldType, Tags...>& proxy_field_;
 };
 
 class ProxyEventBaseAttorney
@@ -45,9 +45,9 @@ class ProxyEventBaseAttorney
   public:
     ProxyEventBaseAttorney(ProxyEventBase& proxy_event_base) noexcept : proxy_event_base_{proxy_event_base} {}
 
-    template <typename FieldType>
-    ProxyEventBaseAttorney(ProxyField<FieldType>& proxy_field) noexcept
-        : proxy_event_base_{ProxyFieldAttorney<FieldType>{proxy_field}.GetProxyEvent()}
+    template <typename FieldType, typename... Tags>
+    ProxyEventBaseAttorney(ProxyField<FieldType, Tags...>& proxy_field) noexcept
+        : proxy_event_base_{ProxyFieldAttorney<FieldType, Tags...>{proxy_field}.GetProxyEvent()}
     {
     }
 

--- a/score/mw/com/impl/tracing/test/proxy_event_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/test/proxy_event_tracing_test.cpp
@@ -69,7 +69,7 @@ class MyDummyProxyWithField : public ProxyBase
   public:
     using ProxyBase::ProxyBase;
 
-    ProxyField<TestSampleType> my_service_element_{*this, kServiceElementName};
+    ProxyField<TestSampleType, WithGetter, WithNotifier, WithSetter> my_service_element_{*this, kServiceElementName};
 };
 
 /// \brief Structs containing types for templated gtests.

--- a/score/mw/com/impl/tracing/test/skeleton_field_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/test/skeleton_field_tracing_test.cpp
@@ -73,7 +73,7 @@ class MyDummySkeleton : public SkeletonBase
   public:
     using SkeletonBase::SkeletonBase;
 
-    SkeletonField<TestSampleType> my_dummy_field_{*this, kFieldName};
+    SkeletonField<TestSampleType, WithGetter, WithNotifier, WithSetter> my_dummy_field_{*this, kFieldName};
 };
 
 TEST(SkeletonFieldTracingTest, TracePointsAreDisabledIfConfigNotReturnedByRuntime)

--- a/score/mw/com/impl/traits.h
+++ b/score/mw/com/impl/traits.h
@@ -14,6 +14,7 @@
 #define SCORE_MW_COM_IMPL_TRAITS_H
 
 #include "score/mw/com/impl/com_error.h"
+#include "score/mw/com/impl/field_tags.h"
 #include "score/mw/com/impl/flag_owner.h"
 #include "score/mw/com/impl/handle_type.h"
 #include "score/mw/com/impl/instance_identifier.h"
@@ -100,19 +101,20 @@ class ProxyWrapperClassTestView;
 ///     typename Trait::template Event<DataType1> struct_event_1_{*this, event_name_0};
 ///     typename Trait::template Event<DataType2> struct_event_2_{*this, event_name_1};
 ///
-///     typename Trait::template Field<DataType1, true, false, true> struct_field_1_{*this,
-///     field_name_0};
-///     typename Trait::template Field<DataType2, enable_getter, enable_setter, enable_notifier>
-///     struct_field_2_{*this, field_name_1};
+///     typename Trait::template Field<DataType1, WithGetter, WithSetter, WithNotifier> struct_field_1_{*this,
+///                                                                                                     field_name_0};
+///     typename Trait::template Field<DataType2, WithNotifier> struct_field_2_{*this, field_name_1};
 ///
 ///     typename Trait::template Method<void(InArgType1)> struct_method_1_{*this, method_name_0};
 ///     typename Trait::template Method<ReturnType()> struct_method_2_{*this, method_name_1};
 ///
 /// };
-/// Notes regarding template args: A field has (besides its data type arg) three bool template args (enable_getter,
-/// enable_setter and enable_notifier). The enable_notifier template parameter is only relevant for certain bindings,
-/// e.g. the LoLa binding does not distinguish between true/false of this template parameter.
-/// A method has a template arg describing the method signature in the form ReturnType(InArgType1, InArgType2, ...).
+/// Notes regarding template args: a field takes its data type plus a pack of tags from {WithGetter, WithSetter,
+/// WithNotifier}. WithGetter / WithSetter enable Get() / Set() on the proxy. WithNotifier enables the proxy notifier
+/// public API (Subscribe, Unsubscribe, GetSubscriptionState, GetFreeSampleCount, GetNumNewSamplesAvailable,
+/// SetReceiveHandler, UnsetReceiveHandler, GetNewSamples). At least one of WithGetter or WithNotifier must be present,
+/// otherwise the value would be invisible to consumers. The skeleton-side Update/Allocate are part of every field. A
+/// method has a template arg describing the method signature in the form ReturnType(InArgType1, InArgType2, ...).
 /// InArgs and ReturnType are optional. Therefore, these are valid signatures:
 /// - void()
 /// - ReturnType1()
@@ -139,10 +141,8 @@ class ProxyTrait
     template <typename SampleType>
     using Event = ProxyEvent<SampleType>;
 
-    // Note : at the moment the SkeletonField::Get implementation is not in the branch which means the skeleton and
-    // proxy side does not have same template parameters.
-    template <typename SampleType, bool EnableSet = false, bool EnableGet = false, bool EnableNotifier = false>
-    using Field = ProxyField<SampleType>;
+    template <typename SampleType, typename... Tags>
+    using Field = ProxyField<SampleType, Tags...>;
 
     template <typename MethodSignature>
     using Method = ProxyMethod<MethodSignature>;
@@ -164,8 +164,8 @@ class SkeletonTrait
     template <typename SampleType>
     using Event = SkeletonEvent<SampleType>;
 
-    template <typename SampleType, bool EnableSet = false, bool EnableNotifier = false>
-    using Field = SkeletonField<SampleType, EnableSet, EnableNotifier>;
+    template <typename SampleType, typename... Tags>
+    using Field = SkeletonField<SampleType, Tags...>;
 
     template <typename MethodSignature>
     using Method = SkeletonMethod<MethodSignature>;

--- a/score/mw/com/impl/traits_test.cpp
+++ b/score/mw/com/impl/traits_test.cpp
@@ -70,7 +70,9 @@ class MyInterface : public InterfaceTrait::Base
     using InterfaceTrait::Base::Base;
 
     typename InterfaceTrait::template Event<TestSampleType> some_event{*this, kEventName};
-    typename InterfaceTrait::template Field<TestSampleType, true> some_field{*this, kFieldName};
+    typename InterfaceTrait::template Field<TestSampleType, WithGetter, WithSetter, WithNotifier> some_field{
+        *this,
+        kFieldName};
     typename InterfaceTrait::template Method<TestMethodType> some_method{*this, kMethodName};
 };
 using MyProxy = AsProxy<MyInterface>;
@@ -127,13 +129,15 @@ class ProxyCreationFixture : public ::testing::Test
         ON_CALL(proxy_field_binding_factory_mock_guard_.factory_mock_, CreateEventBinding(_, kFieldName))
             .WillByDefault(Return(ByMove(std::move(proxy_field_binding_mock_ptr))));
 
+        // By default the Create call on the ProxyFieldBindingFactory returns valid method bindings.
+        ON_CALL(proxy_field_binding_factory_mock_guard_.factory_mock_, CreateGetMethodBinding(_, kFieldName))
+            .WillByDefault(Return(ByMove(std::move(proxy_field_get_binding_mock_ptr))));
+        ON_CALL(proxy_field_binding_factory_mock_guard_.factory_mock_, CreateSetMethodBinding(_, kFieldName))
+            .WillByDefault(Return(ByMove(std::move(proxy_field_set_binding_mock_ptr))));
+
         // By default the Create call on the ProxyMethodBindingFactory returns valid bindings.
         ON_CALL(proxy_method_binding_factory_mock_guard_.factory_mock_, Create(_, _, kMethodName, MethodType::kMethod))
             .WillByDefault(Return(ByMove(std::move(proxy_method_binding_mock_ptr))));
-        ON_CALL(proxy_method_binding_factory_mock_guard_.factory_mock_, Create(_, _, kFieldName, MethodType::kSet))
-            .WillByDefault(Return(ByMove(std::move(proxy_field_set_binding_mock_ptr))));
-        ON_CALL(proxy_method_binding_factory_mock_guard_.factory_mock_, Create(_, _, kFieldName, MethodType::kGet))
-            .WillByDefault(Return(ByMove(std::move(proxy_field_get_binding_mock_ptr))));
 
         // By default that the proxy_binding can successfully call SetupMethods
         ON_CALL(proxy_binding_mock_, SetupMethods()).WillByDefault(Return(score::Result<void>{}));

--- a/score/mw/com/test/common_test_resources/test_interface.h
+++ b/score/mw/com/test/common_test_resources/test_interface.h
@@ -14,6 +14,8 @@
 #ifndef SCORE_MW_COM_TEST_COMMON_TEST_RESOURCES_TEST_INTERFACE_H
 #define SCORE_MW_COM_TEST_COMMON_TEST_RESOURCES_TEST_INTERFACE_H
 
+#include "score/mw/com/types.h"
+
 #include <cstdint>
 #include <vector>
 
@@ -26,7 +28,10 @@ class TestInterface : public T::Base
   public:
     using T::Base::Base;
 
-    typename T::template Field<std::int32_t> test_field{*this, "test_field"};
+    // Only WithNotifier is needed since the proxy subscribes to receive the initial value the skeleton
+    // publishes via Update(). No Get/Set so, WithGetter and WithSetter must stay absent until we add tests that require
+    // them.
+    typename T::template Field<std::int32_t, score::mw::com::WithNotifier> test_field{*this, "test_field"};
 };
 
 }  // namespace score::mw::com::test

--- a/score/mw/com/test/field_initial_value/test_datatype.h
+++ b/score/mw/com/test/field_initial_value/test_datatype.h
@@ -31,7 +31,9 @@ class TestInterface : public T::Base
   public:
     using T::Base::Base;
 
-    typename T::template Field<std::int32_t> test_field{*this, "test_field"};
+    // Only WithNotifier is needed since the proxy subscribes to receive the initial value the skeleton
+    // publishes via Update(). No Get/Set so, WithGetter and WithSetter must stay absent.
+    typename T::template Field<std::int32_t, score::mw::com::WithNotifier> test_field{*this, "test_field"};
 };
 
 using TestDataProxy = score::mw::com::AsProxy<TestInterface>;

--- a/score/mw/com/test/find_any_semantics/test_datatype.h
+++ b/score/mw/com/test/find_any_semantics/test_datatype.h
@@ -34,7 +34,9 @@ class TestInterface : public T::Base
   public:
     using T::Base::Base;
 
-    typename T::template Field<std::int32_t> test_field{*this, "test_field"};
+    // Only WithNotifier is needed: the proxy subscribes to receive the value the skeleton publishes
+    // via Update(). No Get/Set API is involved, so WithGetter and WithSetter must stay absent.
+    typename T::template Field<std::int32_t, score::mw::com::WithNotifier> test_field{*this, "test_field"};
 };
 
 using TestDataProxy = score::mw::com::AsProxy<TestInterface>;

--- a/score/mw/com/types.h
+++ b/score/mw/com/types.h
@@ -18,6 +18,7 @@
 #include "score/mw/com/impl/plumbing/sample_ptr.h"
 
 #include "score/mw/com/impl/event_receive_handler.h"
+#include "score/mw/com/impl/field_tags.h"
 #include "score/mw/com/impl/find_service_handle.h"
 #include "score/mw/com/impl/find_service_handler.h"
 #include "score/mw/com/impl/generic_proxy.h"
@@ -104,6 +105,12 @@ using MethodInArgTypePtr = impl::MethodInArgPtr<ReturnType>;
 /// \brief Callback for event notifications on proxy side.
 /// \requirement SWS_CM_00309
 using EventReceiveHandler = impl::EventReceiveHandler;
+
+/// \api
+/// \brief Field tag types used in service-interface definitions to enable Get/Set/Notifier on a field.
+using WithGetter = impl::WithGetter;
+using WithSetter = impl::WithSetter;
+using WithNotifier = impl::WithNotifier;
 
 /// \api
 /// \brief Interpret an interface that follows our traits as proxy (cf. impl/traits.h)


### PR DESCRIPTION
* This PR aims to migrate from boolean based enabelment of notifier/getter/setter on a field to a more user friendly and strictly typed Tag based mechanism.
* This change would let the users not to worry about the ordering of the boolean flags that would enable user required features on a field instead, they can just name what they want to enable with WithSetter/WithNotifer/WithGetter.
* if any of the above mentioned tags are not provided it is assumed that users wants those respective features to be disabled.