### PR TITLE
Drop confusing rules_oci ubuntu image

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -289,17 +289,6 @@ pip.parse(
 use_repo(pip, "lobster_dependencies")
 
 bazel_dep(name = "rules_oci", version = "2.2.7", dev_dependency = True)
-
-oci = use_extension("@rules_oci//oci:extensions.bzl", "oci", dev_dependency = True)
-oci.pull(
-    name = "ubuntu_24_04",
-    digest = "sha256:2e863c44b718727c860746568e1d54afd13b2fa71b160f5cd9058fc436217b30",
-    image = "ubuntu",
-    platforms = ["linux/amd64"],
-    tag = "24.04",
-)
-use_repo(oci, "ubuntu_24_04", "ubuntu_24_04_linux_amd64")
-
 bazel_dep(name = "rules_distroless", version = "0.6.2", dev_dependency = True)
 
 apt = use_extension(


### PR DESCRIPTION
This is a leftover from switching to rules_distroless image.