### PR TITLE
dependability: Add setup for rules_score for mw::com

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -37,10 +37,10 @@ download_archive(
     urls = ["https://github.com/python-jsonschema/jsonschema/archive/refs/tags/v4.23.0.tar.gz"],
 )
 
-bazel_dep(name = "score_tooling", dev_dependency = True)
+bazel_dep(name = "score_tooling")
 git_override(
     module_name = "score_tooling",
-    commit = "4c83c578069768c6133e4268b63929646754f6a6",
+    commit = "0160d13fff81ee20643769339036505b853e2bb0",
     remote = "https://github.com/eclipse-score/tooling.git",
 )
 

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -7,6 +7,27 @@ local_path_override(
 bazel_dep(name = "rules_cc", version = "0.1.5")
 bazel_dep(name = "score_baselibs", version = "0.2.6")
 
+# Needed because we do not have a current release of score_tooling (as we are in dev phase of safety sentinel)
+git_override(
+    module_name = "score_tooling",
+    commit = "0160d13fff81ee20643769339036505b853e2bb0",
+    remote = "https://github.com/eclipse-score/tooling.git",
+)
+
+# Needed because of score_tooling not defining yet as dependency
+
+git_override(
+    module_name = "trlc",
+    commit = "3a71fd56001b95dfbb5270a49449ec0a631cd56c",  #TRLC 2.0.4
+    remote = "https://github.com/bmw-software-engineering/trlc.git",
+)
+
+git_override(
+    module_name = "lobster",
+    commit = "d528fbdec2cd72ff7967b51546fb0bd935810258",
+    remote = "https://github.com/bmw-software-engineering/lobster.git",
+)
+
 # Only required to build the example, shall be replaceable with nearly every other C++ Toolchain setup
 bazel_dep(name = "score_bazel_platforms", version = "0.1.2", dev_dependency = True)
 bazel_dep(name = "score_bazel_cpp_toolchains", version = "0.3.0", dev_dependency = True)

--- a/score/mw/com/dependability/software_architectural_design/static_view.puml
+++ b/score/mw/com/dependability/software_architectural_design/static_view.puml
@@ -14,21 +14,22 @@
 
 interface "mw_com" as mw_com_public_api
 
-component "mw::com" as mw_com <<SEooC>> {
+' @todo: Support in parser that this is a component!
+package "mw::com" as mw_com <<SEooC>> {
 
-    component "Frontend" as frontend <<component>> {
+    component "Frontend" as frontend_component <<component>> {
         component "Proxy" as frontend_proxy <<unit>>
         component "Skeleton" as frontend_skeleton <<unit>>
         component "Service Discovery" as frontend_sd <<unit>>
     }
 
     component "Bindings" as bindings <<component>> {
-        component "LoLa" as lola <<component>> {
+        component "LoLa" as lola_component <<component>> {
             component "Proxy" as lola_proxy <<unit>>
             component "Skeleton" as lola_skeleton <<unit>>
             component "Service Discovery" as lola_sd <<unit>>
         }
-        component "Mock" as mock_binding <<component>> {
+        component "Mock" as mock_component <<component>> {
         }
     }
 
@@ -57,5 +58,5 @@ public_api -left-() mw_com_public_api
 memory -[hidden]down- lola_sd
 frontend_proxy -[hidden]left- frontend_skeleton
 frontend_skeleton -[hidden]left- frontend_sd
-frontend -[hidden]down- bindings
+frontend_component -[hidden]down- bindings
 @enduml

--- a/score/mw/com/impl/BUILD
+++ b/score/mw/com/impl/BUILD
@@ -13,7 +13,44 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@score_baselibs//:bazel/unit_tests.bzl", "cc_gtest_unit_test", "cc_unit_test", "cc_unit_test_suites_for_host_and_qnx")
+load("@score_tooling//bazel/rules/rules_score:rules_score.bzl", "component", "unit")
 load("//score/mw:common_features.bzl", "COMPILER_WARNING_FEATURES")
+
+component(
+    name = "frontend_component",
+    components = [
+        ":frontend_sd",
+        ":frontend_skeleton",
+        ":frontend_proxy",
+    ],
+    requirements = [],
+    tests = [],
+    visibility = ["//score/mw/com/dependability:__pkg__"],
+)
+
+unit(
+    name = "frontend_sd",
+    scope = [],
+    tests = [],
+    unit_design = [],
+    implementation = [],
+)
+
+unit(
+    name = "frontend_skeleton",
+    scope = [],
+    tests = [],
+    unit_design = [],
+    implementation = [],
+)
+
+unit(
+    name = "frontend_proxy",
+    scope = [],
+    tests = [],
+    unit_design = [],
+    implementation = [],
+)
 
 package(default_visibility = [
     "//score/mw/com/impl:__subpackages__",

--- a/score/mw/com/impl/bindings/BUILD
+++ b/score/mw/com/impl/bindings/BUILD
@@ -10,19 +10,15 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-load("@score_tooling//bazel/rules/rules_score:rules_score.bzl", "dependable_element")
+load("@score_tooling//bazel/rules/rules_score:rules_score.bzl", "component")
 
-dependable_element(
-    name = "mw_com",
-    architectural_design = ["//score/mw/com/dependability/software_architectural_design"],
-    assumptions_of_use = [],
+component(
+    name = "bindings",
     components = [
-        "//score/mw/com/impl:frontend_component",
-        "//score/mw/com/impl/bindings",
+        "//score/mw/com/impl/bindings/lola:lola_component",
+        "//score/mw/com/impl/bindings/mock_binding:mock_component",
     ],
-    dependability_analysis = [],
-    integrity_level = "B",
-    maturity = "development",
     requirements = [],
     tests = [],
+    visibility = ["//score/mw/com/dependability:__pkg__"],
 )

--- a/score/mw/com/impl/bindings/lola/BUILD
+++ b/score/mw/com/impl/bindings/lola/BUILD
@@ -13,7 +13,45 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_library", "cc_test")
 load("@score_baselibs//:bazel/unit_tests.bzl", "cc_gtest_unit_test", "cc_unit_test", "cc_unit_test_suites_for_host_and_qnx")
+load("@score_tooling//bazel/rules/rules_score:rules_score.bzl", "component", "unit")
 load("//score/mw:common_features.bzl", "COMPILER_WARNING_FEATURES")
+
+component(
+    name = "lola_component",
+    components = [
+        ":lola_sd",
+        ":lola_skeleton",
+        ":lola_proxy",
+    ],
+    requirements = [
+    ],
+    tests = [],
+    visibility = ["//score/mw/com/impl/bindings:__pkg__"],
+)
+
+unit(
+    name = "lola_sd",
+    scope = [],
+    tests = [],
+    unit_design = [],
+    implementation = [],
+)
+
+unit(
+    name = "lola_skeleton",
+    scope = [],
+    tests = [],
+    unit_design = [],
+    implementation = [],
+)
+
+unit(
+    name = "lola_proxy",
+    scope = [],
+    tests = [],
+    unit_design = [],
+    implementation = [],
+)
 
 cc_library(
     name = "lola",

--- a/score/mw/com/impl/bindings/mock_binding/BUILD
+++ b/score/mw/com/impl/bindings/mock_binding/BUILD
@@ -12,7 +12,16 @@
 # *******************************************************************************
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@score_tooling//bazel/rules/rules_score:rules_score.bzl", "component")
 load("//score/mw:common_features.bzl", "COMPILER_WARNING_FEATURES")
+
+component(
+    name = "mock_component",
+    components = [],
+    requirements = [],
+    tests = [],
+    visibility = ["//score/mw/com/impl/bindings:__pkg__"],
+)
 
 cc_library(
     name = "mock_binding",


### PR DESCRIPTION
With this commit, we create the skeleton for rules_score usage. Nameingly, we add the necessary components and units within the Bazel files, according to the High-level architecture.