### PR TITLE
Do not include message_passing header depending on the OS

### DIFF
--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service.cpp
@@ -23,11 +23,7 @@
 #include "score/os/errno_logging.h"
 #include "score/result/result.h"
 
-#ifdef __QNX__
-#include "score/message_passing/qnx_dispatch/qnx_dispatch_engine.h"
-#else
-#include "score/message_passing/unix_domain/unix_domain_engine.h"
-#endif
+#include "score/message_passing/engine.h"
 
 #include <memory>
 #include <optional>


### PR DESCRIPTION
This is handled by message_passing library.