### PR TITLE
Mark non trivial constructor test flaky

### DIFF
--- a/score/mw/com/test/methods/non_trivial_constructors/integration_test/BUILD
+++ b/score/mw/com/test/methods/non_trivial_constructors/integration_test/BUILD
@@ -28,6 +28,7 @@ integration_test(
         "non_trivial_constructors_test.py",
     ],
     filesystem = ":filesystem",
+    flaky = True,  # TODO: Remove flaky tag once test is stable: Refer to issue 386
 )
 
 test_suite(


### PR DESCRIPTION
Mitigate flaky test. See https://github.com/eclipse-score/communication/issues/386