### PR TITLE
Fix unused variable warning

### DIFF
--- a/score/message_passing/qnx_dispatch/qnx_dispatch_engine.cpp
+++ b/score/message_passing/qnx_dispatch/qnx_dispatch_engine.cpp
@@ -700,7 +700,7 @@ void QnxDispatchEngine::StopServer(ResourceManagerServer& server) noexcept
     {
         // QNX defect PR# 2561573: resmgr_attach/message_attach calls are not thread-safe for the same dispatch_pointer
         std::lock_guard guard(attach_mutex_);
-        const auto detach_expected = os_resources_.dispatch->resmgr_detach(
+        score::cpp::ignore = os_resources_.dispatch->resmgr_detach(
             dispatch_pointer_, server.resmgr_id_, static_cast<std::uint32_t>(_RESMGR_DETACH_CLOSE));
         server.resmgr_id_ = -1;
     }


### PR DESCRIPTION
It should be fine to ignore a potential error
in this case. According to resmgr_detach documentation, it will only return the error if our attach/detach logic is incorrect (shall already be covered with our tests) or if some non-local error (such as memory
corruption) happened. The error, if happens, will happen at the shutdown of the process, and the best we could do is to log the error and continue.