### PR TITLE
Adding clang-tidy checks

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -12,29 +12,102 @@
 # *******************************************************************************
 
 ---
-# Basic clang-tidy configuration for SCORE Communication project
-# NOTE: the set of enabled checks is yet subject to be tailored for the S-CORE project
+# Clang-tidy configuration for SCORE Communication project
 Checks: >
   -*,
-  clang-analyzer-*,
-  cert-*,
-  cppcoreguidelines-*,
-  bugprone-*,
-  misc-*,
-  performance-*,
-  readability-*,
-  modernize-*
+  # --- autosar-severity-one ---
+  bugprone-use-after-move,
+  bugprone-dynamic-static-initializers,
+  bugprone-suspicious-enum-usage,
+  cert-oop54-cpp,
+  clang-analyzer-core.uninitialized.ArraySubscript,
+  clang-analyzer-core.uninitialized.Assign,
+  clang-analyzer-core.uninitialized.Branch,
+  clang-analyzer-core.uninitialized.CapturedBlockVariable,
+  clang-analyzer-core.uninitialized.UndefReturn,
+  clang-analyzer-optin.cplusplus.UninitializedObject,
+  clang-analyzer-security.FloatLoopCounter,
+  clang-analyzer-valist.Uninitialized,
+  cppcoreguidelines-avoid-goto,
+  cppcoreguidelines-init-variables,
+  cppcoreguidelines-no-malloc,
+  cppcoreguidelines-pro-bounds-constant-array-index,
+  cppcoreguidelines-pro-bounds-pointer-arithmetic,
+  cppcoreguidelines-pro-type-cstyle-cast,
+  cppcoreguidelines-pro-type-member-init,
+  cppcoreguidelines-pro-type-reinterpret-cast,
+  cppcoreguidelines-pro-type-static-cast-downcast,
+  cppcoreguidelines-pro-type-union-access,
+  cppcoreguidelines-virtual-class-destructor,
+  google-default-arguments,
+  google-explicit-constructor,
+  hicpp-no-array-decay,
+  hicpp-no-assembler,
+  misc-definitions-in-headers,
+  misc-unconventional-assign-operator,
+  misc-unused-parameters,
+  modernize-avoid-c-arrays,
+  modernize-deprecated-headers,
+  modernize-make-shared,
+  modernize-use-auto,
+  modernize-use-equals-default,
+  performance-noexcept-move-constructor,
+  readability-inconsistent-declaration-parameter-name,
+  readability-misplaced-array-index,
+  readability-redundant-declaration,
+  # --- autosar-severity-two ---
+  bugprone-forwarding-reference-overload,
+  bugprone-move-forwarding-reference,
+  bugprone-multiple-statement-macro,
+  cert-dcl58-cpp,
+  clang-analyzer-deadcode.DeadStores,
+  clang-analyzer-nullability.NullablePassedToNonnull,
+  clang-analyzer-security.insecureAPI.rand,
+  cppcoreguidelines-narrowing-conversions,
+  cppcoreguidelines-pro-bounds-array-to-pointer-decay,
+  cppcoreguidelines-pro-type-vararg,
+  cppcoreguidelines-special-member-functions,
+  fuchsia-multiple-inheritance,
+  google-build-using-namespace,
+  hicpp-move-const-arg,
+  hicpp-signed-bitwise,
+  hicpp-use-nullptr,
+  misc-no-recursion,
+  modernize-use-noexcept,
+  modernize-use-using,
+  readability-braces-around-statements,
+  readability-implicit-bool-conversion,
+  readability-isolate-declaration,
+  readability-redundant-control-flow,
+  # --- cert ---
+  cert-err52-cpp,
+  clang-analyzer-alpha.security.ArrayBoundV2,
+  clang-analyzer-core.UndefinedBinaryOperatorResult,
+  clang-analyzer-cplusplus.NewDelete,
+  # --- qnx-checks ---
+  bugprone-reserved-identifier,
+  # --- extra ---
+  modernize-concat-nested-namespaces,
 
-# Only treat critical checks as errors, others are warnings
-# NOTE: the `WarningsAsErrors` property is yet subject to be tailored for the enabled checks
 WarningsAsErrors: >
   clang-analyzer-*,
 
-# Exclude third-party and external dependencies' headers from analysis
 HeaderFilterRegex: '^(?!.*/third_party/).*'
 
 FormatStyle: file
 
-# NOTE: all `CheckOptions` are yet subject to be provided for each enabled check
-#CheckOptions:
-# none yet
+CheckOptions:
+  - key: readability-inconsistent-declaration-parameter-name.Strict
+    value: true
+  - key: cppcoreguidelines-special-member-functions.AllowSoleDefaultDtor
+    value: true
+  - key: hicpp-move-const-arg.CheckTriviallyCopyableMove
+    value: false
+  - key: modernize-avoid-c-arrays.AllowStringArrays
+    value: false
+  - key: modernize-make-shared.IncludeStyle
+    value: "llvm"
+  - key: modernize-use-auto.RemoveStars
+    value: false
+  - key: readability-braces-around-statements.ShortStatementLines
+    value: 0


### PR DESCRIPTION
- Add modernize-use-nodiscard, modernize-type-traits, performance-unnecessary-value-param, and other bugprone
- checks to improve static analysis coverage.