### PR TITLE
Rust::com FFI mock implementation for unit test

### DIFF
--- a/score/mw/com/impl/rust/com-api/com-api-concept/BUILD
+++ b/score/mw/com/impl/rust/com-api/com-api-concept/BUILD
@@ -23,6 +23,7 @@ rust_library(
         "lib.rs",
         "reloc.rs",
     ],
+    edition = "2024",
     proc_macro_deps = [
         "//score/mw/com/impl/rust/com-api/com-api-concept-macros",
         "@score_communication_crate_index//:paste",
@@ -40,6 +41,7 @@ rust_library(
 rust_test(
     name = "com-api-concept-test",
     crate = ":com-api-concept",
+    edition = "2024",
     tags = ["manual"],
     deps = [":com-api-concept"],
 )

--- a/score/mw/com/impl/rust/com-api/com-api-concept/error.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-concept/error.rs
@@ -94,6 +94,8 @@ pub enum EventFailedReason {
     EventNotAvailable,
     #[error("Failed to subscribe to event, due to the max_samples parameter being invalid (e.g., zero or exceeding allowed limits)")]
     InvalidMaxSamples,
+    #[error("Sample count out of bounds, expected at most {max}, but got {requested}")]
+    MaxSampleOutOfBounds { max: usize, requested: usize },
 }
 
 /// Error enumeration for different failure cases in the Consumer/Producer/Runtime APIs.

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/BUILD
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/BUILD
@@ -55,3 +55,14 @@ rust_library(
         ":bridge_ffi_rs",
     ],
 )
+
+rust_library(
+    name = "bridge_ffi_lola",
+    srcs = ["bridge_ffi_lola.rs"],
+    visibility = [
+        "//score/mw/com:__subpackages__",
+    ],
+    deps = [
+        ":bridge_ffi_rs",
+    ],
+)

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/BUILD
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/BUILD
@@ -35,6 +35,7 @@ cc_library(
 rust_library(
     name = "bridge_ffi_rs",
     srcs = ["bridge_ffi.rs"],
+    edition = "2024",
     visibility = [
         "//score/mw/com:__subpackages__",
     ],
@@ -48,6 +49,7 @@ rust_library(
 rust_library(
     name = "bridge_ffi_mock",
     srcs = ["bridge_ffi_mock.rs"],
+    edition = "2024",
     visibility = [
         "//score/mw/com:__subpackages__",
     ],
@@ -60,6 +62,7 @@ rust_library(
 rust_library(
     name = "bridge_ffi_lola",
     srcs = ["bridge_ffi_lola.rs"],
+    edition = "2024",
     visibility = [
         "//score/mw/com:__subpackages__",
     ],

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/BUILD
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/BUILD
@@ -53,6 +53,7 @@ rust_library(
     ],
     deps = [
         ":bridge_ffi_rs",
+        "//score/mw/com/impl/plumbing/rust:sample_allocatee_ptr_rs",
     ],
 )
 

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/BUILD
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/BUILD
@@ -44,3 +44,14 @@ rust_library(
         "//score/mw/com/impl/rust:mw_com",
     ],
 )
+
+rust_library(
+    name = "bridge_ffi_mock",
+    srcs = ["bridge_ffi_mock.rs"],
+    visibility = [
+        "//score/mw/com:__subpackages__",
+    ],
+    deps = [
+        ":bridge_ffi_rs",
+    ],
+)

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/BUILD
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/BUILD
@@ -56,6 +56,7 @@ rust_library(
     deps = [
         ":bridge_ffi_rs",
         "//score/mw/com/impl/plumbing/rust:sample_allocatee_ptr_rs",
+        "@score_communication_crate_index//:mockall",
     ],
 )
 

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
@@ -67,6 +67,7 @@
 // - Enables efficient zero-copy string passing for interface_id, event_id, and type_name parameters
 
 use core::fmt::{Debug, Formatter};
+use core::marker::Unpin;
 use std::ffi::c_char;
 
 /// Opaque C++ void* pointer wrapper
@@ -82,7 +83,10 @@ pub use mw_com::proxy::ProxyEventBase;
 pub use mw_com::proxy::ProxyWrapperClass;
 pub use mw_com::InstanceSpecifier;
 
-pub trait FFIBridge {
+/// FFIBridge trait defines the interface for FFI interactions between Rust COM-API and C++ Lola runtime.
+/// This trait abstracts the FFI calls and allows for different implementations
+/// e.g., Lola bridge, mock bridge for testing.
+pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin {
     // Define any methods that the bridge should have here
     unsafe fn get_allocatee_ptr(
         event_ptr: *mut SkeletonEventBase,
@@ -568,6 +572,7 @@ extern "C" {
     fn mw_com_proxy_event_unsubscribe(event_ptr: *mut ProxyEventBase);
 }
 
+#[derive(Debug, Clone)]
 pub struct LolaFFIBridge;
 
 impl FFIBridge for LolaFFIBridge {

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
@@ -82,6 +82,94 @@ pub use mw_com::proxy::ProxyEventBase;
 pub use mw_com::proxy::ProxyWrapperClass;
 pub use mw_com::InstanceSpecifier;
 
+pub trait FFIBridge {
+    // Define any methods that the bridge should have here
+    unsafe fn get_allocatee_ptr(
+        event_ptr: *mut SkeletonEventBase,
+        allocatee_ptr: *mut std::ffi::c_void,
+        event_type: &str,
+    ) -> bool;
+
+    unsafe fn delete_allocatee_ptr(allocatee_ptr: *mut std::ffi::c_void, type_name: &str);
+
+    unsafe fn get_allocatee_data_ptr(
+        allocatee_ptr: *const std::ffi::c_void,
+        type_name: &str,
+    ) -> *mut std::ffi::c_void;
+
+    unsafe fn skeleton_event_send_sample_allocatee(
+        event_ptr: *mut SkeletonEventBase,
+        event_type: &str,
+        allocatee_ptr: *const std::ffi::c_void,
+    ) -> bool;
+
+    unsafe fn sample_ptr_get(
+        sample_ptr: *const std::ffi::c_void,
+        type_name: &str,
+    ) -> *const std::ffi::c_void;
+
+    unsafe fn sample_ptr_delete(sample_ptr: *mut std::ffi::c_void, type_name: &str);
+
+    unsafe fn skeleton_offer_service(skeleton_ptr: *mut SkeletonBase) -> bool;
+
+    unsafe fn skeleton_stop_offer_service(skeleton_ptr: *mut SkeletonBase);
+
+    unsafe fn create_proxy(interface_id: &str, handle_ptr: &HandleType) -> *mut ProxyBase;
+
+    unsafe fn create_skeleton(
+        interface_id: &str,
+        instance_spec: *const NativeInstanceSpecifier,
+    ) -> *mut SkeletonBase;
+
+    unsafe fn destroy_proxy(proxy_ptr: *mut ProxyBase);
+
+    unsafe fn destroy_skeleton(skeleton_ptr: *mut SkeletonBase);
+
+    unsafe fn get_event_from_proxy(
+        proxy_ptr: *mut ProxyBase,
+        interface_id: &str,
+        event_id: &str,
+    ) -> *mut ProxyEventBase;
+
+    unsafe fn get_event_from_skeleton(
+        skeleton_ptr: *mut SkeletonBase,
+        interface_id: &str,
+        event_id: &str,
+    ) -> *mut SkeletonEventBase;
+
+    unsafe fn get_samples_from_event(
+        event_ptr: *mut ProxyEventBase,
+        event_type: &str,
+        callback: &FatPtr,
+        max_samples: u32,
+    ) -> u32;
+
+    unsafe fn skeleton_send_event(
+        event_ptr: *mut SkeletonEventBase,
+        event_type: &str,
+        data_ptr: *const std::ffi::c_void,
+    ) -> bool;
+
+    unsafe fn subscribe_to_event(event_ptr: *mut ProxyEventBase, max_sample_count: u32) -> bool;
+
+    unsafe fn unsubscribe_to_event(event_ptr: *mut ProxyEventBase);
+
+    unsafe fn set_event_receive_handler(
+        proxy_event_ptr: *mut ProxyEventBase,
+        handler: &FatPtr,
+        event_type: &str,
+    ) -> bool;
+
+    unsafe fn clear_event_receive_handler(proxy_event_ptr: *mut ProxyEventBase, event_type: &str);
+
+    unsafe fn start_find_service(
+        callback: &FatPtr,
+        instance_spec: InstanceSpecifier,
+    ) -> *mut FindServiceHandle;
+
+    unsafe fn stop_find_service(handle: *mut FindServiceHandle);
+}
+
 /// Opaque proxy base struct
 #[repr(C)]
 pub struct ProxyBase {
@@ -174,7 +262,7 @@ impl From<&'_ str> for StringView {
 /// - `ptr` must point to a valid FatPtr
 /// - `sample_ptr` must point to valid placement-new storage containing SamplePtr<T>
 #[no_mangle]
-pub unsafe extern "C" fn mw_com_impl_call_dyn_ref_fnmut_sample(
+unsafe extern "C" fn mw_com_impl_call_dyn_ref_fnmut_sample(
     ptr: *const FatPtr,
     sample_ptr: *mut std::ffi::c_void,
 ) {
@@ -205,7 +293,7 @@ pub unsafe extern "C" fn mw_com_impl_call_dyn_ref_fnmut_sample(
 /// - `find_service_handle` must point to valid FindServiceHandle data that can be safely wrapped
 ///   in a NativeFindServiceHandle.
 #[no_mangle]
-pub unsafe extern "C" fn mw_com_impl_call_dyn_ref_fnmut_find_service(
+unsafe extern "C" fn mw_com_impl_call_dyn_ref_fnmut_find_service(
     ptr: *const FatPtr,
     service_handles: *mut NativeHandleContainer,
     find_service_handle: *mut FindServiceHandle,
@@ -480,439 +568,443 @@ extern "C" {
     fn mw_com_proxy_event_unsubscribe(event_ptr: *mut ProxyEventBase);
 }
 
-/// Get allocatee pointer from skeleton event of specific type
-///
-/// # Arguments
-/// * `event_ptr` - Opaque skeleton event pointer
-/// * `allocatee_ptr` - Pointer to pre-allocated memory for allocatee
-/// * `event_type` - Type name string
-///
-/// # Returns
-/// True if allocatee pointer was retrieved successfully, false otherwise
-///
-/// # Safety
-/// event_ptr must point to a valid SkeletonEventBase,
-/// allocatee_ptr must point to valid memory for the allocatee,
-/// and event_type must be a valid UTF-8 string representing the event type.
-pub unsafe fn get_allocatee_ptr(
-    event_ptr: *mut SkeletonEventBase,
-    allocatee_ptr: *mut std::ffi::c_void,
-    event_type: &str,
-) -> bool {
-    // SAFETY: event_ptr is valid which is created using create_skeleton()
-    // and allocatee_ptr has enough memory allocated for the construction of allocatee instance.
-    let event_type = StringView::from(event_type);
-    mw_com_get_allocatee_ptr(event_ptr, allocatee_ptr, event_type)
-}
+pub struct LolaFFIBridge;
 
-/// Delete allocatee pointer of SampleAllocateePtr<T>
-///
-/// # Arguments
-/// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
-/// * `type_name` - Type name string
-///
-/// # Safety
-/// allocatee_ptr must point to a valid SampleAllocateePtr<T> of the specified type.
-pub unsafe fn delete_allocatee_ptr(allocatee_ptr: *mut std::ffi::c_void, type_name: &str) {
-    // SAFETY: allocatee_ptr is valid which is created using get_allocatee_ptr() and
-    // type_name is constructed using static str.
-    let type_name = StringView::from(type_name);
-    mw_com_delete_allocatee_ptr(allocatee_ptr, type_name);
-}
+impl FFIBridge for LolaFFIBridge {
+    /// Get allocatee pointer from skeleton event of specific type
+    ///
+    /// # Arguments
+    /// * `event_ptr` - Opaque skeleton event pointer
+    /// * `allocatee_ptr` - Pointer to pre-allocated memory for allocatee
+    /// * `event_type` - Type name string
+    ///
+    /// # Returns
+    /// True if allocatee pointer was retrieved successfully, false otherwise
+    ///
+    /// # Safety
+    /// event_ptr must point to a valid SkeletonEventBase,
+    /// allocatee_ptr must point to valid memory for the allocatee,
+    /// and event_type must be a valid UTF-8 string representing the event type.
+    unsafe fn get_allocatee_ptr(
+        event_ptr: *mut SkeletonEventBase,
+        allocatee_ptr: *mut std::ffi::c_void,
+        event_type: &str,
+    ) -> bool {
+        // SAFETY: event_ptr is valid which is created using create_skeleton()
+        // and allocatee_ptr has enough memory allocated for the construction of allocatee instance.
+        let event_type = StringView::from(event_type);
+        mw_com_get_allocatee_ptr(event_ptr, allocatee_ptr, event_type)
+    }
 
-/// Get allocatee data pointer from allocatee of specific type
-///
-/// # Arguments
-/// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
-/// * `type_name` - Type name string
-///
-/// # Returns
-/// Pointer to allocatee data, or nullptr if type mismatch
-///
-/// # Safety
-/// allocatee_ptr must point to a valid SampleAllocateePtr<T> of the specified type
-pub unsafe fn get_allocatee_data_ptr(
-    allocatee_ptr: *const std::ffi::c_void,
-    type_name: &str,
-) -> *mut std::ffi::c_void {
-    // SAFETY: allocatee_ptr is valid which is created using get_allocatee_ptr() and
-    // type_name is constructed using static str.
-    let type_name = StringView::from(type_name);
-    mw_com_get_allocatee_data_ptr(allocatee_ptr, type_name)
-}
+    /// Delete allocatee pointer of SampleAllocateePtr<T>
+    ///
+    /// # Arguments
+    /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
+    /// * `type_name` - Type name string
+    ///
+    /// # Safety
+    /// allocatee_ptr must point to a valid SampleAllocateePtr<T> of the specified type.
+    unsafe fn delete_allocatee_ptr(allocatee_ptr: *mut std::ffi::c_void, type_name: &str) {
+        // SAFETY: allocatee_ptr is valid which is created using get_allocatee_ptr() and
+        // type_name is constructed using static str.
+        let type_name = StringView::from(type_name);
+        mw_com_delete_allocatee_ptr(allocatee_ptr, type_name);
+    }
 
-/// Send event via skeleton using allocatee pointer of specific type
-///
-/// # Arguments
-/// * `event_ptr` - Opaque skeleton event pointer
-/// * `event_type` - Type name string
-/// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
-///
-/// # Returns
-/// True if event was sent successfully, false otherwise
-///
-/// # Safety
-/// event_ptr must point to a valid SkeletonEventBase,
-/// allocatee_ptr must point to a valid SampleAllocateePtr<T>,
-/// and event_type must be a valid UTF-8 string representing the event type.
-pub unsafe fn skeleton_event_send_sample_allocatee(
-    event_ptr: *mut SkeletonEventBase,
-    event_type: &str,
-    allocatee_ptr: *const std::ffi::c_void,
-) -> bool {
-    // SAFETY: event_ptr is valid which is created using create_skeleton() and allocatee_ptr is
-    // valid which is created using get_allocatee_ptr().
-    let event_type = StringView::from(event_type);
-    mw_com_skeleton_send_event_allocatee(event_ptr, event_type, allocatee_ptr)
-}
+    /// Get allocatee data pointer from allocatee of specific type
+    ///
+    /// # Arguments
+    /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
+    /// * `type_name` - Type name string
+    ///
+    /// # Returns
+    /// Pointer to allocatee data, or nullptr if type mismatch
+    ///
+    /// # Safety
+    /// allocatee_ptr must point to a valid SampleAllocateePtr<T> of the specified type
+    unsafe fn get_allocatee_data_ptr(
+        allocatee_ptr: *const std::ffi::c_void,
+        type_name: &str,
+    ) -> *mut std::ffi::c_void {
+        // SAFETY: allocatee_ptr is valid which is created using get_allocatee_ptr() and
+        // type_name is constructed using static str.
+        let type_name = StringView::from(type_name);
+        mw_com_get_allocatee_data_ptr(allocatee_ptr, type_name)
+    }
 
-/// Get SamplePtr<T> data pointer
-///
-/// # Arguments
-/// * `sample_ptr` - Opaque sample pointer
-/// * `type_name` - Type name string
-///
-/// # Returns
-/// Pointer to sample data, or nullptr if type mismatch
-/// # Safety
-/// sample_ptr must point to a valid SamplePtr<T> of the specified type.
-pub unsafe fn sample_ptr_get(
-    sample_ptr: *const std::ffi::c_void,
-    type_name: &str,
-) -> *const std::ffi::c_void {
-    // SAFETY: sample_ptr is guaranteed to be valid per the caller's contract.
-    // The C++ implementation handles type checking and data retrieval safely.
-    let type_name = StringView::from(type_name);
-    mw_com_get_sample_ptr(sample_ptr, type_name)
-}
+    /// Send event via skeleton using allocatee pointer of specific type
+    ///
+    /// # Arguments
+    /// * `event_ptr` - Opaque skeleton event pointer
+    /// * `event_type` - Type name string
+    /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
+    ///
+    /// # Returns
+    /// True if event was sent successfully, false otherwise
+    ///
+    /// # Safety
+    /// event_ptr must point to a valid SkeletonEventBase,
+    /// allocatee_ptr must point to a valid SampleAllocateePtr<T>,
+    /// and event_type must be a valid UTF-8 string representing the event type.
+    unsafe fn skeleton_event_send_sample_allocatee(
+        event_ptr: *mut SkeletonEventBase,
+        event_type: &str,
+        allocatee_ptr: *const std::ffi::c_void,
+    ) -> bool {
+        // SAFETY: event_ptr is valid which is created using create_skeleton() and allocatee_ptr is
+        // valid which is created using get_allocatee_ptr().
+        let event_type = StringView::from(event_type);
+        mw_com_skeleton_send_event_allocatee(event_ptr, event_type, allocatee_ptr)
+    }
 
-/// Delete SamplePtr<T>
-///
-/// # Arguments
-/// * `sample_ptr` - Opaque sample pointer
-/// * `type_name` - Type name string
-/// # Safety
-/// sample_ptr must point to a valid SamplePtr<T> of the specified type.
-pub unsafe fn sample_ptr_delete(sample_ptr: *mut std::ffi::c_void, type_name: &str) {
-    // SAFETY: sample_ptr is guaranteed to be valid per the caller's contract.
-    // The C++ implementation handles type checking and deletion safely.
-    let type_name = StringView::from(type_name);
-    mw_com_delete_sample_ptr(sample_ptr, type_name);
-}
+    /// Get SamplePtr<T> data pointer
+    ///
+    /// # Arguments
+    /// * `sample_ptr` - Opaque sample pointer
+    /// * `type_name` - Type name string
+    ///
+    /// # Returns
+    /// Pointer to sample data, or nullptr if type mismatch
+    /// # Safety
+    /// sample_ptr must point to a valid SamplePtr<T> of the specified type.
+    unsafe fn sample_ptr_get(
+        sample_ptr: *const std::ffi::c_void,
+        type_name: &str,
+    ) -> *const std::ffi::c_void {
+        // SAFETY: sample_ptr is guaranteed to be valid per the caller's contract.
+        // The C++ implementation handles type checking and data retrieval safely.
+        let type_name = StringView::from(type_name);
+        mw_com_get_sample_ptr(sample_ptr, type_name)
+    }
 
-/// Unsafe wrapper around mw_com_skeleton_offer_service
-///
-/// # Arguments
-/// * `skeleton_ptr` - Opaque skeleton pointer
-///
-/// # Returns
-/// true if offer was successful, false otherwise
-///
-/// # Safety
-/// skeleton_ptr must be a valid pointer to a SkeletonBase previously created
-/// with create_skeleton().
-/// The pointer must remain valid for the duration of this call.
-pub unsafe fn skeleton_offer_service(skeleton_ptr: *mut SkeletonBase) -> bool {
-    // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
-    // The C++ implementation handles service offering safely.
-    mw_com_skeleton_offer_service(skeleton_ptr)
-}
+    /// Delete SamplePtr<T>
+    ///
+    /// # Arguments
+    /// * `sample_ptr` - Opaque sample pointer
+    /// * `type_name` - Type name string
+    /// # Safety
+    /// sample_ptr must point to a valid SamplePtr<T> of the specified type.
+    unsafe fn sample_ptr_delete(sample_ptr: *mut std::ffi::c_void, type_name: &str) {
+        // SAFETY: sample_ptr is guaranteed to be valid per the caller's contract.
+        // The C++ implementation handles type checking and deletion safely.
+        let type_name = StringView::from(type_name);
+        mw_com_delete_sample_ptr(sample_ptr, type_name);
+    }
 
-/// Unsafe wrapper around mw_com_skeleton_stop_offer_service
-///
-/// # Arguments
-/// * `skeleton_ptr` - Opaque skeleton pointer
-///
-/// # Safety
-/// skeleton_ptr must be a valid pointer to a SkeletonBase previously created
-/// with create_skeleton().
-/// The pointer must remain valid for the duration of this call.
-pub unsafe fn skeleton_stop_offer_service(skeleton_ptr: *mut SkeletonBase) {
-    // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
-    // The C++ implementation handles stopping the service safely.
-    mw_com_skeleton_stop_offer_service(skeleton_ptr);
-}
+    /// Unsafe wrapper around mw_com_skeleton_offer_service
+    ///
+    /// # Arguments
+    /// * `skeleton_ptr` - Opaque skeleton pointer
+    ///
+    /// # Returns
+    /// true if offer was successful, false otherwise
+    ///
+    /// # Safety
+    /// skeleton_ptr must be a valid pointer to a SkeletonBase previously created
+    /// with create_skeleton().
+    /// The pointer must remain valid for the duration of this call.
+    unsafe fn skeleton_offer_service(skeleton_ptr: *mut SkeletonBase) -> bool {
+        // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
+        // The C++ implementation handles service offering safely.
+        mw_com_skeleton_offer_service(skeleton_ptr)
+    }
 
-/// Unsafe wrapper around mw_com_create_proxy
-///
-/// # Arguments
-/// * `interface_id` - Interface UID string
-/// * `handle_ptr` - Opaque handle pointer
-///
-/// # Returns
-/// Opaque proxy pointer, or nullptr if creation failed
-///
-/// # Safety
-/// handle_ptr must be a valid reference to a HandleType.
-/// The returned pointer must eventually be destroyed via destroy_proxy().
-pub unsafe fn create_proxy(interface_id: &str, handle_ptr: &HandleType) -> *mut ProxyBase {
-    // SAFETY: interface_id is a valid string reference and handle_ptr is guaranteed to be valid
-    // per the caller's contract.
-    // The C++ implementation creates and returns a valid proxy pointer or nullptr on failure.
-    let c_uid = StringView::from(interface_id);
-    mw_com_create_proxy(c_uid, handle_ptr)
-}
+    /// Unsafe wrapper around mw_com_skeleton_stop_offer_service
+    ///
+    /// # Arguments
+    /// * `skeleton_ptr` - Opaque skeleton pointer
+    ///
+    /// # Safety
+    /// skeleton_ptr must be a valid pointer to a SkeletonBase previously created
+    /// with create_skeleton().
+    /// The pointer must remain valid for the duration of this call.
+    unsafe fn skeleton_stop_offer_service(skeleton_ptr: *mut SkeletonBase) {
+        // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
+        // The C++ implementation handles stopping the service safely.
+        mw_com_skeleton_stop_offer_service(skeleton_ptr);
+    }
 
-/// Unsafe wrapper around mw_com_create_skeleton
-///
-/// # Arguments
-/// * `interface_id` - Interface UID string
-/// * `instance_spec` - Opaque instance specifier pointer
-///
-/// # Returns
-/// Opaque skeleton pointer, or nullptr if creation failed
-///
-/// # Safety
-/// instance_spec must be a valid NativeInstanceSpecifier.
-/// The returned pointer must eventually be destroyed via destroy_skeleton().
-pub unsafe fn create_skeleton(
-    interface_id: &str,
-    instance_spec: *const NativeInstanceSpecifier,
-) -> *mut SkeletonBase {
-    // SAFETY: interface_id is a valid string reference and instance_spec is guaranteed to be
-    // valid per the caller's contract.
-    // The C++ implementation creates and returns a valid skeleton pointer or nullptr on failure.
-    let c_uid = StringView::from(interface_id);
-    mw_com_create_skeleton(c_uid, instance_spec)
-}
+    /// Unsafe wrapper around mw_com_create_proxy
+    ///
+    /// # Arguments
+    /// * `interface_id` - Interface UID string
+    /// * `handle_ptr` - Opaque handle pointer
+    ///
+    /// # Returns
+    /// Opaque proxy pointer, or nullptr if creation failed
+    ///
+    /// # Safety
+    /// handle_ptr must be a valid reference to a HandleType.
+    /// The returned pointer must eventually be destroyed via destroy_proxy().
+    unsafe fn create_proxy(interface_id: &str, handle_ptr: &HandleType) -> *mut ProxyBase {
+        // SAFETY: interface_id is a valid string reference and handle_ptr is guaranteed to be valid
+        // per the caller's contract.
+        // The C++ implementation creates and returns a valid proxy pointer or nullptr on failure.
+        let c_uid = StringView::from(interface_id);
+        mw_com_create_proxy(c_uid, handle_ptr)
+    }
 
-/// Unsafe wrapper around mw_com_destroy_proxy
-///
-/// # Arguments
-/// * `proxy_ptr` - Opaque proxy pointer to destroy
-///
-/// # Safety
-/// proxy_ptr must be a valid pointer returned from create_proxy() that has not been destroyed yet.
-/// The caller must ensure no other references to this proxy exist after calling this function.
-pub unsafe fn destroy_proxy(proxy_ptr: *mut ProxyBase) {
-    // SAFETY: proxy_ptr is guaranteed to be valid per the caller's contract.
-    // The C++ implementation safely deallocates the proxy.
-    mw_com_destroy_proxy(proxy_ptr);
-}
+    /// Unsafe wrapper around mw_com_create_skeleton
+    ///
+    /// # Arguments
+    /// * `interface_id` - Interface UID string
+    /// * `instance_spec` - Opaque instance specifier pointer
+    ///
+    /// # Returns
+    /// Opaque skeleton pointer, or nullptr if creation failed
+    ///
+    /// # Safety
+    /// instance_spec must be a valid NativeInstanceSpecifier.
+    /// The returned pointer must eventually be destroyed via destroy_skeleton().
+    unsafe fn create_skeleton(
+        interface_id: &str,
+        instance_spec: *const NativeInstanceSpecifier,
+    ) -> *mut SkeletonBase {
+        // SAFETY: interface_id is a valid string reference and instance_spec is guaranteed to be
+        // valid per the caller's contract.
+        // The C++ implementation creates and returns a valid skeleton pointer or nullptr on failure.
+        let c_uid = StringView::from(interface_id);
+        mw_com_create_skeleton(c_uid, instance_spec)
+    }
 
-/// Unsafe wrapper around mw_com_destroy_skeleton
-///
-/// # Arguments
-/// * `skeleton_ptr` - Opaque skeleton pointer to destroy
-///
-/// # Safety
-/// skeleton_ptr must be a valid pointer returned from create_skeleton()-
-/// that has not been destroyed yet.
-/// The caller must ensure no other references to this skeleton exist after calling this function.
-pub unsafe fn destroy_skeleton(skeleton_ptr: *mut SkeletonBase) {
-    // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
-    // The C++ implementation safely deallocates the skeleton.
-    mw_com_destroy_skeleton(skeleton_ptr);
-}
+    /// Unsafe wrapper around mw_com_destroy_proxy
+    ///
+    /// # Arguments
+    /// * `proxy_ptr` - Opaque proxy pointer to destroy
+    ///
+    /// # Safety
+    /// proxy_ptr must be a valid pointer returned from create_proxy() that has not been destroyed yet.
+    /// The caller must ensure no other references to this proxy exist after calling this function.
+    unsafe fn destroy_proxy(proxy_ptr: *mut ProxyBase) {
+        // SAFETY: proxy_ptr is guaranteed to be valid per the caller's contract.
+        // The C++ implementation safely deallocates the proxy.
+        mw_com_destroy_proxy(proxy_ptr);
+    }
 
-/// Unsafe wrapper around mw_com_get_event_from_proxy
-///
-/// # Arguments
-/// * `proxy_ptr` - Opaque proxy pointer
-/// * `interface_id` - Interface UID string
-/// * `event_id` - Event name string
-///
-/// # Returns
-/// Opaque event pointer, or nullptr if not found
-///
-/// # Safety
-/// proxy_ptr must be a valid pointer to a ProxyBase previously created with create_proxy().
-/// The returned pointer remains valid only as long as the proxy remains alive.
-pub unsafe fn get_event_from_proxy(
-    proxy_ptr: *mut ProxyBase,
-    interface_id: &str,
-    event_id: &str,
-) -> *mut ProxyEventBase {
-    // SAFETY: proxy_ptr is guaranteed to be valid per the caller's contract.
-    // The C++ implementation returns a valid pointer or nullptr if the event is not found.
-    let c_id = StringView::from(interface_id);
-    let c_name = StringView::from(event_id);
-    mw_com_get_event_from_proxy(proxy_ptr, c_id, c_name)
-}
+    /// Unsafe wrapper around mw_com_destroy_skeleton
+    ///
+    /// # Arguments
+    /// * `skeleton_ptr` - Opaque skeleton pointer to destroy
+    ///
+    /// # Safety
+    /// skeleton_ptr must be a valid pointer returned from create_skeleton()-
+    /// that has not been destroyed yet.
+    /// The caller must ensure no other references to this skeleton exist after calling this function.
+    unsafe fn destroy_skeleton(skeleton_ptr: *mut SkeletonBase) {
+        // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
+        // The C++ implementation safely deallocates the skeleton.
+        mw_com_destroy_skeleton(skeleton_ptr);
+    }
 
-/// Unsafe wrapper around mw_com_get_event_from_skeleton
-///
-/// # Arguments
-/// * `skeleton_ptr` - Opaque skeleton pointer
-/// * `interface_id` - Interface UID string
-/// * `event_id` - Event name string
-///
-/// # Returns
-/// Opaque event pointer, or nullptr if not found
-///
-/// # Safety
-/// skeleton_ptr must be a valid pointer to a SkeletonBase previously created
-/// with create_skeleton().
-/// The returned pointer remains valid only as long as the skeleton remains alive.
-pub unsafe fn get_event_from_skeleton(
-    skeleton_ptr: *mut SkeletonBase,
-    interface_id: &str,
-    event_id: &str,
-) -> *mut SkeletonEventBase {
-    // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
-    // The C++ implementation returns a valid pointer or nullptr if the event is not found.
-    let c_id = StringView::from(interface_id);
-    let c_name = StringView::from(event_id);
-    mw_com_get_event_from_skeleton(skeleton_ptr, c_id, c_name)
-}
+    /// Unsafe wrapper around mw_com_get_event_from_proxy
+    ///
+    /// # Arguments
+    /// * `proxy_ptr` - Opaque proxy pointer
+    /// * `interface_id` - Interface UID string
+    /// * `event_id` - Event name string
+    ///
+    /// # Returns
+    /// Opaque event pointer, or nullptr if not found
+    ///
+    /// # Safety
+    /// proxy_ptr must be a valid pointer to a ProxyBase previously created with create_proxy().
+    /// The returned pointer remains valid only as long as the proxy remains alive.
+    unsafe fn get_event_from_proxy(
+        proxy_ptr: *mut ProxyBase,
+        interface_id: &str,
+        event_id: &str,
+    ) -> *mut ProxyEventBase {
+        // SAFETY: proxy_ptr is guaranteed to be valid per the caller's contract.
+        // The C++ implementation returns a valid pointer or nullptr if the event is not found.
+        let c_id = StringView::from(interface_id);
+        let c_name = StringView::from(event_id);
+        mw_com_get_event_from_proxy(proxy_ptr, c_id, c_name)
+    }
 
-/// Unsafe wrapper around mw_com_get_samples_from_event
-///
-/// # Arguments
-/// * `event_ptr` - Opaque event pointer
-/// * `event_type` - Event type name string
-/// * `callback` - FatPtr to callback function
-/// * `max_samples` - Maximum number of samples to retrieve
-///
-/// # Returns
-/// Number of samples retrieved, or u32::MAX on error
-///
-/// # Safety
-/// event_ptr must be a valid pointer to a ProxyEventBase previously obtained
-/// from get_event_from_proxy().
-/// callback must be a valid FatPtr referencing a callable compatible with the event type.
-/// The event must have been subscribed to via subscribe_to_event() before calling this function.
-pub unsafe fn get_samples_from_event(
-    event_ptr: *mut ProxyEventBase,
-    event_type: &str,
-    callback: &FatPtr,
-    max_samples: u32,
-) -> u32 {
-    // SAFETY: event_ptr, callback, and event_type are guaranteed
-    // to be valid per the caller's contract.
-    // The C++ implementation handles sample retrieval and callback invocation safely.
-    let c_name = StringView::from(event_type);
-    mw_com_type_registry_get_samples_from_event(event_ptr, c_name, callback, max_samples)
-}
+    /// Unsafe wrapper around mw_com_get_event_from_skeleton
+    ///
+    /// # Arguments
+    /// * `skeleton_ptr` - Opaque skeleton pointer
+    /// * `interface_id` - Interface UID string
+    /// * `event_id` - Event name string
+    ///
+    /// # Returns
+    /// Opaque event pointer, or nullptr if not found
+    ///
+    /// # Safety
+    /// skeleton_ptr must be a valid pointer to a SkeletonBase previously created
+    /// with create_skeleton().
+    /// The returned pointer remains valid only as long as the skeleton remains alive.
+    unsafe fn get_event_from_skeleton(
+        skeleton_ptr: *mut SkeletonBase,
+        interface_id: &str,
+        event_id: &str,
+    ) -> *mut SkeletonEventBase {
+        // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
+        // The C++ implementation returns a valid pointer or nullptr if the event is not found.
+        let c_id = StringView::from(interface_id);
+        let c_name = StringView::from(event_id);
+        mw_com_get_event_from_skeleton(skeleton_ptr, c_id, c_name)
+    }
 
-/// Unsafe wrapper around mw_com_skeleton_send_event
-///
-/// # Arguments
-/// * `event_ptr` - Opaque skeleton event pointer
-/// * `event_type` - Event type name string
-/// * `data_ptr` - Pointer to event data of the matching type
-///
-/// # Safety
-/// event_ptr must be a valid pointer to a SkeletonEventBase previously obtained
-/// from get_event_from_skeleton().
-/// data_ptr must point to valid data whose type matches the event_type.
-/// The lifetime of the data must extend through this function call.
-pub unsafe fn skeleton_send_event(
-    event_ptr: *mut SkeletonEventBase,
-    event_type: &str,
-    data_ptr: *const std::ffi::c_void,
-) -> bool {
-    // SAFETY: event_ptr and data_ptr are guaranteed to be valid per the caller's contract.
-    // The C++ implementation handles type matching and data sending safely.
-    let c_name = StringView::from(event_type);
-    mw_com_skeleton_send_event(event_ptr, c_name, data_ptr)
-}
+    /// Unsafe wrapper around mw_com_get_samples_from_event
+    ///
+    /// # Arguments
+    /// * `event_ptr` - Opaque event pointer
+    /// * `event_type` - Event type name string
+    /// * `callback` - FatPtr to callback function
+    /// * `max_samples` - Maximum number of samples to retrieve
+    ///
+    /// # Returns
+    /// Number of samples retrieved, or u32::MAX on error
+    ///
+    /// # Safety
+    /// event_ptr must be a valid pointer to a ProxyEventBase previously obtained
+    /// from get_event_from_proxy().
+    /// callback must be a valid FatPtr referencing a callable compatible with the event type.
+    /// The event must have been subscribed to via subscribe_to_event() before calling this function.
+    unsafe fn get_samples_from_event(
+        event_ptr: *mut ProxyEventBase,
+        event_type: &str,
+        callback: &FatPtr,
+        max_samples: u32,
+    ) -> u32 {
+        // SAFETY: event_ptr, callback, and event_type are guaranteed
+        // to be valid per the caller's contract.
+        // The C++ implementation handles sample retrieval and callback invocation safely.
+        let c_name = StringView::from(event_type);
+        mw_com_type_registry_get_samples_from_event(event_ptr, c_name, callback, max_samples)
+    }
 
-/// Unsafe wrapper around mw_com_proxy_event_subscribe
-///
-/// # Arguments
-/// * `event_ptr` - Opaque event pointer
-/// * `max_sample_count` - Maximum number of samples to buffer concurrently
-///
-/// # Returns
-/// true if subscription was successful, false otherwise
-///
-/// # Safety
-/// event_ptr must be a valid pointer to a ProxyEventBase previously obtained
-/// from get_event_from_proxy().
-/// This function must be called before attempting to retrieve samples via get_samples_from_event().
-pub unsafe fn subscribe_to_event(event_ptr: *mut ProxyEventBase, max_sample_count: u32) -> bool {
-    // SAFETY: event_ptr is guaranteed to be valid per the caller's contract.
-    // The C++ implementation handles subscription and buffer allocation safely.
-    mw_com_proxy_event_subscribe(event_ptr, max_sample_count)
-}
+    /// Unsafe wrapper around mw_com_skeleton_send_event
+    ///
+    /// # Arguments
+    /// * `event_ptr` - Opaque skeleton event pointer
+    /// * `event_type` - Event type name string
+    /// * `data_ptr` - Pointer to event data of the matching type
+    ///
+    /// # Safety
+    /// event_ptr must be a valid pointer to a SkeletonEventBase previously obtained
+    /// from get_event_from_skeleton().
+    /// data_ptr must point to valid data whose type matches the event_type.
+    /// The lifetime of the data must extend through this function call.
+    unsafe fn skeleton_send_event(
+        event_ptr: *mut SkeletonEventBase,
+        event_type: &str,
+        data_ptr: *const std::ffi::c_void,
+    ) -> bool {
+        // SAFETY: event_ptr and data_ptr are guaranteed to be valid per the caller's contract.
+        // The C++ implementation handles type matching and data sending safely.
+        let c_name = StringView::from(event_type);
+        mw_com_skeleton_send_event(event_ptr, c_name, data_ptr)
+    }
 
-/// Unsafe wrapper around mw_com_proxy_event_unsubscribe
-///
-/// # Arguments
-/// * `event_ptr` - Opaque event pointer
-///
-/// # Safety
-/// event_ptr must be a valid pointer to a ProxyEventBase previously obtained from get_event_from_proxy().
-/// This function should be called only when no `SamplePtr` is held by the user for this event.
-pub unsafe fn unsubscribe_to_event(event_ptr: *mut ProxyEventBase) {
-    // SAFETY: event_ptr is guaranteed to be valid per the caller's contract.
-    // The C++ implementation handles unsubscription and buffer cleanup safely.
-    mw_com_proxy_event_unsubscribe(event_ptr);
-}
+    /// Unsafe wrapper around mw_com_proxy_event_subscribe
+    ///
+    /// # Arguments
+    /// * `event_ptr` - Opaque event pointer
+    /// * `max_sample_count` - Maximum number of samples to buffer concurrently
+    ///
+    /// # Returns
+    /// true if subscription was successful, false otherwise
+    ///
+    /// # Safety
+    /// event_ptr must be a valid pointer to a ProxyEventBase previously obtained
+    /// from get_event_from_proxy().
+    /// This function must be called before attempting to retrieve samples via get_samples_from_event().
+    unsafe fn subscribe_to_event(event_ptr: *mut ProxyEventBase, max_sample_count: u32) -> bool {
+        // SAFETY: event_ptr is guaranteed to be valid per the caller's contract.
+        // The C++ implementation handles subscription and buffer allocation safely.
+        mw_com_proxy_event_subscribe(event_ptr, max_sample_count)
+    }
 
-/// Unsafe wrapper around mw_com_proxy_set_event_receive_handler
-///
-/// # Arguments
-/// * `proxy_event_ptr` - Opaque proxy event pointer
-/// * `handler` - FatPtr to event receive handler function
-///
-/// # Returns
-/// true if handler was set successfully, false otherwise
-///
-/// # Safety
-/// proxy_event_ptr must be a valid pointer to a ProxyEventBase previously obtained
-/// from get_event_from_proxy().
-/// handler must be a valid FatPtr which is used for notifying the proxy of incoming events.
-pub unsafe fn set_event_receive_handler(
-    proxy_event_ptr: *mut ProxyEventBase,
-    handler: &FatPtr,
-    event_type: &str,
-) -> bool {
-    // SAFETY: proxy_event_ptr must be valid per the caller's contract,
-    // and handler must be a valid FatPtr referencing a callable compatible with the callback
-    // signature expected by the C++ implementation.
-    let c_name = StringView::from(event_type);
-    mw_com_proxy_set_event_receive_handler(proxy_event_ptr, handler, c_name)
-}
+    /// Unsafe wrapper around mw_com_proxy_event_unsubscribe
+    ///
+    /// # Arguments
+    /// * `event_ptr` - Opaque event pointer
+    ///
+    /// # Safety
+    /// event_ptr must be a valid pointer to a ProxyEventBase previously obtained from get_event_from_proxy().
+    /// This function should be called only when no `SamplePtr` is held by the user for this event.
+    unsafe fn unsubscribe_to_event(event_ptr: *mut ProxyEventBase) {
+        // SAFETY: event_ptr is guaranteed to be valid per the caller's contract.
+        // The C++ implementation handles unsubscription and buffer cleanup safely.
+        mw_com_proxy_event_unsubscribe(event_ptr);
+    }
 
-/// Unsafe wrapper around mw_com_proxy_clear_event_receive_handler
-///
-/// # Arguments
-/// * `proxy_event_ptr` - Opaque proxy event pointer
-/// * `event_type` - Event type name string
-///
-/// # Safety
-/// proxy_event_ptr must be a valid pointer to a ProxyEventBase previously obtained
-/// from get_event_from_proxy().
-/// event_type must be a valid string corresponding to the event type.
-pub unsafe fn clear_event_receive_handler(proxy_event_ptr: *mut ProxyEventBase, event_type: &str) {
-    // SAFETY: proxy_event_ptr must be valid per the caller's contract.
-    let c_name = StringView::from(event_type);
-    mw_com_proxy_clear_event_receive_handler(proxy_event_ptr, c_name);
-}
+    /// Unsafe wrapper around mw_com_proxy_set_event_receive_handler
+    ///
+    /// # Arguments
+    /// * `proxy_event_ptr` - Opaque proxy event pointer
+    /// * `handler` - FatPtr to event receive handler function
+    ///
+    /// # Returns
+    /// true if handler was set successfully, false otherwise
+    ///
+    /// # Safety
+    /// proxy_event_ptr must be a valid pointer to a ProxyEventBase previously obtained
+    /// from get_event_from_proxy().
+    /// handler must be a valid FatPtr which is used for notifying the proxy of incoming events.
+    unsafe fn set_event_receive_handler(
+        proxy_event_ptr: *mut ProxyEventBase,
+        handler: &FatPtr,
+        event_type: &str,
+    ) -> bool {
+        // SAFETY: proxy_event_ptr must be valid per the caller's contract,
+        // and handler must be a valid FatPtr referencing a callable compatible with the callback
+        // signature expected by the C++ implementation.
+        let c_name = StringView::from(event_type);
+        mw_com_proxy_set_event_receive_handler(proxy_event_ptr, handler, c_name)
+    }
 
-/// Unsafe wrapper around mw_com_start_find_service
-///
-/// # Arguments
-/// * `callback` - FatPtr to callback function to be invoked when services are found
-/// * `instance_spec` - InstanceSpecifier identifying the service instance to find
-///
-/// # Returns
-/// Opaque handle pointer for the find service operation, or nullptr on failure
-///
-/// # Safety
-/// callback must be a valid FatPtr referencing a callable compatible with the find service results.
-/// instance_spec must be a valid InstanceSpecifier for the service to find.
-pub unsafe fn start_find_service(
-    callback: &FatPtr,
-    instance_spec: InstanceSpecifier,
-) -> *mut FindServiceHandle {
-    // SAFETY: callback and instance_spec are guaranteed to be valid per the caller's contract.
-    // The C++ implementation handles the find service operation and callback invocation safely.
-    mw_com_start_find_service(callback, instance_spec.as_native())
-}
+    /// Unsafe wrapper around mw_com_proxy_clear_event_receive_handler
+    ///
+    /// # Arguments
+    /// * `proxy_event_ptr` - Opaque proxy event pointer
+    /// * `event_type` - Event type name string
+    ///
+    /// # Safety
+    /// proxy_event_ptr must be a valid pointer to a ProxyEventBase previously obtained
+    /// from get_event_from_proxy().
+    /// event_type must be a valid string corresponding to the event type.
+    unsafe fn clear_event_receive_handler(proxy_event_ptr: *mut ProxyEventBase, event_type: &str) {
+        // SAFETY: proxy_event_ptr must be valid per the caller's contract.
+        let c_name = StringView::from(event_type);
+        mw_com_proxy_clear_event_receive_handler(proxy_event_ptr, c_name);
+    }
 
-/// Unsafe wrapper around mw_com_stop_find_service
-///
-/// # Arguments
-/// * `handle` - Opaque handle pointer returned from start_find_service()
-///
-/// # Safety
-/// handle must be a valid pointer returned from start_find_service() that has not been stopped yet,
-/// and the caller must ensure no further use of this handle after calling this function.
-pub unsafe fn stop_find_service(handle: *mut FindServiceHandle) {
-    // SAFETY: handle is valid per the caller's contract and has not been stopped yet.
-    // The C++ implementation handles stopping the find service safely.
-    mw_com_stop_find_service(handle);
+    /// Unsafe wrapper around mw_com_start_find_service
+    ///
+    /// # Arguments
+    /// * `callback` - FatPtr to callback function to be invoked when services are found
+    /// * `instance_spec` - InstanceSpecifier identifying the service instance to find
+    ///
+    /// # Returns
+    /// Opaque handle pointer for the find service operation, or nullptr on failure
+    ///
+    /// # Safety
+    /// callback must be a valid FatPtr referencing a callable compatible with the find service results.
+    /// instance_spec must be a valid InstanceSpecifier for the service to find.
+    unsafe fn start_find_service(
+        callback: &FatPtr,
+        instance_spec: InstanceSpecifier,
+    ) -> *mut FindServiceHandle {
+        // SAFETY: callback and instance_spec are guaranteed to be valid per the caller's contract.
+        // The C++ implementation handles the find service operation and callback invocation safely.
+        mw_com_start_find_service(callback, instance_spec.as_native())
+    }
+
+    /// Unsafe wrapper around mw_com_stop_find_service
+    ///
+    /// # Arguments
+    /// * `handle` - Opaque handle pointer returned from start_find_service()
+    ///
+    /// # Safety
+    /// handle must be a valid pointer returned from start_find_service() that has not been stopped yet,
+    /// and the caller must ensure no further use of this handle after calling this function.
+    unsafe fn stop_find_service(handle: *mut FindServiceHandle) {
+        // SAFETY: handle is valid per the caller's contract and has not been stopped yet.
+        // The C++ implementation handles stopping the find service safely.
+        mw_com_stop_find_service(handle);
+    }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
@@ -86,6 +86,8 @@ pub use mw_com::InstanceSpecifier;
 /// FFIBridge trait defines the interface for FFI interactions between Rust COM-API and C++ Lola runtime.
 /// This trait abstracts the FFI calls and allows for different implementations
 /// e.g., Lola bridge, mock bridge for testing.
+/// All this trait bound required because runtime types which use this bridge has these bounds,
+/// an because of that this bridge also need to be bound by these traits to be used in runtime implementation.
 pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin {
     /// # Safety
     /// `event_ptr` must be a valid, non-null pointer to a `SkeletonEventBase` obtained from

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
@@ -87,60 +87,106 @@ pub use mw_com::InstanceSpecifier;
 /// This trait abstracts the FFI calls and allows for different implementations
 /// e.g., Lola bridge, mock bridge for testing.
 pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin {
-    // Define any methods that the bridge should have here
+    /// # Safety
+    /// `event_ptr` must be a valid, non-null pointer to a `SkeletonEventBase` obtained from
+    /// `get_event_from_skeleton`. `allocatee_ptr` must point to valid memory large enough to
+    /// hold the allocatee instance for `event_type`.
     unsafe fn get_allocatee_ptr(
         event_ptr: *mut SkeletonEventBase,
         allocatee_ptr: *mut std::ffi::c_void,
         event_type: &str,
     ) -> bool;
 
+    /// # Safety
+    /// `allocatee_ptr` must be a valid pointer previously returned by `get_allocatee_ptr`
+    /// with the same `type_name`, and must not be used after this call.
     unsafe fn delete_allocatee_ptr(allocatee_ptr: *mut std::ffi::c_void, type_name: &str);
 
+    /// # Safety
+    /// `allocatee_ptr` must be a valid pointer to a `SampleAllocateePtr<T>` of the specified
+    /// `type_name`, previously obtained from `get_allocatee_ptr`.
     unsafe fn get_allocatee_data_ptr(
         allocatee_ptr: *const std::ffi::c_void,
         type_name: &str,
     ) -> *mut std::ffi::c_void;
 
+    /// # Safety
+    /// `event_ptr` must be a valid pointer to a `SkeletonEventBase` obtained from
+    /// `get_event_from_skeleton`. `allocatee_ptr` must be a valid `SampleAllocateePtr<T>`
+    /// whose type matches `event_type`.
     unsafe fn skeleton_event_send_sample_allocatee(
         event_ptr: *mut SkeletonEventBase,
         event_type: &str,
         allocatee_ptr: *const std::ffi::c_void,
     ) -> bool;
 
+    /// # Safety
+    /// `sample_ptr` must be a valid pointer to a `SamplePtr<T>` of the specified `type_name`.
     unsafe fn sample_ptr_get(
         sample_ptr: *const std::ffi::c_void,
         type_name: &str,
     ) -> *const std::ffi::c_void;
 
+    /// # Safety
+    /// `sample_ptr` must be a valid pointer to a `SamplePtr<T>` of the specified `type_name`,
+    /// and must not be used after this call.
     unsafe fn sample_ptr_delete(sample_ptr: *mut std::ffi::c_void, type_name: &str);
 
+    /// # Safety
+    /// `skeleton_ptr` must be a valid, non-null pointer to a `SkeletonBase` previously created
+    /// with `create_skeleton` and not yet destroyed.
     unsafe fn skeleton_offer_service(skeleton_ptr: *mut SkeletonBase) -> bool;
 
+    /// # Safety
+    /// `skeleton_ptr` must be a valid, non-null pointer to a `SkeletonBase` previously created
+    /// with `create_skeleton` and not yet destroyed.
     unsafe fn skeleton_stop_offer_service(skeleton_ptr: *mut SkeletonBase);
 
+    /// # Safety
+    /// `handle_ptr` must be a valid reference to a `HandleType`. The returned pointer must
+    /// eventually be destroyed via `destroy_proxy`.
     unsafe fn create_proxy(interface_id: &str, handle_ptr: &HandleType) -> *mut ProxyBase;
 
+    /// # Safety
+    /// `instance_spec` must be a valid pointer to a `NativeInstanceSpecifier`. The returned
+    /// pointer must eventually be destroyed via `destroy_skeleton`.
     unsafe fn create_skeleton(
         interface_id: &str,
         instance_spec: *const NativeInstanceSpecifier,
     ) -> *mut SkeletonBase;
 
+    /// # Safety
+    /// `proxy_ptr` must be a valid pointer returned from `create_proxy` that has not been
+    /// destroyed yet. No other references to this proxy may be used after this call.
     unsafe fn destroy_proxy(proxy_ptr: *mut ProxyBase);
 
+    /// # Safety
+    /// `skeleton_ptr` must be a valid pointer returned from `create_skeleton` that has not
+    /// been destroyed yet. No other references to this skeleton may be used after this call.
     unsafe fn destroy_skeleton(skeleton_ptr: *mut SkeletonBase);
 
+    /// # Safety
+    /// `proxy_ptr` must be a valid pointer to a `ProxyBase` previously created with
+    /// `create_proxy`. The returned pointer remains valid only as long as the proxy is alive.
     unsafe fn get_event_from_proxy(
         proxy_ptr: *mut ProxyBase,
         interface_id: &str,
         event_id: &str,
     ) -> *mut ProxyEventBase;
 
+    /// # Safety
+    /// `skeleton_ptr` must be a valid pointer to a `SkeletonBase` previously created with
+    /// `create_skeleton`. The returned pointer remains valid only as long as the skeleton is alive.
     unsafe fn get_event_from_skeleton(
         skeleton_ptr: *mut SkeletonBase,
         interface_id: &str,
         event_id: &str,
     ) -> *mut SkeletonEventBase;
 
+    /// # Safety
+    /// `event_ptr` must be a valid pointer to a `ProxyEventBase` obtained from
+    /// `get_event_from_proxy`, and the event must have been subscribed via `subscribe_to_event`.
+    /// `callback` must be a valid `FatPtr` referencing a callable compatible with `event_type`.
     unsafe fn get_samples_from_event(
         event_ptr: *mut ProxyEventBase,
         event_type: &str,
@@ -148,29 +194,54 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin {
         max_samples: u32,
     ) -> u32;
 
+    /// # Safety
+    /// `event_ptr` must be a valid pointer to a `SkeletonEventBase` obtained from
+    /// `get_event_from_skeleton`. `data_ptr` must point to valid data whose type matches
+    /// `event_type` and must remain valid for the duration of this call.
     unsafe fn skeleton_send_event(
         event_ptr: *mut SkeletonEventBase,
         event_type: &str,
         data_ptr: *const std::ffi::c_void,
     ) -> bool;
 
+    /// # Safety
+    /// `event_ptr` must be a valid pointer to a `ProxyEventBase` obtained from
+    /// `get_event_from_proxy`. Must be called before `get_samples_from_event`.
     unsafe fn subscribe_to_event(event_ptr: *mut ProxyEventBase, max_sample_count: u32) -> bool;
 
+    /// # Safety
+    /// `event_ptr` must be a valid pointer to a `ProxyEventBase` obtained from
+    /// `get_event_from_proxy`. Must be called only when no `SamplePtr` for this event is
+    /// still held by the caller.
     unsafe fn unsubscribe_to_event(event_ptr: *mut ProxyEventBase);
 
+    /// # Safety
+    /// `proxy_event_ptr` must be a valid pointer to a `ProxyEventBase` obtained from
+    /// `get_event_from_proxy`. `handler` must be a valid `FatPtr` referencing a callable
+    /// compatible with the receive-handler signature expected by the implementation.
     unsafe fn set_event_receive_handler(
         proxy_event_ptr: *mut ProxyEventBase,
         handler: &FatPtr,
         event_type: &str,
     ) -> bool;
 
+    /// # Safety
+    /// `proxy_event_ptr` must be a valid pointer to a `ProxyEventBase` obtained from
+    /// `get_event_from_proxy`. `event_type` must match the type used when the handler was set.
     unsafe fn clear_event_receive_handler(proxy_event_ptr: *mut ProxyEventBase, event_type: &str);
 
+    /// # Safety
+    /// `callback` must be a valid `FatPtr` referencing a callable compatible with the
+    /// find-service callback signature. `instance_spec` must be a valid `InstanceSpecifier`.
+    /// The returned handle must eventually be passed to `stop_find_service`.
     unsafe fn start_find_service(
         callback: &FatPtr,
         instance_spec: InstanceSpecifier,
     ) -> *mut FindServiceHandle;
 
+    /// # Safety
+    /// `handle` must be a valid pointer returned from `start_find_service` that has not
+    /// been stopped yet. The handle must not be used after this call.
     unsafe fn stop_find_service(handle: *mut FindServiceHandle);
 }
 
@@ -254,762 +325,5 @@ impl From<&'_ str> for StringView {
                 len: s.len() as u32,
             }
         }
-    }
-}
-
-///  Rust closure invocation for C++ callbacks
-///
-/// This function is called by C++ to invoke a Rust closure with a sample pointer.
-/// The closure is reconstructed from the FatPtr trait object.
-///
-/// # Safety
-/// - `ptr` must point to a valid FatPtr
-/// - `sample_ptr` must point to valid placement-new storage containing SamplePtr<T>
-#[no_mangle]
-unsafe extern "C" fn mw_com_impl_call_dyn_ref_fnmut_sample(
-    ptr: *const FatPtr,
-    sample_ptr: *mut std::ffi::c_void,
-) {
-    if ptr.is_null() || sample_ptr.is_null() {
-        return;
-    }
-
-    // Reconstruct the closure from FatPtr
-    // SAFETY: ptr is guaranteed to point to a valid FatPtr that was created by the C++ side
-    // and represents a valid dynamic trait object (dyn FnMut). The transmute is safe because
-    // FatPtr is a binary representation of a trait object's fat pointer (data + vtable).
-    // The caller must ensure the lifetime of the closure outlives this call.
-    let callable: &mut dyn FnMut(*mut std::ffi::c_void) = std::mem::transmute(*ptr);
-
-    // Invoke the closure with the void* sample pointer
-    callable(sample_ptr);
-}
-
-/// Rust closure invocation for C++ callbacks for FindService
-/// This function is called by C++ to invoke a Rust closure for finding services,
-/// passing a vector of service handles.
-/// This function invokes a Rust closure that takes a HandleContainer and a FindServiceHandle.
-/// # Safety
-/// - `ptr` must point to a valid FatPtr representing a closure of type
-///   FnMut(HandleContainer, NativeFindServiceHandle).
-/// - `service_handles` must point to valid NativeHandleContainer data that can be safely wrapped
-///   in a HandleContainer.
-/// - `find_service_handle` must point to valid FindServiceHandle data that can be safely wrapped
-///   in a NativeFindServiceHandle.
-#[no_mangle]
-unsafe extern "C" fn mw_com_impl_call_dyn_ref_fnmut_find_service(
-    ptr: *const FatPtr,
-    service_handles: *mut NativeHandleContainer,
-    find_service_handle: *mut FindServiceHandle,
-) {
-    if ptr.is_null() || service_handles.is_null() {
-        return;
-    }
-
-    // Reconstruct the closure from FatPtr
-    let callable: &mut dyn FnMut(HandleContainer, NativeFindServiceHandle) =
-        std::mem::transmute(*ptr);
-
-    // Invoke with correct types
-    callable(
-        HandleContainer::new(service_handles),
-        NativeFindServiceHandle {
-            handle: find_service_handle,
-        },
-    );
-}
-
-// FFI declarations for C++ functions implemented in registry_bridge_macro.cpp
-extern "C" {
-
-    /// Subscribe to event to start receiving samples
-    ///
-    /// # Arguments
-    /// * `event_ptr` - Opaque event pointer
-    /// * `max_sample_count` - Maximum number of samples to buffer
-    ///
-    /// # Returns
-    /// true if subscription successful, false otherwise
-    fn mw_com_proxy_event_subscribe(event_ptr: *mut ProxyEventBase, max_sample_count: u32) -> bool;
-
-    /// Get event pointer from proxy by event name
-    ///
-    /// # Arguments
-    /// * `proxy_ptr` - Opaque proxy pointer
-    /// * `interface_id` - UTF-8 C string of interface UID
-    /// * `event_id` - UTF-8 C string of event name
-    ///
-    /// # Returns
-    /// Opaque event pointer, or nullptr if event not found
-    fn mw_com_get_event_from_proxy(
-        proxy_ptr: *mut ProxyBase,
-        interface_id: StringView,
-        event_id: StringView,
-    ) -> *mut ProxyEventBase;
-
-    /// Get event pointer from skeleton by event name
-    ///
-    /// # Arguments
-    /// * `skeleton_ptr` - Opaque skeleton pointer
-    /// * `interface_id` - UTF-8 C string of interface UID
-    /// * `event_id` - UTF-8 C string of event name
-    ///
-    /// # Returns
-    /// Opaque event pointer, or nullptr if event not found
-    fn mw_com_get_event_from_skeleton(
-        skeleton_ptr: *mut SkeletonBase,
-        interface_id: StringView,
-        event_id: StringView,
-    ) -> *mut SkeletonEventBase;
-
-    /// Get new samples from an event
-    ///
-    /// # Arguments
-    /// * `event_ptr` - Opaque event pointer
-    /// * `event_type` - Event type name string
-    /// * `callback` - FatPtr to callback function
-    /// * `max_samples` - Maximum number of samples to retrieve
-    ///
-    /// # Returns
-    /// Number of samples retrieved
-    fn mw_com_type_registry_get_samples_from_event(
-        event_ptr: *mut ProxyEventBase,
-        event_type: StringView,
-        callback: *const FatPtr,
-        max_samples: u32,
-    ) -> u32;
-
-    /// Send data via skeleton event
-    ///
-    /// # Arguments
-    /// * `event_ptr` - Opaque skeleton event pointer
-    /// * `event_type` - Event type name string
-    /// * `data_ptr` - Pointer to event data
-    ///
-    /// # Returns
-    /// None (void function)
-    fn mw_com_skeleton_send_event(
-        event_ptr: *mut SkeletonEventBase,
-        event_type: StringView,
-        data_ptr: CVoidPtr,
-    ) -> bool;
-
-    /// Create proxy by UID and handle
-    ///
-    /// # Arguments
-    /// * `interface_id` - UTF-8 C string of interface UID
-    /// * `handle_ptr` - Opaque handle pointer
-    ///
-    /// # Returns
-    /// Opaque proxy pointer, or nullptr if creation failed
-    fn mw_com_create_proxy(interface_id: StringView, handle_ptr: &HandleType) -> *mut ProxyBase;
-
-    /// Create skeleton by UID and instance specifier
-    ///
-    /// # Arguments
-    /// * `interface_id` - UTF-8 C string of interface UID
-    /// * `instance_spec` - Opaque instance specifier pointer
-    ///
-    /// # Returns
-    /// Opaque skeleton pointer, or nullptr if creation failed
-    fn mw_com_create_skeleton(
-        interface_id: StringView,
-        instance_spec: *const NativeInstanceSpecifier,
-    ) -> *mut SkeletonBase;
-
-    /// Destroy proxy
-    ///
-    /// # Arguments
-    /// * `proxy_ptr` - Opaque proxy pointer
-    ///
-    /// # Returns
-    /// None (void function)
-    fn mw_com_destroy_proxy(proxy_ptr: *mut ProxyBase);
-
-    /// Destroy skeleton
-    ///
-    /// # Arguments
-    /// * `skeleton_ptr` - Opaque skeleton pointer
-    ///
-    /// # Returns
-    /// None (void function)
-    fn mw_com_destroy_skeleton(skeleton_ptr: *mut SkeletonBase);
-
-    /// Offer service via skeleton
-    ///
-    /// # Arguments
-    /// * `skeleton_ptr` - Opaque skeleton pointer
-    ///
-    /// # Returns
-    /// true if offer successful, false otherwise
-    fn mw_com_skeleton_offer_service(skeleton_ptr: *mut SkeletonBase) -> bool;
-
-    /// Stop offering service via skeleton
-    ///
-    /// # Arguments
-    /// * `skeleton_ptr` - Opaque skeleton pointer
-    ///
-    /// # Returns
-    /// None (void function)
-    fn mw_com_skeleton_stop_offer_service(skeleton_ptr: *mut SkeletonBase);
-
-    /// Get sample data pointer from SamplePtr<T>
-    ///
-    /// # Arguments
-    /// * `sample_ptr` - Opaque sample pointer
-    /// * `type_name` - Type name string
-    ///
-    /// # Returns
-    /// Pointer to sample data, or nullptr if type mismatch
-    fn mw_com_get_sample_ptr(
-        sample_ptr: *const std::ffi::c_void,
-        type_name: StringView,
-    ) -> *const std::ffi::c_void;
-
-    /// Delete sample pointer of SamplePtr<T>'
-    ///
-    /// # Arguments
-    /// * `sample_ptr` - Opaque sample pointer
-    /// * `type_name` - Type name string
-    fn mw_com_delete_sample_ptr(sample_ptr: *mut std::ffi::c_void, type_name: StringView);
-
-    /// Get allocatee pointer from skeleton event of specific type
-    ///
-    /// # Arguments
-    /// * `event_ptr` - Opaque skeleton event pointer
-    /// * `allocatee_ptr` - Pointer to pre-allocated memory for allocatee
-    /// * `event_type` - Type name string
-    ///
-    /// # Returns
-    /// True if allocatee pointer was retrieved successfully, false otherwise
-    fn mw_com_get_allocatee_ptr(
-        event_ptr: *mut SkeletonEventBase,
-        allocatee_ptr: *mut std::ffi::c_void,
-        event_type: StringView,
-    ) -> bool;
-
-    /// Delete allocatee pointer of SampleAllocateePtr<T>
-    ///
-    /// # Arguments
-    /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
-    /// * `type_name` - Type name string
-    fn mw_com_delete_allocatee_ptr(allocatee_ptr: *mut std::ffi::c_void, type_name: StringView);
-
-    /// Get allocatee data pointer from allocatee of specific type
-    ///
-    /// # Arguments
-    /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
-    /// * `type_name` - Type name string
-    ///
-    /// # Returns
-    /// Pointer to allocatee data, or nullptr if type mismatch
-    fn mw_com_get_allocatee_data_ptr(
-        allocatee_ptr: *const std::ffi::c_void,
-        type_name: StringView,
-    ) -> *mut std::ffi::c_void;
-
-    /// Send event via skeleton using allocatee pointer of specific type
-    ///
-    /// # Arguments
-    /// * `event_ptr` - Opaque skeleton event pointer
-    /// * `event_type` - Type name string
-    /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
-    ///
-    /// # Returns
-    /// True if event was sent successfully, false otherwise
-    fn mw_com_skeleton_send_event_allocatee(
-        event_ptr: *mut SkeletonEventBase,
-        event_type: StringView,
-        allocatee_ptr: *const std::ffi::c_void,
-    ) -> bool;
-
-    /// Set event receive handler for proxy event
-    ///
-    /// # Arguments
-    /// * `proxy_event_ptr` - Opaque proxy event pointer
-    /// * `handler` - FatPtr to event receive handler function
-    ///
-    /// # Returns
-    /// True if handler was set successfully, false otherwise
-    fn mw_com_proxy_set_event_receive_handler(
-        proxy_event_ptr: *mut ProxyEventBase,
-        handler: *const FatPtr,
-        event_type: StringView,
-    ) -> bool;
-
-    /// Clear event receive handler for proxy event
-    ///
-    /// # Arguments
-    /// * `proxy_event_ptr` - Opaque proxy event pointer
-    fn mw_com_proxy_clear_event_receive_handler(
-        proxy_event_ptr: *mut ProxyEventBase,
-        event_type: StringView,
-    );
-
-    /// Start finding services with callback for results
-    ///
-    /// # Arguments
-    /// * `callback` - FatPtr to callback function that will be called with discovery results
-    /// * `instance_spec` - Pointer to instance specifier for the service to find
-    ///
-    /// # Returns
-    /// Opaque pointer to FindServiceHandle which can be used to stop the find operation
-    fn mw_com_start_find_service(
-        callback: *const FatPtr,
-        instance_spec: *const NativeInstanceSpecifier,
-    ) -> *mut FindServiceHandle;
-
-    /// Stop finding services using the provided FindServiceHandle
-    ///
-    /// # Arguments
-    /// * `handle` - Opaque pointer to FindServiceHandle returned by mw_com_start_find_service
-    fn mw_com_stop_find_service(handle: *mut FindServiceHandle);
-
-    /// Unsubscribe from event to stop receiving samples
-    ///
-    /// # Arguments
-    /// * `event_ptr` - Opaque event pointer
-    fn mw_com_proxy_event_unsubscribe(event_ptr: *mut ProxyEventBase);
-}
-
-#[derive(Debug, Clone)]
-pub struct LolaFFIBridge;
-
-impl FFIBridge for LolaFFIBridge {
-    /// Get allocatee pointer from skeleton event of specific type
-    ///
-    /// # Arguments
-    /// * `event_ptr` - Opaque skeleton event pointer
-    /// * `allocatee_ptr` - Pointer to pre-allocated memory for allocatee
-    /// * `event_type` - Type name string
-    ///
-    /// # Returns
-    /// True if allocatee pointer was retrieved successfully, false otherwise
-    ///
-    /// # Safety
-    /// event_ptr must point to a valid SkeletonEventBase,
-    /// allocatee_ptr must point to valid memory for the allocatee,
-    /// and event_type must be a valid UTF-8 string representing the event type.
-    unsafe fn get_allocatee_ptr(
-        event_ptr: *mut SkeletonEventBase,
-        allocatee_ptr: *mut std::ffi::c_void,
-        event_type: &str,
-    ) -> bool {
-        // SAFETY: event_ptr is valid which is created using create_skeleton()
-        // and allocatee_ptr has enough memory allocated for the construction of allocatee instance.
-        let event_type = StringView::from(event_type);
-        mw_com_get_allocatee_ptr(event_ptr, allocatee_ptr, event_type)
-    }
-
-    /// Delete allocatee pointer of SampleAllocateePtr<T>
-    ///
-    /// # Arguments
-    /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
-    /// * `type_name` - Type name string
-    ///
-    /// # Safety
-    /// allocatee_ptr must point to a valid SampleAllocateePtr<T> of the specified type.
-    unsafe fn delete_allocatee_ptr(allocatee_ptr: *mut std::ffi::c_void, type_name: &str) {
-        // SAFETY: allocatee_ptr is valid which is created using get_allocatee_ptr() and
-        // type_name is constructed using static str.
-        let type_name = StringView::from(type_name);
-        mw_com_delete_allocatee_ptr(allocatee_ptr, type_name);
-    }
-
-    /// Get allocatee data pointer from allocatee of specific type
-    ///
-    /// # Arguments
-    /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
-    /// * `type_name` - Type name string
-    ///
-    /// # Returns
-    /// Pointer to allocatee data, or nullptr if type mismatch
-    ///
-    /// # Safety
-    /// allocatee_ptr must point to a valid SampleAllocateePtr<T> of the specified type
-    unsafe fn get_allocatee_data_ptr(
-        allocatee_ptr: *const std::ffi::c_void,
-        type_name: &str,
-    ) -> *mut std::ffi::c_void {
-        // SAFETY: allocatee_ptr is valid which is created using get_allocatee_ptr() and
-        // type_name is constructed using static str.
-        let type_name = StringView::from(type_name);
-        mw_com_get_allocatee_data_ptr(allocatee_ptr, type_name)
-    }
-
-    /// Send event via skeleton using allocatee pointer of specific type
-    ///
-    /// # Arguments
-    /// * `event_ptr` - Opaque skeleton event pointer
-    /// * `event_type` - Type name string
-    /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
-    ///
-    /// # Returns
-    /// True if event was sent successfully, false otherwise
-    ///
-    /// # Safety
-    /// event_ptr must point to a valid SkeletonEventBase,
-    /// allocatee_ptr must point to a valid SampleAllocateePtr<T>,
-    /// and event_type must be a valid UTF-8 string representing the event type.
-    unsafe fn skeleton_event_send_sample_allocatee(
-        event_ptr: *mut SkeletonEventBase,
-        event_type: &str,
-        allocatee_ptr: *const std::ffi::c_void,
-    ) -> bool {
-        // SAFETY: event_ptr is valid which is created using create_skeleton() and allocatee_ptr is
-        // valid which is created using get_allocatee_ptr().
-        let event_type = StringView::from(event_type);
-        mw_com_skeleton_send_event_allocatee(event_ptr, event_type, allocatee_ptr)
-    }
-
-    /// Get SamplePtr<T> data pointer
-    ///
-    /// # Arguments
-    /// * `sample_ptr` - Opaque sample pointer
-    /// * `type_name` - Type name string
-    ///
-    /// # Returns
-    /// Pointer to sample data, or nullptr if type mismatch
-    /// # Safety
-    /// sample_ptr must point to a valid SamplePtr<T> of the specified type.
-    unsafe fn sample_ptr_get(
-        sample_ptr: *const std::ffi::c_void,
-        type_name: &str,
-    ) -> *const std::ffi::c_void {
-        // SAFETY: sample_ptr is guaranteed to be valid per the caller's contract.
-        // The C++ implementation handles type checking and data retrieval safely.
-        let type_name = StringView::from(type_name);
-        mw_com_get_sample_ptr(sample_ptr, type_name)
-    }
-
-    /// Delete SamplePtr<T>
-    ///
-    /// # Arguments
-    /// * `sample_ptr` - Opaque sample pointer
-    /// * `type_name` - Type name string
-    /// # Safety
-    /// sample_ptr must point to a valid SamplePtr<T> of the specified type.
-    unsafe fn sample_ptr_delete(sample_ptr: *mut std::ffi::c_void, type_name: &str) {
-        // SAFETY: sample_ptr is guaranteed to be valid per the caller's contract.
-        // The C++ implementation handles type checking and deletion safely.
-        let type_name = StringView::from(type_name);
-        mw_com_delete_sample_ptr(sample_ptr, type_name);
-    }
-
-    /// Unsafe wrapper around mw_com_skeleton_offer_service
-    ///
-    /// # Arguments
-    /// * `skeleton_ptr` - Opaque skeleton pointer
-    ///
-    /// # Returns
-    /// true if offer was successful, false otherwise
-    ///
-    /// # Safety
-    /// skeleton_ptr must be a valid pointer to a SkeletonBase previously created
-    /// with create_skeleton().
-    /// The pointer must remain valid for the duration of this call.
-    unsafe fn skeleton_offer_service(skeleton_ptr: *mut SkeletonBase) -> bool {
-        // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
-        // The C++ implementation handles service offering safely.
-        mw_com_skeleton_offer_service(skeleton_ptr)
-    }
-
-    /// Unsafe wrapper around mw_com_skeleton_stop_offer_service
-    ///
-    /// # Arguments
-    /// * `skeleton_ptr` - Opaque skeleton pointer
-    ///
-    /// # Safety
-    /// skeleton_ptr must be a valid pointer to a SkeletonBase previously created
-    /// with create_skeleton().
-    /// The pointer must remain valid for the duration of this call.
-    unsafe fn skeleton_stop_offer_service(skeleton_ptr: *mut SkeletonBase) {
-        // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
-        // The C++ implementation handles stopping the service safely.
-        mw_com_skeleton_stop_offer_service(skeleton_ptr);
-    }
-
-    /// Unsafe wrapper around mw_com_create_proxy
-    ///
-    /// # Arguments
-    /// * `interface_id` - Interface UID string
-    /// * `handle_ptr` - Opaque handle pointer
-    ///
-    /// # Returns
-    /// Opaque proxy pointer, or nullptr if creation failed
-    ///
-    /// # Safety
-    /// handle_ptr must be a valid reference to a HandleType.
-    /// The returned pointer must eventually be destroyed via destroy_proxy().
-    unsafe fn create_proxy(interface_id: &str, handle_ptr: &HandleType) -> *mut ProxyBase {
-        // SAFETY: interface_id is a valid string reference and handle_ptr is guaranteed to be valid
-        // per the caller's contract.
-        // The C++ implementation creates and returns a valid proxy pointer or nullptr on failure.
-        let c_uid = StringView::from(interface_id);
-        mw_com_create_proxy(c_uid, handle_ptr)
-    }
-
-    /// Unsafe wrapper around mw_com_create_skeleton
-    ///
-    /// # Arguments
-    /// * `interface_id` - Interface UID string
-    /// * `instance_spec` - Opaque instance specifier pointer
-    ///
-    /// # Returns
-    /// Opaque skeleton pointer, or nullptr if creation failed
-    ///
-    /// # Safety
-    /// instance_spec must be a valid NativeInstanceSpecifier.
-    /// The returned pointer must eventually be destroyed via destroy_skeleton().
-    unsafe fn create_skeleton(
-        interface_id: &str,
-        instance_spec: *const NativeInstanceSpecifier,
-    ) -> *mut SkeletonBase {
-        // SAFETY: interface_id is a valid string reference and instance_spec is guaranteed to be
-        // valid per the caller's contract.
-        // The C++ implementation creates and returns a valid skeleton pointer or nullptr on failure.
-        let c_uid = StringView::from(interface_id);
-        mw_com_create_skeleton(c_uid, instance_spec)
-    }
-
-    /// Unsafe wrapper around mw_com_destroy_proxy
-    ///
-    /// # Arguments
-    /// * `proxy_ptr` - Opaque proxy pointer to destroy
-    ///
-    /// # Safety
-    /// proxy_ptr must be a valid pointer returned from create_proxy() that has not been destroyed yet.
-    /// The caller must ensure no other references to this proxy exist after calling this function.
-    unsafe fn destroy_proxy(proxy_ptr: *mut ProxyBase) {
-        // SAFETY: proxy_ptr is guaranteed to be valid per the caller's contract.
-        // The C++ implementation safely deallocates the proxy.
-        mw_com_destroy_proxy(proxy_ptr);
-    }
-
-    /// Unsafe wrapper around mw_com_destroy_skeleton
-    ///
-    /// # Arguments
-    /// * `skeleton_ptr` - Opaque skeleton pointer to destroy
-    ///
-    /// # Safety
-    /// skeleton_ptr must be a valid pointer returned from create_skeleton()-
-    /// that has not been destroyed yet.
-    /// The caller must ensure no other references to this skeleton exist after calling this function.
-    unsafe fn destroy_skeleton(skeleton_ptr: *mut SkeletonBase) {
-        // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
-        // The C++ implementation safely deallocates the skeleton.
-        mw_com_destroy_skeleton(skeleton_ptr);
-    }
-
-    /// Unsafe wrapper around mw_com_get_event_from_proxy
-    ///
-    /// # Arguments
-    /// * `proxy_ptr` - Opaque proxy pointer
-    /// * `interface_id` - Interface UID string
-    /// * `event_id` - Event name string
-    ///
-    /// # Returns
-    /// Opaque event pointer, or nullptr if not found
-    ///
-    /// # Safety
-    /// proxy_ptr must be a valid pointer to a ProxyBase previously created with create_proxy().
-    /// The returned pointer remains valid only as long as the proxy remains alive.
-    unsafe fn get_event_from_proxy(
-        proxy_ptr: *mut ProxyBase,
-        interface_id: &str,
-        event_id: &str,
-    ) -> *mut ProxyEventBase {
-        // SAFETY: proxy_ptr is guaranteed to be valid per the caller's contract.
-        // The C++ implementation returns a valid pointer or nullptr if the event is not found.
-        let c_id = StringView::from(interface_id);
-        let c_name = StringView::from(event_id);
-        mw_com_get_event_from_proxy(proxy_ptr, c_id, c_name)
-    }
-
-    /// Unsafe wrapper around mw_com_get_event_from_skeleton
-    ///
-    /// # Arguments
-    /// * `skeleton_ptr` - Opaque skeleton pointer
-    /// * `interface_id` - Interface UID string
-    /// * `event_id` - Event name string
-    ///
-    /// # Returns
-    /// Opaque event pointer, or nullptr if not found
-    ///
-    /// # Safety
-    /// skeleton_ptr must be a valid pointer to a SkeletonBase previously created
-    /// with create_skeleton().
-    /// The returned pointer remains valid only as long as the skeleton remains alive.
-    unsafe fn get_event_from_skeleton(
-        skeleton_ptr: *mut SkeletonBase,
-        interface_id: &str,
-        event_id: &str,
-    ) -> *mut SkeletonEventBase {
-        // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
-        // The C++ implementation returns a valid pointer or nullptr if the event is not found.
-        let c_id = StringView::from(interface_id);
-        let c_name = StringView::from(event_id);
-        mw_com_get_event_from_skeleton(skeleton_ptr, c_id, c_name)
-    }
-
-    /// Unsafe wrapper around mw_com_get_samples_from_event
-    ///
-    /// # Arguments
-    /// * `event_ptr` - Opaque event pointer
-    /// * `event_type` - Event type name string
-    /// * `callback` - FatPtr to callback function
-    /// * `max_samples` - Maximum number of samples to retrieve
-    ///
-    /// # Returns
-    /// Number of samples retrieved, or u32::MAX on error
-    ///
-    /// # Safety
-    /// event_ptr must be a valid pointer to a ProxyEventBase previously obtained
-    /// from get_event_from_proxy().
-    /// callback must be a valid FatPtr referencing a callable compatible with the event type.
-    /// The event must have been subscribed to via subscribe_to_event() before calling this function.
-    unsafe fn get_samples_from_event(
-        event_ptr: *mut ProxyEventBase,
-        event_type: &str,
-        callback: &FatPtr,
-        max_samples: u32,
-    ) -> u32 {
-        // SAFETY: event_ptr, callback, and event_type are guaranteed
-        // to be valid per the caller's contract.
-        // The C++ implementation handles sample retrieval and callback invocation safely.
-        let c_name = StringView::from(event_type);
-        mw_com_type_registry_get_samples_from_event(event_ptr, c_name, callback, max_samples)
-    }
-
-    /// Unsafe wrapper around mw_com_skeleton_send_event
-    ///
-    /// # Arguments
-    /// * `event_ptr` - Opaque skeleton event pointer
-    /// * `event_type` - Event type name string
-    /// * `data_ptr` - Pointer to event data of the matching type
-    ///
-    /// # Safety
-    /// event_ptr must be a valid pointer to a SkeletonEventBase previously obtained
-    /// from get_event_from_skeleton().
-    /// data_ptr must point to valid data whose type matches the event_type.
-    /// The lifetime of the data must extend through this function call.
-    unsafe fn skeleton_send_event(
-        event_ptr: *mut SkeletonEventBase,
-        event_type: &str,
-        data_ptr: *const std::ffi::c_void,
-    ) -> bool {
-        // SAFETY: event_ptr and data_ptr are guaranteed to be valid per the caller's contract.
-        // The C++ implementation handles type matching and data sending safely.
-        let c_name = StringView::from(event_type);
-        mw_com_skeleton_send_event(event_ptr, c_name, data_ptr)
-    }
-
-    /// Unsafe wrapper around mw_com_proxy_event_subscribe
-    ///
-    /// # Arguments
-    /// * `event_ptr` - Opaque event pointer
-    /// * `max_sample_count` - Maximum number of samples to buffer concurrently
-    ///
-    /// # Returns
-    /// true if subscription was successful, false otherwise
-    ///
-    /// # Safety
-    /// event_ptr must be a valid pointer to a ProxyEventBase previously obtained
-    /// from get_event_from_proxy().
-    /// This function must be called before attempting to retrieve samples via get_samples_from_event().
-    unsafe fn subscribe_to_event(event_ptr: *mut ProxyEventBase, max_sample_count: u32) -> bool {
-        // SAFETY: event_ptr is guaranteed to be valid per the caller's contract.
-        // The C++ implementation handles subscription and buffer allocation safely.
-        mw_com_proxy_event_subscribe(event_ptr, max_sample_count)
-    }
-
-    /// Unsafe wrapper around mw_com_proxy_event_unsubscribe
-    ///
-    /// # Arguments
-    /// * `event_ptr` - Opaque event pointer
-    ///
-    /// # Safety
-    /// event_ptr must be a valid pointer to a ProxyEventBase previously obtained from get_event_from_proxy().
-    /// This function should be called only when no `SamplePtr` is held by the user for this event.
-    unsafe fn unsubscribe_to_event(event_ptr: *mut ProxyEventBase) {
-        // SAFETY: event_ptr is guaranteed to be valid per the caller's contract.
-        // The C++ implementation handles unsubscription and buffer cleanup safely.
-        mw_com_proxy_event_unsubscribe(event_ptr);
-    }
-
-    /// Unsafe wrapper around mw_com_proxy_set_event_receive_handler
-    ///
-    /// # Arguments
-    /// * `proxy_event_ptr` - Opaque proxy event pointer
-    /// * `handler` - FatPtr to event receive handler function
-    ///
-    /// # Returns
-    /// true if handler was set successfully, false otherwise
-    ///
-    /// # Safety
-    /// proxy_event_ptr must be a valid pointer to a ProxyEventBase previously obtained
-    /// from get_event_from_proxy().
-    /// handler must be a valid FatPtr which is used for notifying the proxy of incoming events.
-    unsafe fn set_event_receive_handler(
-        proxy_event_ptr: *mut ProxyEventBase,
-        handler: &FatPtr,
-        event_type: &str,
-    ) -> bool {
-        // SAFETY: proxy_event_ptr must be valid per the caller's contract,
-        // and handler must be a valid FatPtr referencing a callable compatible with the callback
-        // signature expected by the C++ implementation.
-        let c_name = StringView::from(event_type);
-        mw_com_proxy_set_event_receive_handler(proxy_event_ptr, handler, c_name)
-    }
-
-    /// Unsafe wrapper around mw_com_proxy_clear_event_receive_handler
-    ///
-    /// # Arguments
-    /// * `proxy_event_ptr` - Opaque proxy event pointer
-    /// * `event_type` - Event type name string
-    ///
-    /// # Safety
-    /// proxy_event_ptr must be a valid pointer to a ProxyEventBase previously obtained
-    /// from get_event_from_proxy().
-    /// event_type must be a valid string corresponding to the event type.
-    unsafe fn clear_event_receive_handler(proxy_event_ptr: *mut ProxyEventBase, event_type: &str) {
-        // SAFETY: proxy_event_ptr must be valid per the caller's contract.
-        let c_name = StringView::from(event_type);
-        mw_com_proxy_clear_event_receive_handler(proxy_event_ptr, c_name);
-    }
-
-    /// Unsafe wrapper around mw_com_start_find_service
-    ///
-    /// # Arguments
-    /// * `callback` - FatPtr to callback function to be invoked when services are found
-    /// * `instance_spec` - InstanceSpecifier identifying the service instance to find
-    ///
-    /// # Returns
-    /// Opaque handle pointer for the find service operation, or nullptr on failure
-    ///
-    /// # Safety
-    /// callback must be a valid FatPtr referencing a callable compatible with the find service results.
-    /// instance_spec must be a valid InstanceSpecifier for the service to find.
-    unsafe fn start_find_service(
-        callback: &FatPtr,
-        instance_spec: InstanceSpecifier,
-    ) -> *mut FindServiceHandle {
-        // SAFETY: callback and instance_spec are guaranteed to be valid per the caller's contract.
-        // The C++ implementation handles the find service operation and callback invocation safely.
-        mw_com_start_find_service(callback, instance_spec.as_native())
-    }
-
-    /// Unsafe wrapper around mw_com_stop_find_service
-    ///
-    /// # Arguments
-    /// * `handle` - Opaque handle pointer returned from start_find_service()
-    ///
-    /// # Safety
-    /// handle must be a valid pointer returned from start_find_service() that has not been stopped yet,
-    /// and the caller must ensure no further use of this handle after calling this function.
-    unsafe fn stop_find_service(handle: *mut FindServiceHandle) {
-        // SAFETY: handle is valid per the caller's contract and has not been stopped yet.
-        // The C++ implementation handles stopping the find service safely.
-        mw_com_stop_find_service(handle);
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
@@ -88,12 +88,13 @@ pub use mw_com::InstanceSpecifier;
 /// e.g., Lola bridge, mock bridge for testing.
 /// All this trait bound required because runtime types which use this bridge has these bounds,
 /// an because of that this bridge also need to be bound by these traits to be used in runtime implementation.
-pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin {
+pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin + Default {
     /// # Safety
     /// `event_ptr` must be a valid, non-null pointer to a `SkeletonEventBase` obtained from
     /// `get_event_from_skeleton`. `allocatee_ptr` must point to valid memory large enough to
     /// hold the allocatee instance for `event_type`.
     unsafe fn get_allocatee_ptr(
+        &self,
         event_ptr: *mut SkeletonEventBase,
         allocatee_ptr: *mut std::ffi::c_void,
         event_type: &str,
@@ -102,12 +103,13 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin {
     /// # Safety
     /// `allocatee_ptr` must be a valid pointer previously returned by `get_allocatee_ptr`
     /// with the same `type_name`, and must not be used after this call.
-    unsafe fn delete_allocatee_ptr(allocatee_ptr: *mut std::ffi::c_void, type_name: &str);
+    unsafe fn delete_allocatee_ptr(&self, allocatee_ptr: *mut std::ffi::c_void, type_name: &str);
 
     /// # Safety
     /// `allocatee_ptr` must be a valid pointer to a `SampleAllocateePtr<T>` of the specified
     /// `type_name`, previously obtained from `get_allocatee_ptr`.
     unsafe fn get_allocatee_data_ptr(
+        &self,
         allocatee_ptr: *const std::ffi::c_void,
         type_name: &str,
     ) -> *mut std::ffi::c_void;
@@ -117,6 +119,7 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin {
     /// `get_event_from_skeleton`. `allocatee_ptr` must be a valid `SampleAllocateePtr<T>`
     /// whose type matches `event_type`.
     unsafe fn skeleton_event_send_sample_allocatee(
+        &self,
         event_ptr: *mut SkeletonEventBase,
         event_type: &str,
         allocatee_ptr: *const std::ffi::c_void,
@@ -125,6 +128,7 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin {
     /// # Safety
     /// `sample_ptr` must be a valid pointer to a `SamplePtr<T>` of the specified `type_name`.
     unsafe fn sample_ptr_get(
+        &self,
         sample_ptr: *const std::ffi::c_void,
         type_name: &str,
     ) -> *const std::ffi::c_void;
@@ -132,27 +136,28 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin {
     /// # Safety
     /// `sample_ptr` must be a valid pointer to a `SamplePtr<T>` of the specified `type_name`,
     /// and must not be used after this call.
-    unsafe fn sample_ptr_delete(sample_ptr: *mut std::ffi::c_void, type_name: &str);
+    unsafe fn sample_ptr_delete(&self, sample_ptr: *mut std::ffi::c_void, type_name: &str);
 
     /// # Safety
     /// `skeleton_ptr` must be a valid, non-null pointer to a `SkeletonBase` previously created
     /// with `create_skeleton` and not yet destroyed.
-    unsafe fn skeleton_offer_service(skeleton_ptr: *mut SkeletonBase) -> bool;
+    unsafe fn skeleton_offer_service(&self, skeleton_ptr: *mut SkeletonBase) -> bool;
 
     /// # Safety
     /// `skeleton_ptr` must be a valid, non-null pointer to a `SkeletonBase` previously created
     /// with `create_skeleton` and not yet destroyed.
-    unsafe fn skeleton_stop_offer_service(skeleton_ptr: *mut SkeletonBase);
+    unsafe fn skeleton_stop_offer_service(&self, skeleton_ptr: *mut SkeletonBase);
 
     /// # Safety
     /// `handle_ptr` must be a valid reference to a `HandleType`. The returned pointer must
     /// eventually be destroyed via `destroy_proxy`.
-    unsafe fn create_proxy(interface_id: &str, handle_ptr: &HandleType) -> *mut ProxyBase;
+    unsafe fn create_proxy(&self, interface_id: &str, handle_ptr: &HandleType) -> *mut ProxyBase;
 
     /// # Safety
     /// `instance_spec` must be a valid pointer to a `NativeInstanceSpecifier`. The returned
     /// pointer must eventually be destroyed via `destroy_skeleton`.
     unsafe fn create_skeleton(
+        &self,
         interface_id: &str,
         instance_spec: *const NativeInstanceSpecifier,
     ) -> *mut SkeletonBase;
@@ -160,17 +165,18 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin {
     /// # Safety
     /// `proxy_ptr` must be a valid pointer returned from `create_proxy` that has not been
     /// destroyed yet. No other references to this proxy may be used after this call.
-    unsafe fn destroy_proxy(proxy_ptr: *mut ProxyBase);
+    unsafe fn destroy_proxy(&self, proxy_ptr: *mut ProxyBase);
 
     /// # Safety
     /// `skeleton_ptr` must be a valid pointer returned from `create_skeleton` that has not
     /// been destroyed yet. No other references to this skeleton may be used after this call.
-    unsafe fn destroy_skeleton(skeleton_ptr: *mut SkeletonBase);
+    unsafe fn destroy_skeleton(&self, skeleton_ptr: *mut SkeletonBase);
 
     /// # Safety
     /// `proxy_ptr` must be a valid pointer to a `ProxyBase` previously created with
     /// `create_proxy`. The returned pointer remains valid only as long as the proxy is alive.
     unsafe fn get_event_from_proxy(
+        &self,
         proxy_ptr: *mut ProxyBase,
         interface_id: &str,
         event_id: &str,
@@ -180,6 +186,7 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin {
     /// `skeleton_ptr` must be a valid pointer to a `SkeletonBase` previously created with
     /// `create_skeleton`. The returned pointer remains valid only as long as the skeleton is alive.
     unsafe fn get_event_from_skeleton(
+        &self,
         skeleton_ptr: *mut SkeletonBase,
         interface_id: &str,
         event_id: &str,
@@ -190,6 +197,7 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin {
     /// `get_event_from_proxy`, and the event must have been subscribed via `subscribe_to_event`.
     /// `callback` must be a valid `FatPtr` referencing a callable compatible with `event_type`.
     unsafe fn get_samples_from_event(
+        &self,
         event_ptr: *mut ProxyEventBase,
         event_type: &str,
         callback: &FatPtr,
@@ -201,6 +209,7 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin {
     /// `get_event_from_skeleton`. `data_ptr` must point to valid data whose type matches
     /// `event_type` and must remain valid for the duration of this call.
     unsafe fn skeleton_send_event(
+        &self,
         event_ptr: *mut SkeletonEventBase,
         event_type: &str,
         data_ptr: *const std::ffi::c_void,
@@ -209,19 +218,24 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin {
     /// # Safety
     /// `event_ptr` must be a valid pointer to a `ProxyEventBase` obtained from
     /// `get_event_from_proxy`. Must be called before `get_samples_from_event`.
-    unsafe fn subscribe_to_event(event_ptr: *mut ProxyEventBase, max_sample_count: u32) -> bool;
+    unsafe fn subscribe_to_event(
+        &self,
+        event_ptr: *mut ProxyEventBase,
+        max_sample_count: u32,
+    ) -> bool;
 
     /// # Safety
     /// `event_ptr` must be a valid pointer to a `ProxyEventBase` obtained from
     /// `get_event_from_proxy`. Must be called only when no `SamplePtr` for this event is
     /// still held by the caller.
-    unsafe fn unsubscribe_to_event(event_ptr: *mut ProxyEventBase);
+    unsafe fn unsubscribe_to_event(&self, event_ptr: *mut ProxyEventBase);
 
     /// # Safety
     /// `proxy_event_ptr` must be a valid pointer to a `ProxyEventBase` obtained from
     /// `get_event_from_proxy`. `handler` must be a valid `FatPtr` referencing a callable
     /// compatible with the receive-handler signature expected by the implementation.
     unsafe fn set_event_receive_handler(
+        &self,
         proxy_event_ptr: *mut ProxyEventBase,
         handler: &FatPtr,
         event_type: &str,
@@ -230,13 +244,18 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin {
     /// # Safety
     /// `proxy_event_ptr` must be a valid pointer to a `ProxyEventBase` obtained from
     /// `get_event_from_proxy`. `event_type` must match the type used when the handler was set.
-    unsafe fn clear_event_receive_handler(proxy_event_ptr: *mut ProxyEventBase, event_type: &str);
+    unsafe fn clear_event_receive_handler(
+        &self,
+        proxy_event_ptr: *mut ProxyEventBase,
+        event_type: &str,
+    );
 
     /// # Safety
     /// `callback` must be a valid `FatPtr` referencing a callable compatible with the
     /// find-service callback signature. `instance_spec` must be a valid `InstanceSpecifier`.
     /// The returned handle must eventually be passed to `stop_find_service`.
     unsafe fn start_find_service(
+        &self,
         callback: &FatPtr,
         instance_spec: InstanceSpecifier,
     ) -> *mut FindServiceHandle;
@@ -244,21 +263,22 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin {
     /// # Safety
     /// `handle` must be a valid pointer returned from `start_find_service` that has not
     /// been stopped yet. The handle must not be used after this call.
-    unsafe fn stop_find_service(handle: *mut FindServiceHandle);
+    unsafe fn stop_find_service(&self, handle: *mut FindServiceHandle);
 
     /// # Safety
     /// `container` must be a valid reference to a `HandleContainer` that was produced by the
     /// bridge (e.g. from `start_find_service` callback). Calling this on a sentinel mock pointer
     /// is only safe when the mock implementation ignores the inner pointer.
-    fn handle_container_size(container: &HandleContainer) -> usize;
+    fn handle_container_size(&self, container: &HandleContainer) -> usize;
 
     /// # Safety
     /// Same as `handle_container_size`. `index` need not be in-bounds; the method must return
     /// `None` when `index >= handle_container_size(container)`.
-    fn handle_container_get_at(
-        container: &HandleContainer,
+    fn handle_container_get_at<'a>(
+        &self,
+        container: &'a HandleContainer,
         index: usize,
-    ) -> Option<&HandleType>;
+    ) -> Option<&'a HandleType>;
 }
 
 /// Opaque proxy base struct

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
@@ -243,6 +243,20 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin {
     /// `handle` must be a valid pointer returned from `start_find_service` that has not
     /// been stopped yet. The handle must not be used after this call.
     unsafe fn stop_find_service(handle: *mut FindServiceHandle);
+
+    /// # Safety
+    /// `container` must be a valid reference to a `HandleContainer` that was produced by the
+    /// bridge (e.g. from `start_find_service` callback). Calling this on a sentinel mock pointer
+    /// is only safe when the mock implementation ignores the inner pointer.
+    unsafe fn handle_container_size(container: &HandleContainer) -> usize;
+
+    /// # Safety
+    /// Same as `handle_container_size`. `index` need not be in-bounds; the method must return
+    /// `None` when `index >= handle_container_size(container)`.
+    unsafe fn handle_container_get_at(
+        container: &HandleContainer,
+        index: usize,
+    ) -> Option<&HandleType>;
 }
 
 /// Opaque proxy base struct

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
@@ -250,12 +250,12 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin {
     /// `container` must be a valid reference to a `HandleContainer` that was produced by the
     /// bridge (e.g. from `start_find_service` callback). Calling this on a sentinel mock pointer
     /// is only safe when the mock implementation ignores the inner pointer.
-    unsafe fn handle_container_size(container: &HandleContainer) -> usize;
+    fn handle_container_size(container: &HandleContainer) -> usize;
 
     /// # Safety
     /// Same as `handle_container_size`. `index` need not be in-bounds; the method must return
     /// `None` when `index >= handle_container_size(container)`.
-    unsafe fn handle_container_get_at(
+    fn handle_container_get_at(
         container: &HandleContainer,
         index: usize,
     ) -> Option<&HandleType>;

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
@@ -88,6 +88,7 @@ pub use mw_com::InstanceSpecifier;
 /// e.g., Lola bridge, mock bridge for testing.
 /// All this trait bound required because runtime types which use this bridge has these bounds,
 /// an because of that this bridge also need to be bound by these traits to be used in runtime implementation.
+// In bridge_ffi_rs crate (where FFIBridge trait is defined):
 pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin + Default {
     /// # Safety
     /// `event_ptr` must be a valid, non-null pointer to a `SkeletonEventBase` obtained from
@@ -264,31 +265,18 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin + Default {
     /// `handle` must be a valid pointer returned from `start_find_service` that has not
     /// been stopped yet. The handle must not be used after this call.
     unsafe fn stop_find_service(&self, handle: *mut FindServiceHandle);
-
-    /// # Safety
-    /// `container` must be a valid reference to a `HandleContainer` that was produced by the
-    /// bridge (e.g. from `start_find_service` callback). Calling this on a sentinel mock pointer
-    /// is only safe when the mock implementation ignores the inner pointer.
-    fn handle_container_size(&self, container: &HandleContainer) -> usize;
-
-    /// # Safety
-    /// Same as `handle_container_size`. `index` need not be in-bounds; the method must return
-    /// `None` when `index >= handle_container_size(container)`.
-    fn handle_container_get_at<'a>(
-        &self,
-        container: &'a HandleContainer,
-        index: usize,
-    ) -> Option<&'a HandleType>;
 }
 
 /// Opaque proxy base struct
 #[repr(C)]
+#[derive(Default)]
 pub struct ProxyBase {
     dummy: [u8; 0],
 }
 
 /// Opaque skeleton base struct
 #[repr(C)]
+#[derive(Default)]
 pub struct SkeletonBase {
     dummy: [u8; 0],
 }
@@ -330,6 +318,7 @@ unsafe impl Send for NativeFindServiceHandle {}
 
 /// Opaque skeleton event base struct
 #[repr(C)]
+#[derive(Default)]
 pub struct SkeletonEventBase {
     dummy: [u8; 0],
 }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
@@ -774,10 +774,7 @@ impl FFIBridge for LolaFFIBridge {
     /// * `container` - HandleContainer wrapping the native service handle container
     /// # Returns
     /// The number of service handles in the container
-    ///
-    /// # Safety
-    /// `container` must wrap a valid C++ `ServiceHandleContainer` pointer.
-    unsafe fn handle_container_size(container: &HandleContainer) -> usize {
+    fn handle_container_size(container: &HandleContainer) -> usize {
         container.len()
     }
     /// Get a reference to the service handle at the specified index in the container
@@ -789,10 +786,7 @@ impl FFIBridge for LolaFFIBridge {
     /// # Returns
     /// Some reference to the service handle at the specified index,
     /// or None if the index is out of bounds
-    ///
-    /// # Safety
-    /// `container` must wrap a valid C++ `ServiceHandleContainer` pointer.
-    unsafe fn handle_container_get_at(
+    fn handle_container_get_at(
         container: &HandleContainer,
         index: usize,
     ) -> Option<&HandleType> {

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
@@ -767,4 +767,35 @@ impl FFIBridge for LolaFFIBridge {
         // The C++ implementation handles stopping the find service safely.
         mw_com_stop_find_service(handle);
     }
+
+    /// Get the number of service handles in the container
+    ///
+    /// # Arguments
+    /// * `container` - HandleContainer wrapping the native service handle container
+    /// # Returns
+    /// The number of service handles in the container
+    ///
+    /// # Safety
+    /// `container` must wrap a valid C++ `ServiceHandleContainer` pointer.
+    unsafe fn handle_container_size(container: &HandleContainer) -> usize {
+        container.len()
+    }
+    /// Get a reference to the service handle at the specified index in the container
+    ///
+    /// # Arguments
+    /// * `container` - HandleContainer wrapping the native service handle container
+    /// * `index` - Index of the service handle to retrieve
+    ///
+    /// # Returns
+    /// Some reference to the service handle at the specified index,
+    /// or None if the index is out of bounds
+    ///
+    /// # Safety
+    /// `container` must wrap a valid C++ `ServiceHandleContainer` pointer.
+    unsafe fn handle_container_get_at(
+        container: &HandleContainer,
+        index: usize,
+    ) -> Option<&HandleType> {
+        container.get(index)
+    }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
@@ -25,7 +25,7 @@ pub struct LolaFFIBridge;
 /// # Safety
 /// - `ptr` must point to a valid FatPtr
 /// - `sample_ptr` must point to valid placement-new storage containing SamplePtr<T>
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mw_com_impl_call_dyn_ref_fnmut_sample(
     ptr: *const FatPtr,
     sample_ptr: *mut std::ffi::c_void,
@@ -39,7 +39,7 @@ unsafe extern "C" fn mw_com_impl_call_dyn_ref_fnmut_sample(
     // and represents a valid dynamic trait object (dyn FnMut). The transmute is safe because
     // FatPtr is a binary representation of a trait object's fat pointer (data + vtable).
     // The caller must ensure the lifetime of the closure outlives this call.
-    let callable: &mut dyn FnMut(*mut std::ffi::c_void) = std::mem::transmute(*ptr);
+    let callable: &mut dyn FnMut(*mut std::ffi::c_void) = unsafe { std::mem::transmute(*ptr) };
 
     // Invoke the closure with the void* sample pointer
     callable(sample_ptr);
@@ -56,7 +56,7 @@ unsafe extern "C" fn mw_com_impl_call_dyn_ref_fnmut_sample(
 ///   in a HandleContainer.
 /// - `find_service_handle` must point to valid FindServiceHandle data that can be safely wrapped
 ///   in a NativeFindServiceHandle.
-#[no_mangle]
+#[unsafe(no_mangle)]
 unsafe extern "C" fn mw_com_impl_call_dyn_ref_fnmut_find_service(
     ptr: *const FatPtr,
     service_handles: *mut NativeHandleContainer,
@@ -68,7 +68,7 @@ unsafe extern "C" fn mw_com_impl_call_dyn_ref_fnmut_find_service(
 
     // Reconstruct the closure from FatPtr
     let callable: &mut dyn FnMut(HandleContainer, NativeFindServiceHandle) =
-        std::mem::transmute(*ptr);
+        unsafe { std::mem::transmute(*ptr) };
 
     // Invoke with correct types
     callable(
@@ -78,7 +78,7 @@ unsafe extern "C" fn mw_com_impl_call_dyn_ref_fnmut_find_service(
 }
 
 // FFI declarations for C++ functions implemented in registry_bridge_macro.cpp
-extern "C" {
+unsafe extern "C" {
 
     /// Subscribe to event to start receiving samples
     ///
@@ -353,7 +353,7 @@ impl FFIBridge for LolaFFIBridge {
         // SAFETY: event_ptr is valid which is created using create_skeleton()
         // and allocatee_ptr has enough memory allocated for the construction of allocatee instance.
         let event_type = StringView::from(event_type);
-        mw_com_get_allocatee_ptr(event_ptr, allocatee_ptr, event_type)
+        unsafe { mw_com_get_allocatee_ptr(event_ptr, allocatee_ptr, event_type) }
     }
 
     /// Delete allocatee pointer of SampleAllocateePtr<T>
@@ -368,7 +368,7 @@ impl FFIBridge for LolaFFIBridge {
         // SAFETY: allocatee_ptr is valid which is created using get_allocatee_ptr() and
         // type_name is constructed using static str.
         let type_name = StringView::from(type_name);
-        mw_com_delete_allocatee_ptr(allocatee_ptr, type_name);
+        unsafe { mw_com_delete_allocatee_ptr(allocatee_ptr, type_name); }
     }
 
     /// Get allocatee data pointer from allocatee of specific type
@@ -389,7 +389,7 @@ impl FFIBridge for LolaFFIBridge {
         // SAFETY: allocatee_ptr is valid which is created using get_allocatee_ptr() and
         // type_name is constructed using static str.
         let type_name = StringView::from(type_name);
-        mw_com_get_allocatee_data_ptr(allocatee_ptr, type_name)
+        unsafe { mw_com_get_allocatee_data_ptr(allocatee_ptr, type_name) }
     }
 
     /// Send event via skeleton using allocatee pointer of specific type
@@ -414,7 +414,7 @@ impl FFIBridge for LolaFFIBridge {
         // SAFETY: event_ptr is valid which is created using create_skeleton() and allocatee_ptr is
         // valid which is created using get_allocatee_ptr().
         let event_type = StringView::from(event_type);
-        mw_com_skeleton_send_event_allocatee(event_ptr, event_type, allocatee_ptr)
+        unsafe { mw_com_skeleton_send_event_allocatee(event_ptr, event_type, allocatee_ptr) }
     }
 
     /// Get SamplePtr<T> data pointer
@@ -434,7 +434,7 @@ impl FFIBridge for LolaFFIBridge {
         // SAFETY: sample_ptr is guaranteed to be valid per the caller's contract.
         // The C++ implementation handles type checking and data retrieval safely.
         let type_name = StringView::from(type_name);
-        mw_com_get_sample_ptr(sample_ptr, type_name)
+        unsafe { mw_com_get_sample_ptr(sample_ptr, type_name) }
     }
 
     /// Delete SamplePtr<T>
@@ -448,7 +448,7 @@ impl FFIBridge for LolaFFIBridge {
         // SAFETY: sample_ptr is guaranteed to be valid per the caller's contract.
         // The C++ implementation handles type checking and deletion safely.
         let type_name = StringView::from(type_name);
-        mw_com_delete_sample_ptr(sample_ptr, type_name);
+        unsafe { mw_com_delete_sample_ptr(sample_ptr, type_name); }
     }
 
     /// Unsafe wrapper around mw_com_skeleton_offer_service
@@ -466,7 +466,7 @@ impl FFIBridge for LolaFFIBridge {
     unsafe fn skeleton_offer_service(skeleton_ptr: *mut SkeletonBase) -> bool {
         // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
         // The C++ implementation handles service offering safely.
-        mw_com_skeleton_offer_service(skeleton_ptr)
+        unsafe { mw_com_skeleton_offer_service(skeleton_ptr) }
     }
 
     /// Unsafe wrapper around mw_com_skeleton_stop_offer_service
@@ -481,7 +481,7 @@ impl FFIBridge for LolaFFIBridge {
     unsafe fn skeleton_stop_offer_service(skeleton_ptr: *mut SkeletonBase) {
         // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
         // The C++ implementation handles stopping the service safely.
-        mw_com_skeleton_stop_offer_service(skeleton_ptr);
+        unsafe { mw_com_skeleton_stop_offer_service(skeleton_ptr); }
     }
 
     /// Unsafe wrapper around mw_com_create_proxy
@@ -501,7 +501,7 @@ impl FFIBridge for LolaFFIBridge {
         // per the caller's contract.
         // The C++ implementation creates and returns a valid proxy pointer or nullptr on failure.
         let c_uid = StringView::from(interface_id);
-        mw_com_create_proxy(c_uid, handle_ptr)
+        unsafe { mw_com_create_proxy(c_uid, handle_ptr) }
     }
 
     /// Unsafe wrapper around mw_com_create_skeleton
@@ -524,7 +524,7 @@ impl FFIBridge for LolaFFIBridge {
         // valid per the caller's contract.
         // The C++ implementation creates and returns a valid skeleton pointer or nullptr on failure.
         let c_uid = StringView::from(interface_id);
-        mw_com_create_skeleton(c_uid, instance_spec)
+        unsafe { mw_com_create_skeleton(c_uid, instance_spec) }
     }
 
     /// Unsafe wrapper around mw_com_destroy_proxy
@@ -538,7 +538,7 @@ impl FFIBridge for LolaFFIBridge {
     unsafe fn destroy_proxy(proxy_ptr: *mut ProxyBase) {
         // SAFETY: proxy_ptr is guaranteed to be valid per the caller's contract.
         // The C++ implementation safely deallocates the proxy.
-        mw_com_destroy_proxy(proxy_ptr);
+        unsafe { mw_com_destroy_proxy(proxy_ptr); }
     }
 
     /// Unsafe wrapper around mw_com_destroy_skeleton
@@ -553,7 +553,7 @@ impl FFIBridge for LolaFFIBridge {
     unsafe fn destroy_skeleton(skeleton_ptr: *mut SkeletonBase) {
         // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
         // The C++ implementation safely deallocates the skeleton.
-        mw_com_destroy_skeleton(skeleton_ptr);
+        unsafe { mw_com_destroy_skeleton(skeleton_ptr); }
     }
 
     /// Unsafe wrapper around mw_com_get_event_from_proxy
@@ -578,7 +578,7 @@ impl FFIBridge for LolaFFIBridge {
         // The C++ implementation returns a valid pointer or nullptr if the event is not found.
         let c_id = StringView::from(interface_id);
         let c_name = StringView::from(event_id);
-        mw_com_get_event_from_proxy(proxy_ptr, c_id, c_name)
+        unsafe { mw_com_get_event_from_proxy(proxy_ptr, c_id, c_name) }
     }
 
     /// Unsafe wrapper around mw_com_get_event_from_skeleton
@@ -604,7 +604,7 @@ impl FFIBridge for LolaFFIBridge {
         // The C++ implementation returns a valid pointer or nullptr if the event is not found.
         let c_id = StringView::from(interface_id);
         let c_name = StringView::from(event_id);
-        mw_com_get_event_from_skeleton(skeleton_ptr, c_id, c_name)
+        unsafe { mw_com_get_event_from_skeleton(skeleton_ptr, c_id, c_name) }
     }
 
     /// Unsafe wrapper around mw_com_get_samples_from_event
@@ -633,7 +633,7 @@ impl FFIBridge for LolaFFIBridge {
         // to be valid per the caller's contract.
         // The C++ implementation handles sample retrieval and callback invocation safely.
         let c_name = StringView::from(event_type);
-        mw_com_type_registry_get_samples_from_event(event_ptr, c_name, callback, max_samples)
+        unsafe { mw_com_type_registry_get_samples_from_event(event_ptr, c_name, callback, max_samples) }
     }
 
     /// Unsafe wrapper around mw_com_skeleton_send_event
@@ -656,7 +656,7 @@ impl FFIBridge for LolaFFIBridge {
         // SAFETY: event_ptr and data_ptr are guaranteed to be valid per the caller's contract.
         // The C++ implementation handles type matching and data sending safely.
         let c_name = StringView::from(event_type);
-        mw_com_skeleton_send_event(event_ptr, c_name, data_ptr)
+        unsafe { mw_com_skeleton_send_event(event_ptr, c_name, data_ptr) }
     }
 
     /// Unsafe wrapper around mw_com_proxy_event_subscribe
@@ -675,7 +675,7 @@ impl FFIBridge for LolaFFIBridge {
     unsafe fn subscribe_to_event(event_ptr: *mut ProxyEventBase, max_sample_count: u32) -> bool {
         // SAFETY: event_ptr is guaranteed to be valid per the caller's contract.
         // The C++ implementation handles subscription and buffer allocation safely.
-        mw_com_proxy_event_subscribe(event_ptr, max_sample_count)
+        unsafe { mw_com_proxy_event_subscribe(event_ptr, max_sample_count) }
     }
 
     /// Unsafe wrapper around mw_com_proxy_event_unsubscribe
@@ -689,7 +689,7 @@ impl FFIBridge for LolaFFIBridge {
     unsafe fn unsubscribe_to_event(event_ptr: *mut ProxyEventBase) {
         // SAFETY: event_ptr is guaranteed to be valid per the caller's contract.
         // The C++ implementation handles unsubscription and buffer cleanup safely.
-        mw_com_proxy_event_unsubscribe(event_ptr);
+        unsafe { mw_com_proxy_event_unsubscribe(event_ptr); }
     }
 
     /// Unsafe wrapper around mw_com_proxy_set_event_receive_handler
@@ -714,7 +714,7 @@ impl FFIBridge for LolaFFIBridge {
         // and handler must be a valid FatPtr referencing a callable compatible with the callback
         // signature expected by the C++ implementation.
         let c_name = StringView::from(event_type);
-        mw_com_proxy_set_event_receive_handler(proxy_event_ptr, handler, c_name)
+        unsafe { mw_com_proxy_set_event_receive_handler(proxy_event_ptr, handler, c_name) }
     }
 
     /// Unsafe wrapper around mw_com_proxy_clear_event_receive_handler
@@ -730,7 +730,7 @@ impl FFIBridge for LolaFFIBridge {
     unsafe fn clear_event_receive_handler(proxy_event_ptr: *mut ProxyEventBase, event_type: &str) {
         // SAFETY: proxy_event_ptr must be valid per the caller's contract.
         let c_name = StringView::from(event_type);
-        mw_com_proxy_clear_event_receive_handler(proxy_event_ptr, c_name);
+        unsafe { mw_com_proxy_clear_event_receive_handler(proxy_event_ptr, c_name); }
     }
 
     /// Unsafe wrapper around mw_com_start_find_service
@@ -751,7 +751,7 @@ impl FFIBridge for LolaFFIBridge {
     ) -> *mut FindServiceHandle {
         // SAFETY: callback and instance_spec are guaranteed to be valid per the caller's contract.
         // The C++ implementation handles the find service operation and callback invocation safely.
-        mw_com_start_find_service(callback, instance_spec.as_native())
+        unsafe { mw_com_start_find_service(callback, instance_spec.as_native()) }
     }
 
     /// Unsafe wrapper around mw_com_stop_find_service
@@ -765,7 +765,7 @@ impl FFIBridge for LolaFFIBridge {
     unsafe fn stop_find_service(handle: *mut FindServiceHandle) {
         // SAFETY: handle is valid per the caller's contract and has not been stopped yet.
         // The C++ implementation handles stopping the find service safely.
-        mw_com_stop_find_service(handle);
+        unsafe { mw_com_stop_find_service(handle); }
     }
 
     /// Get the number of service handles in the container

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
@@ -804,30 +804,4 @@ impl FFIBridge for LolaFFIBridge {
             mw_com_stop_find_service(handle);
         }
     }
-
-    /// Get the number of service handles in the container
-    ///
-    /// # Arguments
-    /// * `container` - HandleContainer wrapping the native service handle container
-    /// # Returns
-    /// The number of service handles in the container
-    fn handle_container_size(&self, container: &HandleContainer) -> usize {
-        container.len()
-    }
-    /// Get a reference to the service handle at the specified index in the container
-    ///
-    /// # Arguments
-    /// * `container` - HandleContainer wrapping the native service handle container
-    /// * `index` - Index of the service handle to retrieve
-    ///
-    /// # Returns
-    /// Some reference to the service handle at the specified index,
-    /// or None if the index is out of bounds
-    fn handle_container_get_at<'a>(
-        &self,
-        container: &'a HandleContainer,
-        index: usize,
-    ) -> Option<&'a HandleType> {
-        container.get(index)
-    }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
@@ -13,7 +13,7 @@
 
 use bridge_ffi_rs::*;
 
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, Default)]
 /// unit struct representing the FFI bridge for Lola runtime
 pub struct LolaFFIBridge;
 
@@ -346,6 +346,7 @@ impl FFIBridge for LolaFFIBridge {
     /// allocatee_ptr must point to valid memory for the allocatee,
     /// and event_type must be a valid UTF-8 string representing the event type.
     unsafe fn get_allocatee_ptr(
+        &self,
         event_ptr: *mut SkeletonEventBase,
         allocatee_ptr: *mut std::ffi::c_void,
         event_type: &str,
@@ -364,11 +365,13 @@ impl FFIBridge for LolaFFIBridge {
     ///
     /// # Safety
     /// allocatee_ptr must point to a valid SampleAllocateePtr<T> of the specified type.
-    unsafe fn delete_allocatee_ptr(allocatee_ptr: *mut std::ffi::c_void, type_name: &str) {
+    unsafe fn delete_allocatee_ptr(&self, allocatee_ptr: *mut std::ffi::c_void, type_name: &str) {
         // SAFETY: allocatee_ptr is valid which is created using get_allocatee_ptr() and
         // type_name is constructed using static str.
         let type_name = StringView::from(type_name);
-        unsafe { mw_com_delete_allocatee_ptr(allocatee_ptr, type_name); }
+        unsafe {
+            mw_com_delete_allocatee_ptr(allocatee_ptr, type_name);
+        }
     }
 
     /// Get allocatee data pointer from allocatee of specific type
@@ -383,6 +386,7 @@ impl FFIBridge for LolaFFIBridge {
     /// # Safety
     /// allocatee_ptr must point to a valid SampleAllocateePtr<T> of the specified type
     unsafe fn get_allocatee_data_ptr(
+        &self,
         allocatee_ptr: *const std::ffi::c_void,
         type_name: &str,
     ) -> *mut std::ffi::c_void {
@@ -407,6 +411,7 @@ impl FFIBridge for LolaFFIBridge {
     /// allocatee_ptr must point to a valid SampleAllocateePtr<T>,
     /// and event_type must be a valid UTF-8 string representing the event type.
     unsafe fn skeleton_event_send_sample_allocatee(
+        &self,
         event_ptr: *mut SkeletonEventBase,
         event_type: &str,
         allocatee_ptr: *const std::ffi::c_void,
@@ -428,6 +433,7 @@ impl FFIBridge for LolaFFIBridge {
     /// # Safety
     /// sample_ptr must point to a valid SamplePtr<T> of the specified type.
     unsafe fn sample_ptr_get(
+        &self,
         sample_ptr: *const std::ffi::c_void,
         type_name: &str,
     ) -> *const std::ffi::c_void {
@@ -444,11 +450,13 @@ impl FFIBridge for LolaFFIBridge {
     /// * `type_name` - Type name string
     /// # Safety
     /// sample_ptr must point to a valid SamplePtr<T> of the specified type.
-    unsafe fn sample_ptr_delete(sample_ptr: *mut std::ffi::c_void, type_name: &str) {
+    unsafe fn sample_ptr_delete(&self, sample_ptr: *mut std::ffi::c_void, type_name: &str) {
         // SAFETY: sample_ptr is guaranteed to be valid per the caller's contract.
         // The C++ implementation handles type checking and deletion safely.
         let type_name = StringView::from(type_name);
-        unsafe { mw_com_delete_sample_ptr(sample_ptr, type_name); }
+        unsafe {
+            mw_com_delete_sample_ptr(sample_ptr, type_name);
+        }
     }
 
     /// Unsafe wrapper around mw_com_skeleton_offer_service
@@ -463,7 +471,7 @@ impl FFIBridge for LolaFFIBridge {
     /// skeleton_ptr must be a valid pointer to a SkeletonBase previously created
     /// with create_skeleton().
     /// The pointer must remain valid for the duration of this call.
-    unsafe fn skeleton_offer_service(skeleton_ptr: *mut SkeletonBase) -> bool {
+    unsafe fn skeleton_offer_service(&self, skeleton_ptr: *mut SkeletonBase) -> bool {
         // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
         // The C++ implementation handles service offering safely.
         unsafe { mw_com_skeleton_offer_service(skeleton_ptr) }
@@ -478,10 +486,12 @@ impl FFIBridge for LolaFFIBridge {
     /// skeleton_ptr must be a valid pointer to a SkeletonBase previously created
     /// with create_skeleton().
     /// The pointer must remain valid for the duration of this call.
-    unsafe fn skeleton_stop_offer_service(skeleton_ptr: *mut SkeletonBase) {
+    unsafe fn skeleton_stop_offer_service(&self, skeleton_ptr: *mut SkeletonBase) {
         // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
         // The C++ implementation handles stopping the service safely.
-        unsafe { mw_com_skeleton_stop_offer_service(skeleton_ptr); }
+        unsafe {
+            mw_com_skeleton_stop_offer_service(skeleton_ptr);
+        }
     }
 
     /// Unsafe wrapper around mw_com_create_proxy
@@ -496,7 +506,7 @@ impl FFIBridge for LolaFFIBridge {
     /// # Safety
     /// handle_ptr must be a valid reference to a HandleType.
     /// The returned pointer must eventually be destroyed via destroy_proxy().
-    unsafe fn create_proxy(interface_id: &str, handle_ptr: &HandleType) -> *mut ProxyBase {
+    unsafe fn create_proxy(&self, interface_id: &str, handle_ptr: &HandleType) -> *mut ProxyBase {
         // SAFETY: interface_id is a valid string reference and handle_ptr is guaranteed to be valid
         // per the caller's contract.
         // The C++ implementation creates and returns a valid proxy pointer or nullptr on failure.
@@ -517,6 +527,7 @@ impl FFIBridge for LolaFFIBridge {
     /// instance_spec must be a valid NativeInstanceSpecifier.
     /// The returned pointer must eventually be destroyed via destroy_skeleton().
     unsafe fn create_skeleton(
+        &self,
         interface_id: &str,
         instance_spec: *const NativeInstanceSpecifier,
     ) -> *mut SkeletonBase {
@@ -535,10 +546,12 @@ impl FFIBridge for LolaFFIBridge {
     /// # Safety
     /// proxy_ptr must be a valid pointer returned from create_proxy() that has not been destroyed yet.
     /// The caller must ensure no other references to this proxy exist after calling this function.
-    unsafe fn destroy_proxy(proxy_ptr: *mut ProxyBase) {
+    unsafe fn destroy_proxy(&self, proxy_ptr: *mut ProxyBase) {
         // SAFETY: proxy_ptr is guaranteed to be valid per the caller's contract.
         // The C++ implementation safely deallocates the proxy.
-        unsafe { mw_com_destroy_proxy(proxy_ptr); }
+        unsafe {
+            mw_com_destroy_proxy(proxy_ptr);
+        }
     }
 
     /// Unsafe wrapper around mw_com_destroy_skeleton
@@ -550,10 +563,12 @@ impl FFIBridge for LolaFFIBridge {
     /// skeleton_ptr must be a valid pointer returned from create_skeleton()-
     /// that has not been destroyed yet.
     /// The caller must ensure no other references to this skeleton exist after calling this function.
-    unsafe fn destroy_skeleton(skeleton_ptr: *mut SkeletonBase) {
+    unsafe fn destroy_skeleton(&self, skeleton_ptr: *mut SkeletonBase) {
         // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
         // The C++ implementation safely deallocates the skeleton.
-        unsafe { mw_com_destroy_skeleton(skeleton_ptr); }
+        unsafe {
+            mw_com_destroy_skeleton(skeleton_ptr);
+        }
     }
 
     /// Unsafe wrapper around mw_com_get_event_from_proxy
@@ -570,6 +585,7 @@ impl FFIBridge for LolaFFIBridge {
     /// proxy_ptr must be a valid pointer to a ProxyBase previously created with create_proxy().
     /// The returned pointer remains valid only as long as the proxy remains alive.
     unsafe fn get_event_from_proxy(
+        &self,
         proxy_ptr: *mut ProxyBase,
         interface_id: &str,
         event_id: &str,
@@ -596,6 +612,7 @@ impl FFIBridge for LolaFFIBridge {
     /// with create_skeleton().
     /// The returned pointer remains valid only as long as the skeleton remains alive.
     unsafe fn get_event_from_skeleton(
+        &self,
         skeleton_ptr: *mut SkeletonBase,
         interface_id: &str,
         event_id: &str,
@@ -624,6 +641,7 @@ impl FFIBridge for LolaFFIBridge {
     /// callback must be a valid FatPtr referencing a callable compatible with the event type.
     /// The event must have been subscribed to via subscribe_to_event() before calling this function.
     unsafe fn get_samples_from_event(
+        &self,
         event_ptr: *mut ProxyEventBase,
         event_type: &str,
         callback: &FatPtr,
@@ -633,7 +651,9 @@ impl FFIBridge for LolaFFIBridge {
         // to be valid per the caller's contract.
         // The C++ implementation handles sample retrieval and callback invocation safely.
         let c_name = StringView::from(event_type);
-        unsafe { mw_com_type_registry_get_samples_from_event(event_ptr, c_name, callback, max_samples) }
+        unsafe {
+            mw_com_type_registry_get_samples_from_event(event_ptr, c_name, callback, max_samples)
+        }
     }
 
     /// Unsafe wrapper around mw_com_skeleton_send_event
@@ -649,6 +669,7 @@ impl FFIBridge for LolaFFIBridge {
     /// data_ptr must point to valid data whose type matches the event_type.
     /// The lifetime of the data must extend through this function call.
     unsafe fn skeleton_send_event(
+        &self,
         event_ptr: *mut SkeletonEventBase,
         event_type: &str,
         data_ptr: *const std::ffi::c_void,
@@ -672,7 +693,11 @@ impl FFIBridge for LolaFFIBridge {
     /// event_ptr must be a valid pointer to a ProxyEventBase previously obtained
     /// from get_event_from_proxy().
     /// This function must be called before attempting to retrieve samples via get_samples_from_event().
-    unsafe fn subscribe_to_event(event_ptr: *mut ProxyEventBase, max_sample_count: u32) -> bool {
+    unsafe fn subscribe_to_event(
+        &self,
+        event_ptr: *mut ProxyEventBase,
+        max_sample_count: u32,
+    ) -> bool {
         // SAFETY: event_ptr is guaranteed to be valid per the caller's contract.
         // The C++ implementation handles subscription and buffer allocation safely.
         unsafe { mw_com_proxy_event_subscribe(event_ptr, max_sample_count) }
@@ -686,10 +711,12 @@ impl FFIBridge for LolaFFIBridge {
     /// # Safety
     /// event_ptr must be a valid pointer to a ProxyEventBase previously obtained from get_event_from_proxy().
     /// This function should be called only when no `SamplePtr` is held by the user for this event.
-    unsafe fn unsubscribe_to_event(event_ptr: *mut ProxyEventBase) {
+    unsafe fn unsubscribe_to_event(&self, event_ptr: *mut ProxyEventBase) {
         // SAFETY: event_ptr is guaranteed to be valid per the caller's contract.
         // The C++ implementation handles unsubscription and buffer cleanup safely.
-        unsafe { mw_com_proxy_event_unsubscribe(event_ptr); }
+        unsafe {
+            mw_com_proxy_event_unsubscribe(event_ptr);
+        }
     }
 
     /// Unsafe wrapper around mw_com_proxy_set_event_receive_handler
@@ -706,6 +733,7 @@ impl FFIBridge for LolaFFIBridge {
     /// from get_event_from_proxy().
     /// handler must be a valid FatPtr which is used for notifying the proxy of incoming events.
     unsafe fn set_event_receive_handler(
+        &self,
         proxy_event_ptr: *mut ProxyEventBase,
         handler: &FatPtr,
         event_type: &str,
@@ -727,10 +755,16 @@ impl FFIBridge for LolaFFIBridge {
     /// proxy_event_ptr must be a valid pointer to a ProxyEventBase previously obtained
     /// from get_event_from_proxy().
     /// event_type must be a valid string corresponding to the event type.
-    unsafe fn clear_event_receive_handler(proxy_event_ptr: *mut ProxyEventBase, event_type: &str) {
+    unsafe fn clear_event_receive_handler(
+        &self,
+        proxy_event_ptr: *mut ProxyEventBase,
+        event_type: &str,
+    ) {
         // SAFETY: proxy_event_ptr must be valid per the caller's contract.
         let c_name = StringView::from(event_type);
-        unsafe { mw_com_proxy_clear_event_receive_handler(proxy_event_ptr, c_name); }
+        unsafe {
+            mw_com_proxy_clear_event_receive_handler(proxy_event_ptr, c_name);
+        }
     }
 
     /// Unsafe wrapper around mw_com_start_find_service
@@ -746,6 +780,7 @@ impl FFIBridge for LolaFFIBridge {
     /// callback must be a valid FatPtr referencing a callable compatible with the find service results.
     /// instance_spec must be a valid InstanceSpecifier for the service to find.
     unsafe fn start_find_service(
+        &self,
         callback: &FatPtr,
         instance_spec: InstanceSpecifier,
     ) -> *mut FindServiceHandle {
@@ -762,10 +797,12 @@ impl FFIBridge for LolaFFIBridge {
     /// # Safety
     /// handle must be a valid pointer returned from start_find_service() that has not been stopped yet,
     /// and the caller must ensure no further use of this handle after calling this function.
-    unsafe fn stop_find_service(handle: *mut FindServiceHandle) {
+    unsafe fn stop_find_service(&self, handle: *mut FindServiceHandle) {
         // SAFETY: handle is valid per the caller's contract and has not been stopped yet.
         // The C++ implementation handles stopping the find service safely.
-        unsafe { mw_com_stop_find_service(handle); }
+        unsafe {
+            mw_com_stop_find_service(handle);
+        }
     }
 
     /// Get the number of service handles in the container
@@ -774,7 +811,7 @@ impl FFIBridge for LolaFFIBridge {
     /// * `container` - HandleContainer wrapping the native service handle container
     /// # Returns
     /// The number of service handles in the container
-    fn handle_container_size(container: &HandleContainer) -> usize {
+    fn handle_container_size(&self, container: &HandleContainer) -> usize {
         container.len()
     }
     /// Get a reference to the service handle at the specified index in the container
@@ -786,10 +823,11 @@ impl FFIBridge for LolaFFIBridge {
     /// # Returns
     /// Some reference to the service handle at the specified index,
     /// or None if the index is out of bounds
-    fn handle_container_get_at(
-        container: &HandleContainer,
+    fn handle_container_get_at<'a>(
+        &self,
+        container: &'a HandleContainer,
         index: usize,
-    ) -> Option<&HandleType> {
+    ) -> Option<&'a HandleType> {
         container.get(index)
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
@@ -1,0 +1,770 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+use bridge_ffi_rs::*;
+
+#[derive(Debug, Clone)]
+/// unit struct representing the FFI bridge for Lola runtime
+pub struct LolaFFIBridge;
+
+///  Rust closure invocation for C++ callbacks
+///
+/// This function is called by C++ to invoke a Rust closure with a sample pointer.
+/// The closure is reconstructed from the FatPtr trait object.
+///
+/// # Safety
+/// - `ptr` must point to a valid FatPtr
+/// - `sample_ptr` must point to valid placement-new storage containing SamplePtr<T>
+#[no_mangle]
+unsafe extern "C" fn mw_com_impl_call_dyn_ref_fnmut_sample(
+    ptr: *const FatPtr,
+    sample_ptr: *mut std::ffi::c_void,
+) {
+    if ptr.is_null() || sample_ptr.is_null() {
+        return;
+    }
+
+    // Reconstruct the closure from FatPtr
+    // SAFETY: ptr is guaranteed to point to a valid FatPtr that was created by the C++ side
+    // and represents a valid dynamic trait object (dyn FnMut). The transmute is safe because
+    // FatPtr is a binary representation of a trait object's fat pointer (data + vtable).
+    // The caller must ensure the lifetime of the closure outlives this call.
+    let callable: &mut dyn FnMut(*mut std::ffi::c_void) = std::mem::transmute(*ptr);
+
+    // Invoke the closure with the void* sample pointer
+    callable(sample_ptr);
+}
+
+/// Rust closure invocation for C++ callbacks for FindService
+/// This function is called by C++ to invoke a Rust closure for finding services,
+/// passing a vector of service handles.
+/// This function invokes a Rust closure that takes a HandleContainer and a FindServiceHandle.
+/// # Safety
+/// - `ptr` must point to a valid FatPtr representing a closure of type
+///   FnMut(HandleContainer, NativeFindServiceHandle).
+/// - `service_handles` must point to valid NativeHandleContainer data that can be safely wrapped
+///   in a HandleContainer.
+/// - `find_service_handle` must point to valid FindServiceHandle data that can be safely wrapped
+///   in a NativeFindServiceHandle.
+#[no_mangle]
+unsafe extern "C" fn mw_com_impl_call_dyn_ref_fnmut_find_service(
+    ptr: *const FatPtr,
+    service_handles: *mut NativeHandleContainer,
+    find_service_handle: *mut FindServiceHandle,
+) {
+    if ptr.is_null() || service_handles.is_null() {
+        return;
+    }
+
+    // Reconstruct the closure from FatPtr
+    let callable: &mut dyn FnMut(HandleContainer, NativeFindServiceHandle) =
+        std::mem::transmute(*ptr);
+
+    // Invoke with correct types
+    callable(
+        HandleContainer::new(service_handles),
+        NativeFindServiceHandle::new(find_service_handle),
+    );
+}
+
+// FFI declarations for C++ functions implemented in registry_bridge_macro.cpp
+extern "C" {
+
+    /// Subscribe to event to start receiving samples
+    ///
+    /// # Arguments
+    /// * `event_ptr` - Opaque event pointer
+    /// * `max_sample_count` - Maximum number of samples to buffer
+    ///
+    /// # Returns
+    /// true if subscription successful, false otherwise
+    fn mw_com_proxy_event_subscribe(event_ptr: *mut ProxyEventBase, max_sample_count: u32) -> bool;
+
+    /// Get event pointer from proxy by event name
+    ///
+    /// # Arguments
+    /// * `proxy_ptr` - Opaque proxy pointer
+    /// * `interface_id` - UTF-8 C string of interface UID
+    /// * `event_id` - UTF-8 C string of event name
+    ///
+    /// # Returns
+    /// Opaque event pointer, or nullptr if event not found
+    fn mw_com_get_event_from_proxy(
+        proxy_ptr: *mut ProxyBase,
+        interface_id: StringView,
+        event_id: StringView,
+    ) -> *mut ProxyEventBase;
+
+    /// Get event pointer from skeleton by event name
+    ///
+    /// # Arguments
+    /// * `skeleton_ptr` - Opaque skeleton pointer
+    /// * `interface_id` - UTF-8 C string of interface UID
+    /// * `event_id` - UTF-8 C string of event name
+    ///
+    /// # Returns
+    /// Opaque event pointer, or nullptr if event not found
+    fn mw_com_get_event_from_skeleton(
+        skeleton_ptr: *mut SkeletonBase,
+        interface_id: StringView,
+        event_id: StringView,
+    ) -> *mut SkeletonEventBase;
+
+    /// Get new samples from an event
+    ///
+    /// # Arguments
+    /// * `event_ptr` - Opaque event pointer
+    /// * `event_type` - Event type name string
+    /// * `callback` - FatPtr to callback function
+    /// * `max_samples` - Maximum number of samples to retrieve
+    ///
+    /// # Returns
+    /// Number of samples retrieved
+    fn mw_com_type_registry_get_samples_from_event(
+        event_ptr: *mut ProxyEventBase,
+        event_type: StringView,
+        callback: *const FatPtr,
+        max_samples: u32,
+    ) -> u32;
+
+    /// Send data via skeleton event
+    ///
+    /// # Arguments
+    /// * `event_ptr` - Opaque skeleton event pointer
+    /// * `event_type` - Event type name string
+    /// * `data_ptr` - Pointer to event data
+    ///
+    /// # Returns
+    /// None (void function)
+    fn mw_com_skeleton_send_event(
+        event_ptr: *mut SkeletonEventBase,
+        event_type: StringView,
+        data_ptr: CVoidPtr,
+    ) -> bool;
+
+    /// Create proxy by UID and handle
+    ///
+    /// # Arguments
+    /// * `interface_id` - UTF-8 C string of interface UID
+    /// * `handle_ptr` - Opaque handle pointer
+    ///
+    /// # Returns
+    /// Opaque proxy pointer, or nullptr if creation failed
+    fn mw_com_create_proxy(interface_id: StringView, handle_ptr: &HandleType) -> *mut ProxyBase;
+
+    /// Create skeleton by UID and instance specifier
+    ///
+    /// # Arguments
+    /// * `interface_id` - UTF-8 C string of interface UID
+    /// * `instance_spec` - Opaque instance specifier pointer
+    ///
+    /// # Returns
+    /// Opaque skeleton pointer, or nullptr if creation failed
+    fn mw_com_create_skeleton(
+        interface_id: StringView,
+        instance_spec: *const NativeInstanceSpecifier,
+    ) -> *mut SkeletonBase;
+
+    /// Destroy proxy
+    ///
+    /// # Arguments
+    /// * `proxy_ptr` - Opaque proxy pointer
+    ///
+    /// # Returns
+    /// None (void function)
+    fn mw_com_destroy_proxy(proxy_ptr: *mut ProxyBase);
+
+    /// Destroy skeleton
+    ///
+    /// # Arguments
+    /// * `skeleton_ptr` - Opaque skeleton pointer
+    ///
+    /// # Returns
+    /// None (void function)
+    fn mw_com_destroy_skeleton(skeleton_ptr: *mut SkeletonBase);
+
+    /// Offer service via skeleton
+    ///
+    /// # Arguments
+    /// * `skeleton_ptr` - Opaque skeleton pointer
+    ///
+    /// # Returns
+    /// true if offer successful, false otherwise
+    fn mw_com_skeleton_offer_service(skeleton_ptr: *mut SkeletonBase) -> bool;
+
+    /// Stop offering service via skeleton
+    ///
+    /// # Arguments
+    /// * `skeleton_ptr` - Opaque skeleton pointer
+    ///
+    /// # Returns
+    /// None (void function)
+    fn mw_com_skeleton_stop_offer_service(skeleton_ptr: *mut SkeletonBase);
+
+    /// Get sample data pointer from SamplePtr<T>
+    ///
+    /// # Arguments
+    /// * `sample_ptr` - Opaque sample pointer
+    /// * `type_name` - Type name string
+    ///
+    /// # Returns
+    /// Pointer to sample data, or nullptr if type mismatch
+    fn mw_com_get_sample_ptr(
+        sample_ptr: *const std::ffi::c_void,
+        type_name: StringView,
+    ) -> *const std::ffi::c_void;
+
+    /// Delete sample pointer of SamplePtr<T>'
+    ///
+    /// # Arguments
+    /// * `sample_ptr` - Opaque sample pointer
+    /// * `type_name` - Type name string
+    fn mw_com_delete_sample_ptr(sample_ptr: *mut std::ffi::c_void, type_name: StringView);
+
+    /// Get allocatee pointer from skeleton event of specific type
+    ///
+    /// # Arguments
+    /// * `event_ptr` - Opaque skeleton event pointer
+    /// * `allocatee_ptr` - Pointer to pre-allocated memory for allocatee
+    /// * `event_type` - Type name string
+    ///
+    /// # Returns
+    /// True if allocatee pointer was retrieved successfully, false otherwise
+    fn mw_com_get_allocatee_ptr(
+        event_ptr: *mut SkeletonEventBase,
+        allocatee_ptr: *mut std::ffi::c_void,
+        event_type: StringView,
+    ) -> bool;
+
+    /// Delete allocatee pointer of SampleAllocateePtr<T>
+    ///
+    /// # Arguments
+    /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
+    /// * `type_name` - Type name string
+    fn mw_com_delete_allocatee_ptr(allocatee_ptr: *mut std::ffi::c_void, type_name: StringView);
+
+    /// Get allocatee data pointer from allocatee of specific type
+    ///
+    /// # Arguments
+    /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
+    /// * `type_name` - Type name string
+    ///
+    /// # Returns
+    /// Pointer to allocatee data, or nullptr if type mismatch
+    fn mw_com_get_allocatee_data_ptr(
+        allocatee_ptr: *const std::ffi::c_void,
+        type_name: StringView,
+    ) -> *mut std::ffi::c_void;
+
+    /// Send event via skeleton using allocatee pointer of specific type
+    ///
+    /// # Arguments
+    /// * `event_ptr` - Opaque skeleton event pointer
+    /// * `event_type` - Type name string
+    /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
+    ///
+    /// # Returns
+    /// True if event was sent successfully, false otherwise
+    fn mw_com_skeleton_send_event_allocatee(
+        event_ptr: *mut SkeletonEventBase,
+        event_type: StringView,
+        allocatee_ptr: *const std::ffi::c_void,
+    ) -> bool;
+
+    /// Set event receive handler for proxy event
+    ///
+    /// # Arguments
+    /// * `proxy_event_ptr` - Opaque proxy event pointer
+    /// * `handler` - FatPtr to event receive handler function
+    ///
+    /// # Returns
+    /// True if handler was set successfully, false otherwise
+    fn mw_com_proxy_set_event_receive_handler(
+        proxy_event_ptr: *mut ProxyEventBase,
+        handler: *const FatPtr,
+        event_type: StringView,
+    ) -> bool;
+
+    /// Clear event receive handler for proxy event
+    ///
+    /// # Arguments
+    /// * `proxy_event_ptr` - Opaque proxy event pointer
+    fn mw_com_proxy_clear_event_receive_handler(
+        proxy_event_ptr: *mut ProxyEventBase,
+        event_type: StringView,
+    );
+
+    /// Start finding services with callback for results
+    ///
+    /// # Arguments
+    /// * `callback` - FatPtr to callback function that will be called with discovery results
+    /// * `instance_spec` - Pointer to instance specifier for the service to find
+    ///
+    /// # Returns
+    /// Opaque pointer to FindServiceHandle which can be used to stop the find operation
+    fn mw_com_start_find_service(
+        callback: *const FatPtr,
+        instance_spec: *const NativeInstanceSpecifier,
+    ) -> *mut FindServiceHandle;
+
+    /// Stop finding services using the provided FindServiceHandle
+    ///
+    /// # Arguments
+    /// * `handle` - Opaque pointer to FindServiceHandle returned by mw_com_start_find_service
+    fn mw_com_stop_find_service(handle: *mut FindServiceHandle);
+
+    /// Unsubscribe from event to stop receiving samples
+    ///
+    /// # Arguments
+    /// * `event_ptr` - Opaque event pointer
+    fn mw_com_proxy_event_unsubscribe(event_ptr: *mut ProxyEventBase);
+}
+
+impl FFIBridge for LolaFFIBridge {
+    /// Get allocatee pointer from skeleton event of specific type
+    ///
+    /// # Arguments
+    /// * `event_ptr` - Opaque skeleton event pointer
+    /// * `allocatee_ptr` - Pointer to pre-allocated memory for allocatee
+    /// * `event_type` - Type name string
+    ///
+    /// # Returns
+    /// True if allocatee pointer was retrieved successfully, false otherwise
+    ///
+    /// # Safety
+    /// event_ptr must point to a valid SkeletonEventBase,
+    /// allocatee_ptr must point to valid memory for the allocatee,
+    /// and event_type must be a valid UTF-8 string representing the event type.
+    unsafe fn get_allocatee_ptr(
+        event_ptr: *mut SkeletonEventBase,
+        allocatee_ptr: *mut std::ffi::c_void,
+        event_type: &str,
+    ) -> bool {
+        // SAFETY: event_ptr is valid which is created using create_skeleton()
+        // and allocatee_ptr has enough memory allocated for the construction of allocatee instance.
+        let event_type = StringView::from(event_type);
+        mw_com_get_allocatee_ptr(event_ptr, allocatee_ptr, event_type)
+    }
+
+    /// Delete allocatee pointer of SampleAllocateePtr<T>
+    ///
+    /// # Arguments
+    /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
+    /// * `type_name` - Type name string
+    ///
+    /// # Safety
+    /// allocatee_ptr must point to a valid SampleAllocateePtr<T> of the specified type.
+    unsafe fn delete_allocatee_ptr(allocatee_ptr: *mut std::ffi::c_void, type_name: &str) {
+        // SAFETY: allocatee_ptr is valid which is created using get_allocatee_ptr() and
+        // type_name is constructed using static str.
+        let type_name = StringView::from(type_name);
+        mw_com_delete_allocatee_ptr(allocatee_ptr, type_name);
+    }
+
+    /// Get allocatee data pointer from allocatee of specific type
+    ///
+    /// # Arguments
+    /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
+    /// * `type_name` - Type name string
+    ///
+    /// # Returns
+    /// Pointer to allocatee data, or nullptr if type mismatch
+    ///
+    /// # Safety
+    /// allocatee_ptr must point to a valid SampleAllocateePtr<T> of the specified type
+    unsafe fn get_allocatee_data_ptr(
+        allocatee_ptr: *const std::ffi::c_void,
+        type_name: &str,
+    ) -> *mut std::ffi::c_void {
+        // SAFETY: allocatee_ptr is valid which is created using get_allocatee_ptr() and
+        // type_name is constructed using static str.
+        let type_name = StringView::from(type_name);
+        mw_com_get_allocatee_data_ptr(allocatee_ptr, type_name)
+    }
+
+    /// Send event via skeleton using allocatee pointer of specific type
+    ///
+    /// # Arguments
+    /// * `event_ptr` - Opaque skeleton event pointer
+    /// * `event_type` - Type name string
+    /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
+    ///
+    /// # Returns
+    /// True if event was sent successfully, false otherwise
+    ///
+    /// # Safety
+    /// event_ptr must point to a valid SkeletonEventBase,
+    /// allocatee_ptr must point to a valid SampleAllocateePtr<T>,
+    /// and event_type must be a valid UTF-8 string representing the event type.
+    unsafe fn skeleton_event_send_sample_allocatee(
+        event_ptr: *mut SkeletonEventBase,
+        event_type: &str,
+        allocatee_ptr: *const std::ffi::c_void,
+    ) -> bool {
+        // SAFETY: event_ptr is valid which is created using create_skeleton() and allocatee_ptr is
+        // valid which is created using get_allocatee_ptr().
+        let event_type = StringView::from(event_type);
+        mw_com_skeleton_send_event_allocatee(event_ptr, event_type, allocatee_ptr)
+    }
+
+    /// Get SamplePtr<T> data pointer
+    ///
+    /// # Arguments
+    /// * `sample_ptr` - Opaque sample pointer
+    /// * `type_name` - Type name string
+    ///
+    /// # Returns
+    /// Pointer to sample data, or nullptr if type mismatch
+    /// # Safety
+    /// sample_ptr must point to a valid SamplePtr<T> of the specified type.
+    unsafe fn sample_ptr_get(
+        sample_ptr: *const std::ffi::c_void,
+        type_name: &str,
+    ) -> *const std::ffi::c_void {
+        // SAFETY: sample_ptr is guaranteed to be valid per the caller's contract.
+        // The C++ implementation handles type checking and data retrieval safely.
+        let type_name = StringView::from(type_name);
+        mw_com_get_sample_ptr(sample_ptr, type_name)
+    }
+
+    /// Delete SamplePtr<T>
+    ///
+    /// # Arguments
+    /// * `sample_ptr` - Opaque sample pointer
+    /// * `type_name` - Type name string
+    /// # Safety
+    /// sample_ptr must point to a valid SamplePtr<T> of the specified type.
+    unsafe fn sample_ptr_delete(sample_ptr: *mut std::ffi::c_void, type_name: &str) {
+        // SAFETY: sample_ptr is guaranteed to be valid per the caller's contract.
+        // The C++ implementation handles type checking and deletion safely.
+        let type_name = StringView::from(type_name);
+        mw_com_delete_sample_ptr(sample_ptr, type_name);
+    }
+
+    /// Unsafe wrapper around mw_com_skeleton_offer_service
+    ///
+    /// # Arguments
+    /// * `skeleton_ptr` - Opaque skeleton pointer
+    ///
+    /// # Returns
+    /// true if offer was successful, false otherwise
+    ///
+    /// # Safety
+    /// skeleton_ptr must be a valid pointer to a SkeletonBase previously created
+    /// with create_skeleton().
+    /// The pointer must remain valid for the duration of this call.
+    unsafe fn skeleton_offer_service(skeleton_ptr: *mut SkeletonBase) -> bool {
+        // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
+        // The C++ implementation handles service offering safely.
+        mw_com_skeleton_offer_service(skeleton_ptr)
+    }
+
+    /// Unsafe wrapper around mw_com_skeleton_stop_offer_service
+    ///
+    /// # Arguments
+    /// * `skeleton_ptr` - Opaque skeleton pointer
+    ///
+    /// # Safety
+    /// skeleton_ptr must be a valid pointer to a SkeletonBase previously created
+    /// with create_skeleton().
+    /// The pointer must remain valid for the duration of this call.
+    unsafe fn skeleton_stop_offer_service(skeleton_ptr: *mut SkeletonBase) {
+        // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
+        // The C++ implementation handles stopping the service safely.
+        mw_com_skeleton_stop_offer_service(skeleton_ptr);
+    }
+
+    /// Unsafe wrapper around mw_com_create_proxy
+    ///
+    /// # Arguments
+    /// * `interface_id` - Interface UID string
+    /// * `handle_ptr` - Opaque handle pointer
+    ///
+    /// # Returns
+    /// Opaque proxy pointer, or nullptr if creation failed
+    ///
+    /// # Safety
+    /// handle_ptr must be a valid reference to a HandleType.
+    /// The returned pointer must eventually be destroyed via destroy_proxy().
+    unsafe fn create_proxy(interface_id: &str, handle_ptr: &HandleType) -> *mut ProxyBase {
+        // SAFETY: interface_id is a valid string reference and handle_ptr is guaranteed to be valid
+        // per the caller's contract.
+        // The C++ implementation creates and returns a valid proxy pointer or nullptr on failure.
+        let c_uid = StringView::from(interface_id);
+        mw_com_create_proxy(c_uid, handle_ptr)
+    }
+
+    /// Unsafe wrapper around mw_com_create_skeleton
+    ///
+    /// # Arguments
+    /// * `interface_id` - Interface UID string
+    /// * `instance_spec` - Opaque instance specifier pointer
+    ///
+    /// # Returns
+    /// Opaque skeleton pointer, or nullptr if creation failed
+    ///
+    /// # Safety
+    /// instance_spec must be a valid NativeInstanceSpecifier.
+    /// The returned pointer must eventually be destroyed via destroy_skeleton().
+    unsafe fn create_skeleton(
+        interface_id: &str,
+        instance_spec: *const NativeInstanceSpecifier,
+    ) -> *mut SkeletonBase {
+        // SAFETY: interface_id is a valid string reference and instance_spec is guaranteed to be
+        // valid per the caller's contract.
+        // The C++ implementation creates and returns a valid skeleton pointer or nullptr on failure.
+        let c_uid = StringView::from(interface_id);
+        mw_com_create_skeleton(c_uid, instance_spec)
+    }
+
+    /// Unsafe wrapper around mw_com_destroy_proxy
+    ///
+    /// # Arguments
+    /// * `proxy_ptr` - Opaque proxy pointer to destroy
+    ///
+    /// # Safety
+    /// proxy_ptr must be a valid pointer returned from create_proxy() that has not been destroyed yet.
+    /// The caller must ensure no other references to this proxy exist after calling this function.
+    unsafe fn destroy_proxy(proxy_ptr: *mut ProxyBase) {
+        // SAFETY: proxy_ptr is guaranteed to be valid per the caller's contract.
+        // The C++ implementation safely deallocates the proxy.
+        mw_com_destroy_proxy(proxy_ptr);
+    }
+
+    /// Unsafe wrapper around mw_com_destroy_skeleton
+    ///
+    /// # Arguments
+    /// * `skeleton_ptr` - Opaque skeleton pointer to destroy
+    ///
+    /// # Safety
+    /// skeleton_ptr must be a valid pointer returned from create_skeleton()-
+    /// that has not been destroyed yet.
+    /// The caller must ensure no other references to this skeleton exist after calling this function.
+    unsafe fn destroy_skeleton(skeleton_ptr: *mut SkeletonBase) {
+        // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
+        // The C++ implementation safely deallocates the skeleton.
+        mw_com_destroy_skeleton(skeleton_ptr);
+    }
+
+    /// Unsafe wrapper around mw_com_get_event_from_proxy
+    ///
+    /// # Arguments
+    /// * `proxy_ptr` - Opaque proxy pointer
+    /// * `interface_id` - Interface UID string
+    /// * `event_id` - Event name string
+    ///
+    /// # Returns
+    /// Opaque event pointer, or nullptr if not found
+    ///
+    /// # Safety
+    /// proxy_ptr must be a valid pointer to a ProxyBase previously created with create_proxy().
+    /// The returned pointer remains valid only as long as the proxy remains alive.
+    unsafe fn get_event_from_proxy(
+        proxy_ptr: *mut ProxyBase,
+        interface_id: &str,
+        event_id: &str,
+    ) -> *mut ProxyEventBase {
+        // SAFETY: proxy_ptr is guaranteed to be valid per the caller's contract.
+        // The C++ implementation returns a valid pointer or nullptr if the event is not found.
+        let c_id = StringView::from(interface_id);
+        let c_name = StringView::from(event_id);
+        mw_com_get_event_from_proxy(proxy_ptr, c_id, c_name)
+    }
+
+    /// Unsafe wrapper around mw_com_get_event_from_skeleton
+    ///
+    /// # Arguments
+    /// * `skeleton_ptr` - Opaque skeleton pointer
+    /// * `interface_id` - Interface UID string
+    /// * `event_id` - Event name string
+    ///
+    /// # Returns
+    /// Opaque event pointer, or nullptr if not found
+    ///
+    /// # Safety
+    /// skeleton_ptr must be a valid pointer to a SkeletonBase previously created
+    /// with create_skeleton().
+    /// The returned pointer remains valid only as long as the skeleton remains alive.
+    unsafe fn get_event_from_skeleton(
+        skeleton_ptr: *mut SkeletonBase,
+        interface_id: &str,
+        event_id: &str,
+    ) -> *mut SkeletonEventBase {
+        // SAFETY: skeleton_ptr is guaranteed to be valid per the caller's contract.
+        // The C++ implementation returns a valid pointer or nullptr if the event is not found.
+        let c_id = StringView::from(interface_id);
+        let c_name = StringView::from(event_id);
+        mw_com_get_event_from_skeleton(skeleton_ptr, c_id, c_name)
+    }
+
+    /// Unsafe wrapper around mw_com_get_samples_from_event
+    ///
+    /// # Arguments
+    /// * `event_ptr` - Opaque event pointer
+    /// * `event_type` - Event type name string
+    /// * `callback` - FatPtr to callback function
+    /// * `max_samples` - Maximum number of samples to retrieve
+    ///
+    /// # Returns
+    /// Number of samples retrieved, or u32::MAX on error
+    ///
+    /// # Safety
+    /// event_ptr must be a valid pointer to a ProxyEventBase previously obtained
+    /// from get_event_from_proxy().
+    /// callback must be a valid FatPtr referencing a callable compatible with the event type.
+    /// The event must have been subscribed to via subscribe_to_event() before calling this function.
+    unsafe fn get_samples_from_event(
+        event_ptr: *mut ProxyEventBase,
+        event_type: &str,
+        callback: &FatPtr,
+        max_samples: u32,
+    ) -> u32 {
+        // SAFETY: event_ptr, callback, and event_type are guaranteed
+        // to be valid per the caller's contract.
+        // The C++ implementation handles sample retrieval and callback invocation safely.
+        let c_name = StringView::from(event_type);
+        mw_com_type_registry_get_samples_from_event(event_ptr, c_name, callback, max_samples)
+    }
+
+    /// Unsafe wrapper around mw_com_skeleton_send_event
+    ///
+    /// # Arguments
+    /// * `event_ptr` - Opaque skeleton event pointer
+    /// * `event_type` - Event type name string
+    /// * `data_ptr` - Pointer to event data of the matching type
+    ///
+    /// # Safety
+    /// event_ptr must be a valid pointer to a SkeletonEventBase previously obtained
+    /// from get_event_from_skeleton().
+    /// data_ptr must point to valid data whose type matches the event_type.
+    /// The lifetime of the data must extend through this function call.
+    unsafe fn skeleton_send_event(
+        event_ptr: *mut SkeletonEventBase,
+        event_type: &str,
+        data_ptr: *const std::ffi::c_void,
+    ) -> bool {
+        // SAFETY: event_ptr and data_ptr are guaranteed to be valid per the caller's contract.
+        // The C++ implementation handles type matching and data sending safely.
+        let c_name = StringView::from(event_type);
+        mw_com_skeleton_send_event(event_ptr, c_name, data_ptr)
+    }
+
+    /// Unsafe wrapper around mw_com_proxy_event_subscribe
+    ///
+    /// # Arguments
+    /// * `event_ptr` - Opaque event pointer
+    /// * `max_sample_count` - Maximum number of samples to buffer concurrently
+    ///
+    /// # Returns
+    /// true if subscription was successful, false otherwise
+    ///
+    /// # Safety
+    /// event_ptr must be a valid pointer to a ProxyEventBase previously obtained
+    /// from get_event_from_proxy().
+    /// This function must be called before attempting to retrieve samples via get_samples_from_event().
+    unsafe fn subscribe_to_event(event_ptr: *mut ProxyEventBase, max_sample_count: u32) -> bool {
+        // SAFETY: event_ptr is guaranteed to be valid per the caller's contract.
+        // The C++ implementation handles subscription and buffer allocation safely.
+        mw_com_proxy_event_subscribe(event_ptr, max_sample_count)
+    }
+
+    /// Unsafe wrapper around mw_com_proxy_event_unsubscribe
+    ///
+    /// # Arguments
+    /// * `event_ptr` - Opaque event pointer
+    ///
+    /// # Safety
+    /// event_ptr must be a valid pointer to a ProxyEventBase previously obtained from get_event_from_proxy().
+    /// This function should be called only when no `SamplePtr` is held by the user for this event.
+    unsafe fn unsubscribe_to_event(event_ptr: *mut ProxyEventBase) {
+        // SAFETY: event_ptr is guaranteed to be valid per the caller's contract.
+        // The C++ implementation handles unsubscription and buffer cleanup safely.
+        mw_com_proxy_event_unsubscribe(event_ptr);
+    }
+
+    /// Unsafe wrapper around mw_com_proxy_set_event_receive_handler
+    ///
+    /// # Arguments
+    /// * `proxy_event_ptr` - Opaque proxy event pointer
+    /// * `handler` - FatPtr to event receive handler function
+    ///
+    /// # Returns
+    /// true if handler was set successfully, false otherwise
+    ///
+    /// # Safety
+    /// proxy_event_ptr must be a valid pointer to a ProxyEventBase previously obtained
+    /// from get_event_from_proxy().
+    /// handler must be a valid FatPtr which is used for notifying the proxy of incoming events.
+    unsafe fn set_event_receive_handler(
+        proxy_event_ptr: *mut ProxyEventBase,
+        handler: &FatPtr,
+        event_type: &str,
+    ) -> bool {
+        // SAFETY: proxy_event_ptr must be valid per the caller's contract,
+        // and handler must be a valid FatPtr referencing a callable compatible with the callback
+        // signature expected by the C++ implementation.
+        let c_name = StringView::from(event_type);
+        mw_com_proxy_set_event_receive_handler(proxy_event_ptr, handler, c_name)
+    }
+
+    /// Unsafe wrapper around mw_com_proxy_clear_event_receive_handler
+    ///
+    /// # Arguments
+    /// * `proxy_event_ptr` - Opaque proxy event pointer
+    /// * `event_type` - Event type name string
+    ///
+    /// # Safety
+    /// proxy_event_ptr must be a valid pointer to a ProxyEventBase previously obtained
+    /// from get_event_from_proxy().
+    /// event_type must be a valid string corresponding to the event type.
+    unsafe fn clear_event_receive_handler(proxy_event_ptr: *mut ProxyEventBase, event_type: &str) {
+        // SAFETY: proxy_event_ptr must be valid per the caller's contract.
+        let c_name = StringView::from(event_type);
+        mw_com_proxy_clear_event_receive_handler(proxy_event_ptr, c_name);
+    }
+
+    /// Unsafe wrapper around mw_com_start_find_service
+    ///
+    /// # Arguments
+    /// * `callback` - FatPtr to callback function to be invoked when services are found
+    /// * `instance_spec` - InstanceSpecifier identifying the service instance to find
+    ///
+    /// # Returns
+    /// Opaque handle pointer for the find service operation, or nullptr on failure
+    ///
+    /// # Safety
+    /// callback must be a valid FatPtr referencing a callable compatible with the find service results.
+    /// instance_spec must be a valid InstanceSpecifier for the service to find.
+    unsafe fn start_find_service(
+        callback: &FatPtr,
+        instance_spec: InstanceSpecifier,
+    ) -> *mut FindServiceHandle {
+        // SAFETY: callback and instance_spec are guaranteed to be valid per the caller's contract.
+        // The C++ implementation handles the find service operation and callback invocation safely.
+        mw_com_start_find_service(callback, instance_spec.as_native())
+    }
+
+    /// Unsafe wrapper around mw_com_stop_find_service
+    ///
+    /// # Arguments
+    /// * `handle` - Opaque handle pointer returned from start_find_service()
+    ///
+    /// # Safety
+    /// handle must be a valid pointer returned from start_find_service() that has not been stopped yet,
+    /// and the caller must ensure no further use of this handle after calling this function.
+    unsafe fn stop_find_service(handle: *mut FindServiceHandle) {
+        // SAFETY: handle is valid per the caller's contract and has not been stopped yet.
+        // The C++ implementation handles stopping the find service safely.
+        mw_com_stop_find_service(handle);
+    }
+}

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -12,222 +12,226 @@
  ********************************************************************************/
 
 pub use bridge_ffi_rs::{
-    CMutVoidPtr, CVoidPtr, FatPtr, FindServiceHandle, HandleContainer, HandleType,
+    CMutVoidPtr, CVoidPtr, FFIBridge, FatPtr, FindServiceHandle, HandleContainer, HandleType,
     InstanceSpecifier, NativeFindServiceHandle, NativeHandleContainer, NativeInstanceSpecifier,
     ProxyBase, ProxyEventBase, ProxyWrapperClass, SkeletonBase, SkeletonEventBase,
 };
 
-/// Mock implementation of get_allocatee_ptr.
-/// # Safety
-/// Returns true if event_ptr is non-null (mock behavior).
-pub unsafe fn get_allocatee_ptr(
-    event_ptr: *mut SkeletonEventBase,
-    _allocatee_ptr: *mut std::ffi::c_void,
-    _event_type: &str,
-) -> bool {
-    !event_ptr.is_null()
-}
+pub struct MockFFIBridge;
 
-/// Mock implementation of delete_allocatee_ptr.
-/// # Safety
-/// No-op for mock.
-pub unsafe fn delete_allocatee_ptr(_allocatee_ptr: *mut std::ffi::c_void, _type_name: &str) {}
-
-/// Mock implementation of get_allocatee_data_ptr.
-/// # Safety
-/// Returns the input pointer cast to mutable (mock behavior).
-pub unsafe fn get_allocatee_data_ptr(
-    allocatee_ptr: *const std::ffi::c_void,
-    _type_name: &str,
-) -> *mut std::ffi::c_void {
-    allocatee_ptr as *mut std::ffi::c_void
-}
-
-/// Mock implementation of skeleton_event_send_sample_allocatee.
-/// # Safety
-/// Returns true if event_ptr is non-null (mock behavior).
-pub unsafe fn skeleton_event_send_sample_allocatee(
-    event_ptr: *mut SkeletonEventBase,
-    _event_type: &str,
-    _allocatee_ptr: *const std::ffi::c_void,
-) -> bool {
-    !event_ptr.is_null()
-}
-
-/// Mock implementation of sample_ptr_get.
-/// # Safety
-/// Returns the input pointer unchanged (mock behavior).
-pub unsafe fn sample_ptr_get(
-    sample_ptr: *const std::ffi::c_void,
-    _type_name: &str,
-) -> *const std::ffi::c_void {
-    sample_ptr
-}
-
-/// Mock implementation of sample_ptr_delete.
-/// # Safety
-/// No-op for mock.
-pub unsafe fn sample_ptr_delete(_sample_ptr: *mut std::ffi::c_void, _type_name: &str) {}
-
-/// Mock implementation of skeleton_offer_service.
-/// # Safety
-/// Returns true if skeleton_ptr is non-null (mock behavior).
-pub unsafe fn skeleton_offer_service(skeleton_ptr: *mut SkeletonBase) -> bool {
-    !skeleton_ptr.is_null()
-}
-
-/// Mock implementation of skeleton_stop_offer_service.
-/// # Safety
-/// No-op for mock.
-pub unsafe fn skeleton_stop_offer_service(_skeleton_ptr: *mut SkeletonBase) {}
-
-/// Mock implementation of create_proxy.
-/// # Safety
-/// Allocates and returns a new ProxyBase pointer from heap.
-/// Caller must eventually destroy with destroy_proxy.
-pub unsafe fn create_proxy(_interface_id: &str, _handle_ptr: &HandleType) -> *mut ProxyBase {
-    Box::into_raw(Box::new(std::mem::zeroed::<ProxyBase>()))
-}
-
-/// Mock implementation of create_skeleton.
-/// # Safety
-/// Allocates and returns a new SkeletonBase pointer from heap.
-/// Caller must eventually destroy with destroy_skeleton.
-pub unsafe fn create_skeleton(
-    _interface_id: &str,
-    _instance_spec: *const NativeInstanceSpecifier,
-) -> *mut SkeletonBase {
-    Box::into_raw(Box::new(std::mem::zeroed::<SkeletonBase>()))
-}
-
-/// Mock implementation of destroy_proxy.
-/// # Safety
-/// proxy_ptr must have been returned from create_proxy.
-/// Caller must not use proxy_ptr after this call.
-pub unsafe fn destroy_proxy(proxy_ptr: *mut ProxyBase) {
-    if !proxy_ptr.is_null() {
-        // SAFETY: proxy_ptr was allocated by create_proxy via Box::into_raw
-        drop(Box::from_raw(proxy_ptr));
+impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
+    /// Mock implementation of get_allocatee_ptr.
+    /// # Safety
+    /// Returns true if event_ptr is non-null (mock behavior).
+    unsafe fn get_allocatee_ptr(
+        event_ptr: *mut SkeletonEventBase,
+        _allocatee_ptr: *mut std::ffi::c_void,
+        _event_type: &str,
+    ) -> bool {
+        !event_ptr.is_null()
     }
-}
 
-/// Mock implementation of destroy_skeleton.
-/// # Safety
-/// skeleton_ptr must have been returned from create_skeleton.
-/// Caller must not use skeleton_ptr after this call.
-pub unsafe fn destroy_skeleton(skeleton_ptr: *mut SkeletonBase) {
-    if !skeleton_ptr.is_null() {
-        // SAFETY: skeleton_ptr was allocated by create_skeleton via Box::into_raw
-        drop(Box::from_raw(skeleton_ptr));
+    /// Mock implementation of delete_allocatee_ptr.
+    /// # Safety
+    /// No-op for mock.
+    unsafe fn delete_allocatee_ptr(_allocatee_ptr: *mut std::ffi::c_void, _type_name: &str) {}
+
+    /// Mock implementation of get_allocatee_data_ptr.
+    /// # Safety
+    /// Returns the input pointer cast to mutable (mock behavior).
+    unsafe fn get_allocatee_data_ptr(
+        allocatee_ptr: *const std::ffi::c_void,
+        _type_name: &str,
+    ) -> *mut std::ffi::c_void {
+        allocatee_ptr as *mut std::ffi::c_void
     }
-}
 
-/// Mock implementation of get_event_from_proxy.
-/// # Safety
-/// proxy_ptr must be non-null for non-null return.
-/// Returned pointer remains valid only while proxy is alive.
-pub unsafe fn get_event_from_proxy(
-    proxy_ptr: *mut ProxyBase,
-    _interface_id: &str,
-    _event_id: &str,
-) -> *mut ProxyEventBase {
-    if proxy_ptr.is_null() {
-        return std::ptr::null_mut();
+    /// Mock implementation of skeleton_event_send_sample_allocatee.
+    /// # Safety
+    /// Returns true if event_ptr is non-null (mock behavior).
+    unsafe fn skeleton_event_send_sample_allocatee(
+        event_ptr: *mut SkeletonEventBase,
+        _event_type: &str,
+        _allocatee_ptr: *const std::ffi::c_void,
+    ) -> bool {
+        !event_ptr.is_null()
     }
-    // ProxyEventBase is a ZST opaque type. The runtime never frees event pointers
-    // (NativeProxyEventBase has no Drop); returning a non-null sentinel is sufficient.
-    std::ptr::NonNull::<ProxyEventBase>::dangling().as_ptr()
-}
 
-/// Mock implementation of get_event_from_skeleton.
-/// # Safety
-/// Returns a dangling pointer sentinel (mock behavior). Valid only for null checks.
-pub unsafe fn get_event_from_skeleton(
-    _skeleton_ptr: *mut SkeletonBase,
-    _interface_id: &str,
-    _event_id: &str,
-) -> *mut SkeletonEventBase {
-    // SkeletonEventBase is a ZST opaque type. The runtime never frees event pointers
-    // (NativeSkeletonEventBase has no Drop); returning a non-null sentinel is sufficient.
-    std::ptr::NonNull::<SkeletonEventBase>::dangling().as_ptr()
-}
-
-/// Mock implementation of get_samples_from_event.
-/// # Safety
-/// event_ptr must be non-null or returns u32::MAX (mock behavior).
-pub unsafe fn get_samples_from_event(
-    event_ptr: *mut ProxyEventBase,
-    _event_type: &str,
-    _callback: &FatPtr,
-    _max_samples: u32,
-) -> u32 {
-    if event_ptr.is_null() {
-        return u32::MAX;
+    /// Mock implementation of sample_ptr_get.
+    /// # Safety
+    /// Returns the input pointer unchanged (mock behavior).
+    unsafe fn sample_ptr_get(
+        sample_ptr: *const std::ffi::c_void,
+        _type_name: &str,
+    ) -> *const std::ffi::c_void {
+        sample_ptr
     }
-    0
-}
 
-/// Mock implementation of skeleton_send_event.
-/// # Safety
-/// Returns true if event_ptr is non-null (mock behavior).
-pub unsafe fn skeleton_send_event(
-    event_ptr: *mut SkeletonEventBase,
-    _event_type: &str,
-    _data_ptr: *const std::ffi::c_void,
-) -> bool {
-    !event_ptr.is_null()
-}
+    /// Mock implementation of sample_ptr_delete.
+    /// # Safety
+    /// No-op for mock.
+    unsafe fn sample_ptr_delete(_sample_ptr: *mut std::ffi::c_void, _type_name: &str) {}
 
-/// Mock implementation of subscribe_to_event.
-/// # Safety
-/// Returns true if event_ptr is non-null (mock behavior).
-pub unsafe fn subscribe_to_event(event_ptr: *mut ProxyEventBase, _max_sample_count: u32) -> bool {
-    !event_ptr.is_null()
-}
+    /// Mock implementation of skeleton_offer_service.
+    /// # Safety
+    /// Returns true if skeleton_ptr is non-null (mock behavior).
+    unsafe fn skeleton_offer_service(skeleton_ptr: *mut SkeletonBase) -> bool {
+        !skeleton_ptr.is_null()
+    }
 
-/// Mock implementation of unsubscribe_to_event.
-/// # Safety
-/// No-op for mock.
-pub unsafe fn unsubscribe_to_event(_event_ptr: *mut ProxyEventBase) {}
+    /// Mock implementation of skeleton_stop_offer_service.
+    /// # Safety
+    /// No-op for mock.
+    unsafe fn skeleton_stop_offer_service(_skeleton_ptr: *mut SkeletonBase) {}
 
-/// Mock implementation of set_event_receive_handler.
-/// # Safety
-/// Returns true if proxy_event_ptr is non-null (mock behavior).
-pub unsafe fn set_event_receive_handler(
-    proxy_event_ptr: *mut ProxyEventBase,
-    _handler: &FatPtr,
-    _event_type: &str,
-) -> bool {
-    !proxy_event_ptr.is_null()
-}
+    /// Mock implementation of create_proxy.
+    /// # Safety
+    /// Allocates and returns a new ProxyBase pointer from heap.
+    /// Caller must eventually destroy with destroy_proxy.
+    unsafe fn create_proxy(_interface_id: &str, _handle_ptr: &HandleType) -> *mut ProxyBase {
+        Box::into_raw(Box::new(std::mem::zeroed::<ProxyBase>()))
+    }
 
-/// Mock implementation of clear_event_receive_handler.
-/// # Safety
-/// No-op for mock.
-pub unsafe fn clear_event_receive_handler(
-    _proxy_event_ptr: *mut ProxyEventBase,
-    _event_type: &str,
-) {
-}
+    /// Mock implementation of create_skeleton.
+    /// # Safety
+    /// Allocates and returns a new SkeletonBase pointer from heap.
+    /// Caller must eventually destroy with destroy_skeleton.
+    unsafe fn create_skeleton(
+        _interface_id: &str,
+        _instance_spec: *const NativeInstanceSpecifier,
+    ) -> *mut SkeletonBase {
+        Box::into_raw(Box::new(std::mem::zeroed::<SkeletonBase>()))
+    }
 
-/// Mock implementation of start_find_service.
-/// # Safety
-/// Allocates and returns a new FindServiceHandle pointer.
-/// Caller must eventually destroy with stop_find_service.
-pub unsafe fn start_find_service(
-    _callback: &FatPtr,
-    _instance_spec: InstanceSpecifier,
-) -> *mut FindServiceHandle {
-    Box::into_raw(Box::new(std::mem::zeroed::<FindServiceHandle>()))
-}
+    /// Mock implementation of destroy_proxy.
+    /// # Safety
+    /// proxy_ptr must have been returned from create_proxy.
+    /// Caller must not use proxy_ptr after this call.
+    unsafe fn destroy_proxy(proxy_ptr: *mut ProxyBase) {
+        if !proxy_ptr.is_null() {
+            // SAFETY: proxy_ptr was allocated by create_proxy via Box::into_raw
+            drop(Box::from_raw(proxy_ptr));
+        }
+    }
 
-/// Mock implementation of stop_find_service.
-/// # Safety
-/// handle must have been returned from start_find_service.
-/// Caller must not use handle after this call.
-pub unsafe fn stop_find_service(handle: *mut FindServiceHandle) {
-    if !handle.is_null() {
-        // SAFETY: handle was allocated by start_find_service via Box::into_raw
-        drop(Box::from_raw(handle));
+    /// Mock implementation of destroy_skeleton.
+    /// # Safety
+    /// skeleton_ptr must have been returned from create_skeleton.
+    /// Caller must not use skeleton_ptr after this call.
+    unsafe fn destroy_skeleton(skeleton_ptr: *mut SkeletonBase) {
+        if !skeleton_ptr.is_null() {
+            // SAFETY: skeleton_ptr was allocated by create_skeleton via Box::into_raw
+            drop(Box::from_raw(skeleton_ptr));
+        }
+    }
+
+    /// Mock implementation of get_event_from_proxy.
+    /// # Safety
+    /// proxy_ptr must be non-null for non-null return.
+    /// Returned pointer remains valid only while proxy is alive.
+    unsafe fn get_event_from_proxy(
+        proxy_ptr: *mut ProxyBase,
+        _interface_id: &str,
+        _event_id: &str,
+    ) -> *mut ProxyEventBase {
+        if proxy_ptr.is_null() {
+            return std::ptr::null_mut();
+        }
+        // ProxyEventBase is a ZST opaque type. The runtime never frees event pointers
+        // (NativeProxyEventBase has no Drop); returning a non-null sentinel is sufficient.
+        std::ptr::NonNull::<ProxyEventBase>::dangling().as_ptr()
+    }
+
+    /// Mock implementation of get_event_from_skeleton.
+    /// # Safety
+    /// Returns a dangling pointer sentinel (mock behavior). Valid only for null checks.
+    unsafe fn get_event_from_skeleton(
+        _skeleton_ptr: *mut SkeletonBase,
+        _interface_id: &str,
+        _event_id: &str,
+    ) -> *mut SkeletonEventBase {
+        // SkeletonEventBase is a ZST opaque type. The runtime never frees event pointers
+        // (NativeSkeletonEventBase has no Drop); returning a non-null sentinel is sufficient.
+        std::ptr::NonNull::<SkeletonEventBase>::dangling().as_ptr()
+    }
+
+    /// Mock implementation of get_samples_from_event.
+    /// # Safety
+    /// event_ptr must be non-null or returns u32::MAX (mock behavior).
+    unsafe fn get_samples_from_event(
+        event_ptr: *mut ProxyEventBase,
+        _event_type: &str,
+        _callback: &FatPtr,
+        _max_samples: u32,
+    ) -> u32 {
+        if event_ptr.is_null() {
+            return u32::MAX;
+        }
+        0
+    }
+
+    /// Mock implementation of skeleton_send_event.
+    /// # Safety
+    /// Returns true if event_ptr is non-null (mock behavior).
+    unsafe fn skeleton_send_event(
+        event_ptr: *mut SkeletonEventBase,
+        _event_type: &str,
+        _data_ptr: *const std::ffi::c_void,
+    ) -> bool {
+        !event_ptr.is_null()
+    }
+
+    /// Mock implementation of subscribe_to_event.
+    /// # Safety
+    /// Returns true if event_ptr is non-null (mock behavior).
+    unsafe fn subscribe_to_event(event_ptr: *mut ProxyEventBase, _max_sample_count: u32) -> bool {
+        !event_ptr.is_null()
+    }
+
+    /// Mock implementation of unsubscribe_to_event.
+    /// # Safety
+    /// No-op for mock.
+    unsafe fn unsubscribe_to_event(_event_ptr: *mut ProxyEventBase) {}
+
+    /// Mock implementation of set_event_receive_handler.
+    /// # Safety
+    /// Returns true if proxy_event_ptr is non-null (mock behavior).
+    unsafe fn set_event_receive_handler(
+        proxy_event_ptr: *mut ProxyEventBase,
+        _handler: &FatPtr,
+        _event_type: &str,
+    ) -> bool {
+        !proxy_event_ptr.is_null()
+    }
+
+    /// Mock implementation of clear_event_receive_handler.
+    /// # Safety
+    /// No-op for mock.
+    unsafe fn clear_event_receive_handler(
+        _proxy_event_ptr: *mut ProxyEventBase,
+        _event_type: &str,
+    ) {
+    }
+
+    /// Mock implementation of start_find_service.
+    /// # Safety
+    /// Allocates and returns a new FindServiceHandle pointer.
+    /// Caller must eventually destroy with stop_find_service.
+    unsafe fn start_find_service(
+        _callback: &FatPtr,
+        _instance_spec: InstanceSpecifier,
+    ) -> *mut FindServiceHandle {
+        Box::into_raw(Box::new(std::mem::zeroed::<FindServiceHandle>()))
+    }
+
+    /// Mock implementation of stop_find_service.
+    /// # Safety
+    /// handle must have been returned from start_find_service.
+    /// Caller must not use handle after this call.
+    unsafe fn stop_find_service(handle: *mut FindServiceHandle) {
+        if !handle.is_null() {
+            // SAFETY: handle was allocated by start_find_service via Box::into_raw
+            drop(Box::from_raw(handle));
+        }
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -17,6 +17,7 @@
 // input parameters. In future, we will enhance this mock implementation to verify
 // all the test cases and scenarios.
 #![doc(hidden)]
+#![allow(clippy::missing_safety_doc)]
 
 use bridge_ffi_rs::{
     FatPtr, FindServiceHandle, HandleContainer, HandleType, InstanceSpecifier,
@@ -43,9 +44,6 @@ thread_local! {
 pub struct MockFFIBridge;
 
 impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
-    /// Mock implementation of get_allocatee_ptr.
-    /// # Safety
-    /// Returns true if event_ptr is non-null (mock behavior).
     unsafe fn get_allocatee_ptr(
         event_ptr: *mut SkeletonEventBase,
         allocatee_ptr: *mut std::ffi::c_void,
@@ -54,19 +52,14 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         if event_ptr.is_null() {
             return false;
         }
-        ALLOC_SIZE.with(|s| {
-            let size = *s.borrow();
-            if size > 0 {
-                // SAFETY: allocatee_ptr is MaybeUninit<SampleAllocateePtr<T>> with `size` bytes.
-                std::ptr::write_bytes(allocatee_ptr as *mut u8, 0, size);
-            }
-        });
+        let size = ALLOC_SIZE.with(|s| *s.borrow());
+        if size == 0 {
+            return false;
+        }
+        std::ptr::write_bytes(allocatee_ptr as *mut u8, 0, size);
         true
     }
 
-    /// Mock implementation of delete_allocatee_ptr.
-    /// # Safety
-    /// No-op for mock.
     unsafe fn delete_allocatee_ptr(_allocatee_ptr: *mut std::ffi::c_void, _type_name: &str) {
         DATA_BACKING.with(|d| {
             if let Some((ptr, drop_fn)) = d.borrow_mut().take() {
@@ -76,16 +69,10 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         ALLOC_SIZE.with(|s| *s.borrow_mut() = 0);
     }
 
-    /// Mock implementation of get_allocatee_data_ptr.
-    /// # Safety
-    /// `MockFFIBridge::set_alloc_backing::<T>()` must have been called before this.
-    /// Returns a pointer to the heap-allocated `MaybeUninit<T>` buffer where the caller
-    /// may write `T` and later read it back via `Deref`.
     unsafe fn get_allocatee_data_ptr(
         _allocatee_ptr: *const std::ffi::c_void,
         _type_name: &str,
     ) -> *mut std::ffi::c_void {
-        // Return the pre-allocated MaybeUninit<T> buffer registered by set_alloc_backing.
         DATA_BACKING.with(|d| {
             d.borrow()
                 .as_ref()
@@ -94,9 +81,6 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         })
     }
 
-    /// Mock implementation of skeleton_event_send_sample_allocatee.
-    /// # Safety
-    /// Returns true if event_ptr is non-null (mock behavior).
     unsafe fn skeleton_event_send_sample_allocatee(
         event_ptr: *mut SkeletonEventBase,
         _event_type: &str,
@@ -105,9 +89,6 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         !event_ptr.is_null()
     }
 
-    /// Mock implementation of sample_ptr_get.
-    /// # Safety
-    /// Returns the input pointer unchanged (mock behavior).
     unsafe fn sample_ptr_get(
         sample_ptr: *const std::ffi::c_void,
         _type_name: &str,
@@ -115,35 +96,18 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         sample_ptr
     }
 
-    /// Mock implementation of sample_ptr_delete.
-    /// # Safety
-    /// No-op for mock.
     unsafe fn sample_ptr_delete(_sample_ptr: *mut std::ffi::c_void, _type_name: &str) {}
 
-    /// Mock implementation of skeleton_offer_service.
-    /// # Safety
-    /// Returns true if skeleton_ptr is non-null (mock behavior).
     unsafe fn skeleton_offer_service(skeleton_ptr: *mut SkeletonBase) -> bool {
         !skeleton_ptr.is_null()
     }
 
-    /// Mock implementation of skeleton_stop_offer_service.
-    /// # Safety
-    /// No-op for mock.
     unsafe fn skeleton_stop_offer_service(_skeleton_ptr: *mut SkeletonBase) {}
 
-    /// Mock implementation of create_proxy.
-    /// # Safety
-    /// Allocates and returns a new ProxyBase pointer from heap.
-    /// Caller must eventually destroy with destroy_proxy.
     unsafe fn create_proxy(_interface_id: &str, _handle_ptr: &HandleType) -> *mut ProxyBase {
         Box::into_raw(Box::new(std::mem::zeroed::<ProxyBase>()))
     }
 
-    /// Mock implementation of create_skeleton.
-    /// # Safety
-    /// Allocates and returns a new SkeletonBase pointer from heap.
-    /// Caller must eventually destroy with destroy_skeleton.
     unsafe fn create_skeleton(
         _interface_id: &str,
         _instance_spec: *const NativeInstanceSpecifier,
@@ -151,10 +115,6 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         Box::into_raw(Box::new(std::mem::zeroed::<SkeletonBase>()))
     }
 
-    /// Mock implementation of destroy_proxy.
-    /// # Safety
-    /// proxy_ptr must have been returned from create_proxy.
-    /// Caller must not use proxy_ptr after this call.
     unsafe fn destroy_proxy(proxy_ptr: *mut ProxyBase) {
         if !proxy_ptr.is_null() {
             // SAFETY: proxy_ptr was allocated by create_proxy via Box::into_raw
@@ -162,10 +122,6 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         }
     }
 
-    /// Mock implementation of destroy_skeleton.
-    /// # Safety
-    /// skeleton_ptr must have been returned from create_skeleton.
-    /// Caller must not use skeleton_ptr after this call.
     unsafe fn destroy_skeleton(skeleton_ptr: *mut SkeletonBase) {
         if !skeleton_ptr.is_null() {
             // SAFETY: skeleton_ptr was allocated by create_skeleton via Box::into_raw
@@ -173,10 +129,6 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         }
     }
 
-    /// Mock implementation of get_event_from_proxy.
-    /// # Safety
-    /// proxy_ptr must be non-null for non-null return.
-    /// Returned pointer remains valid only while proxy is alive.
     unsafe fn get_event_from_proxy(
         proxy_ptr: *mut ProxyBase,
         _interface_id: &str,
@@ -185,27 +137,19 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         if proxy_ptr.is_null() {
             return std::ptr::null_mut();
         }
-        // ProxyEventBase is a ZST opaque type. The runtime never frees event pointers
-        // (NativeProxyEventBase has no Drop); returning a non-null sentinel is sufficient.
+        // ProxyEventBase is a ZST opaque type; a non-null sentinel is sufficient.
         std::ptr::NonNull::<ProxyEventBase>::dangling().as_ptr()
     }
 
-    /// Mock implementation of get_event_from_skeleton.
-    /// # Safety
-    /// Returns a dangling pointer sentinel (mock behavior). Valid only for null checks.
     unsafe fn get_event_from_skeleton(
         _skeleton_ptr: *mut SkeletonBase,
         _interface_id: &str,
         _event_id: &str,
     ) -> *mut SkeletonEventBase {
-        // SkeletonEventBase is a ZST opaque type. The runtime never frees event pointers
-        // (NativeSkeletonEventBase has no Drop); returning a non-null sentinel is sufficient.
+        // SkeletonEventBase is a ZST opaque type; a non-null sentinel is sufficient.
         std::ptr::NonNull::<SkeletonEventBase>::dangling().as_ptr()
     }
 
-    /// Mock implementation of get_samples_from_event.
-    /// # Safety
-    /// event_ptr must be non-null or returns u32::MAX (mock behavior).
     unsafe fn get_samples_from_event(
         event_ptr: *mut ProxyEventBase,
         _event_type: &str,
@@ -218,9 +162,6 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         0
     }
 
-    /// Mock implementation of skeleton_send_event.
-    /// # Safety
-    /// Returns true if event_ptr is non-null (mock behavior).
     unsafe fn skeleton_send_event(
         event_ptr: *mut SkeletonEventBase,
         _event_type: &str,
@@ -229,21 +170,12 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         !event_ptr.is_null()
     }
 
-    /// Mock implementation of subscribe_to_event.
-    /// # Safety
-    /// Returns true if event_ptr is non-null (mock behavior).
     unsafe fn subscribe_to_event(event_ptr: *mut ProxyEventBase, _max_sample_count: u32) -> bool {
         !event_ptr.is_null()
     }
 
-    /// Mock implementation of unsubscribe_to_event.
-    /// # Safety
-    /// No-op for mock.
     unsafe fn unsubscribe_to_event(_event_ptr: *mut ProxyEventBase) {}
 
-    /// Mock implementation of set_event_receive_handler.
-    /// # Safety
-    /// Returns true if proxy_event_ptr is non-null (mock behavior).
     unsafe fn set_event_receive_handler(
         proxy_event_ptr: *mut ProxyEventBase,
         _handler: &FatPtr,
@@ -252,19 +184,12 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         !proxy_event_ptr.is_null()
     }
 
-    /// Mock implementation of clear_event_receive_handler.
-    /// # Safety
-    /// No-op for mock.
     unsafe fn clear_event_receive_handler(
         _proxy_event_ptr: *mut ProxyEventBase,
         _event_type: &str,
     ) {
     }
 
-    /// Mock implementation of start_find_service.
-    /// # Safety
-    /// Allocates and returns a new FindServiceHandle pointer.
-    /// Caller must eventually destroy with stop_find_service.
     unsafe fn start_find_service(
         _callback: &FatPtr,
         _instance_spec: InstanceSpecifier,
@@ -272,45 +197,52 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         Box::into_raw(Box::new(std::mem::zeroed::<FindServiceHandle>()))
     }
 
-    /// Mock implementation of stop_find_service.
-    /// # Safety
-    /// handle must have been returned from start_find_service.
-    /// Caller must not use handle after this call.
     unsafe fn stop_find_service(handle: *mut FindServiceHandle) {
         if !handle.is_null() {
             // SAFETY: handle was allocated by start_find_service via Box::into_raw
             drop(Box::from_raw(handle));
         }
     }
+
+    unsafe fn handle_container_size(_container: &HandleContainer) -> usize {
+        0
+    }
+
+    unsafe fn handle_container_get_at(
+        _container: &HandleContainer,
+        _index: usize,
+    ) -> Option<&HandleType> {
+        None
+    }
 }
 
 impl MockFFIBridge {
-    /// The handle container is backed by a heap-allocated zeroed stub so the pointer
-    /// is stable and non-dangling.  An extra `Arc` clone is intentionally forgotten
-    /// inside this function so the strong count is permanently pinned above zero —
-    /// meaning `HandleContainer::drop` (which calls real C++) is never invoked
-    /// regardless of how many clones the caller makes or drops.
+    // The handle container is backed by a heap-allocated zeroed stub so the pointer
+    // is stable and non-dangling.  An extra `Arc` clone is intentionally forgotten
+    // inside this function so the strong count is permanently pinned above zero —
+    // meaning `HandleContainer::drop` (which calls real C++) is never invoked
+    // regardless of how many clones the caller makes or drops.
     pub fn make_handle_container() -> std::sync::Arc<HandleContainer> {
-        // A zeroed usize gives a stable heap pointer.
-        let ptr = Box::leak(Box::new(0usize)) as *mut usize as *mut NativeHandleContainer;
+        // A dangling non-null sentinel: the inner pointer is never passed to C++ because
+        // MockFFIBridge::handle_container_size / handle_container_get_at always return 0 / None.
+        let ptr = std::ptr::NonNull::<NativeHandleContainer>::dangling().as_ptr();
         let hc = std::sync::Arc::new(HandleContainer::new(ptr));
-        //To avoid the drop of HandleContainer which will call the real C++ destructor.
+        // Prevent HandleContainer::drop (which would call real C++ delete) by pinning the refcount.
         std::mem::forget(std::sync::Arc::clone(&hc));
         hc
     }
 
-    /// `ProxyEventBase` is a ZST opaque type, a dangling non-null pointer is the
-    /// canonical representation for "valid but empty" in the mock.
+    // `ProxyEventBase` is a ZST opaque type, a dangling non-null pointer is the
+    // canonical representation for "valid but empty" in the mock.
     pub fn make_proxy_event_ptr() -> *mut ProxyEventBase {
         std::ptr::NonNull::<ProxyEventBase>::dangling().as_ptr()
     }
 
-    /// Registers type `T` as the backing type for the next `get_allocatee_ptr` /
-    /// `get_allocatee_data_ptr` cycle.
-    ///
-    /// Heap-allocates a `MaybeUninit<T>` buffer whose address is returned by
-    /// `get_allocatee_data_ptr`, and records `size_of::<SampleAllocateePtr<T>>()` so that
-    /// `get_allocatee_ptr` can zero-fill the caller's slot (making `assume_init()` safe).
+    // Registers type `T` as the backing type for the next `get_allocatee_ptr` /
+    // `get_allocatee_data_ptr` cycle.
+    // Heap-allocates a `MaybeUninit<T>` buffer whose address is returned by
+    // `get_allocatee_data_ptr`, and records `size_of::<SampleAllocateePtr<T>>()` so that
+    // `get_allocatee_ptr` can zero-fill the caller's slot (making `assume_init()` safe).
     pub fn set_alloc_backing<T: 'static>() {
         use sample_allocatee_ptr_rs::SampleAllocateePtr;
         let data_ptr =

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -12,10 +12,17 @@
  ********************************************************************************/
 
 // This file provides a mock implementation of the FFIBridge trait for testing purposes.
-// It is kind of stub code which we will change according to the needs of our tests.
-// As of now, it just provide basic mock implementation and returning values based on
-// input parameters. In future, we will enhance this mock implementation to verify
-// all the test cases and scenarios.
+// It allows pre-configuring responses for FFI calls and simulates success/failure based on the
+// presence of pre-configured data or null-checks of input pointers.
+// The mock maintains internal state for allocatee backing data, sample backing data, proxies, skeletons, and events.
+// It Provide the ability to set up expected data and behavior for tests using setter methods of the MockFFIBridge struct.
+// We have Skeleton, Proxy and Event unit structs as placeholders for the pointers returned by the mock, allowing us to track and manage these resources in tests
+// and in future we can extend these structs to hold additional metadata if needed for more complex test scenarios.
+// We ensure that all heap-allocated resources are properly freed by implementing Drop for BackingEntry and MockFFIBridgeState,
+// and by using the drop functions stored in BackingEntry to free the correct types of data.
+// This Mock can work as a real FFIBridge implementation and
+// each test can configure the mock with the expected data and behavior for that test,
+// allowing us to test the LolaRuntime and related components in isolation from the actual FFI layer.
 
 // This mock back-end (FFIBridge implementation) is used for unit testing of Lola-Runtime
 // So we do not want to expose this mock in the public API docs and crate level documentation, hence the `doc(hidden)` attribute.
@@ -23,10 +30,20 @@
 
 use bridge_ffi_rs::{
     FatPtr, FindServiceHandle, HandleContainer, HandleType, InstanceSpecifier,
-    NativeHandleContainer, NativeInstanceSpecifier, ProxyBase, ProxyEventBase, SkeletonBase,
-    SkeletonEventBase,
+    NativeInstanceSpecifier, ProxyBase, ProxyEventBase, SkeletonBase, SkeletonEventBase,
 };
+use std::collections::HashMap;
+use std::ffi::c_void;
+use std::mem::size_of;
+use std::num::NonZeroUsize;
 use std::sync::{Arc, Mutex};
+
+// Unit types for mock objects, kept for future extensibility and clarity
+struct Event {}
+
+struct Proxy {}
+
+struct Skeleton {}
 
 // Holds a heap-allocated pointer and its associated drop function.
 // Used for type-erased heap allocations in the mock FFI bridge.
@@ -36,6 +53,8 @@ struct BackingEntry {
     ptr: *mut std::ffi::c_void,
     // Drop function that knows how to properly free the data
     drop_fn: fn(*mut std::ffi::c_void),
+    // Size of the allocation
+    size: usize,
 }
 
 // SAFETY: BackingEntry is safe to Send because the drop_fn ensures that the heap allocation is properly freed,
@@ -67,24 +86,148 @@ impl Drop for BackingEntry {
 // To match this signature while mutating internal state (e.g., storing/retrieving mock data),
 // we need interior mutability. Arc<Mutex<...>> ensures thread safety at the cost of some performance,
 // which is acceptable for test code where safety is more important than performance.
-#[derive(Debug, Clone)]
+/// Thread-safe, test-isolated FFI bridge mock
+#[derive(Debug, Clone, Default)]
 pub struct MockFFIBridge {
-    //DATA_BACKING holds a pointer to the heap-allocated backing data and a drop function to free it.
-    //We are using this when user calls get_allocatee_data_ptr to return a pointer to this backing data.
-    data_backing: Arc<Mutex<Option<BackingEntry>>>,
-    //ALLOC_SIZE holds the size of the allocatee type for the next get_allocatee_ptr call, allowing
-    //the mock to zero-fill the caller's slot correctly.
-    alloc_size: Arc<Mutex<usize>>,
-    //SAMPLE_BACKING holds a pointer to the heap-allocated sample data and a drop function to free it.
-    sample_backing: Arc<Mutex<Option<BackingEntry>>>,
+    state: Arc<Mutex<MockFFIBridgeState>>,
 }
 
-impl Default for MockFFIBridge {
-    fn default() -> Self {
+#[derive(Debug, Default)]
+struct MockFFIBridgeState {
+    allocatee_backing: HashMap<String, BackingEntry>,
+    sample_backing: HashMap<String, BackingEntry>,
+    max_sample_count: Option<NonZeroUsize>,
+    proxies: HashMap<String, *mut ProxyBase>,
+    skeletons: HashMap<String, *mut SkeletonBase>,
+    proxy_events: HashMap<String, *mut ProxyEventBase>,
+    skeleton_events: HashMap<String, *mut SkeletonEventBase>,
+}
+
+// SAFETY: MockFFIBridgeState is safe to Send because all access to its internal state is protected by a Mutex,
+// Implementation in runtime handles the concurrent access and mutable access.
+unsafe impl Send for MockFFIBridgeState {}
+
+impl MockFFIBridge {
+    pub fn new() -> Self {
         Self {
-            data_backing: Arc::new(Mutex::new(None)),
-            alloc_size: Arc::new(Mutex::new(0)),
-            sample_backing: Arc::new(Mutex::new(None)),
+            state: Arc::new(Mutex::new(MockFFIBridgeState::default())),
+        }
+    }
+    /// Pre-configure heap-allocated backing data for an allocatee of a specific event type.
+    pub fn set_allocatee_backing<T: 'static>(&self, event_type: &str, value: T) {
+        let boxed = Box::new(value);
+        let ptr = Box::into_raw(boxed) as *mut c_void;
+
+        let entry = BackingEntry {
+            ptr,
+            drop_fn: |p| unsafe {
+                drop(Box::from_raw(p as *mut T));
+            },
+            size: size_of::<T>(),
+        };
+
+        let mut state = self.state.lock().expect("Failed to lock state");
+        state
+            .allocatee_backing
+            .insert(event_type.to_string(), entry);
+    }
+
+    /// Pre-configure heap-allocated backing data for a sample of a specific type.
+    pub fn set_sample_backing<T: 'static>(&self, type_name: &str, value: T) {
+        let boxed = Box::new(value);
+        let ptr = Box::into_raw(boxed) as *mut c_void;
+
+        let entry = BackingEntry {
+            ptr,
+            drop_fn: |p| unsafe {
+                drop(Box::from_raw(p as *mut T));
+            },
+            size: size_of::<T>(),
+        };
+
+        let mut state = self.state.lock().expect("Failed to lock state");
+        state.sample_backing.insert(type_name.to_string(), entry);
+    }
+
+    /// Configure the maximum sample count.
+    pub fn set_max_sample_count(&self, count: Option<NonZeroUsize>) {
+        self.state
+            .lock()
+            .expect("Failed to lock state")
+            .max_sample_count = count;
+    }
+
+    /// Pre-configure a proxy for a specific interface type.
+    /// Returns the pointer that will be returned by create_proxy for this interface_id.
+    pub fn set_proxy(&self, interface_id: &str) -> *mut ProxyBase {
+        let proxy = Box::new(Proxy {});
+        let ptr = Box::into_raw(proxy) as *mut ProxyBase;
+        self.state
+            .lock()
+            .expect("Failed to lock state")
+            .proxies
+            .insert(interface_id.to_string(), ptr);
+        ptr
+    }
+
+    /// Pre-configure a skeleton for a specific interface type.
+    /// Returns the pointer that will be returned by create_skeleton for this interface_id.
+    pub fn set_skeleton(&self, interface_id: &str) -> *mut SkeletonBase {
+        let skeleton = Box::new(Skeleton {});
+        let ptr = Box::into_raw(skeleton) as *mut SkeletonBase;
+        self.state
+            .lock()
+            .expect("Failed to lock state")
+            .skeletons
+            .insert(interface_id.to_string(), ptr);
+        ptr
+    }
+
+    /// Pre-configure a proxy event.
+    /// Returns the pointer that can be used for proxy event operations.
+    pub fn set_proxy_event(&self, interface_id: &str, event_id: &str) -> *mut ProxyEventBase {
+        let event = Box::new(Event {});
+        let ptr = Box::into_raw(event) as *mut ProxyEventBase;
+        let event_key = format!("{}::{}", interface_id, event_id);
+        self.state
+            .lock()
+            .expect("Failed to lock state")
+            .proxy_events
+            .insert(event_key.to_string(), ptr);
+        ptr
+    }
+
+    /// Pre-configure a skeleton event.
+    /// Returns the pointer that will be returned by create_skeleton_event for this interface_id and event_id.
+    pub fn set_skeleton_event(&self, interface_id: &str, event_id: &str) -> *mut SkeletonEventBase {
+        let event = Box::new(Event {});
+        let ptr = Box::into_raw(event) as *mut SkeletonEventBase;
+        let event_key = format!("{}::{}", interface_id, event_id);
+        self.state
+            .lock()
+            .expect("Failed to lock state")
+            .skeleton_events
+            .insert(event_key.to_string(), ptr);
+        ptr
+    }
+}
+
+impl Drop for MockFFIBridgeState {
+    fn drop(&mut self) {
+        // Cleanup any leaked resources
+        unsafe {
+            for (_key, ptr) in self.proxies.drain() {
+                drop(Box::from_raw(ptr));
+            }
+            for (_key, ptr) in self.skeletons.drain() {
+                drop(Box::from_raw(ptr));
+            }
+            for (_key, ptr) in self.proxy_events.drain() {
+                drop(Box::from_raw(ptr));
+            }
+            for (_key, ptr) in self.skeleton_events.drain() {
+                drop(Box::from_raw(ptr));
+            }
         }
     }
 }
@@ -98,42 +241,40 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         allocatee_ptr: *mut std::ffi::c_void,
         _event_type: &str,
     ) -> bool {
-        if event_ptr.is_null() || allocatee_ptr.is_null() {
+        if event_ptr.is_null() {
             return false;
         }
-        let size = *self.alloc_size.lock().expect("Failed to lock alloc_size");
-        if size == 0 {
+        // If we have backing data for this allocatee, copy it into the provided pointer.
+        let state = self.state.lock().expect("Failed to lock state");
+        if let Some(entry) = state.allocatee_backing.get(_event_type) {
+            unsafe {
+                std::ptr::copy_nonoverlapping(entry.ptr, allocatee_ptr, entry.size);
+            }
+            return true;
+        } else {
             return false;
         }
-        unsafe { std::ptr::write_bytes(allocatee_ptr as *mut u8, 0, size) };
-        true
     }
 
     // Deletes the heap-allocated backing data for the current allocatee, if any, and resets alloc_size.
-    unsafe fn delete_allocatee_ptr(&self, _allocatee_ptr: *mut std::ffi::c_void, _type_name: &str) {
-        if let Some(entry) = self
-            .data_backing
-            .lock()
-            .expect("Failed to lock data_backing")
-            .take()
-        {
-            (entry.drop_fn)(entry.ptr);
-        }
-        *self.alloc_size.lock().expect("Failed to lock alloc_size") = 0;
+    unsafe fn delete_allocatee_ptr(&self, _allocatee_ptr: *mut std::ffi::c_void, type_name: &str) {
+        let mut state = self.state.lock().expect("Failed to lock state");
+        // Removing the entry from the HashMap will call BackingEntry::drop automatically
+        state.allocatee_backing.remove(type_name);
     }
 
     // Returns a pointer to the heap-allocated backing data for the current allocatee, if any.
     unsafe fn get_allocatee_data_ptr(
         &self,
         _allocatee_ptr: *const std::ffi::c_void,
-        _type_name: &str,
+        type_name: &str,
     ) -> *mut std::ffi::c_void {
-        self.data_backing
-            .lock()
-            .expect("Failed to lock data_backing")
-            .as_ref()
-            .map(|entry| entry.ptr)
-            .unwrap_or(std::ptr::null_mut())
+        let state = self.state.lock().expect("Failed to lock state");
+        if let Some(entry) = state.allocatee_backing.get(type_name) {
+            entry.ptr
+        } else {
+            std::ptr::null_mut()
+        }
     }
 
     // Returns true if event_ptr is non-null, simulating successful event sending.
@@ -152,24 +293,19 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         _sample_ptr: *const std::ffi::c_void,
         _type_name: &str,
     ) -> *const std::ffi::c_void {
-        self.sample_backing
-            .lock()
-            .expect("Failed to lock sample_backing")
-            .as_ref()
-            .map(|entry| entry.ptr as *const std::ffi::c_void)
-            .unwrap_or(std::ptr::null())
+        let state = self.state.lock().expect("Failed to lock state");
+        if let Some(entry) = state.sample_backing.get(_type_name) {
+            entry.ptr
+        } else {
+            std::ptr::null()
+        }
     }
 
     // Deletes the heap-allocated sample backing data for the current sample, if any.
-    unsafe fn sample_ptr_delete(&self, _sample_ptr: *mut std::ffi::c_void, _type_name: &str) {
-        if let Some(entry) = self
-            .sample_backing
-            .lock()
-            .expect("Failed to lock sample_backing")
-            .take()
-        {
-            (entry.drop_fn)(entry.ptr);
-        }
+    unsafe fn sample_ptr_delete(&self, _sample_ptr: *mut std::ffi::c_void, type_name: &str) {
+        let mut state = self.state.lock().expect("Failed to lock state");
+        // Removing the entry from the HashMap will call BackingEntry::drop automatically
+        state.sample_backing.remove(type_name);
     }
 
     // The following methods simulate success/failure based on null-checks of input pointers.
@@ -181,25 +317,48 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
     unsafe fn skeleton_stop_offer_service(&self, _skeleton_ptr: *mut SkeletonBase) {}
 
     // Creates a new ProxyBase instance and returns a pointer to it.
-    // The actual content is not important for the mock, so we return zeroed instances.
-    unsafe fn create_proxy(&self, _interface_id: &str, _handle_ptr: &HandleType) -> *mut ProxyBase {
-        unsafe { Box::into_raw(Box::new(std::mem::zeroed::<ProxyBase>())) }
+    // If a proxy was pre-configured via set_proxy for this interface_id, returns that.
+    // Otherwise allocates a new one and tracks it.
+    unsafe fn create_proxy(&self, interface_id: &str, _handle_ptr: &HandleType) -> *mut ProxyBase {
+        let mut state = self.state.lock().expect("Failed to lock state");
+        // Check if pre-configured
+        if let Some(&ptr) = state.proxies.get(interface_id) {
+            return ptr;
+        }
+        // Allocate new
+        let proxy = Box::new(Proxy {});
+        let ptr = Box::into_raw(proxy) as *mut ProxyBase;
+        state.proxies.insert(interface_id.to_string(), ptr);
+        ptr
     }
 
     // Creates a new SkeletonBase instance and returns a pointer to it.
-    // The actual content is not important for the mock, so we return zeroed instances.
+    // If a skeleton was pre-configured via set_skeleton for this interface_id, returns that.
+    // Otherwise allocates a new one and tracks it.
     unsafe fn create_skeleton(
         &self,
-        _interface_id: &str,
+        interface_id: &str,
         _instance_spec: *const NativeInstanceSpecifier,
     ) -> *mut SkeletonBase {
-        unsafe { Box::into_raw(Box::new(std::mem::zeroed::<SkeletonBase>())) }
+        let mut state = self.state.lock().expect("Failed to lock state");
+        // Check if pre-configured
+        if let Some(&ptr) = state.skeletons.get(interface_id) {
+            return ptr;
+        }
+        // Allocate new
+        let skeleton = Box::new(Skeleton {});
+        let ptr = Box::into_raw(skeleton) as *mut SkeletonBase;
+        state.skeletons.insert(interface_id.to_string(), ptr);
+        ptr
     }
 
     // Destroys a ProxyBase instance created by create_proxy.
     unsafe fn destroy_proxy(&self, proxy_ptr: *mut ProxyBase) {
         if !proxy_ptr.is_null() {
-            // SAFETY: proxy_ptr was allocated by create_proxy via Box::into_raw
+            let mut state = self.state.lock().expect("Failed to lock state");
+            // Find and remove by value
+            state.proxies.retain(|_k, &mut v| v != proxy_ptr);
+            // Now safe to drop
             unsafe { drop(Box::from_raw(proxy_ptr)) };
         }
     }
@@ -207,7 +366,10 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
     // Destroys a SkeletonBase instance created by create_skeleton.
     unsafe fn destroy_skeleton(&self, skeleton_ptr: *mut SkeletonBase) {
         if !skeleton_ptr.is_null() {
-            // SAFETY: skeleton_ptr was allocated by create_skeleton via Box::into_raw
+            let mut state = self.state.lock().expect("Failed to lock state");
+            // Find and remove by value
+            state.skeletons.retain(|_k, &mut v| v != skeleton_ptr);
+            // Now safe to drop
             unsafe { drop(Box::from_raw(skeleton_ptr)) };
         }
     }
@@ -217,32 +379,47 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
     unsafe fn get_event_from_proxy(
         &self,
         proxy_ptr: *mut ProxyBase,
-        _interface_id: &str,
-        _event_id: &str,
+        interface_id: &str,
+        event_id: &str,
     ) -> *mut ProxyEventBase {
         if proxy_ptr.is_null() {
             return std::ptr::null_mut();
         }
-        // ProxyEventBase is a ZST opaque type; a non-null sentinel is sufficient.
-        // LIMITATION: The returned pointer is intentionally dangling and must NOT be
-        // dereferenced. It is only valid as a non-null sentinel for null-checks in the
-        // mock. Any test that dereferences this pointer will trigger undefined behavior.
-        std::ptr::NonNull::<ProxyEventBase>::dangling().as_ptr()
+        let mut state = self.state.lock().expect("Failed to lock state");
+        let event_key = format!("{}::{}", interface_id, event_id);
+        // Check if pre-configured
+        if let Some(&ptr) = state.proxy_events.get(&event_key) {
+            return ptr;
+        }
+        // Allocate new
+        let event = Box::new(Event {});
+        let ptr = Box::into_raw(event) as *mut ProxyEventBase;
+        state.proxy_events.insert(event_key, ptr);
+        ptr
     }
 
     // The following method returns a non-null sentinel pointer for the event
     // if the input skeleton pointer is non-null, simulating successful event retrieval.
     unsafe fn get_event_from_skeleton(
         &self,
-        _skeleton_ptr: *mut SkeletonBase,
-        _interface_id: &str,
-        _event_id: &str,
+        skeleton_ptr: *mut SkeletonBase,
+        interface_id: &str,
+        event_id: &str,
     ) -> *mut SkeletonEventBase {
-        // SkeletonEventBase is a ZST opaque type; a non-null sentinel is sufficient.
-        // LIMITATION: The returned pointer is intentionally dangling and must NOT be
-        // dereferenced. It is only valid as a non-null sentinel for null-checks in the
-        // mock. Any test that dereferences this pointer will trigger undefined behavior.
-        std::ptr::NonNull::<SkeletonEventBase>::dangling().as_ptr()
+        if skeleton_ptr.is_null() {
+            return std::ptr::null_mut();
+        }
+        let mut state = self.state.lock().expect("Failed to lock state");
+        let event_key = format!("{}::{}", interface_id, event_id);
+        // Check if pre-configured
+        if let Some(&ptr) = state.skeleton_events.get(&event_key) {
+            return ptr;
+        }
+        // Allocate new
+        let event = Box::new(Event {});
+        let ptr = Box::into_raw(event) as *mut SkeletonEventBase;
+        state.skeleton_events.insert(event_key, ptr);
+        ptr
     }
 
     // The following methods simulate event subscription and handling based on null-checks of input pointers.
@@ -253,10 +430,15 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         _callback: &FatPtr,
         _max_samples: u32,
     ) -> u32 {
-        if event_ptr.is_null() {
-            return u32::MAX;
+        match self
+            .state
+            .lock()
+            .expect("Failed to lock state")
+            .max_sample_count
+        {
+            Some(count) if !event_ptr.is_null() => count.get() as u32,
+            _ => 0,
         }
-        0
     }
 
     // The following method simulates event sending based on null-check of the event pointer.
@@ -307,12 +489,12 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         _callback: &FatPtr,
         _instance_spec: InstanceSpecifier,
     ) -> *mut FindServiceHandle {
-        unsafe { Box::into_raw(Box::new(std::mem::zeroed::<FindServiceHandle>())) }
+        Box::into_raw(Box::new(unsafe { std::mem::zeroed::<FindServiceHandle>() }))
     }
 
+    // The following method simulates stopping service discovery. Since this is a mock, it simply drops the handle.
     unsafe fn stop_find_service(&self, handle: *mut FindServiceHandle) {
         if !handle.is_null() {
-            // SAFETY: handle was allocated by start_find_service via Box::into_raw
             unsafe { drop(Box::from_raw(handle)) };
         }
     }
@@ -329,81 +511,5 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         _index: usize,
     ) -> Option<&'a HandleType> {
         None
-    }
-}
-
-impl MockFFIBridge {
-    // The handle container is backed by a heap-allocated zeroed stub so the pointer
-    // is stable and non-dangling.  An extra `Arc` clone is intentionally forgotten
-    // inside this function so the strong count is permanently pinned above zero —
-    // meaning `HandleContainer::drop` (which calls real C++) is never invoked
-    // regardless of how many clones the caller makes or drops.
-    pub fn make_handle_container() -> std::sync::Arc<HandleContainer> {
-        // A dangling non-null sentinel: the inner pointer is never passed to C++ because
-        // MockFFIBridge::handle_container_size / handle_container_get_at always return 0 / None.
-        // LIMITATION: `ptr` is intentionally dangling and must NOT be dereferenced.
-        // It is safe only because the mock's handle_container_size / handle_container_get_at
-        // implementations never expose or forward this pointer to any code that would read it.
-        // Tests must not call any real C++ handle-container operations on the returned Arc.
-        let ptr = std::ptr::NonNull::<NativeHandleContainer>::dangling().as_ptr();
-        let hc = std::sync::Arc::new(HandleContainer::new(ptr));
-        // Prevent HandleContainer::drop (which would call real C++ delete) by pinning the refcount.
-        std::mem::forget(std::sync::Arc::clone(&hc));
-        hc
-    }
-
-    // `ProxyEventBase` is a ZST opaque type, a dangling non-null pointer is the
-    // canonical representation for "valid but empty" in the mock.
-    //
-    // LIMITATION: The returned pointer is intentionally dangling and must NOT be
-    // dereferenced. Tests may only use it as a non-null sentinel (e.g., to satisfy
-    // null-checks in other mock methods). Dereferencing it is undefined behavior.
-    pub fn make_proxy_event_ptr() -> *mut ProxyEventBase {
-        std::ptr::NonNull::<ProxyEventBase>::dangling().as_ptr()
-    }
-
-    // Registers type `T` as the backing type for the next `get_allocatee_ptr` /
-    // `get_allocatee_data_ptr` cycle.
-    // Heap-allocates a `MaybeUninit<T>` buffer whose address is returned by
-    // `get_allocatee_data_ptr`, and records `size_of::<SampleAllocateePtr<T>>()` so that
-    // `get_allocatee_ptr` can zero-fill the caller's slot (making `assume_init()` safe).
-    pub fn set_alloc_backing<T: 'static>(&self) {
-        use sample_allocatee_ptr_rs::SampleAllocateePtr;
-        let data_ptr =
-            Box::into_raw(Box::new(std::mem::MaybeUninit::<T>::uninit())) as *mut std::ffi::c_void;
-        // Drop glue: frees the MaybeUninit<T> box without running T's destructor.
-        let drop_fn: fn(*mut std::ffi::c_void) = |p| {
-            // SAFETY: p was allocated as Box<MaybeUninit<T>> by set_alloc_backing::<T>.
-            drop(unsafe { Box::from_raw(p as *mut std::mem::MaybeUninit<T>) });
-        };
-        // Replace any previous backing - Drop trait automatically cleans up the old entry
-        *self
-            .data_backing
-            .lock()
-            .expect("Failed to lock data_backing") = Some(BackingEntry {
-            ptr: data_ptr,
-            drop_fn,
-        });
-        *self.alloc_size.lock().expect("Failed to lock alloc_size") =
-            std::mem::size_of::<SampleAllocateePtr<T>>();
-    }
-
-    // Registers `data` as the backing value for the next `sample_ptr_get` /
-    // `sample_ptr_delete` cycle.
-    //
-    // Heap-allocates `data` and stores a typed drop-glue so `sample_ptr_delete`
-    // can free it without knowing `T`. `sample_ptr_get` returns the pointer to
-    // the heap `T`, making `get_data()` return a valid `&T`.
-    pub fn set_sample_backing<T: 'static>(&self, data: T) {
-        let ptr = Box::into_raw(Box::new(data)) as *mut std::ffi::c_void;
-        let drop_fn: fn(*mut std::ffi::c_void) = |p| {
-            // SAFETY: p was allocated as Box<T> by set_sample_backing::<T>.
-            drop(unsafe { Box::from_raw(p as *mut T) });
-        };
-        // Replace any previous backing - Drop trait automatically cleans up the old entry
-        *self
-            .sample_backing
-            .lock()
-            .expect("Failed to lock sample_backing") = Some(BackingEntry { ptr, drop_fn });
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -16,9 +16,6 @@
 // As of now, it just provide basic mock implementation and returning values based on
 // input parameters. In future, we will enhance this mock implementation to verify
 // all the test cases and scenarios.
-#![doc(hidden)]
-#![allow(clippy::missing_safety_doc)]
-
 use bridge_ffi_rs::{
     FatPtr, FindServiceHandle, HandleContainer, HandleType, InstanceSpecifier,
     NativeHandleContainer, NativeInstanceSpecifier, ProxyBase, ProxyEventBase, SkeletonBase,
@@ -26,32 +23,79 @@ use bridge_ffi_rs::{
 };
 use std::cell::RefCell;
 
-/// Holds a heap-allocated pointer and its associated drop function.
-/// Used for type-erased heap allocations in the mock FFI bridge.
+// Holds a heap-allocated pointer and its associated drop function.
+// Used for type-erased heap allocations in the mock FFI bridge.
+#[derive(Clone)]
 struct BackingEntry {
-    /// Pointer to the heap-allocated data
+    // Pointer to the heap-allocated data
     ptr: *mut std::ffi::c_void,
-    /// Drop function that knows how to properly free the data
+    // Drop function that knows how to properly free the data
     drop_fn: fn(*mut std::ffi::c_void),
 }
 
-// The thread-local storage is used to hold the backing data for the mock FFI bridge.
-thread_local! {
-    //DATA_BACKING holds a pointer to the heap-allocated backing data and a drop function to free it.
-    //We are using this when user calls get_allocatee_data_ptr to return a pointer to this backing data.
-    static DATA_BACKING: RefCell<Option<BackingEntry>> = RefCell::new(None);
-    //ALLOC_SIZE holds the size of the allocatee type for the next get_allocatee_ptr call, allowing
-    //the mock to zero-fill the caller's slot correctly.
-    static ALLOC_SIZE: RefCell<usize> = const { RefCell::new(0) };
-    //SAMPLE_BACKING holds a pointer to the heap-allocated sample data and a drop function to free it.
-    static SAMPLE_BACKING: RefCell<Option<BackingEntry>> = RefCell::new(None);
+// SAFETY: BackingEntry is only used within MockFFIBridge which controls access via Mutex.
+// The pointer is heap-allocated and the drop_fn ensures proper cleanup.
+unsafe impl Send for BackingEntry {}
+unsafe impl Sync for BackingEntry {}
+
+impl std::fmt::Debug for BackingEntry {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("BackingEntry").finish()
+    }
 }
 
+impl Drop for BackingEntry {
+    fn drop(&mut self) {
+        // SAFETY: The drop_fn knows the actual type of the pointer and was stored
+        // when the pointer was allocated (in set_alloc_backing or set_sample_backing).
+        // The drop_fn will properly free the heap allocation.
+        (self.drop_fn)(self.ptr);
+    }
+}
+
+// Mock FFI Bridge with instance state for testing.
+//
+// FFIBridge trait requires Clone - when Runtime creates a consumer/producer, it clones
+// the bridge instance.
+// RefCell<...> provides interior mutability: FFIBridge trait methods take &self (not &mut self)
+// To match this signature while mutating internal state (e.g., storing/retrieving mock data),
+// we need interior mutability.
 #[derive(Debug, Clone)]
-pub struct MockFFIBridge;
+pub struct MockFFIBridge {
+    //DATA_BACKING holds a pointer to the heap-allocated backing data and a drop function to free it.
+    //We are using this when user calls get_allocatee_data_ptr to return a pointer to this backing data.
+    data_backing: RefCell<Option<BackingEntry>>,
+    //ALLOC_SIZE holds the size of the allocatee type for the next get_allocatee_ptr call, allowing
+    //the mock to zero-fill the caller's slot correctly.
+    alloc_size: RefCell<usize>,
+    //SAMPLE_BACKING holds a pointer to the heap-allocated sample data and a drop function to free it.
+    sample_backing: RefCell<Option<BackingEntry>>,
+}
+
+// SAFETY: MockFFIBridge is safe to Send because each test will typically use its own instance of MockFFIBridge,
+// so there is no shared mutable state across threads.
+unsafe impl Send for MockFFIBridge {}
+
+// SAFETY: MockFFIBridge is safe to Sync because it uses RefCell for interior mutability,
+// which is not thread-safe.
+// However, each test will use its own instance of MockFFIBridge and will not share it across threads.
+unsafe impl Sync for MockFFIBridge {}
+
+impl Default for MockFFIBridge {
+    fn default() -> Self {
+        Self {
+            data_backing: RefCell::new(None),
+            alloc_size: RefCell::new(0),
+            sample_backing: RefCell::new(None),
+        }
+    }
+}
 
 impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
+    // Return value based on null-check of input pointers, simulating success/failure of FFI calls.
+    // Also alloc_ptr is zero-filled if size is set.
     unsafe fn get_allocatee_ptr(
+        &self,
         event_ptr: *mut SkeletonEventBase,
         allocatee_ptr: *mut std::ffi::c_void,
         _event_type: &str,
@@ -59,36 +103,38 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         if event_ptr.is_null() || allocatee_ptr.is_null() {
             return false;
         }
-        let size = ALLOC_SIZE.with(|s| *s.borrow());
+        let size = *self.alloc_size.borrow();
         if size == 0 {
             return false;
         }
-       unsafe { std::ptr::write_bytes(allocatee_ptr as *mut u8, 0, size) };
+        unsafe { std::ptr::write_bytes(allocatee_ptr as *mut u8, 0, size) };
         true
     }
 
-    unsafe fn delete_allocatee_ptr(_allocatee_ptr: *mut std::ffi::c_void, _type_name: &str) {
-        DATA_BACKING.with(|d| {
-            if let Some(entry) = d.borrow_mut().take() {
-                (entry.drop_fn)(entry.ptr);
-            }
-        });
-        ALLOC_SIZE.with(|s| *s.borrow_mut() = 0);
+    // Deletes the heap-allocated backing data for the current allocatee, if any, and resets alloc_size.
+    unsafe fn delete_allocatee_ptr(&self, _allocatee_ptr: *mut std::ffi::c_void, _type_name: &str) {
+        if let Some(entry) = self.data_backing.borrow_mut().take() {
+            (entry.drop_fn)(entry.ptr);
+        }
+        *self.alloc_size.borrow_mut() = 0;
     }
 
+    // Returns a pointer to the heap-allocated backing data for the current allocatee, if any.
     unsafe fn get_allocatee_data_ptr(
+        &self,
         _allocatee_ptr: *const std::ffi::c_void,
         _type_name: &str,
     ) -> *mut std::ffi::c_void {
-        DATA_BACKING.with(|d| {
-            d.borrow()
-                .as_ref()
-                .map(|entry| entry.ptr)
-                .unwrap_or(std::ptr::null_mut())
-        })
+        self.data_backing
+            .borrow()
+            .as_ref()
+            .map(|entry| entry.ptr)
+            .unwrap_or(std::ptr::null_mut())
     }
 
+    // Returns true if event_ptr is non-null, simulating successful event sending.
     unsafe fn skeleton_event_send_sample_allocatee(
+        &self,
         event_ptr: *mut SkeletonEventBase,
         _event_type: &str,
         _allocatee_ptr: *const std::ffi::c_void,
@@ -96,58 +142,70 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         !event_ptr.is_null()
     }
 
+    // Returns a pointer to the heap-allocated sample data for the current sample from the mock, if any.
     unsafe fn sample_ptr_get(
+        &self,
         _sample_ptr: *const std::ffi::c_void,
         _type_name: &str,
     ) -> *const std::ffi::c_void {
-        SAMPLE_BACKING.with(|s| {
-            s.borrow()
-                .as_ref()
-                .map(|entry| entry.ptr as *const std::ffi::c_void)
-                .unwrap_or(std::ptr::null())
-        })
+        self.sample_backing
+            .borrow()
+            .as_ref()
+            .map(|entry| entry.ptr as *const std::ffi::c_void)
+            .unwrap_or(std::ptr::null())
     }
 
-    unsafe fn sample_ptr_delete(_sample_ptr: *mut std::ffi::c_void, _type_name: &str) {
-        SAMPLE_BACKING.with(|s| {
-            if let Some(entry) = s.borrow_mut().take() {
-                (entry.drop_fn)(entry.ptr);
-            }
-        });
+    // Deletes the heap-allocated sample backing data for the current sample, if any.
+    unsafe fn sample_ptr_delete(&self, _sample_ptr: *mut std::ffi::c_void, _type_name: &str) {
+        if let Some(entry) = self.sample_backing.borrow_mut().take() {
+            (entry.drop_fn)(entry.ptr);
+        }
     }
 
-    unsafe fn skeleton_offer_service(skeleton_ptr: *mut SkeletonBase) -> bool {
+    // The following methods simulate success/failure based on null-checks of input pointers.
+    unsafe fn skeleton_offer_service(&self, skeleton_ptr: *mut SkeletonBase) -> bool {
         !skeleton_ptr.is_null()
     }
 
-    unsafe fn skeleton_stop_offer_service(_skeleton_ptr: *mut SkeletonBase) {}
+    // This mock does not track offered services, so stop_offer_service is a no-op.
+    unsafe fn skeleton_stop_offer_service(&self, _skeleton_ptr: *mut SkeletonBase) {}
 
-    unsafe fn create_proxy(_interface_id: &str, _handle_ptr: &HandleType) -> *mut ProxyBase {
+    // Creates a new ProxyBase instance and returns a pointer to it.
+    // The actual content is not important for the mock, so we return zeroed instances.
+    unsafe fn create_proxy(&self, _interface_id: &str, _handle_ptr: &HandleType) -> *mut ProxyBase {
         unsafe { Box::into_raw(Box::new(std::mem::zeroed::<ProxyBase>())) }
     }
 
+    // Creates a new SkeletonBase instance and returns a pointer to it.
+    // The actual content is not important for the mock, so we return zeroed instances.
     unsafe fn create_skeleton(
+        &self,
         _interface_id: &str,
         _instance_spec: *const NativeInstanceSpecifier,
     ) -> *mut SkeletonBase {
         unsafe { Box::into_raw(Box::new(std::mem::zeroed::<SkeletonBase>())) }
     }
 
-    unsafe fn destroy_proxy(proxy_ptr: *mut ProxyBase) {
+    // Destroys a ProxyBase instance created by create_proxy.
+    unsafe fn destroy_proxy(&self, proxy_ptr: *mut ProxyBase) {
         if !proxy_ptr.is_null() {
             // SAFETY: proxy_ptr was allocated by create_proxy via Box::into_raw
             unsafe { drop(Box::from_raw(proxy_ptr)) };
         }
     }
 
-    unsafe fn destroy_skeleton(skeleton_ptr: *mut SkeletonBase) {
+    // Destroys a SkeletonBase instance created by create_skeleton.
+    unsafe fn destroy_skeleton(&self, skeleton_ptr: *mut SkeletonBase) {
         if !skeleton_ptr.is_null() {
             // SAFETY: skeleton_ptr was allocated by create_skeleton via Box::into_raw
             unsafe { drop(Box::from_raw(skeleton_ptr)) };
         }
     }
 
+    // The following methods return non-null sentinel pointers for events
+    // if the input proxy/skeleton pointer is non-null, simulating successful event retrieval.
     unsafe fn get_event_from_proxy(
+        &self,
         proxy_ptr: *mut ProxyBase,
         _interface_id: &str,
         _event_id: &str,
@@ -162,7 +220,10 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         std::ptr::NonNull::<ProxyEventBase>::dangling().as_ptr()
     }
 
+    // The following method returns a non-null sentinel pointer for the event
+    // if the input skeleton pointer is non-null, simulating successful event retrieval.
     unsafe fn get_event_from_skeleton(
+        &self,
         _skeleton_ptr: *mut SkeletonBase,
         _interface_id: &str,
         _event_id: &str,
@@ -174,7 +235,9 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         std::ptr::NonNull::<SkeletonEventBase>::dangling().as_ptr()
     }
 
+    // The following methods simulate event subscription and handling based on null-checks of input pointers.
     unsafe fn get_samples_from_event(
+        &self,
         event_ptr: *mut ProxyEventBase,
         _event_type: &str,
         _callback: &FatPtr,
@@ -186,7 +249,9 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         0
     }
 
+    // The following method simulates event sending based on null-check of the event pointer.
     unsafe fn skeleton_send_event(
+        &self,
         event_ptr: *mut SkeletonEventBase,
         _event_type: &str,
         _data_ptr: *const std::ffi::c_void,
@@ -194,13 +259,22 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         !event_ptr.is_null()
     }
 
-    unsafe fn subscribe_to_event(event_ptr: *mut ProxyEventBase, _max_sample_count: u32) -> bool {
+    // The following methods simulate event subscription and
+    // handler registration based on null-checks of input pointers.
+    unsafe fn subscribe_to_event(
+        &self,
+        event_ptr: *mut ProxyEventBase,
+        _max_sample_count: u32,
+    ) -> bool {
         !event_ptr.is_null()
     }
 
-    unsafe fn unsubscribe_to_event(_event_ptr: *mut ProxyEventBase) {}
+    // The following method simulates event unsubscription. Since this is a mock,
+    // it does not track subscriptions.
+    unsafe fn unsubscribe_to_event(&self, _event_ptr: *mut ProxyEventBase) {}
 
     unsafe fn set_event_receive_handler(
+        &self,
         proxy_event_ptr: *mut ProxyEventBase,
         _handler: &FatPtr,
         _event_type: &str,
@@ -208,34 +282,42 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         !proxy_event_ptr.is_null()
     }
 
+    // The following method simulates clearing the event receive handler. Since this is a mock,
+    // it does not track handlers, so this is a no-op.
     unsafe fn clear_event_receive_handler(
+        &self,
         _proxy_event_ptr: *mut ProxyEventBase,
         _event_type: &str,
     ) {
     }
 
+    // The following methods simulate service discovery based on null-checks of input pointers.
     unsafe fn start_find_service(
+        &self,
         _callback: &FatPtr,
         _instance_spec: InstanceSpecifier,
     ) -> *mut FindServiceHandle {
-       unsafe { Box::into_raw(Box::new(std::mem::zeroed::<FindServiceHandle>())) }
+        unsafe { Box::into_raw(Box::new(std::mem::zeroed::<FindServiceHandle>())) }
     }
 
-    unsafe fn stop_find_service(handle: *mut FindServiceHandle) {
+    unsafe fn stop_find_service(&self, handle: *mut FindServiceHandle) {
         if !handle.is_null() {
             // SAFETY: handle was allocated by start_find_service via Box::into_raw
-           unsafe { drop(Box::from_raw(handle)) };
+            unsafe { drop(Box::from_raw(handle)) };
         }
     }
 
-    fn handle_container_size(_container: &HandleContainer) -> usize {
+    // Returns the handle count of the container, which is always zero in this mock implementation.
+    fn handle_container_size(&self, _container: &HandleContainer) -> usize {
         0
     }
 
-    fn handle_container_get_at(
-        _container: &HandleContainer,
+    // Returns None for any index, since the container is always empty in this mock implementation.
+    fn handle_container_get_at<'a>(
+        &self,
+        _container: &'a HandleContainer,
         _index: usize,
-    ) -> Option<&HandleType> {
+    ) -> Option<&'a HandleType> {
         None
     }
 }
@@ -275,7 +357,7 @@ impl MockFFIBridge {
     // Heap-allocates a `MaybeUninit<T>` buffer whose address is returned by
     // `get_allocatee_data_ptr`, and records `size_of::<SampleAllocateePtr<T>>()` so that
     // `get_allocatee_ptr` can zero-fill the caller's slot (making `assume_init()` safe).
-    pub fn set_alloc_backing<T: 'static>() {
+    pub fn set_alloc_backing<T: 'static>(&self) {
         use sample_allocatee_ptr_rs::SampleAllocateePtr;
         let data_ptr =
             Box::into_raw(Box::new(std::mem::MaybeUninit::<T>::uninit())) as *mut std::ffi::c_void;
@@ -285,12 +367,14 @@ impl MockFFIBridge {
             drop(unsafe { Box::from_raw(p as *mut std::mem::MaybeUninit<T>) });
         };
         // Replace any previous backing (prevents leaks on repeated calls).
-        DATA_BACKING.with(|d| {
-            if let Some(old_entry) = d.borrow_mut().replace(BackingEntry { ptr: data_ptr, drop_fn }) {
-                (old_entry.drop_fn)(old_entry.ptr);
-            }
-        });
-        ALLOC_SIZE.with(|s| *s.borrow_mut() = std::mem::size_of::<SampleAllocateePtr<T>>());
+        let mut data_backing = self.data_backing.borrow_mut();
+        if let Some(old_entry) = data_backing.replace(BackingEntry {
+            ptr: data_ptr,
+            drop_fn,
+        }) {
+            (old_entry.drop_fn)(old_entry.ptr);
+        }
+        *self.alloc_size.borrow_mut() = std::mem::size_of::<SampleAllocateePtr<T>>();
     }
 
     // Registers `data` as the backing value for the next `sample_ptr_get` /
@@ -299,42 +383,16 @@ impl MockFFIBridge {
     // Heap-allocates `data` and stores a typed drop-glue so `sample_ptr_delete`
     // can free it without knowing `T`. `sample_ptr_get` returns the pointer to
     // the heap `T`, making `get_data()` return a valid `&T`.
-    pub fn set_sample_backing<T: 'static>(data: T) {
+    pub fn set_sample_backing<T: 'static>(&self, data: T) {
         let ptr = Box::into_raw(Box::new(data)) as *mut std::ffi::c_void;
         let drop_fn: fn(*mut std::ffi::c_void) = |p| {
             // SAFETY: p was allocated as Box<T> by set_sample_backing::<T>.
             drop(unsafe { Box::from_raw(p as *mut T) });
         };
         // Replace any previous backing (prevents leaks on repeated calls).
-        SAMPLE_BACKING.with(|s| {
-            if let Some(old_entry) = s.borrow_mut().replace(BackingEntry { ptr, drop_fn }) {
-                (old_entry.drop_fn)(old_entry.ptr);
-            }
-        });
-    }
-
-    // Drops all heap-allocated backing data stored in thread-locals and resets ALLOC_SIZE
-    // to zero.
-    fn reset() {
-        DATA_BACKING.with(|d| {
-            if let Some(entry) = d.borrow_mut().take() {
-                (entry.drop_fn)(entry.ptr);
-            }
-        });
-        ALLOC_SIZE.with(|s| *s.borrow_mut() = 0);
-        SAMPLE_BACKING.with(|s| {
-            if let Some(entry) = s.borrow_mut().take() {
-                (entry.drop_fn)(entry.ptr);
-            }
-        });
-    }
-}
-
-// RAII guard that resets all `MockFFIBridge` thread-local state when it goes out of scope.
-pub struct MockFFIBridgeGuard;
-
-impl Drop for MockFFIBridgeGuard {
-    fn drop(&mut self) {
-        MockFFIBridge::reset();
+        let mut sample_backing = self.sample_backing.borrow_mut();
+        if let Some(old_entry) = sample_backing.replace(BackingEntry { ptr, drop_fn }) {
+            (old_entry.drop_fn)(old_entry.ptr);
+        }
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -11,505 +11,469 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
-// This file provides a mock implementation of the FFIBridge trait for testing purposes.
-// It allows pre-configuring responses for FFI calls and simulates success/failure based on the
-// presence of pre-configured data or null-checks of input pointers.
-// The mock maintains internal state for allocatee backing data, sample backing data, proxies, skeletons, and events.
-// It Provide the ability to set up expected data and behavior for tests using setter methods of the MockFFIBridge struct.
-// We have Skeleton, Proxy and Event unit structs as placeholders for the pointers returned by the mock, allowing us to track and manage these resources in tests
-// and in future we can extend these structs to hold additional metadata if needed for more complex test scenarios.
-// We ensure that all heap-allocated resources are properly freed by implementing Drop for BackingEntry and MockFFIBridgeState,
-// and by using the drop functions stored in BackingEntry to free the correct types of data.
-// This Mock can work as a real FFIBridge implementation and
-// each test can configure the mock with the expected data and behavior for that test,
-// allowing us to test the LolaRuntime and related components in isolation from the actual FFI layer.
-
-// This mock back-end (FFIBridge implementation) is used for unit testing of Lola-Runtime
-// So we do not want to expose this mock in the public API docs and crate level documentation, hence the `doc(hidden)` attribute.
+// This is for internal use only, not part of public API, so we can hide it from crate level docs.
 #![doc(hidden)]
 
+//! Mock implementation of FFIBridge using mockall for type-safe, per-test configuration.
+//!
+//! This provides a mockall-based mock where tests can configure expectations locally.
+//! Uses a hybrid approach: mockall for most methods, with a wrapper for lifetime constraints.
+//! The SharedMockBridge wrapper allows all clones to share the same underlying mock instance and expectations,
+//! eliminating the need for complex clone expectation setup in tests.
+//! Tests can create a SharedMockBridge with a configured MockFFIBridge, and all clones will automatically share the same expectations.
+//! Example usage in a test:
+//! ```rust,ignore
+//! let mut mock = MockFFIBridge::new();
+//! mock.expect_create_proxy()
+//!     .returning(|_, _| Box::into_raw(Box::new(unsafe { std::mem::zeroed() }))); // this is just an example, configure expectations as needed
+//! let bridge = SharedMockBridge::new(mock);
+//! let clone1 = bridge.clone();
+//! let clone2 = bridge.clone();
+//! ```
+//!
+//! This mock back-end is used for unit testing of Lola-Runtime.
+
 use bridge_ffi_rs::{
-    FatPtr, FindServiceHandle, HandleContainer, HandleType, InstanceSpecifier,
-    NativeInstanceSpecifier, ProxyBase, ProxyEventBase, SkeletonBase, SkeletonEventBase,
+    FatPtr, FindServiceHandle, HandleType, InstanceSpecifier, NativeInstanceSpecifier, ProxyBase,
+    ProxyEventBase, SkeletonBase, SkeletonEventBase,
 };
-use std::collections::HashMap;
-use std::ffi::c_void;
-use std::mem::size_of;
-use std::num::NonZeroUsize;
-use std::sync::{Arc, Mutex};
+use mockall::mock;
 
-// Unit types for mock objects, kept for future extensibility and clarity
-struct Event {}
+// Internal mockall-generated mock (without the lifetime method)
+mock! {
+    // This is type name for mock macro, it is not the same as FFIBridge trait,
+    // This will produce a struct named MockFFIBridge which implements FFIBridge trait.
+    #[derive(Debug)]
+    pub FFIBridge {}
 
-struct Proxy {}
-
-struct Skeleton {}
-
-// Holds a heap-allocated pointer and its associated drop function.
-// Used for type-erased heap allocations in the mock FFI bridge.
-#[derive(Clone)]
-struct BackingEntry {
-    // Pointer to the heap-allocated data
-    ptr: *mut std::ffi::c_void,
-    // Drop function that knows how to properly free the data
-    drop_fn: fn(*mut std::ffi::c_void),
-    // Size of the allocation
-    size: usize,
-}
-
-// SAFETY: BackingEntry is safe to Send because the drop_fn ensures that the heap allocation is properly freed,
-// and the pointer is only accessed through the mock's controlled methods which enforce thread safety via Mutex.
-// No mutbale operation on the pointer is exposed to the caller,
-// and the mock's internal methods ensure that any access to the pointer is thread-safe.
-unsafe impl Send for BackingEntry {}
-
-impl std::fmt::Debug for BackingEntry {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("BackingEntry").finish()
+    impl Clone for FFIBridge {
+        fn clone(&self) -> Self;
     }
+    // SAFETY comment for unsafe function already provided in the trait definition, it is impl block of that trait, so we don't need to repeat it here.
+    impl bridge_ffi_rs::FFIBridge for FFIBridge {
+        unsafe fn get_allocatee_ptr(
+            &self,
+            event_ptr: *mut SkeletonEventBase,
+            allocatee_ptr: *mut std::ffi::c_void,
+            event_type: &str,
+        ) -> bool;
+
+        unsafe fn delete_allocatee_ptr(&self, allocatee_ptr: *mut std::ffi::c_void, type_name: &str);
+
+        unsafe fn get_allocatee_data_ptr(
+            &self,
+            allocatee_ptr: *const std::ffi::c_void,
+            type_name: &str,
+        ) -> *mut std::ffi::c_void;
+
+        unsafe fn skeleton_event_send_sample_allocatee(
+            &self,
+            event_ptr: *mut SkeletonEventBase,
+            event_type: &str,
+            allocatee_ptr: *const std::ffi::c_void,
+        ) -> bool;
+
+        unsafe fn sample_ptr_get(
+            &self,
+            sample_ptr: *const std::ffi::c_void,
+            type_name: &str,
+        ) -> *const std::ffi::c_void;
+
+        unsafe fn sample_ptr_delete(&self, sample_ptr: *mut std::ffi::c_void, type_name: &str);
+
+        unsafe fn skeleton_offer_service(&self, skeleton_ptr: *mut SkeletonBase) -> bool;
+
+        unsafe fn skeleton_stop_offer_service(&self, skeleton_ptr: *mut SkeletonBase);
+
+        unsafe fn create_proxy(&self, interface_id: &str, handle_ptr: &HandleType) -> *mut ProxyBase;
+
+        unsafe fn create_skeleton(
+            &self,
+            interface_id: &str,
+            instance_spec: *const NativeInstanceSpecifier,
+        ) -> *mut SkeletonBase;
+
+        unsafe fn destroy_proxy(&self, proxy_ptr: *mut ProxyBase);
+
+        unsafe fn destroy_skeleton(&self, skeleton_ptr: *mut SkeletonBase);
+
+        unsafe fn get_event_from_proxy(
+            &self,
+            proxy_ptr: *mut ProxyBase,
+            interface_id: &str,
+            event_id: &str,
+        ) -> *mut ProxyEventBase;
+
+        unsafe fn get_event_from_skeleton(
+            &self,
+            skeleton_ptr: *mut SkeletonBase,
+            interface_id: &str,
+            event_id: &str,
+        ) -> *mut SkeletonEventBase;
+
+        unsafe fn get_samples_from_event(
+            &self,
+            event_ptr: *mut ProxyEventBase,
+            event_type: &str,
+            callback: &FatPtr,
+            max_samples: u32,
+        ) -> u32;
+
+        unsafe fn skeleton_send_event(
+            &self,
+            event_ptr: *mut SkeletonEventBase,
+            event_type: &str,
+            data_ptr: *const std::ffi::c_void,
+        ) -> bool;
+
+        unsafe fn subscribe_to_event(
+            &self,
+            event_ptr: *mut ProxyEventBase,
+            max_sample_count: u32,
+        ) -> bool;
+
+        unsafe fn unsubscribe_to_event(&self, event_ptr: *mut ProxyEventBase);
+
+        unsafe fn set_event_receive_handler(
+            &self,
+            proxy_event_ptr: *mut ProxyEventBase,
+            handler: &FatPtr,
+            event_type: &str,
+        ) -> bool;
+
+        unsafe fn clear_event_receive_handler(
+            &self,
+            proxy_event_ptr: *mut ProxyEventBase,
+            event_type: &str,
+        );
+
+        unsafe fn start_find_service(
+            &self,
+            callback: &FatPtr,
+            instance_spec: InstanceSpecifier,
+        ) -> *mut FindServiceHandle;
+
+        unsafe fn stop_find_service(&self, handle: *mut FindServiceHandle);
+}
 }
 
-impl Drop for BackingEntry {
-    fn drop(&mut self) {
-        // SAFETY: The drop_fn knows the actual type of the pointer and was stored
-        // when the pointer was allocated (in set_alloc_backing or set_sample_backing).
-        // The drop_fn will properly free the heap allocation.
-        (self.drop_fn)(self.ptr);
-    }
-}
-
-// Mock FFI Bridge with instance state for testing.
-//
-// FFIBridge trait requires Clone - when Runtime creates a consumer/producer, it clones
-// the bridge instance.
-// Arc<Mutex<...>> provides thread-safe interior mutability: FFIBridge trait methods take &self (not &mut self)
-// To match this signature while mutating internal state (e.g., storing/retrieving mock data),
-// we need interior mutability. Arc<Mutex<...>> ensures thread safety at the cost of some performance,
-// which is acceptable for test code where safety is more important than performance.
-/// Thread-safe, test-isolated FFI bridge mock
-#[derive(Debug, Clone, Default)]
-pub struct MockFFIBridge {
-    state: Arc<Mutex<MockFFIBridgeState>>,
-}
-
+/// A shared wrapper around MockFFIBridge that automatically shares expectations across clones.
+///
+/// This wrapper uses Arc<Mutex<MockFFIBridge>> internally, allowing all clones to share
+/// the same underlying mock instance and its expectations. This eliminates the need for
+/// complex clone expectation setup in tests.
+///
+/// # Usage
+/// ```rust,ignore
+/// let mut mock = MockFFIBridge::new();
+/// mock.expect_create_proxy()
+///     .returning(|_, _| Box::into_raw(Box::new(unsafe { std::mem::zeroed() })));
+///
+/// let bridge = SharedMockBridge::new(mock);
+/// // All clones automatically share the same expectations
+/// let clone1 = bridge.clone();
+/// let clone2 = bridge.clone();
+/// ```
 #[derive(Debug, Default)]
-struct MockFFIBridgeState {
-    allocatee_backing: HashMap<String, BackingEntry>,
-    sample_backing: HashMap<String, BackingEntry>,
-    max_sample_count: Option<NonZeroUsize>,
-    proxies: HashMap<String, *mut ProxyBase>,
-    skeletons: HashMap<String, *mut SkeletonBase>,
-    proxy_events: HashMap<String, *mut ProxyEventBase>,
-    skeleton_events: HashMap<String, *mut SkeletonEventBase>,
-}
+pub struct SharedMockBridge(std::sync::Arc<std::sync::Mutex<MockFFIBridge>>);
 
-// SAFETY: MockFFIBridgeState is safe to Send because all access to its internal state is protected by a Mutex,
-// Implementation in runtime handles the concurrent access and mutable access.
-unsafe impl Send for MockFFIBridgeState {}
-
-impl MockFFIBridge {
-    pub fn new() -> Self {
-        Self {
-            state: Arc::new(Mutex::new(MockFFIBridgeState::default())),
-        }
-    }
-    /// Pre-configure heap-allocated backing data for an allocatee of a specific event type.
-    pub fn set_allocatee_backing<T: 'static>(&self, event_type: &str, value: T) {
-        let boxed = Box::new(value);
-        let ptr = Box::into_raw(boxed) as *mut c_void;
-
-        let entry = BackingEntry {
-            ptr,
-            drop_fn: |p| unsafe {
-                drop(Box::from_raw(p as *mut T));
-            },
-            size: size_of::<T>(),
-        };
-
-        let mut state = self.state.lock().expect("Failed to lock state");
-        state
-            .allocatee_backing
-            .insert(event_type.to_string(), entry);
+impl SharedMockBridge {
+    /// Create a new SharedMockBridge wrapping the given MockFFIBridge
+    pub fn new(mock: MockFFIBridge) -> Self {
+        Self(std::sync::Arc::new(std::sync::Mutex::new(mock)))
     }
 
-    /// Pre-configure heap-allocated backing data for a sample of a specific type.
-    pub fn set_sample_backing<T: 'static>(&self, type_name: &str, value: T) {
-        let boxed = Box::new(value);
-        let ptr = Box::into_raw(boxed) as *mut c_void;
-
-        let entry = BackingEntry {
-            ptr,
-            drop_fn: |p| unsafe {
-                drop(Box::from_raw(p as *mut T));
-            },
-            size: size_of::<T>(),
-        };
-
-        let mut state = self.state.lock().expect("Failed to lock state");
-        state.sample_backing.insert(type_name.to_string(), entry);
-    }
-
-    /// Configure the maximum sample count.
-    pub fn set_max_sample_count(&self, count: Option<NonZeroUsize>) {
-        self.state
-            .lock()
-            .expect("Failed to lock state")
-            .max_sample_count = count;
-    }
-
-    /// Pre-configure a proxy for a specific interface type.
-    /// Returns the pointer that will be returned by create_proxy for this interface_id.
-    pub fn set_proxy(&self, interface_id: &str) -> *mut ProxyBase {
-        let proxy = Box::new(Proxy {});
-        let ptr = Box::into_raw(proxy) as *mut ProxyBase;
-        self.state
-            .lock()
-            .expect("Failed to lock state")
-            .proxies
-            .insert(interface_id.to_string(), ptr);
-        ptr
-    }
-
-    /// Pre-configure a skeleton for a specific interface type.
-    /// Returns the pointer that will be returned by create_skeleton for this interface_id.
-    pub fn set_skeleton(&self, interface_id: &str) -> *mut SkeletonBase {
-        let skeleton = Box::new(Skeleton {});
-        let ptr = Box::into_raw(skeleton) as *mut SkeletonBase;
-        self.state
-            .lock()
-            .expect("Failed to lock state")
-            .skeletons
-            .insert(interface_id.to_string(), ptr);
-        ptr
-    }
-
-    /// Pre-configure a proxy event.
-    /// Returns the pointer that can be used for proxy event operations.
-    pub fn set_proxy_event(&self, interface_id: &str, event_id: &str) -> *mut ProxyEventBase {
-        let event = Box::new(Event {});
-        let ptr = Box::into_raw(event) as *mut ProxyEventBase;
-        let event_key = format!("{}::{}", interface_id, event_id);
-        self.state
-            .lock()
-            .expect("Failed to lock state")
-            .proxy_events
-            .insert(event_key.to_string(), ptr);
-        ptr
-    }
-
-    /// Pre-configure a skeleton event.
-    /// Returns the pointer that will be returned by create_skeleton_event for this interface_id and event_id.
-    pub fn set_skeleton_event(&self, interface_id: &str, event_id: &str) -> *mut SkeletonEventBase {
-        let event = Box::new(Event {});
-        let ptr = Box::into_raw(event) as *mut SkeletonEventBase;
-        let event_key = format!("{}::{}", interface_id, event_id);
-        self.state
-            .lock()
-            .expect("Failed to lock state")
-            .skeleton_events
-            .insert(event_key.to_string(), ptr);
-        ptr
+    /// Access the inner MockFFIBridge for verification and assertions.
+    ///
+    /// This is useful for calling mockall's methods like `assert` on the inner mock after the test actions.
+    pub fn with_mock<F, R>(&self, f: F) -> R
+    where
+        F: FnOnce(&mut MockFFIBridge) -> R,
+    {
+        let mut guard = self.0.lock().expect("Failed to acquire lock");
+        f(&mut *guard)
     }
 }
 
-impl Drop for MockFFIBridgeState {
-    fn drop(&mut self) {
-        // Cleanup any leaked resources
-        unsafe {
-            for (_key, ptr) in self.proxies.drain() {
-                drop(Box::from_raw(ptr));
-            }
-            for (_key, ptr) in self.skeletons.drain() {
-                drop(Box::from_raw(ptr));
-            }
-            for (_key, ptr) in self.proxy_events.drain() {
-                drop(Box::from_raw(ptr));
-            }
-            for (_key, ptr) in self.skeleton_events.drain() {
-                drop(Box::from_raw(ptr));
-            }
-        }
+impl Clone for SharedMockBridge {
+    fn clone(&self) -> Self {
+        Self(std::sync::Arc::clone(&self.0))
     }
 }
 
-impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
-    // Return value based on null-check of input pointers, simulating success/failure of FFI calls.
-    // Also alloc_ptr is zero-filled if size is set.
+// Implement FFIBridge by forwarding all calls to the inner MockFFIBridge
+// SAFETY comment for unsafe function already provided in the trait definition, it is impl block of that trait, so we don't need to repeat it here.
+impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
     unsafe fn get_allocatee_ptr(
         &self,
         event_ptr: *mut SkeletonEventBase,
         allocatee_ptr: *mut std::ffi::c_void,
-        _event_type: &str,
+        event_type: &str,
     ) -> bool {
-        if event_ptr.is_null() {
-            return false;
-        }
-        // If we have backing data for this allocatee, copy it into the provided pointer.
-        let state = self.state.lock().expect("Failed to lock state");
-        if let Some(entry) = state.allocatee_backing.get(_event_type) {
-            unsafe {
-                std::ptr::copy_nonoverlapping(entry.ptr, allocatee_ptr, entry.size);
-            }
-            return true;
-        } else {
-            return false;
+        //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .get_allocatee_ptr(event_ptr, allocatee_ptr, event_type)
         }
     }
 
-    // Deletes the heap-allocated backing data for the current allocatee, if any, and resets alloc_size.
-    unsafe fn delete_allocatee_ptr(&self, _allocatee_ptr: *mut std::ffi::c_void, type_name: &str) {
-        let mut state = self.state.lock().expect("Failed to lock state");
-        // Removing the entry from the HashMap will call BackingEntry::drop automatically
-        state.allocatee_backing.remove(type_name);
+    unsafe fn delete_allocatee_ptr(&self, allocatee_ptr: *mut std::ffi::c_void, type_name: &str) {
+        //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .delete_allocatee_ptr(allocatee_ptr, type_name)
+        }
     }
 
-    // Returns a pointer to the heap-allocated backing data for the current allocatee, if any.
     unsafe fn get_allocatee_data_ptr(
         &self,
-        _allocatee_ptr: *const std::ffi::c_void,
+        allocatee_ptr: *const std::ffi::c_void,
         type_name: &str,
     ) -> *mut std::ffi::c_void {
-        let state = self.state.lock().expect("Failed to lock state");
-        if let Some(entry) = state.allocatee_backing.get(type_name) {
-            entry.ptr
-        } else {
-            std::ptr::null_mut()
+        //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .get_allocatee_data_ptr(allocatee_ptr, type_name)
         }
     }
 
-    // Returns true if event_ptr is non-null, simulating successful event sending.
     unsafe fn skeleton_event_send_sample_allocatee(
         &self,
         event_ptr: *mut SkeletonEventBase,
-        _event_type: &str,
-        _allocatee_ptr: *const std::ffi::c_void,
+        event_type: &str,
+        allocatee_ptr: *const std::ffi::c_void,
     ) -> bool {
-        !event_ptr.is_null()
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .skeleton_event_send_sample_allocatee(event_ptr, event_type, allocatee_ptr)
+        }
     }
 
-    // Returns a pointer to the heap-allocated sample data for the current sample from the mock, if any.
     unsafe fn sample_ptr_get(
         &self,
-        _sample_ptr: *const std::ffi::c_void,
-        _type_name: &str,
+        sample_ptr: *const std::ffi::c_void,
+        type_name: &str,
     ) -> *const std::ffi::c_void {
-        let state = self.state.lock().expect("Failed to lock state");
-        if let Some(entry) = state.sample_backing.get(_type_name) {
-            entry.ptr
-        } else {
-            std::ptr::null()
+        //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .sample_ptr_get(sample_ptr, type_name)
         }
     }
 
-    // Deletes the heap-allocated sample backing data for the current sample, if any.
-    unsafe fn sample_ptr_delete(&self, _sample_ptr: *mut std::ffi::c_void, type_name: &str) {
-        let mut state = self.state.lock().expect("Failed to lock state");
-        // Removing the entry from the HashMap will call BackingEntry::drop automatically
-        state.sample_backing.remove(type_name);
+    unsafe fn sample_ptr_delete(&self, sample_ptr: *mut std::ffi::c_void, type_name: &str) {
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .sample_ptr_delete(sample_ptr, type_name)
+        }
     }
 
-    // The following methods simulate success/failure based on null-checks of input pointers.
     unsafe fn skeleton_offer_service(&self, skeleton_ptr: *mut SkeletonBase) -> bool {
-        !skeleton_ptr.is_null()
-    }
-
-    // This mock does not track offered services, so stop_offer_service is a no-op.
-    unsafe fn skeleton_stop_offer_service(&self, _skeleton_ptr: *mut SkeletonBase) {}
-
-    // Creates a new ProxyBase instance and returns a pointer to it.
-    // If a proxy was pre-configured via set_proxy for this interface_id, returns that.
-    // Otherwise allocates a new one and tracks it.
-    unsafe fn create_proxy(&self, interface_id: &str, _handle_ptr: &HandleType) -> *mut ProxyBase {
-        let mut state = self.state.lock().expect("Failed to lock state");
-        // Check if pre-configured
-        if let Some(&ptr) = state.proxies.get(interface_id) {
-            return ptr;
+        //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .skeleton_offer_service(skeleton_ptr)
         }
-        // Allocate new
-        let proxy = Box::new(Proxy {});
-        let ptr = Box::into_raw(proxy) as *mut ProxyBase;
-        state.proxies.insert(interface_id.to_string(), ptr);
-        ptr
     }
 
-    // Creates a new SkeletonBase instance and returns a pointer to it.
-    // If a skeleton was pre-configured via set_skeleton for this interface_id, returns that.
-    // Otherwise allocates a new one and tracks it.
+    unsafe fn skeleton_stop_offer_service(&self, skeleton_ptr: *mut SkeletonBase) {
+        //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .skeleton_stop_offer_service(skeleton_ptr)
+        }
+    }
+
+    unsafe fn create_proxy(&self, interface_id: &str, handle_ptr: &HandleType) -> *mut ProxyBase {
+        //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .create_proxy(interface_id, handle_ptr)
+        }
+    }
+
     unsafe fn create_skeleton(
         &self,
         interface_id: &str,
-        _instance_spec: *const NativeInstanceSpecifier,
+        instance_spec: *const NativeInstanceSpecifier,
     ) -> *mut SkeletonBase {
-        let mut state = self.state.lock().expect("Failed to lock state");
-        // Check if pre-configured
-        if let Some(&ptr) = state.skeletons.get(interface_id) {
-            return ptr;
+        //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .create_skeleton(interface_id, instance_spec)
         }
-        // Allocate new
-        let skeleton = Box::new(Skeleton {});
-        let ptr = Box::into_raw(skeleton) as *mut SkeletonBase;
-        state.skeletons.insert(interface_id.to_string(), ptr);
-        ptr
     }
 
-    // Destroys a ProxyBase instance created by create_proxy.
     unsafe fn destroy_proxy(&self, proxy_ptr: *mut ProxyBase) {
-        if !proxy_ptr.is_null() {
-            let mut state = self.state.lock().expect("Failed to lock state");
-            // Find and remove by value
-            state.proxies.retain(|_k, &mut v| v != proxy_ptr);
-            // Now safe to drop
-            unsafe { drop(Box::from_raw(proxy_ptr)) };
+        //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .destroy_proxy(proxy_ptr)
         }
     }
 
-    // Destroys a SkeletonBase instance created by create_skeleton.
     unsafe fn destroy_skeleton(&self, skeleton_ptr: *mut SkeletonBase) {
-        if !skeleton_ptr.is_null() {
-            let mut state = self.state.lock().expect("Failed to lock state");
-            // Find and remove by value
-            state.skeletons.retain(|_k, &mut v| v != skeleton_ptr);
-            // Now safe to drop
-            unsafe { drop(Box::from_raw(skeleton_ptr)) };
+        //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .destroy_skeleton(skeleton_ptr)
         }
     }
 
-    // The following methods return non-null sentinel pointers for events
-    // if the input proxy/skeleton pointer is non-null, simulating successful event retrieval.
     unsafe fn get_event_from_proxy(
         &self,
         proxy_ptr: *mut ProxyBase,
         interface_id: &str,
         event_id: &str,
     ) -> *mut ProxyEventBase {
-        if proxy_ptr.is_null() {
-            return std::ptr::null_mut();
+        //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .get_event_from_proxy(proxy_ptr, interface_id, event_id)
         }
-        let mut state = self.state.lock().expect("Failed to lock state");
-        let event_key = format!("{}::{}", interface_id, event_id);
-        // Check if pre-configured
-        if let Some(&ptr) = state.proxy_events.get(&event_key) {
-            return ptr;
-        }
-        // Allocate new
-        let event = Box::new(Event {});
-        let ptr = Box::into_raw(event) as *mut ProxyEventBase;
-        state.proxy_events.insert(event_key, ptr);
-        ptr
     }
 
-    // The following method returns a non-null sentinel pointer for the event
-    // if the input skeleton pointer is non-null, simulating successful event retrieval.
     unsafe fn get_event_from_skeleton(
         &self,
         skeleton_ptr: *mut SkeletonBase,
         interface_id: &str,
         event_id: &str,
     ) -> *mut SkeletonEventBase {
-        if skeleton_ptr.is_null() {
-            return std::ptr::null_mut();
-        }
-        let mut state = self.state.lock().expect("Failed to lock state");
-        let event_key = format!("{}::{}", interface_id, event_id);
-        // Check if pre-configured
-        if let Some(&ptr) = state.skeleton_events.get(&event_key) {
-            return ptr;
-        }
-        // Allocate new
-        let event = Box::new(Event {});
-        let ptr = Box::into_raw(event) as *mut SkeletonEventBase;
-        state.skeleton_events.insert(event_key, ptr);
-        ptr
-    }
-
-    // The following methods simulate event subscription and handling based on null-checks of input pointers.
-    unsafe fn get_samples_from_event(
-        &self,
-        event_ptr: *mut ProxyEventBase,
-        _event_type: &str,
-        _callback: &FatPtr,
-        _max_samples: u32,
-    ) -> u32 {
-        match self
-            .state
-            .lock()
-            .expect("Failed to lock state")
-            .max_sample_count
-        {
-            Some(count) if !event_ptr.is_null() => count.get() as u32,
-            _ => 0,
+        //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .get_event_from_skeleton(skeleton_ptr, interface_id, event_id)
         }
     }
 
-    // The following method simulates event sending based on null-check of the event pointer.
-    unsafe fn skeleton_send_event(
-        &self,
-        event_ptr: *mut SkeletonEventBase,
-        _event_type: &str,
-        _data_ptr: *const std::ffi::c_void,
-    ) -> bool {
-        !event_ptr.is_null()
-    }
-
-    // The following methods simulate event subscription and
-    // handler registration based on null-checks of input pointers.
     unsafe fn subscribe_to_event(
         &self,
         event_ptr: *mut ProxyEventBase,
-        _max_sample_count: u32,
+        max_num_samples: u32,
     ) -> bool {
-        !event_ptr.is_null()
-    }
-
-    // The following method simulates event unsubscription. Since this is a mock,
-    // it does not track subscriptions.
-    unsafe fn unsubscribe_to_event(&self, _event_ptr: *mut ProxyEventBase) {}
-
-    unsafe fn set_event_receive_handler(
-        &self,
-        proxy_event_ptr: *mut ProxyEventBase,
-        _handler: &FatPtr,
-        _event_type: &str,
-    ) -> bool {
-        !proxy_event_ptr.is_null()
-    }
-
-    // The following method simulates clearing the event receive handler. Since this is a mock,
-    // it does not track handlers, so this is a no-op.
-    unsafe fn clear_event_receive_handler(
-        &self,
-        _proxy_event_ptr: *mut ProxyEventBase,
-        _event_type: &str,
-    ) {
-    }
-
-    // The following methods simulate service discovery based on null-checks of input pointers.
-    unsafe fn start_find_service(
-        &self,
-        _callback: &FatPtr,
-        _instance_spec: InstanceSpecifier,
-    ) -> *mut FindServiceHandle {
-        Box::into_raw(Box::new(unsafe { std::mem::zeroed::<FindServiceHandle>() }))
-    }
-
-    // The following method simulates stopping service discovery. Since this is a mock, it simply drops the handle.
-    unsafe fn stop_find_service(&self, handle: *mut FindServiceHandle) {
-        if !handle.is_null() {
-            unsafe { drop(Box::from_raw(handle)) };
+        //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .subscribe_to_event(event_ptr, max_num_samples)
         }
     }
 
-    // Returns the handle count of the container, which is always zero in this mock implementation.
-    fn handle_container_size(&self, _container: &HandleContainer) -> usize {
-        0
+    unsafe fn unsubscribe_to_event(&self, event_ptr: *mut ProxyEventBase) {
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .unsubscribe_to_event(event_ptr)
+        }
     }
 
-    // Returns None for any index, since the container is always empty in this mock implementation.
-    fn handle_container_get_at<'a>(
+    unsafe fn get_samples_from_event(
         &self,
-        _container: &'a HandleContainer,
-        _index: usize,
-    ) -> Option<&'a HandleType> {
-        None
+        event_ptr: *mut ProxyEventBase,
+        event_type: &str,
+        callback: &FatPtr,
+        max_num_samples: u32,
+    ) -> u32 {
+        //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .get_samples_from_event(event_ptr, event_type, callback, max_num_samples)
+        }
+    }
+
+    unsafe fn skeleton_send_event(
+        &self,
+        event_ptr: *mut SkeletonEventBase,
+        event_type: &str,
+        data_ptr: *const std::ffi::c_void,
+    ) -> bool {
+        //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .skeleton_send_event(event_ptr, event_type, data_ptr)
+        }
+    }
+
+    unsafe fn set_event_receive_handler(
+        &self,
+        event_ptr: *mut ProxyEventBase,
+        callback: &FatPtr,
+        event_type: &str,
+    ) -> bool {
+        //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .set_event_receive_handler(event_ptr, callback, event_type)
+        }
+    }
+
+    unsafe fn clear_event_receive_handler(&self, event_ptr: *mut ProxyEventBase, event_type: &str) {
+        //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .clear_event_receive_handler(event_ptr, event_type)
+        }
+    }
+
+    unsafe fn start_find_service(
+        &self,
+        callback: &FatPtr,
+        instance_spec: InstanceSpecifier,
+    ) -> *mut FindServiceHandle {
+        //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .start_find_service(callback, instance_spec)
+        }
+    }
+
+    unsafe fn stop_find_service(&self, find_service_handle: *mut FindServiceHandle) {
+        //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
+        unsafe {
+            self.0
+                .lock()
+                .expect("Failed to acquire lock")
+                .stop_find_service(find_service_handle)
+        }
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -26,8 +26,14 @@ use bridge_ffi_rs::{
 };
 use std::cell::RefCell;
 
-// Type alias for the heap-pointer + drop-glue pair stored in backing thread-locals.
-type BackingEntry = (*mut std::ffi::c_void, fn(*mut std::ffi::c_void));
+/// Holds a heap-allocated pointer and its associated drop function.
+/// Used for type-erased heap allocations in the mock FFI bridge.
+struct BackingEntry {
+    /// Pointer to the heap-allocated data
+    ptr: *mut std::ffi::c_void,
+    /// Drop function that knows how to properly free the data
+    drop_fn: fn(*mut std::ffi::c_void),
+}
 
 // The thread-local storage is used to hold the backing data for the mock FFI bridge.
 thread_local! {
@@ -63,8 +69,8 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
 
     unsafe fn delete_allocatee_ptr(_allocatee_ptr: *mut std::ffi::c_void, _type_name: &str) {
         DATA_BACKING.with(|d| {
-            if let Some((ptr, drop_fn)) = d.borrow_mut().take() {
-                drop_fn(ptr);
+            if let Some(entry) = d.borrow_mut().take() {
+                (entry.drop_fn)(entry.ptr);
             }
         });
         ALLOC_SIZE.with(|s| *s.borrow_mut() = 0);
@@ -77,7 +83,7 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         DATA_BACKING.with(|d| {
             d.borrow()
                 .as_ref()
-                .map(|(ptr, _)| *ptr)
+                .map(|entry| entry.ptr)
                 .unwrap_or(std::ptr::null_mut())
         })
     }
@@ -97,15 +103,15 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         SAMPLE_BACKING.with(|s| {
             s.borrow()
                 .as_ref()
-                .map(|(ptr, _)| *ptr as *const std::ffi::c_void)
+                .map(|entry| entry.ptr as *const std::ffi::c_void)
                 .unwrap_or(std::ptr::null())
         })
     }
 
     unsafe fn sample_ptr_delete(_sample_ptr: *mut std::ffi::c_void, _type_name: &str) {
         SAMPLE_BACKING.with(|s| {
-            if let Some((ptr, drop_fn)) = s.borrow_mut().take() {
-                drop_fn(ptr);
+            if let Some(entry) = s.borrow_mut().take() {
+                (entry.drop_fn)(entry.ptr);
             }
         });
     }
@@ -222,11 +228,11 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         }
     }
 
-    unsafe fn handle_container_size(_container: &HandleContainer) -> usize {
+    fn handle_container_size(_container: &HandleContainer) -> usize {
         0
     }
 
-    unsafe fn handle_container_get_at(
+    fn handle_container_get_at(
         _container: &HandleContainer,
         _index: usize,
     ) -> Option<&HandleType> {
@@ -280,8 +286,8 @@ impl MockFFIBridge {
         };
         // Replace any previous backing (prevents leaks on repeated calls).
         DATA_BACKING.with(|d| {
-            if let Some((old_ptr, old_drop)) = d.borrow_mut().replace((data_ptr, drop_fn)) {
-                old_drop(old_ptr);
+            if let Some(old_entry) = d.borrow_mut().replace(BackingEntry { ptr: data_ptr, drop_fn }) {
+                (old_entry.drop_fn)(old_entry.ptr);
             }
         });
         ALLOC_SIZE.with(|s| *s.borrow_mut() = std::mem::size_of::<SampleAllocateePtr<T>>());
@@ -301,8 +307,8 @@ impl MockFFIBridge {
         };
         // Replace any previous backing (prevents leaks on repeated calls).
         SAMPLE_BACKING.with(|s| {
-            if let Some((old_ptr, old_drop)) = s.borrow_mut().replace((ptr, drop_fn)) {
-                old_drop(old_ptr);
+            if let Some(old_entry) = s.borrow_mut().replace(BackingEntry { ptr, drop_fn }) {
+                (old_entry.drop_fn)(old_entry.ptr);
             }
         });
     }
@@ -311,14 +317,14 @@ impl MockFFIBridge {
     // to zero.
     fn reset() {
         DATA_BACKING.with(|d| {
-            if let Some((ptr, drop_fn)) = d.borrow_mut().take() {
-                drop_fn(ptr);
+            if let Some(entry) = d.borrow_mut().take() {
+                (entry.drop_fn)(entry.ptr);
             }
         });
         ALLOC_SIZE.with(|s| *s.borrow_mut() = 0);
         SAMPLE_BACKING.with(|s| {
-            if let Some((ptr, drop_fn)) = s.borrow_mut().take() {
-                drop_fn(ptr);
+            if let Some(entry) = s.borrow_mut().take() {
+                (entry.drop_fn)(entry.ptr);
             }
         });
     }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -17,6 +17,7 @@ pub use bridge_ffi_rs::{
     ProxyBase, ProxyEventBase, ProxyWrapperClass, SkeletonBase, SkeletonEventBase,
 };
 
+#[derive(Debug, Clone)]
 pub struct MockFFIBridge;
 
 impl bridge_ffi_rs::FFIBridge for MockFFIBridge {

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -63,7 +63,7 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         if size == 0 {
             return false;
         }
-        std::ptr::write_bytes(allocatee_ptr as *mut u8, 0, size);
+       unsafe { std::ptr::write_bytes(allocatee_ptr as *mut u8, 0, size) };
         true
     }
 
@@ -123,27 +123,27 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
     unsafe fn skeleton_stop_offer_service(_skeleton_ptr: *mut SkeletonBase) {}
 
     unsafe fn create_proxy(_interface_id: &str, _handle_ptr: &HandleType) -> *mut ProxyBase {
-        Box::into_raw(Box::new(std::mem::zeroed::<ProxyBase>()))
+        unsafe { Box::into_raw(Box::new(std::mem::zeroed::<ProxyBase>())) }
     }
 
     unsafe fn create_skeleton(
         _interface_id: &str,
         _instance_spec: *const NativeInstanceSpecifier,
     ) -> *mut SkeletonBase {
-        Box::into_raw(Box::new(std::mem::zeroed::<SkeletonBase>()))
+        unsafe { Box::into_raw(Box::new(std::mem::zeroed::<SkeletonBase>())) }
     }
 
     unsafe fn destroy_proxy(proxy_ptr: *mut ProxyBase) {
         if !proxy_ptr.is_null() {
             // SAFETY: proxy_ptr was allocated by create_proxy via Box::into_raw
-            drop(Box::from_raw(proxy_ptr));
+            unsafe { drop(Box::from_raw(proxy_ptr)) };
         }
     }
 
     unsafe fn destroy_skeleton(skeleton_ptr: *mut SkeletonBase) {
         if !skeleton_ptr.is_null() {
             // SAFETY: skeleton_ptr was allocated by create_skeleton via Box::into_raw
-            drop(Box::from_raw(skeleton_ptr));
+            unsafe { drop(Box::from_raw(skeleton_ptr)) };
         }
     }
 
@@ -218,13 +218,13 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         _callback: &FatPtr,
         _instance_spec: InstanceSpecifier,
     ) -> *mut FindServiceHandle {
-        Box::into_raw(Box::new(std::mem::zeroed::<FindServiceHandle>()))
+       unsafe { Box::into_raw(Box::new(std::mem::zeroed::<FindServiceHandle>())) }
     }
 
     unsafe fn stop_find_service(handle: *mut FindServiceHandle) {
         if !handle.is_null() {
             // SAFETY: handle was allocated by start_find_service via Box::into_raw
-            drop(Box::from_raw(handle));
+           unsafe { drop(Box::from_raw(handle)) };
         }
     }
 

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -33,8 +33,9 @@ struct BackingEntry {
     drop_fn: fn(*mut std::ffi::c_void),
 }
 
-// SAFETY: BackingEntry is only used within MockFFIBridge which controls access via Mutex.
-// The pointer is heap-allocated and the drop_fn ensures proper cleanup.
+// SAFETY: BackingEntry is safe to Send and Sync because,
+// each test will typically use its own instance of MockFFIBridge and thus its own BackingEntry,
+// so there is no shared mutable state across threads.
 unsafe impl Send for BackingEntry {}
 unsafe impl Sync for BackingEntry {}
 
@@ -72,13 +73,9 @@ pub struct MockFFIBridge {
     sample_backing: RefCell<Option<BackingEntry>>,
 }
 
-// SAFETY: MockFFIBridge is safe to Send because each test will typically use its own instance of MockFFIBridge,
+// SAFETY: MockFFIBridge is safe to Send and Sync because each test will typically use its own instance of MockFFIBridge,
 // so there is no shared mutable state across threads.
 unsafe impl Send for MockFFIBridge {}
-
-// SAFETY: MockFFIBridge is safe to Sync because it uses RefCell for interior mutability,
-// which is not thread-safe.
-// However, each test will use its own instance of MockFFIBridge and will not share it across threads.
 unsafe impl Sync for MockFFIBridge {}
 
 impl Default for MockFFIBridge {
@@ -366,14 +363,11 @@ impl MockFFIBridge {
             // SAFETY: p was allocated as Box<MaybeUninit<T>> by set_alloc_backing::<T>.
             drop(unsafe { Box::from_raw(p as *mut std::mem::MaybeUninit<T>) });
         };
-        // Replace any previous backing (prevents leaks on repeated calls).
-        let mut data_backing = self.data_backing.borrow_mut();
-        if let Some(old_entry) = data_backing.replace(BackingEntry {
+        // Replace any previous backing - Drop trait automatically cleans up the old entry
+        *self.data_backing.borrow_mut() = Some(BackingEntry {
             ptr: data_ptr,
             drop_fn,
-        }) {
-            (old_entry.drop_fn)(old_entry.ptr);
-        }
+        });
         *self.alloc_size.borrow_mut() = std::mem::size_of::<SampleAllocateePtr<T>>();
     }
 
@@ -389,10 +383,7 @@ impl MockFFIBridge {
             // SAFETY: p was allocated as Box<T> by set_sample_backing::<T>.
             drop(unsafe { Box::from_raw(p as *mut T) });
         };
-        // Replace any previous backing (prevents leaks on repeated calls).
-        let mut sample_backing = self.sample_backing.borrow_mut();
-        if let Some(old_entry) = sample_backing.replace(BackingEntry { ptr, drop_fn }) {
-            (old_entry.drop_fn)(old_entry.ptr);
-        }
+        // Replace any previous backing - Drop trait automatically cleans up the old entry
+        *self.sample_backing.borrow_mut() = Some(BackingEntry { ptr, drop_fn });
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -23,6 +23,21 @@ use bridge_ffi_rs::{
     NativeHandleContainer, NativeInstanceSpecifier, ProxyBase, ProxyEventBase, SkeletonBase,
     SkeletonEventBase,
 };
+use std::cell::RefCell;
+
+// Per-test thread-local backing storage for the allocate-and-send mock path.
+//
+// `DATA_BACKING` holds a type-erased pointer to a heap-allocated `MaybeUninit<T>` buffer
+// paired with a drop-glue function so `clear_alloc_backing` can free it without knowing `T`.
+//
+// `ALLOC_SIZE` holds `size_of::<SampleAllocateePtr<T>>()` so `get_allocatee_ptr` can
+// zero-fill the caller's `MaybeUninit` slot — zeroed = Blank variant (_index = 0),
+// which makes `assume_init()` defined behaviour.
+thread_local! {
+    static DATA_BACKING: RefCell<Option<(*mut std::ffi::c_void, fn(*mut std::ffi::c_void))>> =
+        RefCell::new(None);
+    static ALLOC_SIZE: RefCell<usize> = RefCell::new(0);
+}
 
 #[derive(Debug, Clone)]
 pub struct MockFFIBridge;
@@ -33,25 +48,50 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
     /// Returns true if event_ptr is non-null (mock behavior).
     unsafe fn get_allocatee_ptr(
         event_ptr: *mut SkeletonEventBase,
-        _allocatee_ptr: *mut std::ffi::c_void,
+        allocatee_ptr: *mut std::ffi::c_void,
         _event_type: &str,
     ) -> bool {
-        !event_ptr.is_null()
+        if event_ptr.is_null() {
+            return false;
+        }
+        ALLOC_SIZE.with(|s| {
+            let size = *s.borrow();
+            if size > 0 {
+                // SAFETY: allocatee_ptr is MaybeUninit<SampleAllocateePtr<T>> with `size` bytes.
+                std::ptr::write_bytes(allocatee_ptr as *mut u8, 0, size);
+            }
+        });
+        true
     }
 
     /// Mock implementation of delete_allocatee_ptr.
     /// # Safety
     /// No-op for mock.
-    unsafe fn delete_allocatee_ptr(_allocatee_ptr: *mut std::ffi::c_void, _type_name: &str) {}
+    unsafe fn delete_allocatee_ptr(_allocatee_ptr: *mut std::ffi::c_void, _type_name: &str) {
+        DATA_BACKING.with(|d| {
+            if let Some((ptr, drop_fn)) = d.borrow_mut().take() {
+                drop_fn(ptr);
+            }
+        });
+        ALLOC_SIZE.with(|s| *s.borrow_mut() = 0);
+    }
 
     /// Mock implementation of get_allocatee_data_ptr.
     /// # Safety
-    /// Returns the input pointer cast to mutable (mock behavior).
+    /// `MockFFIBridge::set_alloc_backing::<T>()` must have been called before this.
+    /// Returns a pointer to the heap-allocated `MaybeUninit<T>` buffer where the caller
+    /// may write `T` and later read it back via `Deref`.
     unsafe fn get_allocatee_data_ptr(
-        allocatee_ptr: *const std::ffi::c_void,
+        _allocatee_ptr: *const std::ffi::c_void,
         _type_name: &str,
     ) -> *mut std::ffi::c_void {
-        allocatee_ptr as *mut std::ffi::c_void
+        // Return the pre-allocated MaybeUninit<T> buffer registered by set_alloc_backing.
+        DATA_BACKING.with(|d| {
+            d.borrow()
+                .as_ref()
+                .map(|(ptr, _)| *ptr)
+                .unwrap_or(std::ptr::null_mut())
+        })
     }
 
     /// Mock implementation of skeleton_event_send_sample_allocatee.
@@ -263,5 +303,29 @@ impl MockFFIBridge {
     /// canonical representation for "valid but empty" in the mock.
     pub fn make_proxy_event_ptr() -> *mut ProxyEventBase {
         std::ptr::NonNull::<ProxyEventBase>::dangling().as_ptr()
+    }
+
+    /// Registers type `T` as the backing type for the next `get_allocatee_ptr` /
+    /// `get_allocatee_data_ptr` cycle.
+    ///
+    /// Heap-allocates a `MaybeUninit<T>` buffer whose address is returned by
+    /// `get_allocatee_data_ptr`, and records `size_of::<SampleAllocateePtr<T>>()` so that
+    /// `get_allocatee_ptr` can zero-fill the caller's slot (making `assume_init()` safe).
+    pub fn set_alloc_backing<T: 'static>() {
+        use sample_allocatee_ptr_rs::SampleAllocateePtr;
+        let data_ptr =
+            Box::into_raw(Box::new(std::mem::MaybeUninit::<T>::uninit())) as *mut std::ffi::c_void;
+        // Drop glue: frees the MaybeUninit<T> box without running T's destructor.
+        let drop_fn: fn(*mut std::ffi::c_void) = |p| {
+            // SAFETY: p was allocated as Box<MaybeUninit<T>> by set_alloc_backing::<T>.
+            drop(unsafe { Box::from_raw(p as *mut std::mem::MaybeUninit<T>) });
+        };
+        // Replace any previous backing (prevents leaks on repeated calls).
+        DATA_BACKING.with(|d| {
+            if let Some((old_ptr, old_drop)) = d.borrow_mut().replace((data_ptr, drop_fn)) {
+                old_drop(old_ptr);
+            }
+        });
+        ALLOC_SIZE.with(|s| *s.borrow_mut() = std::mem::size_of::<SampleAllocateePtr<T>>());
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -18,10 +18,10 @@
 // all the test cases and scenarios.
 #![doc(hidden)]
 
-pub use bridge_ffi_rs::{
-    CMutVoidPtr, CVoidPtr, FFIBridge, FatPtr, FindServiceHandle, HandleContainer, HandleType,
-    InstanceSpecifier, NativeFindServiceHandle, NativeHandleContainer, NativeInstanceSpecifier,
-    ProxyBase, ProxyEventBase, ProxyWrapperClass, SkeletonBase, SkeletonEventBase,
+use bridge_ffi_rs::{
+    FatPtr, FindServiceHandle, HandleContainer, HandleType, InstanceSpecifier,
+    NativeHandleContainer, NativeInstanceSpecifier, ProxyBase, ProxyEventBase, SkeletonBase,
+    SkeletonEventBase,
 };
 
 #[derive(Debug, Clone)]

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -1,0 +1,233 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+pub use bridge_ffi_rs::{
+    CMutVoidPtr, CVoidPtr, FatPtr, FindServiceHandle, HandleContainer, HandleType,
+    InstanceSpecifier, NativeFindServiceHandle, NativeHandleContainer, NativeInstanceSpecifier,
+    ProxyBase, ProxyEventBase, ProxyWrapperClass, SkeletonBase, SkeletonEventBase,
+};
+
+/// Mock implementation of get_allocatee_ptr.
+/// # Safety
+/// Returns true if event_ptr is non-null (mock behavior).
+pub unsafe fn get_allocatee_ptr(
+    event_ptr: *mut SkeletonEventBase,
+    _allocatee_ptr: *mut std::ffi::c_void,
+    _event_type: &str,
+) -> bool {
+    !event_ptr.is_null()
+}
+
+/// Mock implementation of delete_allocatee_ptr.
+/// # Safety
+/// No-op for mock.
+pub unsafe fn delete_allocatee_ptr(_allocatee_ptr: *mut std::ffi::c_void, _type_name: &str) {}
+
+/// Mock implementation of get_allocatee_data_ptr.
+/// # Safety
+/// Returns the input pointer cast to mutable (mock behavior).
+pub unsafe fn get_allocatee_data_ptr(
+    allocatee_ptr: *const std::ffi::c_void,
+    _type_name: &str,
+) -> *mut std::ffi::c_void {
+    allocatee_ptr as *mut std::ffi::c_void
+}
+
+/// Mock implementation of skeleton_event_send_sample_allocatee.
+/// # Safety
+/// Returns true if event_ptr is non-null (mock behavior).
+pub unsafe fn skeleton_event_send_sample_allocatee(
+    event_ptr: *mut SkeletonEventBase,
+    _event_type: &str,
+    _allocatee_ptr: *const std::ffi::c_void,
+) -> bool {
+    !event_ptr.is_null()
+}
+
+/// Mock implementation of sample_ptr_get.
+/// # Safety
+/// Returns the input pointer unchanged (mock behavior).
+pub unsafe fn sample_ptr_get(
+    sample_ptr: *const std::ffi::c_void,
+    _type_name: &str,
+) -> *const std::ffi::c_void {
+    sample_ptr
+}
+
+/// Mock implementation of sample_ptr_delete.
+/// # Safety
+/// No-op for mock.
+pub unsafe fn sample_ptr_delete(_sample_ptr: *mut std::ffi::c_void, _type_name: &str) {}
+
+/// Mock implementation of skeleton_offer_service.
+/// # Safety
+/// Returns true if skeleton_ptr is non-null (mock behavior).
+pub unsafe fn skeleton_offer_service(skeleton_ptr: *mut SkeletonBase) -> bool {
+    !skeleton_ptr.is_null()
+}
+
+/// Mock implementation of skeleton_stop_offer_service.
+/// # Safety
+/// No-op for mock.
+pub unsafe fn skeleton_stop_offer_service(_skeleton_ptr: *mut SkeletonBase) {}
+
+/// Mock implementation of create_proxy.
+/// # Safety
+/// Allocates and returns a new ProxyBase pointer from heap.
+/// Caller must eventually destroy with destroy_proxy.
+pub unsafe fn create_proxy(_interface_id: &str, _handle_ptr: &HandleType) -> *mut ProxyBase {
+    Box::into_raw(Box::new(std::mem::zeroed::<ProxyBase>()))
+}
+
+/// Mock implementation of create_skeleton.
+/// # Safety
+/// Allocates and returns a new SkeletonBase pointer from heap.
+/// Caller must eventually destroy with destroy_skeleton.
+pub unsafe fn create_skeleton(
+    _interface_id: &str,
+    _instance_spec: *const NativeInstanceSpecifier,
+) -> *mut SkeletonBase {
+    Box::into_raw(Box::new(std::mem::zeroed::<SkeletonBase>()))
+}
+
+/// Mock implementation of destroy_proxy.
+/// # Safety
+/// proxy_ptr must have been returned from create_proxy.
+/// Caller must not use proxy_ptr after this call.
+pub unsafe fn destroy_proxy(proxy_ptr: *mut ProxyBase) {
+    if !proxy_ptr.is_null() {
+        // SAFETY: proxy_ptr was allocated by create_proxy via Box::into_raw
+        drop(Box::from_raw(proxy_ptr));
+    }
+}
+
+/// Mock implementation of destroy_skeleton.
+/// # Safety
+/// skeleton_ptr must have been returned from create_skeleton.
+/// Caller must not use skeleton_ptr after this call.
+pub unsafe fn destroy_skeleton(skeleton_ptr: *mut SkeletonBase) {
+    if !skeleton_ptr.is_null() {
+        // SAFETY: skeleton_ptr was allocated by create_skeleton via Box::into_raw
+        drop(Box::from_raw(skeleton_ptr));
+    }
+}
+
+/// Mock implementation of get_event_from_proxy.
+/// # Safety
+/// proxy_ptr must be non-null for non-null return.
+/// Returned pointer remains valid only while proxy is alive.
+pub unsafe fn get_event_from_proxy(
+    proxy_ptr: *mut ProxyBase,
+    _interface_id: &str,
+    _event_id: &str,
+) -> *mut ProxyEventBase {
+    if proxy_ptr.is_null() {
+        return std::ptr::null_mut();
+    }
+    // ProxyEventBase is a ZST opaque type. The runtime never frees event pointers
+    // (NativeProxyEventBase has no Drop); returning a non-null sentinel is sufficient.
+    std::ptr::NonNull::<ProxyEventBase>::dangling().as_ptr()
+}
+
+/// Mock implementation of get_event_from_skeleton.
+/// # Safety
+/// Returns a dangling pointer sentinel (mock behavior). Valid only for null checks.
+pub unsafe fn get_event_from_skeleton(
+    _skeleton_ptr: *mut SkeletonBase,
+    _interface_id: &str,
+    _event_id: &str,
+) -> *mut SkeletonEventBase {
+    // SkeletonEventBase is a ZST opaque type. The runtime never frees event pointers
+    // (NativeSkeletonEventBase has no Drop); returning a non-null sentinel is sufficient.
+    std::ptr::NonNull::<SkeletonEventBase>::dangling().as_ptr()
+}
+
+/// Mock implementation of get_samples_from_event.
+/// # Safety
+/// event_ptr must be non-null or returns u32::MAX (mock behavior).
+pub unsafe fn get_samples_from_event(
+    event_ptr: *mut ProxyEventBase,
+    _event_type: &str,
+    _callback: &FatPtr,
+    _max_samples: u32,
+) -> u32 {
+    if event_ptr.is_null() {
+        return u32::MAX;
+    }
+    0
+}
+
+/// Mock implementation of skeleton_send_event.
+/// # Safety
+/// Returns true if event_ptr is non-null (mock behavior).
+pub unsafe fn skeleton_send_event(
+    event_ptr: *mut SkeletonEventBase,
+    _event_type: &str,
+    _data_ptr: *const std::ffi::c_void,
+) -> bool {
+    !event_ptr.is_null()
+}
+
+/// Mock implementation of subscribe_to_event.
+/// # Safety
+/// Returns true if event_ptr is non-null (mock behavior).
+pub unsafe fn subscribe_to_event(event_ptr: *mut ProxyEventBase, _max_sample_count: u32) -> bool {
+    !event_ptr.is_null()
+}
+
+/// Mock implementation of unsubscribe_to_event.
+/// # Safety
+/// No-op for mock.
+pub unsafe fn unsubscribe_to_event(_event_ptr: *mut ProxyEventBase) {}
+
+/// Mock implementation of set_event_receive_handler.
+/// # Safety
+/// Returns true if proxy_event_ptr is non-null (mock behavior).
+pub unsafe fn set_event_receive_handler(
+    proxy_event_ptr: *mut ProxyEventBase,
+    _handler: &FatPtr,
+    _event_type: &str,
+) -> bool {
+    !proxy_event_ptr.is_null()
+}
+
+/// Mock implementation of clear_event_receive_handler.
+/// # Safety
+/// No-op for mock.
+pub unsafe fn clear_event_receive_handler(
+    _proxy_event_ptr: *mut ProxyEventBase,
+    _event_type: &str,
+) {
+}
+
+/// Mock implementation of start_find_service.
+/// # Safety
+/// Allocates and returns a new FindServiceHandle pointer.
+/// Caller must eventually destroy with stop_find_service.
+pub unsafe fn start_find_service(
+    _callback: &FatPtr,
+    _instance_spec: InstanceSpecifier,
+) -> *mut FindServiceHandle {
+    Box::into_raw(Box::new(std::mem::zeroed::<FindServiceHandle>()))
+}
+
+/// Mock implementation of stop_find_service.
+/// # Safety
+/// handle must have been returned from start_find_service.
+/// Caller must not use handle after this call.
+pub unsafe fn stop_find_service(handle: *mut FindServiceHandle) {
+    if !handle.is_null() {
+        // SAFETY: handle was allocated by start_find_service via Box::into_raw
+        drop(Box::from_raw(handle));
+    }
+}

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -16,12 +16,17 @@
 // As of now, it just provide basic mock implementation and returning values based on
 // input parameters. In future, we will enhance this mock implementation to verify
 // all the test cases and scenarios.
+
+// This mock back-end (FFIBridge implementation) is used for unit testing of Lola-Runtime
+// So we do not want to expose this mock in the public API docs and crate level documentation, hence the `doc(hidden)` attribute.
+#![doc(hidden)]
+
 use bridge_ffi_rs::{
     FatPtr, FindServiceHandle, HandleContainer, HandleType, InstanceSpecifier,
     NativeHandleContainer, NativeInstanceSpecifier, ProxyBase, ProxyEventBase, SkeletonBase,
     SkeletonEventBase,
 };
-use std::cell::RefCell;
+use std::sync::{Arc, Mutex};
 
 // Holds a heap-allocated pointer and its associated drop function.
 // Used for type-erased heap allocations in the mock FFI bridge.
@@ -33,11 +38,11 @@ struct BackingEntry {
     drop_fn: fn(*mut std::ffi::c_void),
 }
 
-// SAFETY: BackingEntry is safe to Send and Sync because,
-// each test will typically use its own instance of MockFFIBridge and thus its own BackingEntry,
-// so there is no shared mutable state across threads.
+// SAFETY: BackingEntry is safe to Send because the drop_fn ensures that the heap allocation is properly freed,
+// and the pointer is only accessed through the mock's controlled methods which enforce thread safety via Mutex.
+// No mutbale operation on the pointer is exposed to the caller,
+// and the mock's internal methods ensure that any access to the pointer is thread-safe.
 unsafe impl Send for BackingEntry {}
-unsafe impl Sync for BackingEntry {}
 
 impl std::fmt::Debug for BackingEntry {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
@@ -58,32 +63,28 @@ impl Drop for BackingEntry {
 //
 // FFIBridge trait requires Clone - when Runtime creates a consumer/producer, it clones
 // the bridge instance.
-// RefCell<...> provides interior mutability: FFIBridge trait methods take &self (not &mut self)
+// Arc<Mutex<...>> provides thread-safe interior mutability: FFIBridge trait methods take &self (not &mut self)
 // To match this signature while mutating internal state (e.g., storing/retrieving mock data),
-// we need interior mutability.
+// we need interior mutability. Arc<Mutex<...>> ensures thread safety at the cost of some performance,
+// which is acceptable for test code where safety is more important than performance.
 #[derive(Debug, Clone)]
 pub struct MockFFIBridge {
     //DATA_BACKING holds a pointer to the heap-allocated backing data and a drop function to free it.
     //We are using this when user calls get_allocatee_data_ptr to return a pointer to this backing data.
-    data_backing: RefCell<Option<BackingEntry>>,
+    data_backing: Arc<Mutex<Option<BackingEntry>>>,
     //ALLOC_SIZE holds the size of the allocatee type for the next get_allocatee_ptr call, allowing
     //the mock to zero-fill the caller's slot correctly.
-    alloc_size: RefCell<usize>,
+    alloc_size: Arc<Mutex<usize>>,
     //SAMPLE_BACKING holds a pointer to the heap-allocated sample data and a drop function to free it.
-    sample_backing: RefCell<Option<BackingEntry>>,
+    sample_backing: Arc<Mutex<Option<BackingEntry>>>,
 }
-
-// SAFETY: MockFFIBridge is safe to Send and Sync because each test will typically use its own instance of MockFFIBridge,
-// so there is no shared mutable state across threads.
-unsafe impl Send for MockFFIBridge {}
-unsafe impl Sync for MockFFIBridge {}
 
 impl Default for MockFFIBridge {
     fn default() -> Self {
         Self {
-            data_backing: RefCell::new(None),
-            alloc_size: RefCell::new(0),
-            sample_backing: RefCell::new(None),
+            data_backing: Arc::new(Mutex::new(None)),
+            alloc_size: Arc::new(Mutex::new(0)),
+            sample_backing: Arc::new(Mutex::new(None)),
         }
     }
 }
@@ -100,7 +101,7 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         if event_ptr.is_null() || allocatee_ptr.is_null() {
             return false;
         }
-        let size = *self.alloc_size.borrow();
+        let size = *self.alloc_size.lock().expect("Failed to lock alloc_size");
         if size == 0 {
             return false;
         }
@@ -110,10 +111,15 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
 
     // Deletes the heap-allocated backing data for the current allocatee, if any, and resets alloc_size.
     unsafe fn delete_allocatee_ptr(&self, _allocatee_ptr: *mut std::ffi::c_void, _type_name: &str) {
-        if let Some(entry) = self.data_backing.borrow_mut().take() {
+        if let Some(entry) = self
+            .data_backing
+            .lock()
+            .expect("Failed to lock data_backing")
+            .take()
+        {
             (entry.drop_fn)(entry.ptr);
         }
-        *self.alloc_size.borrow_mut() = 0;
+        *self.alloc_size.lock().expect("Failed to lock alloc_size") = 0;
     }
 
     // Returns a pointer to the heap-allocated backing data for the current allocatee, if any.
@@ -123,7 +129,8 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         _type_name: &str,
     ) -> *mut std::ffi::c_void {
         self.data_backing
-            .borrow()
+            .lock()
+            .expect("Failed to lock data_backing")
             .as_ref()
             .map(|entry| entry.ptr)
             .unwrap_or(std::ptr::null_mut())
@@ -146,7 +153,8 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         _type_name: &str,
     ) -> *const std::ffi::c_void {
         self.sample_backing
-            .borrow()
+            .lock()
+            .expect("Failed to lock sample_backing")
             .as_ref()
             .map(|entry| entry.ptr as *const std::ffi::c_void)
             .unwrap_or(std::ptr::null())
@@ -154,7 +162,12 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
 
     // Deletes the heap-allocated sample backing data for the current sample, if any.
     unsafe fn sample_ptr_delete(&self, _sample_ptr: *mut std::ffi::c_void, _type_name: &str) {
-        if let Some(entry) = self.sample_backing.borrow_mut().take() {
+        if let Some(entry) = self
+            .sample_backing
+            .lock()
+            .expect("Failed to lock sample_backing")
+            .take()
+        {
             (entry.drop_fn)(entry.ptr);
         }
     }
@@ -364,11 +377,15 @@ impl MockFFIBridge {
             drop(unsafe { Box::from_raw(p as *mut std::mem::MaybeUninit<T>) });
         };
         // Replace any previous backing - Drop trait automatically cleans up the old entry
-        *self.data_backing.borrow_mut() = Some(BackingEntry {
+        *self
+            .data_backing
+            .lock()
+            .expect("Failed to lock data_backing") = Some(BackingEntry {
             ptr: data_ptr,
             drop_fn,
         });
-        *self.alloc_size.borrow_mut() = std::mem::size_of::<SampleAllocateePtr<T>>();
+        *self.alloc_size.lock().expect("Failed to lock alloc_size") =
+            std::mem::size_of::<SampleAllocateePtr<T>>();
     }
 
     // Registers `data` as the backing value for the next `sample_ptr_get` /
@@ -384,6 +401,9 @@ impl MockFFIBridge {
             drop(unsafe { Box::from_raw(p as *mut T) });
         };
         // Replace any previous backing - Drop trait automatically cleans up the old entry
-        *self.sample_backing.borrow_mut() = Some(BackingEntry { ptr, drop_fn });
+        *self
+            .sample_backing
+            .lock()
+            .expect("Failed to lock sample_backing") = Some(BackingEntry { ptr, drop_fn });
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -50,7 +50,7 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         allocatee_ptr: *mut std::ffi::c_void,
         _event_type: &str,
     ) -> bool {
-        if event_ptr.is_null() {
+        if event_ptr.is_null() || allocatee_ptr.is_null() {
             return false;
         }
         let size = ALLOC_SIZE.with(|s| *s.borrow());
@@ -150,6 +150,9 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
             return std::ptr::null_mut();
         }
         // ProxyEventBase is a ZST opaque type; a non-null sentinel is sufficient.
+        // LIMITATION: The returned pointer is intentionally dangling and must NOT be
+        // dereferenced. It is only valid as a non-null sentinel for null-checks in the
+        // mock. Any test that dereferences this pointer will trigger undefined behavior.
         std::ptr::NonNull::<ProxyEventBase>::dangling().as_ptr()
     }
 
@@ -159,6 +162,9 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
         _event_id: &str,
     ) -> *mut SkeletonEventBase {
         // SkeletonEventBase is a ZST opaque type; a non-null sentinel is sufficient.
+        // LIMITATION: The returned pointer is intentionally dangling and must NOT be
+        // dereferenced. It is only valid as a non-null sentinel for null-checks in the
+        // mock. Any test that dereferences this pointer will trigger undefined behavior.
         std::ptr::NonNull::<SkeletonEventBase>::dangling().as_ptr()
     }
 
@@ -237,6 +243,10 @@ impl MockFFIBridge {
     pub fn make_handle_container() -> std::sync::Arc<HandleContainer> {
         // A dangling non-null sentinel: the inner pointer is never passed to C++ because
         // MockFFIBridge::handle_container_size / handle_container_get_at always return 0 / None.
+        // LIMITATION: `ptr` is intentionally dangling and must NOT be dereferenced.
+        // It is safe only because the mock's handle_container_size / handle_container_get_at
+        // implementations never expose or forward this pointer to any code that would read it.
+        // Tests must not call any real C++ handle-container operations on the returned Arc.
         let ptr = std::ptr::NonNull::<NativeHandleContainer>::dangling().as_ptr();
         let hc = std::sync::Arc::new(HandleContainer::new(ptr));
         // Prevent HandleContainer::drop (which would call real C++ delete) by pinning the refcount.
@@ -246,6 +256,10 @@ impl MockFFIBridge {
 
     // `ProxyEventBase` is a ZST opaque type, a dangling non-null pointer is the
     // canonical representation for "valid but empty" in the mock.
+    //
+    // LIMITATION: The returned pointer is intentionally dangling and must NOT be
+    // dereferenced. Tests may only use it as a non-null sentinel (e.g., to satisfy
+    // null-checks in other mock methods). Dereferencing it is undefined behavior.
     pub fn make_proxy_event_ptr() -> *mut ProxyEventBase {
         std::ptr::NonNull::<ProxyEventBase>::dangling().as_ptr()
     }
@@ -291,5 +305,30 @@ impl MockFFIBridge {
                 old_drop(old_ptr);
             }
         });
+    }
+
+    // Drops all heap-allocated backing data stored in thread-locals and resets ALLOC_SIZE
+    // to zero.
+    fn reset() {
+        DATA_BACKING.with(|d| {
+            if let Some((ptr, drop_fn)) = d.borrow_mut().take() {
+                drop_fn(ptr);
+            }
+        });
+        ALLOC_SIZE.with(|s| *s.borrow_mut() = 0);
+        SAMPLE_BACKING.with(|s| {
+            if let Some((ptr, drop_fn)) = s.borrow_mut().take() {
+                drop_fn(ptr);
+            }
+        });
+    }
+}
+
+// RAII guard that resets all `MockFFIBridge` thread-local state when it goes out of scope.
+pub struct MockFFIBridgeGuard;
+
+impl Drop for MockFFIBridgeGuard {
+    fn drop(&mut self) {
+        MockFFIBridge::reset();
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -18,17 +18,54 @@
 //!
 //! This provides a mockall-based mock where tests can configure expectations locally.
 //! Uses a hybrid approach: mockall for most methods, with a wrapper for lifetime constraints.
-//! The SharedMockBridge wrapper allows all clones to share the same underlying mock instance and expectations,
+//!
+//! # Components
+//!
+//! ## SharedMockBridge
+//! Wrapper that allows all clones to share the same underlying mock instance and expectations,
 //! eliminating the need for complex clone expectation setup in tests.
-//! Tests can create a SharedMockBridge with a configured MockFFIBridge, and all clones will automatically share the same expectations.
-//! Example usage in a test:
-//! ```rust,ignore
+//!
+//! ## MockPointerAllocator
+//! Helper utility for managing FFI pointer allocations in tests. Eliminates the repetitive
+//! `Arc<Mutex<Vec<Box<T>>>>` pattern and provides automatic cleanup tracking.
+//!
+//! # Usage
+//! ```ignore
+//! use bridge_ffi_mock::{MockFFIBridge, SharedMockBridge, MockPointerAllocator};
+//!
 //! let mut mock = MockFFIBridge::new();
-//! mock.expect_create_proxy()
-//!     .returning(|_, _| Box::into_raw(Box::new(unsafe { std::mem::zeroed() }))); // this is just an example, configure expectations as needed
+//! // Use MockPointerAllocator for cleaner pointer management
+//! let skeleton_alloc = MockPointerAllocator::<SkeletonBase>::new();
+//! let skel = skeleton_alloc.clone();
+//! mock.expect_create_skeleton()
+//!     .returning(move |_, _| skel.allocate());
+//!
 //! let bridge = SharedMockBridge::new(mock);
+//! // All clones automatically share the same expectations
 //! let clone1 = bridge.clone();
-//! let clone2 = bridge.clone();
+//! ```
+//!
+//! # With Call Sequencing
+//! Use `mockall::Sequence` to enforce call ordering:
+//! ```ignore
+//! use mockall::Sequence;
+//!
+//! let mut mock = MockFFIBridge::new();
+//! let mut seq = Sequence::new();
+//!
+//! let skeleton_alloc = MockPointerAllocator::<SkeletonBase>::new();
+//! let skel = skeleton_alloc.clone();
+//! mock.expect_create_skeleton()
+//!     .in_sequence(&mut seq)
+//!     .returning(move |_, _| skel.allocate());
+//!
+//! let event_alloc = MockPointerAllocator::<SkeletonEventBase>::new();
+//! let evt = event_alloc.clone();
+//! mock.expect_get_event_from_skeleton()
+//!     .in_sequence(&mut seq)
+//!     .returning(move |_, _, _| evt.allocate());
+//!
+//! // Enforces: create_skeleton must be called before get_event_from_skeleton
 //! ```
 //!
 //! This mock back-end is used for unit testing of Lola-Runtime.
@@ -162,18 +199,6 @@ mock! {
 /// This wrapper uses Arc<Mutex<MockFFIBridge>> internally, allowing all clones to share
 /// the same underlying mock instance and its expectations. This eliminates the need for
 /// complex clone expectation setup in tests.
-///
-/// # Usage
-/// ```rust,ignore
-/// let mut mock = MockFFIBridge::new();
-/// mock.expect_create_proxy()
-///     .returning(|_, _| Box::into_raw(Box::new(unsafe { std::mem::zeroed() })));
-///
-/// let bridge = SharedMockBridge::new(mock);
-/// // All clones automatically share the same expectations
-/// let clone1 = bridge.clone();
-/// let clone2 = bridge.clone();
-/// ```
 #[derive(Debug, Default)]
 pub struct SharedMockBridge(std::sync::Arc<std::sync::Mutex<MockFFIBridge>>);
 
@@ -192,6 +217,10 @@ impl SharedMockBridge {
     {
         let mut guard = self.0.lock().expect("Failed to acquire lock");
         f(&mut *guard)
+    }
+
+    fn locked(&self) -> std::sync::MutexGuard<'_, MockFFIBridge> {
+        self.0.lock().expect("Failed to acquire lock")
     }
 }
 
@@ -212,21 +241,14 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
     ) -> bool {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
         unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
+            self.locked()
                 .get_allocatee_ptr(event_ptr, allocatee_ptr, event_type)
         }
     }
 
     unsafe fn delete_allocatee_ptr(&self, allocatee_ptr: *mut std::ffi::c_void, type_name: &str) {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
-        unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
-                .delete_allocatee_ptr(allocatee_ptr, type_name)
-        }
+        unsafe { self.locked().delete_allocatee_ptr(allocatee_ptr, type_name) }
     }
 
     unsafe fn get_allocatee_data_ptr(
@@ -236,9 +258,7 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
     ) -> *mut std::ffi::c_void {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
         unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
+            self.locked()
                 .get_allocatee_data_ptr(allocatee_ptr, type_name)
         }
     }
@@ -250,9 +270,7 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
         allocatee_ptr: *const std::ffi::c_void,
     ) -> bool {
         unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
+            self.locked()
                 .skeleton_event_send_sample_allocatee(event_ptr, event_type, allocatee_ptr)
         }
     }
@@ -263,51 +281,26 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
         type_name: &str,
     ) -> *const std::ffi::c_void {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
-        unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
-                .sample_ptr_get(sample_ptr, type_name)
-        }
+        unsafe { self.locked().sample_ptr_get(sample_ptr, type_name) }
     }
 
     unsafe fn sample_ptr_delete(&self, sample_ptr: *mut std::ffi::c_void, type_name: &str) {
-        unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
-                .sample_ptr_delete(sample_ptr, type_name)
-        }
+        unsafe { self.locked().sample_ptr_delete(sample_ptr, type_name) }
     }
 
     unsafe fn skeleton_offer_service(&self, skeleton_ptr: *mut SkeletonBase) -> bool {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
-        unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
-                .skeleton_offer_service(skeleton_ptr)
-        }
+        unsafe { self.locked().skeleton_offer_service(skeleton_ptr) }
     }
 
     unsafe fn skeleton_stop_offer_service(&self, skeleton_ptr: *mut SkeletonBase) {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
-        unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
-                .skeleton_stop_offer_service(skeleton_ptr)
-        }
+        unsafe { self.locked().skeleton_stop_offer_service(skeleton_ptr) }
     }
 
     unsafe fn create_proxy(&self, interface_id: &str, handle_ptr: &HandleType) -> *mut ProxyBase {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
-        unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
-                .create_proxy(interface_id, handle_ptr)
-        }
+        unsafe { self.locked().create_proxy(interface_id, handle_ptr) }
     }
 
     unsafe fn create_skeleton(
@@ -316,32 +309,17 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
         instance_spec: *const NativeInstanceSpecifier,
     ) -> *mut SkeletonBase {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
-        unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
-                .create_skeleton(interface_id, instance_spec)
-        }
+        unsafe { self.locked().create_skeleton(interface_id, instance_spec) }
     }
 
     unsafe fn destroy_proxy(&self, proxy_ptr: *mut ProxyBase) {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
-        unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
-                .destroy_proxy(proxy_ptr)
-        }
+        unsafe { self.locked().destroy_proxy(proxy_ptr) }
     }
 
     unsafe fn destroy_skeleton(&self, skeleton_ptr: *mut SkeletonBase) {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
-        unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
-                .destroy_skeleton(skeleton_ptr)
-        }
+        unsafe { self.locked().destroy_skeleton(skeleton_ptr) }
     }
 
     unsafe fn get_event_from_proxy(
@@ -352,9 +330,7 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
     ) -> *mut ProxyEventBase {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
         unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
+            self.locked()
                 .get_event_from_proxy(proxy_ptr, interface_id, event_id)
         }
     }
@@ -367,9 +343,7 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
     ) -> *mut SkeletonEventBase {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
         unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
+            self.locked()
                 .get_event_from_skeleton(skeleton_ptr, interface_id, event_id)
         }
     }
@@ -380,21 +354,11 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
         max_num_samples: u32,
     ) -> bool {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
-        unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
-                .subscribe_to_event(event_ptr, max_num_samples)
-        }
+        unsafe { self.locked().subscribe_to_event(event_ptr, max_num_samples) }
     }
 
     unsafe fn unsubscribe_to_event(&self, event_ptr: *mut ProxyEventBase) {
-        unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
-                .unsubscribe_to_event(event_ptr)
-        }
+        unsafe { self.locked().unsubscribe_to_event(event_ptr) }
     }
 
     unsafe fn get_samples_from_event(
@@ -406,9 +370,7 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
     ) -> u32 {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
         unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
+            self.locked()
                 .get_samples_from_event(event_ptr, event_type, callback, max_num_samples)
         }
     }
@@ -421,9 +383,7 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
     ) -> bool {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
         unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
+            self.locked()
                 .skeleton_send_event(event_ptr, event_type, data_ptr)
         }
     }
@@ -436,9 +396,7 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
     ) -> bool {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
         unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
+            self.locked()
                 .set_event_receive_handler(event_ptr, callback, event_type)
         }
     }
@@ -446,9 +404,7 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
     unsafe fn clear_event_receive_handler(&self, event_ptr: *mut ProxyEventBase, event_type: &str) {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
         unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
+            self.locked()
                 .clear_event_receive_handler(event_ptr, event_type)
         }
     }
@@ -459,21 +415,97 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
         instance_spec: InstanceSpecifier,
     ) -> *mut FindServiceHandle {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
-        unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
-                .start_find_service(callback, instance_spec)
-        }
+        unsafe { self.locked().start_find_service(callback, instance_spec) }
     }
 
     unsafe fn stop_find_service(&self, find_service_handle: *mut FindServiceHandle) {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
-        unsafe {
-            self.0
-                .lock()
-                .expect("Failed to acquire lock")
-                .stop_find_service(find_service_handle)
+        unsafe { self.locked().stop_find_service(find_service_handle) }
+    }
+}
+
+/// Helper for managing mock pointer allocations with automatic cleanup tracking,
+/// eliminating the need for repetitive Arc<Mutex<Vec<Box<T>>>> patterns in tests.
+/// We can use for any FFI pointer type (e.g., SkeletonBase, ProxyBase) by specifying T.
+/// The allocator tracks all allocated pointers and provides a `free` method to clean them up,
+/// which can be used in test assertions to ensure proper resource management.
+#[derive(Debug)]
+pub struct MockPointerAllocator<T> {
+    allocations: std::sync::Arc<std::sync::Mutex<Vec<Box<T>>>>,
+}
+
+impl<T: Default> MockPointerAllocator<T> {
+    /// Create a new pointer allocator for type `T`.
+    pub fn new() -> Self {
+        Self {
+            allocations: std::sync::Arc::new(std::sync::Mutex::new(Vec::new())),
         }
+    }
+
+    fn locked(&self) -> std::sync::MutexGuard<'_, Vec<Box<T>>> {
+        self.allocations.lock().expect("Failed to acquire lock")
+    }
+
+    /// Allocate a new heap-backed pointer with default value.
+    ///
+    /// # Returns
+    /// A raw mutable pointer to a heap-allocated `T` with default value.
+    pub fn allocate(&self) -> *mut T {
+        let mut allocs = self.locked();
+        allocs.push(Box::default());
+        allocs
+            .last_mut()
+            .expect("Failed to allocate pointer")
+            .as_mut() as *mut T
+    }
+
+    /// Free a previously allocated pointer.
+    ///
+    /// # Parameters
+    /// - `ptr`: The raw pointer to free, previously returned by `allocate()`
+    ///
+    /// # Returns
+    /// - `true` if the pointer was found and freed
+    /// - `false` if the pointer was not found in tracked allocations
+    pub fn free(&self, ptr: *mut T) -> bool {
+        let mut allocs = self.locked();
+        allocs
+            .extract_if(.., |b| b.as_mut() as *mut T == ptr)
+            .next()
+            .is_some()
+    }
+
+    /// Assert that all allocations have been freed (count is 0).
+    ///
+    /// # Panics
+    /// Panics if there are still tracked allocations.
+    ///
+    /// # Example
+    /// ```ignore
+    /// allocator.assert_all_freed(); // Instead of assert_eq!(allocator.count(), 0, ...)
+    /// ```
+    pub fn assert_all_freed(&self) {
+        let count = self.locked().len();
+        assert_eq!(
+            count,
+            0,
+            "memory leak: {} pointer(s) of type {} not freed",
+            count,
+            std::any::type_name::<T>()
+        );
+    }
+}
+
+impl<T: Default> Clone for MockPointerAllocator<T> {
+    fn clone(&self) -> Self {
+        Self {
+            allocations: std::sync::Arc::clone(&self.allocations),
+        }
+    }
+}
+
+impl<T: Default> Default for MockPointerAllocator<T> {
+    fn default() -> Self {
+        Self::new()
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -11,6 +11,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+// This file provides a mock implementation of the FFIBridge trait for testing purposes.
+// It is kind of stub code which we will change according to the needs of our tests.
+// As of now, it just provide basic mock implementation and returning values based on
+// input parameters. In future, we will enhance this mock implementation to verify
+// all the test cases and scenarios.
+#![doc(hidden)]
+
 pub use bridge_ffi_rs::{
     CMutVoidPtr, CVoidPtr, FFIBridge, FatPtr, FindServiceHandle, HandleContainer, HandleType,
     InstanceSpecifier, NativeFindServiceHandle, NativeHandleContainer, NativeInstanceSpecifier,
@@ -234,5 +241,27 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
             // SAFETY: handle was allocated by start_find_service via Box::into_raw
             drop(Box::from_raw(handle));
         }
+    }
+}
+
+impl MockFFIBridge {
+    /// The handle container is backed by a heap-allocated zeroed stub so the pointer
+    /// is stable and non-dangling.  An extra `Arc` clone is intentionally forgotten
+    /// inside this function so the strong count is permanently pinned above zero —
+    /// meaning `HandleContainer::drop` (which calls real C++) is never invoked
+    /// regardless of how many clones the caller makes or drops.
+    pub fn make_handle_container() -> std::sync::Arc<HandleContainer> {
+        // A zeroed usize gives a stable heap pointer.
+        let ptr = Box::leak(Box::new(0usize)) as *mut usize as *mut NativeHandleContainer;
+        let hc = std::sync::Arc::new(HandleContainer::new(ptr));
+        //To avoid the drop of HandleContainer which will call the real C++ destructor.
+        std::mem::forget(std::sync::Arc::clone(&hc));
+        hc
+    }
+
+    /// `ProxyEventBase` is a ZST opaque type, a dangling non-null pointer is the
+    /// canonical representation for "valid but empty" in the mock.
+    pub fn make_proxy_event_ptr() -> *mut ProxyEventBase {
+        std::ptr::NonNull::<ProxyEventBase>::dangling().as_ptr()
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -26,18 +26,19 @@ use bridge_ffi_rs::{
 };
 use std::cell::RefCell;
 
-// Per-test thread-local backing storage for the allocate-and-send mock path.
-//
-// `DATA_BACKING` holds a type-erased pointer to a heap-allocated `MaybeUninit<T>` buffer
-// paired with a drop-glue function so `clear_alloc_backing` can free it without knowing `T`.
-//
-// `ALLOC_SIZE` holds `size_of::<SampleAllocateePtr<T>>()` so `get_allocatee_ptr` can
-// zero-fill the caller's `MaybeUninit` slot — zeroed = Blank variant (_index = 0),
-// which makes `assume_init()` defined behaviour.
+// Type alias for the heap-pointer + drop-glue pair stored in backing thread-locals.
+type BackingEntry = (*mut std::ffi::c_void, fn(*mut std::ffi::c_void));
+
+// The thread-local storage is used to hold the backing data for the mock FFI bridge.
 thread_local! {
-    static DATA_BACKING: RefCell<Option<(*mut std::ffi::c_void, fn(*mut std::ffi::c_void))>> =
-        RefCell::new(None);
-    static ALLOC_SIZE: RefCell<usize> = RefCell::new(0);
+    //DATA_BACKING holds a pointer to the heap-allocated backing data and a drop function to free it.
+    //We are using this when user calls get_allocatee_data_ptr to return a pointer to this backing data.
+    static DATA_BACKING: RefCell<Option<BackingEntry>> = RefCell::new(None);
+    //ALLOC_SIZE holds the size of the allocatee type for the next get_allocatee_ptr call, allowing
+    //the mock to zero-fill the caller's slot correctly.
+    static ALLOC_SIZE: RefCell<usize> = const { RefCell::new(0) };
+    //SAMPLE_BACKING holds a pointer to the heap-allocated sample data and a drop function to free it.
+    static SAMPLE_BACKING: RefCell<Option<BackingEntry>> = RefCell::new(None);
 }
 
 #[derive(Debug, Clone)]
@@ -90,13 +91,24 @@ impl bridge_ffi_rs::FFIBridge for MockFFIBridge {
     }
 
     unsafe fn sample_ptr_get(
-        sample_ptr: *const std::ffi::c_void,
+        _sample_ptr: *const std::ffi::c_void,
         _type_name: &str,
     ) -> *const std::ffi::c_void {
-        sample_ptr
+        SAMPLE_BACKING.with(|s| {
+            s.borrow()
+                .as_ref()
+                .map(|(ptr, _)| *ptr as *const std::ffi::c_void)
+                .unwrap_or(std::ptr::null())
+        })
     }
 
-    unsafe fn sample_ptr_delete(_sample_ptr: *mut std::ffi::c_void, _type_name: &str) {}
+    unsafe fn sample_ptr_delete(_sample_ptr: *mut std::ffi::c_void, _type_name: &str) {
+        SAMPLE_BACKING.with(|s| {
+            if let Some((ptr, drop_fn)) = s.borrow_mut().take() {
+                drop_fn(ptr);
+            }
+        });
+    }
 
     unsafe fn skeleton_offer_service(skeleton_ptr: *mut SkeletonBase) -> bool {
         !skeleton_ptr.is_null()
@@ -259,5 +271,25 @@ impl MockFFIBridge {
             }
         });
         ALLOC_SIZE.with(|s| *s.borrow_mut() = std::mem::size_of::<SampleAllocateePtr<T>>());
+    }
+
+    // Registers `data` as the backing value for the next `sample_ptr_get` /
+    // `sample_ptr_delete` cycle.
+    //
+    // Heap-allocates `data` and stores a typed drop-glue so `sample_ptr_delete`
+    // can free it without knowing `T`. `sample_ptr_get` returns the pointer to
+    // the heap `T`, making `get_data()` return a valid `&T`.
+    pub fn set_sample_backing<T: 'static>(data: T) {
+        let ptr = Box::into_raw(Box::new(data)) as *mut std::ffi::c_void;
+        let drop_fn: fn(*mut std::ffi::c_void) = |p| {
+            // SAFETY: p was allocated as Box<T> by set_sample_backing::<T>.
+            drop(unsafe { Box::from_raw(p as *mut T) });
+        };
+        // Replace any previous backing (prevents leaks on repeated calls).
+        SAMPLE_BACKING.with(|s| {
+            if let Some((old_ptr, old_drop)) = s.borrow_mut().replace((ptr, drop_fn)) {
+                old_drop(old_ptr);
+            }
+        });
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/BUILD
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/BUILD
@@ -30,6 +30,7 @@ rust_library(
         "//score/mw/com/impl/rust:mw_com",
         "//score/mw/com/impl/rust/com-api/com-api-concept",
         "//score/mw/com/impl/rust/com-api/com-api-ffi-lola:bridge_ffi_rs",
+        "//score/mw/com/impl/rust/com-api/com-api-ffi-lola:bridge_ffi_lola",
         "@score_communication_crate_index//:futures",
     ],
 )

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/BUILD
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/BUILD
@@ -29,8 +29,8 @@ rust_library(
         "//score/mw/com/impl/plumbing/rust:sample_ptr_rs",
         "//score/mw/com/impl/rust:mw_com",
         "//score/mw/com/impl/rust/com-api/com-api-concept",
-        "//score/mw/com/impl/rust/com-api/com-api-ffi-lola:bridge_ffi_rs",
         "//score/mw/com/impl/rust/com-api/com-api-ffi-lola:bridge_ffi_lola",
+        "//score/mw/com/impl/rust/com-api/com-api-ffi-lola:bridge_ffi_rs",
         "@score_communication_crate_index//:futures",
     ],
 )
@@ -38,8 +38,12 @@ rust_library(
 rust_test(
     name = "com-api-runtime-lola-tests",
     crate = ":com-api-runtime-lola",
-    deps = [":com-api-runtime-lola",
-    "//score/mw/com/impl/rust/com-api/com-api-ffi-lola:bridge_ffi_mock",],
+    #tag will be removed wwhen sanitizer issue resolved for this
+    tags = ["manual"],
+    deps = [
+        ":com-api-runtime-lola",
+        "//score/mw/com/impl/rust/com-api/com-api-ffi-lola:bridge_ffi_mock",
+    ],
 )
 
 rust_doc_test(

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/BUILD
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/BUILD
@@ -37,8 +37,8 @@ rust_library(
 rust_test(
     name = "com-api-runtime-lola-tests",
     crate = ":com-api-runtime-lola",
-    tags = ["manual"],
-    deps = [":com-api-runtime-lola"],
+    deps = [":com-api-runtime-lola",
+    "//score/mw/com/impl/rust/com-api/com-api-ffi-lola:bridge_ffi_mock",],
 )
 
 rust_doc_test(

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/BUILD
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/BUILD
@@ -21,6 +21,7 @@ rust_library(
         "producer.rs",
         "runtime.rs",
     ],
+    edition = "2024",
     visibility = [
         "//visibility:public",  # platform_only
     ],
@@ -38,6 +39,7 @@ rust_library(
 rust_test(
     name = "com-api-runtime-lola-tests",
     crate = ":com-api-runtime-lola",
+    edition = "2024",
     #tag will be removed wwhen sanitizer issue resolved for this
     tags = ["manual"],
     deps = [

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/BUILD
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/BUILD
@@ -45,6 +45,7 @@ rust_test(
     deps = [
         ":com-api-runtime-lola",
         "//score/mw/com/impl/rust/com-api/com-api-ffi-lola:bridge_ffi_mock",
+        "@score_communication_crate_index//:mockall",
     ],
 )
 

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -291,7 +291,9 @@ pub struct SubscribableImpl<T, B: FFIBridge> {
     data: PhantomData<T>,
 }
 
-impl<T: CommData + Debug, B: FFIBridge> Subscriber<T, LolaRuntimeImpl<B>> for SubscribableImpl<T, B> {
+impl<T: CommData + Debug, B: FFIBridge> Subscriber<T, LolaRuntimeImpl<B>>
+    for SubscribableImpl<T, B>
+{
     type Subscription = SubscriberImpl<T, B>;
     fn new(identifier: &'static str, instance_info: LolaConsumerInfo<B>) -> Result<Self> {
         let handle = instance_info.get_handle().ok_or(Error::ConsumerError(
@@ -803,13 +805,13 @@ impl std::fmt::Debug for DiscoveryStateData {
     }
 }
 
-pub struct SampleConsumerDiscovery<I, B: FFIBridge> {
+pub struct LolaConsumerDiscovery<I, B: FFIBridge> {
     pub instance_specifier: InstanceSpecifier,
     pub _interface: PhantomData<I>,
     pub _bridge: PhantomData<B>,
 }
 
-impl<I: Interface, B: FFIBridge> SampleConsumerDiscovery<I, B> {
+impl<I: Interface, B: FFIBridge> LolaConsumerDiscovery<I, B> {
     pub fn new(_runtime: &LolaRuntimeImpl<B>, instance_specifier: InstanceSpecifier) -> Self {
         Self {
             instance_specifier,
@@ -819,12 +821,13 @@ impl<I: Interface, B: FFIBridge> SampleConsumerDiscovery<I, B> {
     }
 }
 
-impl<I: Interface + Send, B: FFIBridge> ServiceDiscovery<I, LolaRuntimeImpl<B>> for SampleConsumerDiscovery<I, B>
+impl<I: Interface + Send, B: FFIBridge> ServiceDiscovery<I, LolaRuntimeImpl<B>>
+    for LolaConsumerDiscovery<I, B>
 where
-    SampleConsumerBuilder<I, B>: ConsumerBuilder<I, LolaRuntimeImpl<B>>,
+    LolaConsumerBuilder<I, B>: ConsumerBuilder<I, LolaRuntimeImpl<B>>,
 {
-    type ConsumerBuilder = SampleConsumerBuilder<I, B>;
-    type ServiceEnumerator = Vec<SampleConsumerBuilder<I, B>>;
+    type ConsumerBuilder = LolaConsumerBuilder<I, B>;
+    type ServiceEnumerator = Vec<LolaConsumerBuilder<I, B>>;
 
     fn get_available_instances(&self) -> Result<Self::ServiceEnumerator> {
         //If ANY Support is added in Lola, then we need to return all available instances
@@ -961,15 +964,13 @@ impl<I: Interface, B: FFIBridge> Drop for ServiceDiscoveryFuture<I, B> {
         // This unconditional call ensures the C++ discovery operation is always
         // cleaned up, even when the future is dropped before the callback fires.
         unsafe {
-            B::stop_find_service(
-                self.find_handle.as_mut() as *mut bridge_ffi_rs::FindServiceHandle
-            );
+            B::stop_find_service(self.find_handle.as_mut() as *mut bridge_ffi_rs::FindServiceHandle);
         }
     }
 }
 
 impl<I: Interface, B: FFIBridge> Future for ServiceDiscoveryFuture<I, B> {
-    type Output = Result<Vec<SampleConsumerBuilder<I, B>>>;
+    type Output = Result<Vec<LolaConsumerBuilder<I, B>>>;
 
     fn poll(
         self: std::pin::Pin<&mut Self>,
@@ -1017,20 +1018,27 @@ impl<I: Interface, B: FFIBridge> Future for ServiceDiscoveryFuture<I, B> {
     }
 }
 
-impl<I: Interface, B: FFIBridge> ConsumerBuilder<I, LolaRuntimeImpl<B>> for SampleConsumerBuilder<I, B> {}
+impl<I: Interface, B: FFIBridge> ConsumerBuilder<I, LolaRuntimeImpl<B>>
+    for LolaConsumerBuilder<I, B>
+{
+}
 
-impl<I: Interface, B: FFIBridge> Builder<I::Consumer<LolaRuntimeImpl<B>>> for SampleConsumerBuilder<I, B> {
+impl<I: Interface, B: FFIBridge> Builder<I::Consumer<LolaRuntimeImpl<B>>>
+    for LolaConsumerBuilder<I, B>
+{
     fn build(self) -> Result<I::Consumer<LolaRuntimeImpl<B>>> {
         Ok(Consumer::new(self.instance_info))
     }
 }
 
-pub struct SampleConsumerBuilder<I: Interface, B: FFIBridge> {
+pub struct LolaConsumerBuilder<I: Interface, B: FFIBridge> {
     pub instance_info: LolaConsumerInfo<B>,
     pub _interface: PhantomData<I>,
 }
 
-impl<I: Interface, B: FFIBridge> ConsumerDescriptor<LolaRuntimeImpl<B>> for SampleConsumerBuilder<I, B> {
+impl<I: Interface, B: FFIBridge> ConsumerDescriptor<LolaRuntimeImpl<B>>
+    for LolaConsumerBuilder<I, B>
+{
     fn get_instance_identifier(&self) -> &InstanceSpecifier {
         //if InstanceSpecifier::ANY support enable by lola
         //then this API should get InstanceSpecifier from FFI Call
@@ -1151,120 +1159,92 @@ pub fn create_sample_callback<'a, T: CommData + Debug, B: FFIBridge>(
 
 #[cfg(test)]
 mod test {
-    use com_api_concept::{
-        CommData, Consumer, Interface, OfferedProducer, Producer, Result, Runtime, ServiceDiscovery,
-    };
 
-    #[derive(Debug, Clone, Copy)]
+    use super::*;
+    use bridge_ffi_mock::MockFFIBridge;
+
+    #[derive(Debug)]
     #[repr(C)]
-    struct TestData(u32);
+    struct TestData {
+        value: i32,
+    }
 
     unsafe impl com_api_concept::Reloc for TestData {}
 
-    impl CommData for TestData {
+    impl com_api_concept::CommData for TestData {
         const ID: &'static str = "TestData";
     }
 
-    // Test Consumer implementation
-    #[derive(Debug)]
-    struct TestConsumer;
+    // Builds a ProxyInstanceManager<MockFFIBridge>
+    fn make_proxy_instance(interface_id: &'static str) -> ProxyInstanceManager<MockFFIBridge> {
+        // SAFETY: HandleType is a ZST; zeroed() produces a valid value.
+        let handle: HandleType = unsafe { core::mem::zeroed() };
+        let native_proxy = NativeProxyBase::<MockFFIBridge>::new(interface_id, &handle)
+            .expect("MockFFIBridge::create_proxy should not fail");
+        ProxyInstanceManager(Arc::new(native_proxy))
+    }
 
-    impl<R: Runtime + ?Sized> Consumer<R> for TestConsumer {
-        fn new(_: R::ConsumerInfo) -> Self {
-            TestConsumer
+    // Builds a `LolaConsumerInfo<MockFFIBridge>` backed by a mock handle container.
+    fn make_instance_info() -> LolaConsumerInfo<MockFFIBridge> {
+        LolaConsumerInfo::<MockFFIBridge> {
+            handle_container: MockFFIBridge::make_handle_container(),
+            handle_index: 0,
+            interface_id: "TestInterface",
+            _marker: PhantomData,
         }
     }
 
-    // Test Producer implementation
-    #[derive(Debug)]
-    struct TestProducer;
-
-    impl<R: Runtime + ?Sized> Producer<R> for TestProducer {
-        type Interface = TestVehicleInterface;
-        type OfferedProducer = TestOfferedProducer;
-
-        fn offer(self) -> Result<Self::OfferedProducer> {
-            Ok(TestOfferedProducer)
-        }
-
-        fn new(_: R::ProviderInfo) -> Result<Self>
-        where
-            Self: Sized,
-        {
-            Ok(TestProducer)
-        }
+    #[test]
+    fn test_lola_consumer_info() {
+        let instance_info = make_instance_info();
+        assert!(instance_info.get_handle().is_none());
     }
-
-    // Test OfferedProducer implementation
-    struct TestOfferedProducer;
-
-    impl<R: Runtime + ?Sized> OfferedProducer<R> for TestOfferedProducer {
-        type Interface = TestVehicleInterface;
-        type Producer = TestProducer;
-
-        fn unoffer(self) -> Result<Self::Producer> {
-            Ok(TestProducer)
-        }
-    }
-
-    // Test Interface implementation
-    struct TestVehicleInterface;
-
-    impl Interface for TestVehicleInterface {
-        const INTERFACE_ID: &'static str = "TestVehicleInterface";
-        type Consumer<R: Runtime + ?Sized> = TestConsumer;
-        type Producer<R: Runtime + ?Sized> = TestProducer;
+    #[test]
+    fn test_sample() {
+        // SamplePtr is an opaque FFI type; use zeroed() to construct storage.
+        // MockFFIBridge::sample_ptr_delete is a no-op so this is safe.
+        let sample = Sample::<TestData, MockFFIBridge> {
+            id: 1,
+            inner: LolaBinding::<TestData, MockFFIBridge> {
+                data: ManuallyDrop::new(unsafe {
+                    core::mem::zeroed::<sample_ptr_rs::SamplePtr<TestData>>()
+                }),
+                _bridge: PhantomData,
+            },
+        };
+        assert_eq!(sample.id, 1);
+        let _data = sample.get_data();
     }
 
     #[test]
-    fn test_comm_data_trait() {
-        // Verify TestData implements CommData
-        assert_eq!(TestData::ID, "TestData");
-        let _data = TestData(42);
+    fn test_subscribable_impl() {
+        let subscribable = SubscribableImpl::<TestData, MockFFIBridge> {
+            identifier: "TestEvent",
+            instance_info: make_instance_info(),
+            proxy_instance: make_proxy_instance("TestInterface"),
+            data: PhantomData,
+        };
+        let _ = subscribable.subscribe(3);
     }
 
     #[test]
-    fn test_discovery_state_data_creation() {
-        // Test that DiscoveryStateData can be created with None values
-        let state = super::DiscoveryStateData { handles: None };
-        assert!(state.handles.is_none());
-    }
-
-    #[test]
-    fn test_discovery_state_data_debug() {
-        // Test that DiscoveryStateData debug formatting works
-        let state = super::DiscoveryStateData { handles: None };
-        let debug_string = format!("{:?}", state);
-        assert!(debug_string.contains("DiscoveryStateData"));
-        assert!(debug_string.contains("handles"));
-    }
-
-    #[test]
-    fn test_sample_consumer_discovery_creation() {
-        // Test that LolaConsumerDiscovery can be created with valid interface
-        let instance_specifier = com_api_concept::InstanceSpecifier::new("/test/vehicle")
-            .expect("Failed to create instance specifier");
-
-        let _discovery = super::LolaConsumerDiscovery::<TestVehicleInterface>::new(
-            &super::super::LolaRuntimeImpl {},
-            instance_specifier,
-        );
-        // Discovery created successfully
-    }
-
-    #[test]
-    #[ignore] // Requires LoLa runtime initialization and configuration
-    fn test_get_available_instances_method_exists() {
-        // Test that get_available_instances() can be called on ServiceDiscovery trait
-        let instance_specifier = com_api_concept::InstanceSpecifier::new("/test/vehicle")
-            .expect("Failed to create instance specifier");
-
-        let discovery = super::LolaConsumerDiscovery::<TestVehicleInterface>::new(
-            &super::super::LolaRuntimeImpl {},
-            instance_specifier,
-        );
-
-        // Call get_available_instances - verifies the method exists and is callable
-        let _result = discovery.get_available_instances();
+    fn test_subscriber_impl() {
+        let subscriber = SubscriberImpl::<TestData, MockFFIBridge> {
+            event: ProxyEventManager {
+                event: MockFFIBridge::make_proxy_event_ptr(),
+                in_progress: AtomicBool::new(false),
+            },
+            event_id: "TestEvent",
+            max_num_samples: 10,
+            instance_info: make_instance_info(),
+            waker_storage: Arc::new(AtomicWaker::new()),
+            async_init_status: std::sync::Once::new(),
+            _proxy: make_proxy_instance("TestInterface"),
+            _phantom: PhantomData,
+        };
+        let mut sample_container = SampleContainer::new(5);
+        let _ = subscriber.try_receive(&mut sample_container, 5);
+        let _ = subscriber.init_async_receive(&mut subscriber.event.get_proxy_event());
+        let _ = subscriber.receive(sample_container, 5, 5);
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -1219,6 +1219,7 @@ mod test {
 
     use super::*;
     use bridge_ffi_mock::{MockFFIBridge, SharedMockBridge};
+    use std::sync::Mutex;
 
     #[derive(Debug)]
     #[repr(C)]
@@ -1268,15 +1269,49 @@ mod test {
     #[test]
     fn test_subscribe_event() {
         let mut mock = MockFFIBridge::new();
+        // we need Arc here because expect closures are take the ownership of the variables,
+        // and we need to share the state between multiple expectations.
+        // vec is required to store multiple proxies/events and simulate multiple calls to create_proxy/subscribe_to_event/get_event_from_proxy/unsubscribe_to_event/destroy_proxy.
+        // also cleanup the created proxies/events by removing them from the vec when destroy/unsubscribe is called, and assert the pointer passed in is valid by checking if it exists in the vec.
+        let proxy_vec = Arc::new(Mutex::new(Vec::new()));
+        let event_vec = Arc::new(Mutex::new(Vec::new()));
 
         // Set up all expectations - all clones of SharedMockBridge will share these
+        let proxy = proxy_vec.clone();
+        mock.expect_create_proxy().returning(move |_, _| {
+            let mut proxy = proxy.lock().expect("not able to acquire lock on proxy_vec");
+            proxy.push(Box::<ProxyBase>::default());
+            // Push first, then take the pointer from the last element no borrow conflict.
+            proxy.last_mut().unwrap().as_mut() as *mut ProxyBase
+        });
         mock.expect_subscribe_to_event().returning(|_, _| true);
+        let event = event_vec.clone();
         mock.expect_get_event_from_proxy()
-            .returning(|_, _, _| Box::into_raw(Box::default()));
-        mock.expect_unsubscribe_to_event().returning(|_| ());
-        mock.expect_destroy_proxy().returning(|_| ());
-        mock.expect_create_proxy()
-            .returning(|_, _| Box::into_raw(Box::default()));
+            .returning(move |_, _, _| {
+                let mut event = event.lock().expect("not able to acquire lock on event_vec");
+                event.push(Box::<ProxyEventBase>::default());
+                // Push first, then take the pointer from the last element to avoid borrow conflict.
+                event.last_mut().unwrap().as_mut() as *mut ProxyEventBase
+            });
+        let event = event_vec.clone();
+        mock.expect_unsubscribe_to_event().returning(move |ptr| {
+            let mut event = event.lock().expect("not able to acquire lock on event_vec");
+            let pos = event
+                .iter_mut()
+                .position(|b| b.as_mut() as *mut ProxyEventBase == ptr)
+                .expect("unsubscribe_to_event called with unknown pointer");
+            event.remove(pos);
+        });
+
+        let proxy = proxy_vec.clone();
+        mock.expect_destroy_proxy().returning(move |ptr| {
+            let mut proxy = proxy.lock().expect("not able to acquire lock on proxy_vec");
+            let pos = proxy
+                .iter_mut()
+                .position(|b| b.as_mut() as *mut ProxyBase == ptr)
+                .expect("destroy_proxy called with unknown pointer");
+            proxy.remove(pos);
+        });
         // Create a single shared mock with all necessary expectations
         let bridge = SharedMockBridge::new(mock);
 

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -22,6 +22,9 @@
 //! The implementation ensures proper memory management and resource handling
 //! through Rust's ownership model and FFI safety practices.
 
+// Cloning to bridge is fine here because LolaFFIBridge is ZST and has no internal state,
+// so all clones are identical and stateless.
+
 //lifetime warning for all the Sample struct impl block, it is required for the Sample struct
 // event lifetime parameter
 // and mentaining lifetime of instances and data reference
@@ -58,15 +61,14 @@ pub struct LolaConsumerInfo<B: FFIBridge> {
     handle_container: Arc<mw_com::proxy::HandleContainer>,
     handle_index: usize,
     interface_id: &'static str,
-    _marker: PhantomData<B>,
+    bridge: B,
 }
 
 impl<B: FFIBridge> LolaConsumerInfo<B> {
     /// Get a reference to the handle, guaranteed valid as long as this struct exists
     pub fn get_handle(&self) -> Option<&HandleType> {
-        // SAFETY: handle_container was produced by the bridge or a trusted mock;
-        // both implementations uphold the contract of handle_container_get_at.
-        B::handle_container_get_at(&self.handle_container, self.handle_index)
+        self.bridge
+            .handle_container_get_at(&self.handle_container, self.handle_index)
     }
 }
 
@@ -79,7 +81,7 @@ where
     T: CommData + Debug,
 {
     data: ManuallyDrop<sample_ptr_rs::SamplePtr<T>>,
-    _bridge: PhantomData<B>,
+    bridge: B,
 }
 
 impl<T, B: FFIBridge> Drop for LolaBinding<T, B>
@@ -91,7 +93,7 @@ where
         //SamplePtr created by FFI
         unsafe {
             let mut sample_ptr = ManuallyDrop::take(&mut self.data);
-            B::sample_ptr_delete(
+            self.bridge.sample_ptr_delete(
                 std::ptr::from_mut(&mut sample_ptr) as *mut std::ffi::c_void,
                 T::ID,
             );
@@ -120,7 +122,7 @@ where
         //SAFETY: It is safe to get the data pointer because SamplePtr is valid
         //and data is valid as long as SamplePtr is valid
         unsafe {
-            let data_ptr = B::sample_ptr_get(
+            let data_ptr = self.inner.bridge.sample_ptr_get(
                 std::ptr::from_ref(&(*self.inner.data)) as *const std::ffi::c_void,
                 T::ID,
             );
@@ -204,7 +206,7 @@ impl<B: FFIBridge> std::fmt::Debug for ProxyInstanceManager<B> {
 /// Or must not provide any method to access the proxy instance directly
 pub struct NativeProxyBase<B: FFIBridge> {
     proxy: NonNull<ProxyBase>, // Stores the proxy instance
-    _marker: PhantomData<B>,
+    bridge: B,
 }
 
 //SAFETY: NativeProxyBase is safe to share between threads because:
@@ -220,7 +222,7 @@ impl<B: FFIBridge> Drop for NativeProxyBase<B> {
         //SAFETY: It is safe to destroy the proxy because it was created by FFI
         // and proxy pointer received at the time of create_proxy called
         unsafe {
-            B::destroy_proxy(self.proxy.as_ptr());
+            self.bridge.destroy_proxy(self.proxy.as_ptr());
         }
     }
 }
@@ -232,16 +234,16 @@ impl<B: FFIBridge> std::fmt::Debug for NativeProxyBase<B> {
 }
 
 impl<B: FFIBridge> NativeProxyBase<B> {
-    pub fn new(interface_id: &str, handle: &HandleType) -> Result<Self> {
+    pub fn new(bridge: &B, interface_id: &str, handle: &HandleType) -> Result<Self> {
         //SAFETY: It is safe to create the proxy because interface_id and handle are valid
         //Handle received at the time of get_avaible_instances called with correct interface_id
-        let raw_proxy_ptr = unsafe { B::create_proxy(interface_id, handle) };
+        let raw_proxy_ptr = unsafe { bridge.create_proxy(interface_id, handle) };
         let proxy = std::ptr::NonNull::new(raw_proxy_ptr).ok_or(Error::ConsumerError(
             ConsumerFailedReason::ProxyCreationFailed,
         ))?;
         Ok(Self {
             proxy,
-            _marker: PhantomData,
+            bridge: bridge.clone(),
         })
     }
 }
@@ -266,13 +268,18 @@ unsafe impl Send for NativeProxyEventBase {}
 impl NativeProxyEventBase {
     pub fn new<B: FFIBridge>(
         proxy: &NonNull<ProxyBase>,
-        interface_id: &str,
+        instance_info: &LolaConsumerInfo<B>,
         identifier: &str,
     ) -> Result<Self> {
         //SAFETY: It is safe as we are passing valid proxy pointer and interface id to get event
         // proxy pointer is created during consumer creation
-        let raw_event_ptr =
-            unsafe { B::get_event_from_proxy(proxy.as_ptr(), interface_id, identifier) };
+        let raw_event_ptr = unsafe {
+            instance_info.bridge.get_event_from_proxy(
+                proxy.as_ptr(),
+                instance_info.interface_id,
+                identifier,
+            )
+        };
         let proxy_event_ptr = std::ptr::NonNull::new(raw_event_ptr)
             .ok_or(Error::EventError(EventFailedReason::EventCreationFailed))?;
         Ok(Self { proxy_event_ptr })
@@ -308,7 +315,8 @@ impl<T: CommData + Debug, B: FFIBridge> Subscriber<T, LolaRuntimeImpl<B>>
         let handle = instance_info.get_handle().ok_or(Error::ConsumerError(
             ConsumerFailedReason::ServiceHandleNotFound,
         ))?;
-        let native_proxy = NativeProxyBase::new(instance_info.interface_id, handle)?;
+        let native_proxy =
+            NativeProxyBase::new(&instance_info.bridge, instance_info.interface_id, handle)?;
         let proxy_instance = ProxyInstanceManager(Arc::new(native_proxy));
         Ok(Self {
             identifier,
@@ -324,7 +332,7 @@ impl<T: CommData + Debug, B: FFIBridge> Subscriber<T, LolaRuntimeImpl<B>>
         let instance_info = self.instance_info.clone();
         let event_instance = NativeProxyEventBase::new::<B>(
             &self.proxy_instance.0.proxy,
-            self.instance_info.interface_id,
+            &instance_info,
             self.identifier,
         )?;
         let max_num_samples_u32 = u32::try_from(max_num_samples).map_err(|_| {
@@ -336,7 +344,7 @@ impl<T: CommData + Debug, B: FFIBridge> Subscriber<T, LolaRuntimeImpl<B>>
         //SAFETY: It is safe to subscribe to event because event_instance is valid
         // which was obtained from valid proxy instance
         let status = unsafe {
-            B::subscribe_to_event(
+            self.instance_info.bridge.subscribe_to_event(
                 std::ptr::from_ref(event_instance.get_proxy_event_base()) as *mut ProxyEventBase,
                 max_num_samples_u32,
             )
@@ -476,9 +484,13 @@ impl<T: CommData + Debug, B: FFIBridge> Drop for SubscriberImpl<T, B> {
             if self.async_init_status.get().is_some()
             // Check if the async receive callback was initialized
             {
-                B::clear_event_receive_handler(guard.deref_mut(), T::ID);
+                self.instance_info
+                    .bridge
+                    .clear_event_receive_handler(guard.deref_mut(), T::ID);
             }
-            B::unsubscribe_to_event(guard.deref_mut());
+            self.instance_info
+                .bridge
+                .unsubscribe_to_event(guard.deref_mut());
         }
     }
 }
@@ -499,7 +511,11 @@ impl<T: CommData + Debug, B: FFIBridge> SubscriberImpl<T, B> {
         // and the lifetime of the callback is managed by Rust, it will not outlive the scope of
         // this function call.
         let status = unsafe {
-            B::set_event_receive_handler(event_guard.deref_mut(), &fat_ptr, T::ID)
+            self.instance_info.bridge.set_event_receive_handler(
+                event_guard.deref_mut(),
+                &fat_ptr,
+                T::ID,
+            )
         };
         if !status {
             // SAFETY: ptr was allocated as Box<dyn FnMut() + Send + 'static> via Box::into_raw
@@ -592,6 +608,7 @@ where
         max_samples: usize,
     ) -> Result<usize> {
         try_receive_samples::<T, B>(
+            &self.instance_info.bridge,
             self.event.get_proxy_event().deref_mut(),
             scratch,
             self.max_num_samples,
@@ -639,6 +656,7 @@ where
                 max_samples,
                 total_received: 0,
                 cancellation: core::pin::pin!(cancellation),
+                bridge: self.instance_info.bridge.clone(),
             }
             .await
         }
@@ -674,6 +692,7 @@ struct ReceiveFuture<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBrid
     max_samples: usize,
     total_received: usize,
     cancellation: Pin<&'a mut F>,
+    bridge: B,
 }
 
 impl<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBridge> Future for ReceiveFuture<'a, T, F, B> {
@@ -685,6 +704,10 @@ impl<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBridge> Future for R
         let new_samples = self.new_samples;
         let max_num_samples = self.max_num_samples;
         let total_received = self.total_received;
+        // Clone bridge to avoid borrow checker conflict:
+        // We need an immutable reference to bridge while also mutably borrowing self.scratch and self.event_guard.
+        // For LolaFFIBridge (ZST), clone is free.
+        let bridge = self.bridge.clone();
 
         // Poll the cancellation future first to ensure prompt handling of cancellation requests.
         if self.cancellation.as_mut().poll(ctx).is_ready() {
@@ -706,6 +729,7 @@ impl<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBridge> Future for R
             if let Some(mut scratch) = self.scratch.take() {
                 if let Some(event_guard) = self.event_guard.as_mut() {
                     let result = try_receive_samples::<T, B>(
+                        &bridge,
                         event_guard.deref_mut(),
                         &mut scratch,
                         max_num_samples,
@@ -832,17 +856,17 @@ impl std::fmt::Debug for DiscoveryStateData {
 }
 
 pub struct LolaConsumerDiscovery<I, B: FFIBridge> {
-    pub instance_specifier: InstanceSpecifier,
-    pub _interface: PhantomData<I>,
-    pub _bridge: PhantomData<B>,
+    pub(crate) instance_specifier: InstanceSpecifier,
+    pub(crate) _interface: PhantomData<I>,
+    pub(crate) bridge: B,
 }
 
 impl<I: Interface, B: FFIBridge> LolaConsumerDiscovery<I, B> {
-    pub fn new(_runtime: &LolaRuntimeImpl<B>, instance_specifier: InstanceSpecifier) -> Self {
+    pub fn new(runtime: &LolaRuntimeImpl<B>, instance_specifier: InstanceSpecifier) -> Self {
         Self {
             instance_specifier,
             _interface: PhantomData,
-            _bridge: PhantomData,
+            bridge: runtime.bridge.clone(),
         }
     }
 }
@@ -872,7 +896,7 @@ where
                     handle_container: Arc::clone(&service_handle_arc),
                     handle_index,
                     interface_id: I::INTERFACE_ID,
-                    _marker: PhantomData,
+                    bridge: self.bridge.clone(),
                 };
                 LolaConsumerBuilder {
                     instance_info,
@@ -935,12 +959,13 @@ where
         // the same representation in memory as a FnMut fat pointer
         let fat_ptr: FatPtr = unsafe { std::mem::transmute(dyn_callback) };
 
+        let bridge = self.bridge.clone();
         let find_service_result = instance_specifier_lola.and_then(|spec| {
             // SAFETY: start_find_service is safe because fat_ptr is valid and
             // instance specifier is valid. The returned handle is stored
             // synchronously — before any async polling — guaranteeing
             // stop_find_service is always called in Drop.
-            let raw_handle = unsafe { B::start_find_service(&fat_ptr, spec) };
+            let raw_handle = unsafe { bridge.start_find_service(&fat_ptr, spec) };
             if raw_handle.is_null() {
                 Err(Error::ServiceError(
                     ServiceFailedReason::FailedToStartDiscovery,
@@ -961,7 +986,7 @@ where
                 discovery_state,
                 waker_storage,
                 _interface: PhantomData,
-                _bridge: PhantomData,
+                bridge,
             }
             .await
         }
@@ -980,7 +1005,7 @@ struct ServiceDiscoveryFuture<I: Interface, B: FFIBridge> {
     discovery_state: Arc<std::sync::Mutex<DiscoveryStateData>>,
     waker_storage: Arc<futures::task::AtomicWaker>,
     _interface: PhantomData<I>,
-    _bridge: PhantomData<B>,
+    bridge: B,
 }
 
 impl<I: Interface, B: FFIBridge> Drop for ServiceDiscoveryFuture<I, B> {
@@ -990,7 +1015,9 @@ impl<I: Interface, B: FFIBridge> Drop for ServiceDiscoveryFuture<I, B> {
         // This unconditional call ensures the C++ discovery operation is always
         // cleaned up, even when the future is dropped before the callback fires.
         unsafe {
-            B::stop_find_service(self.find_handle.as_mut() as *mut bridge_ffi_rs::FindServiceHandle);
+            self.bridge.stop_find_service(
+                self.find_handle.as_mut() as *mut bridge_ffi_rs::FindServiceHandle
+            );
         }
     }
 }
@@ -1028,7 +1055,7 @@ impl<I: Interface, B: FFIBridge> Future for ServiceDiscoveryFuture<I, B> {
                         handle_container: Arc::clone(&service_handle_arc),
                         handle_index,
                         interface_id: I::INTERFACE_ID,
-                        _marker: PhantomData,
+                        bridge: self.bridge.clone(),
                     };
                     LolaConsumerBuilder {
                         instance_info,
@@ -1086,6 +1113,7 @@ impl<I: Interface, B: FFIBridge> ConsumerDescriptor<LolaRuntimeImpl<B>>
 /// * `max_num_samples` - Maximum allowed samples for this subscription
 /// * `max_samples` - How many samples to fetch in this call
 fn try_receive_samples<T: CommData + Debug, B: FFIBridge>(
+    bridge: &B,
     event: &mut ProxyEventBase,
     scratch: &mut SampleContainer<Sample<T, B>>,
     max_num_samples: usize,
@@ -1108,7 +1136,7 @@ fn try_receive_samples<T: CommData + Debug, B: FFIBridge>(
         ));
     }
     // Create a callback that will be called by the C++ side for each new sample arrival
-    let mut callback = create_sample_callback::<T, B>(scratch, max_samples);
+    let mut callback = create_sample_callback::<T, B>(bridge, scratch, max_samples);
     // Convert closure to FatPtr for C++ callback
     let dyn_callback: &mut dyn FnMut(*mut sample_ptr_rs::SamplePtr<T>) = &mut callback;
     // SAFETY: it is safe to transmute the closure reference to a FatPtr because
@@ -1117,7 +1145,7 @@ fn try_receive_samples<T: CommData + Debug, B: FFIBridge>(
     // SAFETY: event is a valid ProxyEventBase pointer obtained during subscription.
     // The lifetime of the callback is managed by Rust and will not outlive this function call.
     let count = unsafe {
-        B::get_samples_from_event(
+        bridge.get_samples_from_event(
             event as *mut ProxyEventBase,
             T::ID,
             &fat_ptr,
@@ -1149,6 +1177,7 @@ fn try_receive_samples<T: CommData + Debug, B: FFIBridge>(
 /// * `scratch` - Mutable reference to the sample container
 /// * `max_samples` - Maximum number of samples to maintain in the container
 pub fn create_sample_callback<'a, T: CommData + Debug, B: FFIBridge>(
+    bridge: &'a B,
     scratch: &'a mut SampleContainer<Sample<T, B>>,
     max_samples: usize,
 ) -> impl FnMut(*mut sample_ptr_rs::SamplePtr<T>) + 'a {
@@ -1164,7 +1193,7 @@ pub fn create_sample_callback<'a, T: CommData + Debug, B: FFIBridge>(
                 id: ID_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
                 inner: LolaBinding {
                     data: ManuallyDrop::new(sample_ptr),
-                    _bridge: PhantomData,
+                    bridge: bridge.clone(),
                 },
             };
 
@@ -1187,7 +1216,7 @@ pub fn create_sample_callback<'a, T: CommData + Debug, B: FFIBridge>(
 mod test {
 
     use super::*;
-    use bridge_ffi_mock::{MockFFIBridge, MockFFIBridgeGuard};
+    use bridge_ffi_mock::MockFFIBridge;
 
     #[derive(Debug)]
     #[repr(C)]
@@ -1205,8 +1234,9 @@ mod test {
     fn make_proxy_instance(interface_id: &'static str) -> ProxyInstanceManager<MockFFIBridge> {
         // SAFETY: HandleType is a ZST; zeroed() produces a valid value.
         let handle: HandleType = unsafe { core::mem::zeroed() };
-        let native_proxy = NativeProxyBase::<MockFFIBridge>::new(interface_id, &handle)
-            .expect("MockFFIBridge::create_proxy should not fail");
+        let native_proxy =
+            NativeProxyBase::<MockFFIBridge>::new(&MockFFIBridge, interface_id, &handle)
+                .expect("MockFFIBridge::create_proxy should not fail");
         ProxyInstanceManager(Arc::new(native_proxy))
     }
 
@@ -1216,7 +1246,7 @@ mod test {
             handle_container: MockFFIBridge::make_handle_container(),
             handle_index: 0,
             interface_id: "TestInterface",
-            _marker: PhantomData,
+            bridge: MockFFIBridge,
         }
     }
 
@@ -1228,7 +1258,7 @@ mod test {
     #[test]
     fn test_sample() {
         //this is for cleanup of thread local state.
-        let _guard = MockFFIBridgeGuard;
+        // MockFFIBridge instance will clean up automatically on drop
         MockFFIBridge::set_sample_backing::<TestData>(TestData { value: 42 });
         let sample = Sample::<TestData, MockFFIBridge> {
             id: 1,
@@ -1236,7 +1266,7 @@ mod test {
                 data: ManuallyDrop::new(unsafe {
                     core::mem::zeroed::<sample_ptr_rs::SamplePtr<TestData>>()
                 }),
-                _bridge: PhantomData,
+                bridge: MockFFIBridge,
             },
         };
         assert_eq!(sample.id, 1);
@@ -1249,6 +1279,7 @@ mod test {
             identifier: "TestEvent",
             instance_info: make_instance_info(),
             proxy_instance: make_proxy_instance("TestInterface"),
+            bridge: MockFFIBridge,
             data: PhantomData,
         };
         assert!(
@@ -1270,6 +1301,7 @@ mod test {
             waker_storage: Arc::new(AtomicWaker::new()),
             async_init_status: std::sync::OnceLock::new(),
             _proxy: make_proxy_instance("TestInterface"),
+            bridge: MockFFIBridge,
             _phantom: PhantomData,
         };
         let mut sample_container = SampleContainer::new(5);

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -1214,8 +1214,7 @@ pub fn create_sample_callback<'a, T: CommData + Debug, B: FFIBridge>(
 mod test {
 
     use super::*;
-    use bridge_ffi_mock::{MockFFIBridge, SharedMockBridge};
-    use std::sync::Mutex;
+    use bridge_ffi_mock::{MockFFIBridge, MockPointerAllocator, SharedMockBridge};
 
     #[derive(Debug)]
     #[repr(C)]
@@ -1265,49 +1264,41 @@ mod test {
     #[test]
     fn test_subscribe_event() {
         let mut mock = MockFFIBridge::new();
-        // we need Arc here because expect closures are take the ownership of the variables,
-        // and we need to share the state between multiple expectations.
-        // vec is required to store multiple proxies/events and simulate multiple calls to create_proxy/subscribe_to_event/get_event_from_proxy/unsubscribe_to_event/destroy_proxy.
-        // also cleanup the created proxies/events by removing them from the vec when destroy/unsubscribe is called, and assert the pointer passed in is valid by checking if it exists in the vec.
-        let proxy_vec = Arc::new(Mutex::new(Vec::new()));
-        let event_vec = Arc::new(Mutex::new(Vec::new()));
+        let mut seq = mockall::Sequence::new();
+        let proxy_alloc = MockPointerAllocator::<ProxyBase>::new();
+        let event_alloc = MockPointerAllocator::<ProxyEventBase>::new();
+        let prox = proxy_alloc.clone();
+        let evt = event_alloc.clone();
 
-        // Set up all expectations - all clones of SharedMockBridge will share these
-        let proxy = proxy_vec.clone();
-        mock.expect_create_proxy().returning(move |_, _| {
-            let mut proxy = proxy.lock().expect("not able to acquire lock on proxy_vec");
-            proxy.push(Box::<ProxyBase>::default());
-            // Push first, then take the pointer from the last element no borrow conflict.
-            proxy.last_mut().unwrap().as_mut() as *mut ProxyBase
-        });
-        mock.expect_subscribe_to_event().returning(|_, _| true);
-        let event = event_vec.clone();
+        mock.expect_create_proxy()
+            .in_sequence(&mut seq)
+            .returning(move |_, _| prox.allocate());
         mock.expect_get_event_from_proxy()
-            .returning(move |_, _, _| {
-                let mut event = event.lock().expect("not able to acquire lock on event_vec");
-                event.push(Box::<ProxyEventBase>::default());
-                // Push first, then take the pointer from the last element to avoid borrow conflict.
-                event.last_mut().unwrap().as_mut() as *mut ProxyEventBase
-            });
-        let event = event_vec.clone();
-        mock.expect_unsubscribe_to_event().returning(move |ptr| {
-            let mut event = event.lock().expect("not able to acquire lock on event_vec");
-            let pos = event
-                .iter_mut()
-                .position(|b| b.as_mut() as *mut ProxyEventBase == ptr)
-                .expect("unsubscribe_to_event called with unknown pointer");
-            event.remove(pos);
-        });
+            .in_sequence(&mut seq)
+            .returning(move |_, _, _| evt.allocate());
+        mock.expect_subscribe_to_event()
+            .in_sequence(&mut seq)
+            .returning(|_, _| true);
 
-        let proxy = proxy_vec.clone();
-        mock.expect_destroy_proxy().returning(move |ptr| {
-            let mut proxy = proxy.lock().expect("not able to acquire lock on proxy_vec");
-            let pos = proxy
-                .iter_mut()
-                .position(|b| b.as_mut() as *mut ProxyBase == ptr)
-                .expect("destroy_proxy called with unknown pointer");
-            proxy.remove(pos);
-        });
+        let evt_cleanup = event_alloc.clone();
+        mock.expect_unsubscribe_to_event()
+            .in_sequence(&mut seq)
+            .returning(move |ptr| {
+                assert!(
+                    evt_cleanup.free(ptr),
+                    "unsubscribe_to_event called with unknown pointer"
+                );
+            });
+        let prox_cleanup = proxy_alloc.clone();
+        mock.expect_destroy_proxy()
+            .in_sequence(&mut seq)
+            .returning(move |ptr| {
+                assert!(
+                    prox_cleanup.free(ptr),
+                    "destroy_proxy called with unknown pointer"
+                );
+            });
+
         // Create a single shared mock with all necessary expectations
         let bridge = SharedMockBridge::new(mock);
 
@@ -1321,40 +1312,63 @@ mod test {
             .subscribe(3)
             .expect("subscribe should succeed with proper mock setup");
         assert_eq!(subscriber.event_id, "TestEvent");
+
+        // Unsubscribe and drop subscriber to trigger cleanup
+        drop(subscriber.unsubscribe());
+
+        // Verify all allocations were cleaned up
+        proxy_alloc.assert_all_freed();
+        event_alloc.assert_all_freed();
     }
 
     #[test]
     fn test_event_try_receive() {
+        let proxy_alloc = MockPointerAllocator::<ProxyBase>::new();
+        let event_alloc = MockPointerAllocator::<ProxyEventBase>::new();
+        let mut seq = mockall::Sequence::new();
         let mut mock = MockFFIBridge::new();
 
-        // Set up all expectations - all clones of SharedMockBridge will share these
+        let proxy_alloc_clone = proxy_alloc.clone();
+        let event_alloc_clone = event_alloc.clone();
         mock.expect_create_proxy()
-            .returning(|_, _| Box::into_raw(Box::default()));
+            .in_sequence(&mut seq)
+            .returning(move |_, _| proxy_alloc_clone.allocate());
         mock.expect_get_event_from_proxy()
-            .returning(|_, _, _| Box::into_raw(Box::default()));
-        mock.expect_subscribe_to_event().returning(|_, _| true);
+            .in_sequence(&mut seq)
+            .returning(move |_, _, _| event_alloc_clone.allocate());
+
+        mock.expect_subscribe_to_event()
+            .in_sequence(&mut seq)
+            .returning(|_, _| true);
         mock.expect_get_samples_from_event()
+            .in_sequence(&mut seq)
             .returning(|_, _, _, _| 1);
         mock.expect_set_event_receive_handler()
+            .in_sequence(&mut seq)
             .returning(|_, _, _| true);
         mock.expect_clear_event_receive_handler()
+            .in_sequence(&mut seq)
             .returning(|_, _| ());
-        mock.expect_unsubscribe_to_event().returning(|event| {
-            // SAFETY: the event pointer is valid because it was created by the mock's get_event_from_proxy expectation
-            unsafe {
-                drop(Box::from_raw(event));
-            }
-        });
-        mock.expect_destroy_proxy().returning(|proxy| {
-            // SAFETY: the proxy pointer is valid because it was created by the mock's create_proxy expectation
-            unsafe {
-                drop(Box::from_raw(proxy));
-            }
-        });
+
+        mock.expect_unsubscribe_to_event()
+            .in_sequence(&mut seq)
+            .returning(move |ptr| {
+                assert!(
+                    event_alloc.free(ptr),
+                    "unsubscribe_to_event called with unknown pointer"
+                );
+            });
+        mock.expect_destroy_proxy()
+            .in_sequence(&mut seq)
+            .returning(move |ptr| {
+                assert!(
+                    proxy_alloc.free(ptr),
+                    "destroy_proxy called with unknown pointer"
+                );
+            });
+
         // Create a single shared mock with all necessary expectations
         let bridge = SharedMockBridge::new(mock);
-
-        // Create subscriber through the proper flow
         let subscribable = SubscribableImpl::<TestData, SharedMockBridge> {
             identifier: "TestEvent",
             instance_info: make_instance_info(bridge.clone()),

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -66,7 +66,7 @@ impl<B: FFIBridge> LolaConsumerInfo<B> {
     pub fn get_handle(&self) -> Option<&HandleType> {
         // SAFETY: handle_container was produced by the bridge or a trusted mock;
         // both implementations uphold the contract of handle_container_get_at.
-        unsafe { B::handle_container_get_at(&self.handle_container, self.handle_index) }
+        B::handle_container_get_at(&self.handle_container, self.handle_index)
     }
 }
 

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -327,12 +327,18 @@ impl<T: CommData + Debug, B: FFIBridge> Subscriber<T, LolaRuntimeImpl<B>>
             self.instance_info.interface_id,
             self.identifier,
         )?;
+        let max_num_samples_u32 = u32::try_from(max_num_samples).map_err(|_| {
+            Error::EventError(EventFailedReason::MaxSampleOutOfBounds {
+                max: u32::MAX as usize,
+                requested: max_num_samples,
+            })
+        })?;
         //SAFETY: It is safe to subscribe to event because event_instance is valid
         // which was obtained from valid proxy instance
         let status = unsafe {
             B::subscribe_to_event(
                 std::ptr::from_ref(event_instance.get_proxy_event_base()) as *mut ProxyEventBase,
-                max_num_samples.try_into().unwrap(),
+                max_num_samples_u32,
             )
         };
         if !status {
@@ -347,7 +353,7 @@ impl<T: CommData + Debug, B: FFIBridge> Subscriber<T, LolaRuntimeImpl<B>>
             max_num_samples,
             instance_info,
             waker_storage: Arc::default(),
-            async_init_status: std::sync::Once::new(),
+            async_init_status: std::sync::OnceLock::new(),
             _proxy: self.proxy_instance.clone(),
             _phantom: PhantomData,
         })
@@ -453,7 +459,7 @@ where
     max_num_samples: usize,
     instance_info: LolaConsumerInfo<B>,
     waker_storage: Arc<AtomicWaker>,
-    async_init_status: std::sync::Once,
+    async_init_status: std::sync::OnceLock<()>,
     _proxy: ProxyInstanceManager<B>,
     _phantom: PhantomData<T>,
 }
@@ -467,7 +473,7 @@ impl<T: CommData + Debug, B: FFIBridge> Drop for SubscriberImpl<T, B> {
         // and then unsubscribe from the event to clean up resources on the C++ side.
         let mut guard = self.event.get_proxy_event();
         unsafe {
-            if self.async_init_status.is_completed()
+            if self.async_init_status.get().is_some()
             // Check if the async receive callback was initialized
             {
                 B::clear_event_receive_handler(guard.deref_mut(), T::ID);
@@ -492,8 +498,15 @@ impl<T: CommData + Debug, B: FFIBridge> SubscriberImpl<T, B> {
         // The callback is a simple waker that wakes the future when new samples arrive,
         // and the lifetime of the callback is managed by Rust, it will not outlive the scope of
         // this function call.
-        unsafe {
-            B::set_event_receive_handler(event_guard.deref_mut(), &fat_ptr, T::ID);
+        let status = unsafe {
+            B::set_event_receive_handler(event_guard.deref_mut(), &fat_ptr, T::ID)
+        };
+        if !status {
+            // SAFETY: ptr was allocated as Box<dyn FnMut() + Send + 'static> via Box::into_raw
+            // above. The handler was not registered so this side retains ownership and must
+            // free it to prevent a leak.
+            drop(unsafe { Box::from_raw(ptr) });
+            return Err(Error::ReceiveError(ReceiveFailedReason::ReceiveError));
         }
         Ok(())
     }
@@ -607,12 +620,16 @@ where
             // Get the event guard to ensure no concurrent receive calls
             // on the same subscriber instance.
             let mut event_guard = self.event.get_proxy_event();
-            // Initialize the async receive callback only once when the first receive call is made
-            // We are using std::sync::Once to ensure that the callback is set only once.
-            self.async_init_status.call_once(|| {
-                self.init_async_receive(&mut event_guard)
-                    .expect("Failed to initialize async receive callback");
-            });
+            // Initialize the async receive callback only once when the first receive call is made.
+            // ProxyEventManager already prevents concurrent receive calls, so the check-then-set
+            // sequence is race-free. Using get/set instead of get_or_try_init avoids the
+            // unstable `once_cell_try` feature while still propagating errors via `?`.
+            if self.async_init_status.get().is_none() {
+                self.init_async_receive(&mut event_guard)?;
+                // Ignore Err: the only way set() fails is if another thread raced us,
+                // which cannot happen because ProxyEventManager panics on concurrent access.
+                let _ = self.async_init_status.set(());
+            }
             ReceiveFuture {
                 event_guard: Some(event_guard),
                 waker_storage: Arc::clone(&self.waker_storage),
@@ -1170,7 +1187,7 @@ pub fn create_sample_callback<'a, T: CommData + Debug, B: FFIBridge>(
 mod test {
 
     use super::*;
-    use bridge_ffi_mock::MockFFIBridge;
+    use bridge_ffi_mock::{MockFFIBridge, MockFFIBridgeGuard};
 
     #[derive(Debug)]
     #[repr(C)]
@@ -1210,6 +1227,8 @@ mod test {
     }
     #[test]
     fn test_sample() {
+        //this is for cleanup of thread local state.
+        let _guard = MockFFIBridgeGuard;
         MockFFIBridge::set_sample_backing::<TestData>(TestData { value: 42 });
         let sample = Sample::<TestData, MockFFIBridge> {
             id: 1,
@@ -1232,7 +1251,10 @@ mod test {
             proxy_instance: make_proxy_instance("TestInterface"),
             data: PhantomData,
         };
-        let _ = subscribable.subscribe(3);
+        assert!(
+            subscribable.subscribe(3).is_ok(),
+            "subscribe should succeed when the mock returns a non-null proxy event sentinel"
+        );
     }
 
     #[test]
@@ -1246,13 +1268,23 @@ mod test {
             max_num_samples: 10,
             instance_info: make_instance_info(),
             waker_storage: Arc::new(AtomicWaker::new()),
-            async_init_status: std::sync::Once::new(),
+            async_init_status: std::sync::OnceLock::new(),
             _proxy: make_proxy_instance("TestInterface"),
             _phantom: PhantomData,
         };
         let mut sample_container = SampleContainer::new(5);
-        let _ = subscriber.try_receive(&mut sample_container, 5);
-        let _ = subscriber.init_async_receive(&mut subscriber.event.get_proxy_event());
-        std::mem::drop(subscriber.receive(sample_container, 5, 5));
+        let count = subscriber
+            .try_receive(&mut sample_container, 5)
+            .expect("try_receive should succeed with a valid mock event");
+        assert_eq!(
+            count, 0,
+            "no samples should be returned by try_receive when the mock event is empty"
+        );
+        let mut event_guard = subscriber.event.get_proxy_event();
+        subscriber
+            .init_async_receive(&mut event_guard)
+            .expect("init_async_receive should succeed");
+        drop(event_guard);
+        drop(subscriber.receive(sample_container, 5, 5));
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -1332,19 +1332,29 @@ mod test {
         let mut mock = MockFFIBridge::new();
 
         // Set up all expectations - all clones of SharedMockBridge will share these
-        mock.expect_subscribe_to_event().returning(|_, _| true);
+        mock.expect_create_proxy()
+            .returning(|_, _| Box::into_raw(Box::default()));
         mock.expect_get_event_from_proxy()
             .returning(|_, _, _| Box::into_raw(Box::default()));
+        mock.expect_subscribe_to_event().returning(|_, _| true);
         mock.expect_get_samples_from_event()
             .returning(|_, _, _, _| 1);
         mock.expect_set_event_receive_handler()
             .returning(|_, _, _| true);
-        mock.expect_unsubscribe_to_event().returning(|_| ());
         mock.expect_clear_event_receive_handler()
             .returning(|_, _| ());
-        mock.expect_destroy_proxy().returning(|_| ());
-        mock.expect_create_proxy()
-            .returning(|_, _| Box::into_raw(Box::default()));
+        mock.expect_unsubscribe_to_event().returning(|event| {
+            // SAFETY: the event pointer is valid because it was created by the mock's get_event_from_proxy expectation
+            unsafe {
+                drop(Box::from_raw(event));
+            }
+        });
+        mock.expect_destroy_proxy().returning(|proxy| {
+            // SAFETY: the proxy pointer is valid because it was created by the mock's create_proxy expectation
+            unsafe {
+                drop(Box::from_raw(proxy));
+            }
+        });
         // Create a single shared mock with all necessary expectations
         let bridge = SharedMockBridge::new(mock);
 

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -641,9 +641,11 @@ where
             // Initialize the async receive callback only once when the first receive call is made.
             // ProxyEventManager already prevents concurrent receive calls, so the check-then-set
             // sequence is race-free. Using get/set instead of get_or_try_init avoids the
-            // unstable `once_cell_try` feature while still propagating errors via `?`.
+            // unstable `once_cell_try` feature while still propagating errors.
             if self.async_init_status.get().is_none() {
-                self.init_async_receive(&mut event_guard)?;
+                if let Err(e) = self.init_async_receive(&mut event_guard) {
+                    return (scratch, Err(e));
+                }
                 // Ignore Err: the only way set() fails is if another thread raced us,
                 // which cannot happen because ProxyEventManager panics on concurrent access.
                 let _ = self.async_init_status.set(());
@@ -692,10 +694,7 @@ struct ReceiveFuture<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBrid
     new_samples: usize,
     max_samples: usize,
     total_received: usize,
-<<<<<<< HEAD
     cancellation: Pin<&'a mut F>,
-=======
->>>>>>> d1f2a252 (Rust::com Update FFI mock)
     bridge: B,
 }
 
@@ -1233,42 +1232,49 @@ mod test {
     }
 
     // Builds a ProxyInstanceManager<MockFFIBridge>
-    fn make_proxy_instance(interface_id: &'static str) -> ProxyInstanceManager<MockFFIBridge> {
+    fn make_proxy_instance(
+        bridge: &MockFFIBridge,
+        interface_id: &'static str,
+    ) -> ProxyInstanceManager<MockFFIBridge> {
         // SAFETY: HandleType is a ZST; zeroed() produces a valid value.
         let handle: HandleType = unsafe { core::mem::zeroed() };
-        let native_proxy =
-            NativeProxyBase::<MockFFIBridge>::new(&MockFFIBridge, interface_id, &handle)
-                .expect("MockFFIBridge::create_proxy should not fail");
+        let native_proxy = NativeProxyBase::<MockFFIBridge>::new(bridge, interface_id, &handle)
+            .expect("MockFFIBridge::create_proxy should not fail");
         ProxyInstanceManager(Arc::new(native_proxy))
     }
 
     // Builds a `LolaConsumerInfo<MockFFIBridge>` backed by a mock handle container.
-    fn make_instance_info() -> LolaConsumerInfo<MockFFIBridge> {
+    fn make_instance_info(bridge: MockFFIBridge) -> LolaConsumerInfo<MockFFIBridge> {
+        // Create mock bridge and empty handle container (null pointer for testing)
+        let handle_container = Arc::new(HandleContainer::new(std::ptr::null_mut()));
         LolaConsumerInfo::<MockFFIBridge> {
-            handle_container: MockFFIBridge::make_handle_container(),
+            handle_container,
             handle_index: 0,
             interface_id: "TestInterface",
-            bridge: MockFFIBridge,
+            bridge,
         }
     }
 
     #[test]
     fn test_lola_consumer_info() {
-        let instance_info = make_instance_info();
+        let bridge = MockFFIBridge::new();
+        bridge.set_proxy("TestInterface");
+        let instance_info = make_instance_info(bridge);
         assert!(instance_info.get_handle().is_none());
     }
     #[test]
     fn test_sample() {
         //this is for cleanup of thread local state.
         // MockFFIBridge instance will clean up automatically on drop
-        MockFFIBridge::set_sample_backing::<TestData>(TestData { value: 42 });
+        let bridge = MockFFIBridge::new();
+        bridge.set_sample_backing::<TestData>("TestData", TestData { value: 42 });
         let sample = Sample::<TestData, MockFFIBridge> {
             id: 1,
             inner: LolaBinding::<TestData, MockFFIBridge> {
                 data: ManuallyDrop::new(unsafe {
                     core::mem::zeroed::<sample_ptr_rs::SamplePtr<TestData>>()
                 }),
-                bridge: MockFFIBridge,
+                bridge,
             },
         };
         assert_eq!(sample.id, 1);
@@ -1277,11 +1283,13 @@ mod test {
 
     #[test]
     fn test_subscribable_impl() {
+        let bridge = MockFFIBridge::new();
+        bridge.set_proxy("TestInterface");
+        bridge.set_proxy_event("TestInterface", "TestEvent");
         let subscribable = SubscribableImpl::<TestData, MockFFIBridge> {
             identifier: "TestEvent",
-            instance_info: make_instance_info(),
-            proxy_instance: make_proxy_instance("TestInterface"),
-            bridge: MockFFIBridge,
+            instance_info: make_instance_info(bridge.clone()),
+            proxy_instance: make_proxy_instance(&bridge, "TestInterface"),
             data: PhantomData,
         };
         assert!(
@@ -1292,17 +1300,25 @@ mod test {
 
     #[test]
     fn test_subscriber_impl() {
+        let bridge = MockFFIBridge::new();
+        bridge.set_proxy("TestInterface");
+        bridge.set_proxy_event("TestInterface", "TestEvent");
+        let event_ptr = unsafe {
+            let handle: HandleType = core::mem::zeroed();
+            let proxy = bridge.create_proxy("TestInterface", &handle);
+            bridge.get_event_from_proxy(proxy, "TestInterface", "TestEvent")
+        };
         let subscriber = SubscriberImpl::<TestData, MockFFIBridge> {
             event: ProxyEventManager {
-                event: MockFFIBridge::make_proxy_event_ptr(),
+                event: event_ptr,
                 in_progress: AtomicBool::new(false),
             },
             event_id: "TestEvent",
             max_num_samples: 10,
-            instance_info: make_instance_info(),
+            instance_info: make_instance_info(bridge.clone()),
             waker_storage: Arc::new(AtomicWaker::new()),
             async_init_status: std::sync::OnceLock::new(),
-            _proxy: make_proxy_instance("TestInterface"),
+            _proxy: make_proxy_instance(&bridge, "TestInterface"),
             _phantom: PhantomData,
         };
         let mut sample_container = SampleContainer::new(5);

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -664,10 +664,10 @@ where
         }
     }
 
-    fn to_stream<'a>(&'a mut  self) -> impl Stream<Item = Result<Self::Sample<'a>>> + Unpin + 'a {   
+    fn to_stream<'a>(&'a mut self) -> impl Stream<Item = Result<Self::Sample<'a>>> + Unpin + 'a {
         // Initialize the async receive callback only once when the first receive call is made
-        // We are using std::sync::Once to ensure that the callback is set only once.
-        self.async_init_status.call_once(|| {
+        // We are using std::sync::OnceLock to ensure that the callback is set only once.
+        self.async_init_status.get_or_init(|| {
             self.init_async_receive(&mut self.event.get_proxy_event())
                 .expect("Failed to initialize async receive callback");
         });
@@ -782,13 +782,13 @@ impl<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBridge> Future
 /// It also holds an exclusive `ProxyEventManagerGuard` for the lifetime of the stream to prevent
 /// concurrent receives on the same subscriber instance.
 /// On each poll, it first yields any buffered samples before attempting to receive more from the FFI callback.
-struct SampleStream<'a, T: CommData + Debug> {
-    subscriber: &'a SubscriberImpl<T>,
-    sample_container: SampleContainer<Sample<T>>,
+struct SampleStream<'a, T: CommData + Debug, B: FFIBridge> {
+    subscriber: &'a SubscriberImpl<T, B>,
+    sample_container: SampleContainer<Sample<T, B>>,
 }
 
-impl<'a, T: CommData + Debug> Stream for SampleStream<'a, T> {
-    type Item = Result<Sample<T>>;
+impl<'a, T: CommData + Debug, B: FFIBridge> Stream for SampleStream<'a, T, B> {
+    type Item = Result<Sample<T, B>>;
 
     fn poll_next(mut self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<Option<Self::Item>> {
         // Yield any buffered samples from a previous batch fetch first.
@@ -802,27 +802,23 @@ impl<'a, T: CommData + Debug> Stream for SampleStream<'a, T> {
         self.subscriber.waker_storage.register(cx.waker());
         let max_num_samples = self.subscriber.max_num_samples;
 
-        // get a mutable reference of pinned self, with this 
+        // get a mutable reference of pinned self, with this
         // we can avoid borrow checker issue for self in try_receive_samples function call
         let this = self.as_mut().get_mut();
-        
-        let samples_received = try_receive_samples::<T>(
-            this.subscriber
-                .event
-                .get_proxy_event()
-                .deref_mut(), // Get mutable reference to the proxy event for FFI call
+
+        let samples_received = try_receive_samples::<T, B>(
+            &this.subscriber.instance_info.bridge,
+            this.subscriber.event.get_proxy_event().deref_mut(), // Get mutable reference to the proxy event for FFI call
             &mut this.sample_container,
             max_num_samples,
             max_num_samples,
         );
 
         match samples_received {
-            Ok(_count) => {
-                match this.sample_container.pop_front() {
-                    Some(sample) => Poll::Ready(Some(Ok(sample))),
-                    None => Poll::Pending,
-                }
-            }
+            Ok(_count) => match this.sample_container.pop_front() {
+                Some(sample) => Poll::Ready(Some(Ok(sample))),
+                None => Poll::Pending,
+            },
             Err(e) => Poll::Ready(Some(Err(e))),
         }
     }

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -68,8 +68,7 @@ pub struct LolaConsumerInfo<B: FFIBridge> {
 impl<B: FFIBridge> LolaConsumerInfo<B> {
     /// Get a reference to the handle, guaranteed valid as long as this struct exists
     pub fn get_handle(&self) -> Option<&HandleType> {
-        self.bridge
-            .handle_container_get_at(&self.handle_container, self.handle_index)
+        self.handle_container.get(self.handle_index)
     }
 }
 
@@ -698,7 +697,9 @@ struct ReceiveFuture<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBrid
     bridge: B,
 }
 
-impl<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBridge> Future for ReceiveFuture<'a, T, F, B> {
+impl<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBridge> Future
+    for ReceiveFuture<'a, T, F, B>
+{
     type Output = (SampleContainer<Sample<T, B>>, Result<usize>);
 
     fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -1217,7 +1218,7 @@ pub fn create_sample_callback<'a, T: CommData + Debug, B: FFIBridge>(
 mod test {
 
     use super::*;
-    use bridge_ffi_mock::MockFFIBridge;
+    use bridge_ffi_mock::{MockFFIBridge, SharedMockBridge};
 
     #[derive(Debug)]
     #[repr(C)]
@@ -1231,23 +1232,22 @@ mod test {
         const ID: &'static str = "TestData";
     }
 
-    // Builds a ProxyInstanceManager<MockFFIBridge>
+    // Builds a ProxyInstanceManager<SharedMockBridge>
     fn make_proxy_instance(
-        bridge: &MockFFIBridge,
+        bridge: SharedMockBridge,
         interface_id: &'static str,
-    ) -> ProxyInstanceManager<MockFFIBridge> {
-        // SAFETY: HandleType is a ZST; zeroed() produces a valid value.
-        let handle: HandleType = unsafe { core::mem::zeroed() };
-        let native_proxy = NativeProxyBase::<MockFFIBridge>::new(bridge, interface_id, &handle)
-            .expect("MockFFIBridge::create_proxy should not fail");
+    ) -> ProxyInstanceManager<SharedMockBridge> {
+        let handle: HandleType = HandleType::default();
+        let native_proxy = NativeProxyBase::<SharedMockBridge>::new(&bridge, interface_id, &handle)
+            .expect("SharedMockBridge::create_proxy should not fail");
         ProxyInstanceManager(Arc::new(native_proxy))
     }
 
-    // Builds a `LolaConsumerInfo<MockFFIBridge>` backed by a mock handle container.
-    fn make_instance_info(bridge: MockFFIBridge) -> LolaConsumerInfo<MockFFIBridge> {
+    // Builds a `LolaConsumerInfo<SharedMockBridge>` backed by a mock handle container.
+    fn make_instance_info(bridge: SharedMockBridge) -> LolaConsumerInfo<SharedMockBridge> {
         // Create mock bridge and empty handle container (null pointer for testing)
         let handle_container = Arc::new(HandleContainer::new(std::ptr::null_mut()));
-        LolaConsumerInfo::<MockFFIBridge> {
+        LolaConsumerInfo::<SharedMockBridge> {
             handle_container,
             handle_index: 0,
             interface_id: "TestInterface",
@@ -1257,83 +1257,81 @@ mod test {
 
     #[test]
     fn test_lola_consumer_info() {
-        let bridge = MockFFIBridge::new();
-        bridge.set_proxy("TestInterface");
+        let mock = MockFFIBridge::new();
+        let bridge = SharedMockBridge::new(mock);
         let instance_info = make_instance_info(bridge);
-        assert!(instance_info.get_handle().is_none());
-    }
-    #[test]
-    fn test_sample() {
-        //this is for cleanup of thread local state.
-        // MockFFIBridge instance will clean up automatically on drop
-        let bridge = MockFFIBridge::new();
-        bridge.set_sample_backing::<TestData>("TestData", TestData { value: 42 });
-        let sample = Sample::<TestData, MockFFIBridge> {
-            id: 1,
-            inner: LolaBinding::<TestData, MockFFIBridge> {
-                data: ManuallyDrop::new(unsafe {
-                    core::mem::zeroed::<sample_ptr_rs::SamplePtr<TestData>>()
-                }),
-                bridge,
-            },
-        };
-        assert_eq!(sample.id, 1);
-        assert_eq!(sample.get_data().value, 42);
+        // Test that the instance_info is created successfully with mock data
+        assert_eq!(instance_info.interface_id, "TestInterface");
+        assert_eq!(instance_info.handle_index, 0);
     }
 
     #[test]
-    fn test_subscribable_impl() {
-        let bridge = MockFFIBridge::new();
-        bridge.set_proxy("TestInterface");
-        bridge.set_proxy_event("TestInterface", "TestEvent");
-        let subscribable = SubscribableImpl::<TestData, MockFFIBridge> {
+    fn test_subscribe_event() {
+        let mut mock = MockFFIBridge::new();
+
+        // Set up all expectations - all clones of SharedMockBridge will share these
+        mock.expect_subscribe_to_event().returning(|_, _| true);
+        mock.expect_get_event_from_proxy()
+            .returning(|_, _, _| Box::into_raw(Box::default()));
+        mock.expect_unsubscribe_to_event().returning(|_| ());
+        mock.expect_destroy_proxy().returning(|_| ());
+        mock.expect_create_proxy()
+            .returning(|_, _| Box::into_raw(Box::default()));
+        // Create a single shared mock with all necessary expectations
+        let bridge = SharedMockBridge::new(mock);
+
+        let subscribable = SubscribableImpl::<TestData, SharedMockBridge> {
             identifier: "TestEvent",
             instance_info: make_instance_info(bridge.clone()),
-            proxy_instance: make_proxy_instance(&bridge, "TestInterface"),
+            proxy_instance: make_proxy_instance(bridge.clone(), "TestInterface"),
             data: PhantomData,
         };
-        assert!(
-            subscribable.subscribe(3).is_ok(),
-            "subscribe should succeed when the mock returns a non-null proxy event sentinel"
-        );
+        let subscriber = subscribable
+            .subscribe(3)
+            .expect("subscribe should succeed with proper mock setup");
+        assert_eq!(subscriber.event_id, "TestEvent");
     }
 
     #[test]
-    fn test_subscriber_impl() {
-        let bridge = MockFFIBridge::new();
-        bridge.set_proxy("TestInterface");
-        bridge.set_proxy_event("TestInterface", "TestEvent");
-        let event_ptr = unsafe {
-            let handle: HandleType = core::mem::zeroed();
-            let proxy = bridge.create_proxy("TestInterface", &handle);
-            bridge.get_event_from_proxy(proxy, "TestInterface", "TestEvent")
-        };
-        let subscriber = SubscriberImpl::<TestData, MockFFIBridge> {
-            event: ProxyEventManager {
-                event: event_ptr,
-                in_progress: AtomicBool::new(false),
-            },
-            event_id: "TestEvent",
-            max_num_samples: 10,
+    fn test_event_try_receive() {
+        let mut mock = MockFFIBridge::new();
+
+        // Set up all expectations - all clones of SharedMockBridge will share these
+        mock.expect_subscribe_to_event().returning(|_, _| true);
+        mock.expect_get_event_from_proxy()
+            .returning(|_, _, _| Box::into_raw(Box::default()));
+        mock.expect_get_samples_from_event()
+            .returning(|_, _, _, _| 1);
+        mock.expect_set_event_receive_handler()
+            .returning(|_, _, _| true);
+        mock.expect_unsubscribe_to_event().returning(|_| ());
+        mock.expect_clear_event_receive_handler()
+            .returning(|_, _| ());
+        mock.expect_destroy_proxy().returning(|_| ());
+        mock.expect_create_proxy()
+            .returning(|_, _| Box::into_raw(Box::default()));
+        // Create a single shared mock with all necessary expectations
+        let bridge = SharedMockBridge::new(mock);
+
+        // Create subscriber through the proper flow
+        let subscribable = SubscribableImpl::<TestData, SharedMockBridge> {
+            identifier: "TestEvent",
             instance_info: make_instance_info(bridge.clone()),
-            waker_storage: Arc::new(AtomicWaker::new()),
-            async_init_status: std::sync::OnceLock::new(),
-            _proxy: make_proxy_instance(&bridge, "TestInterface"),
-            _phantom: PhantomData,
+            proxy_instance: make_proxy_instance(bridge.clone(), "TestInterface"),
+            data: PhantomData,
         };
+
+        let subscriber = subscribable
+            .subscribe(10)
+            .expect("subscribe should succeed with proper mock setup");
+
         let mut sample_container = SampleContainer::new(5);
         let count = subscriber
             .try_receive(&mut sample_container, 5)
             .expect("try_receive should succeed with a valid mock event");
         assert_eq!(
-            count, 0,
-            "no samples should be returned by try_receive when the mock event is empty"
+            count, 1,
+            "one sample should be returned by try_receive when the mock event has one sample"
         );
-        let mut event_guard = subscriber.event.get_proxy_event();
-        subscriber
-            .init_async_receive(&mut event_guard)
-            .expect("init_async_receive should succeed");
-        drop(event_guard);
-        drop(subscriber.receive(sample_container, 5, 5));
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -1210,8 +1210,7 @@ mod test {
     }
     #[test]
     fn test_sample() {
-        // SamplePtr is an opaque FFI type; use zeroed() to construct storage.
-        // MockFFIBridge::sample_ptr_delete is a no-op so this is safe.
+        MockFFIBridge::set_sample_backing::<TestData>(TestData { value: 42 });
         let sample = Sample::<TestData, MockFFIBridge> {
             id: 1,
             inner: LolaBinding::<TestData, MockFFIBridge> {
@@ -1222,7 +1221,7 @@ mod test {
             },
         };
         assert_eq!(sample.id, 1);
-        let _data = sample.get_data();
+        assert_eq!(sample.get_data().value, 42);
     }
 
     #[test]
@@ -1254,6 +1253,6 @@ mod test {
         let mut sample_container = SampleContainer::new(5);
         let _ = subscriber.try_receive(&mut sample_container, 5);
         let _ = subscriber.init_async_receive(&mut subscriber.event.get_proxy_event());
-        let _ = subscriber.receive(sample_container, 5, 5);
+        std::mem::drop(subscriber.receive(sample_container, 5, 5));
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -54,13 +54,14 @@ use bridge_ffi_rs::*;
 use crate::LolaRuntimeImpl;
 
 #[derive(Clone, Debug)]
-pub struct LolaConsumerInfo {
+pub struct LolaConsumerInfo<B: FFIBridge> {
     handle_container: Arc<mw_com::proxy::HandleContainer>,
     handle_index: usize,
     interface_id: &'static str,
+    _marker: PhantomData<B>,
 }
 
-impl LolaConsumerInfo {
+impl<B: FFIBridge> LolaConsumerInfo<B> {
     /// Get a reference to the handle, guaranteed valid as long as this struct exists
     pub fn get_handle(&self) -> Option<&HandleType> {
         self.handle_container.get(self.handle_index)
@@ -71,14 +72,15 @@ impl LolaConsumerInfo {
 //And sample_ptr_rs::SamplePtr<T> FFI function should be move in plumbing folder
 //sample_ptr_rs module
 #[derive(Debug)]
-pub struct LolaBinding<T>
+pub struct LolaBinding<T, B: FFIBridge>
 where
     T: CommData + Debug,
 {
     data: ManuallyDrop<sample_ptr_rs::SamplePtr<T>>,
+    _bridge: PhantomData<B>,
 }
 
-impl<T> Drop for LolaBinding<T>
+impl<T, B: FFIBridge> Drop for LolaBinding<T, B>
 where
     T: CommData + Debug,
 {
@@ -87,7 +89,7 @@ where
         //SamplePtr created by FFI
         unsafe {
             let mut sample_ptr = ManuallyDrop::take(&mut self.data);
-            bridge_ffi_rs::sample_ptr_delete(
+            B::sample_ptr_delete(
                 std::ptr::from_mut(&mut sample_ptr) as *mut std::ffi::c_void,
                 T::ID,
             );
@@ -96,19 +98,19 @@ where
 }
 
 #[derive(Debug)]
-pub struct Sample<T>
+pub struct Sample<T, B: FFIBridge>
 where
     T: CommData + Debug,
 {
     //we need unique id for each sample to implement Ord and Eq traits for sorting in
     // SampleContainer
     id: usize,
-    inner: LolaBinding<T>,
+    inner: LolaBinding<T, B>,
 }
 
 pub static ID_COUNTER: AtomicUsize = AtomicUsize::new(0);
 
-impl<T> Sample<T>
+impl<T, B: FFIBridge> Sample<T, B>
 where
     T: CommData + Debug,
 {
@@ -116,7 +118,7 @@ where
         //SAFETY: It is safe to get the data pointer because SamplePtr is valid
         //and data is valid as long as SamplePtr is valid
         unsafe {
-            let data_ptr = bridge_ffi_rs::sample_ptr_get(
+            let data_ptr = B::sample_ptr_get(
                 std::ptr::from_ref(&(*self.inner.data)) as *const std::ffi::c_void,
                 T::ID,
             );
@@ -127,7 +129,7 @@ where
     }
 }
 
-impl<T> Deref for Sample<T>
+impl<T, B: FFIBridge> Deref for Sample<T, B>
 where
     T: CommData + Debug,
 {
@@ -138,10 +140,10 @@ where
     }
 }
 
-impl<T> com_api_concept::Sample<T> for Sample<T> where T: CommData + Debug {}
+impl<T, B: FFIBridge> com_api_concept::Sample<T> for Sample<T, B> where T: CommData + Debug {}
 
 // Ordering traits for Sample<T> are using id field to provide total ordering
-impl<T> PartialEq for Sample<T>
+impl<T, B: FFIBridge> PartialEq for Sample<T, B>
 where
     T: CommData + Debug,
 {
@@ -150,9 +152,9 @@ where
     }
 }
 
-impl<T> Eq for Sample<T> where T: CommData + Debug {}
+impl<T, B: FFIBridge> Eq for Sample<T, B> where T: CommData + Debug {}
 
-impl<T> PartialOrd for Sample<T>
+impl<T, B: FFIBridge> PartialOrd for Sample<T, B>
 where
     T: CommData + Debug,
 {
@@ -161,7 +163,7 @@ where
     }
 }
 
-impl<T> Ord for Sample<T>
+impl<T, B: FFIBridge> Ord for Sample<T, B>
 where
     T: CommData + Debug,
 {
@@ -173,15 +175,15 @@ where
 /// Manages the lifetime of the native proxy instance,
 /// user should clone this to share between threads
 /// Always use this struct to manage the proxy instance pointer
-pub struct ProxyInstanceManager(Arc<NativeProxyBase>);
+pub struct ProxyInstanceManager<B: FFIBridge>(Arc<NativeProxyBase<B>>);
 
-impl Clone for ProxyInstanceManager {
+impl<B: FFIBridge> Clone for ProxyInstanceManager<B> {
     fn clone(&self) -> Self {
         Self(Arc::clone(&self.0))
     }
 }
 
-impl std::fmt::Debug for ProxyInstanceManager {
+impl<B: FFIBridge> std::fmt::Debug for ProxyInstanceManager<B> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("ProxyInstanceManager").finish()
     }
@@ -198,8 +200,9 @@ impl std::fmt::Debug for ProxyInstanceManager {
 /// As it has Send and Sync unsafe impls,
 /// it must not expose any mutable access to the proxy instance
 /// Or must not provide any method to access the proxy instance directly
-pub struct NativeProxyBase {
-    proxy: NonNull<ProxyBase>, // Stores the proxy instance
+pub struct NativeProxyBase<B: FFIBridge> {
+   proxy: NonNull<ProxyBase>, // Stores the proxy instance
+    _marker: PhantomData<B>,
 }
 
 //SAFETY: NativeProxyBase is safe to share between threads because:
@@ -207,34 +210,34 @@ pub struct NativeProxyBase {
 // Access is controlled through Arc which provides atomic reference counting
 // The proxy lifetime is managed safely through Drop
 // and it does not provide any mutable access to the underlying proxy instance
-unsafe impl Send for NativeProxyBase {}
-unsafe impl Sync for NativeProxyBase {}
+unsafe impl<B: FFIBridge> Send for NativeProxyBase<B> {}
+unsafe impl<B: FFIBridge> Sync for NativeProxyBase<B> {}
 
-impl Drop for NativeProxyBase {
+impl<B: FFIBridge> Drop for NativeProxyBase<B> {
     fn drop(&mut self) {
         //SAFETY: It is safe to destroy the proxy because it was created by FFI
         // and proxy pointer received at the time of create_proxy called
         unsafe {
-            bridge_ffi_rs::destroy_proxy(self.proxy.as_ptr());
+            B::destroy_proxy(self.proxy.as_ptr());
         }
     }
 }
 
-impl std::fmt::Debug for NativeProxyBase {
+impl<B: FFIBridge> std::fmt::Debug for NativeProxyBase<B> {
     fn fmt(&self, f: &mut core::fmt::Formatter<'_>) -> core::fmt::Result {
         f.debug_struct("NativeProxyBase").finish()
     }
 }
 
-impl NativeProxyBase {
+impl<B: FFIBridge> NativeProxyBase<B> {
     pub fn new(interface_id: &str, handle: &HandleType) -> Result<Self> {
         //SAFETY: It is safe to create the proxy because interface_id and handle are valid
         //Handle received at the time of get_avaible_instances called with correct interface_id
-        let raw_proxy_ptr = unsafe { bridge_ffi_rs::create_proxy(interface_id, handle) };
+        let raw_proxy_ptr = unsafe { B::create_proxy(interface_id, handle) };
         let proxy = std::ptr::NonNull::new(raw_proxy_ptr).ok_or(Error::ConsumerError(
             ConsumerFailedReason::ProxyCreationFailed,
         ))?;
-        Ok(Self { proxy })
+        Ok(Self { proxy, _marker: PhantomData })
     }
 }
 
@@ -256,12 +259,11 @@ pub struct NativeProxyEventBase {
 unsafe impl Send for NativeProxyEventBase {}
 
 impl NativeProxyEventBase {
-    pub fn new(proxy: &NonNull<ProxyBase>, interface_id: &str, identifier: &str) -> Result<Self> {
+    pub fn new<B: FFIBridge>(proxy: &NonNull<ProxyBase>, interface_id: &str, identifier: &str) -> Result<Self> {
         //SAFETY: It is safe as we are passing valid proxy pointer and interface id to get event
         // proxy pointer is created during consumer creation
-        let raw_event_ptr = unsafe {
-            bridge_ffi_rs::get_event_from_proxy(proxy.as_ptr(), interface_id, identifier)
-        };
+        let raw_event_ptr =
+            unsafe { B::get_event_from_proxy(proxy.as_ptr(), interface_id, identifier) };
         let proxy_event_ptr = std::ptr::NonNull::new(raw_event_ptr)
             .ok_or(Error::EventError(EventFailedReason::EventCreationFailed))?;
         Ok(Self { proxy_event_ptr })
@@ -282,16 +284,16 @@ impl std::fmt::Debug for NativeProxyEventBase {
 }
 
 #[derive(Debug)]
-pub struct SubscribableImpl<T> {
+pub struct SubscribableImpl<T, B: FFIBridge> {
     identifier: &'static str,
-    instance_info: LolaConsumerInfo,
-    proxy_instance: ProxyInstanceManager,
+    instance_info: LolaConsumerInfo<B>,
+    proxy_instance: ProxyInstanceManager<B>,
     data: PhantomData<T>,
 }
 
-impl<T: CommData + Debug> Subscriber<T, LolaRuntimeImpl> for SubscribableImpl<T> {
-    type Subscription = SubscriberImpl<T>;
-    fn new(identifier: &'static str, instance_info: LolaConsumerInfo) -> Result<Self> {
+impl<T: CommData + Debug, B: FFIBridge> Subscriber<T, LolaRuntimeImpl<B>> for SubscribableImpl<T, B> {
+    type Subscription = SubscriberImpl<T, B>;
+    fn new(identifier: &'static str, instance_info: LolaConsumerInfo<B>) -> Result<Self> {
         let handle = instance_info.get_handle().ok_or(Error::ConsumerError(
             ConsumerFailedReason::ServiceHandleNotFound,
         ))?;
@@ -309,7 +311,7 @@ impl<T: CommData + Debug> Subscriber<T, LolaRuntimeImpl> for SubscribableImpl<T>
             return Err(Error::EventError(EventFailedReason::InvalidMaxSamples));
         }
         let instance_info = self.instance_info.clone();
-        let event_instance = NativeProxyEventBase::new(
+        let event_instance = NativeProxyEventBase::new::<B>(
             &self.proxy_instance.0.proxy,
             self.instance_info.interface_id,
             self.identifier,
@@ -317,7 +319,7 @@ impl<T: CommData + Debug> Subscriber<T, LolaRuntimeImpl> for SubscribableImpl<T>
         //SAFETY: It is safe to subscribe to event because event_instance is valid
         // which was obtained from valid proxy instance
         let status = unsafe {
-            bridge_ffi_rs::subscribe_to_event(
+            B::subscribe_to_event(
                 std::ptr::from_ref(event_instance.get_proxy_event_base()) as *mut ProxyEventBase,
                 max_num_samples.try_into().unwrap(),
             )
@@ -431,21 +433,21 @@ impl<'a> DerefMut for ProxyEventManagerGuard<'a> {
 /// It also manages the asynchronous initialization of the receive callback
 /// and the waker storage for async notifications when new samples arrive.
 #[derive(Debug)]
-pub struct SubscriberImpl<T>
+pub struct SubscriberImpl<T, B: FFIBridge>
 where
     T: CommData + Debug,
 {
     event: ProxyEventManager,
     event_id: &'static str,
     max_num_samples: usize,
-    instance_info: LolaConsumerInfo,
+    instance_info: LolaConsumerInfo<B>,
     waker_storage: Arc<AtomicWaker>,
     async_init_status: std::sync::Once,
-    _proxy: ProxyInstanceManager,
+    _proxy: ProxyInstanceManager<B>,
     _phantom: PhantomData<T>,
 }
 
-impl<T: CommData + Debug> Drop for SubscriberImpl<T> {
+impl<T: CommData + Debug, B: FFIBridge> Drop for SubscriberImpl<T, B> {
     fn drop(&mut self) {
         // SAFETY: It is safe to unsubscribe from the event because the event pointer is valid
         // and was created during subscription.
@@ -457,14 +459,14 @@ impl<T: CommData + Debug> Drop for SubscriberImpl<T> {
             if self.async_init_status.is_completed()
             // Check if the async receive callback was initialized
             {
-                bridge_ffi_rs::clear_event_receive_handler(guard.deref_mut(), T::ID);
+                B::clear_event_receive_handler(guard.deref_mut(), T::ID);
             }
-            bridge_ffi_rs::unsubscribe_to_event(guard.deref_mut());
+            B::unsubscribe_to_event(guard.deref_mut());
         }
     }
 }
 
-impl<T: CommData + Debug> SubscriberImpl<T> {
+impl<T: CommData + Debug, B: FFIBridge> SubscriberImpl<T, B> {
     fn init_async_receive(&self, event_guard: &mut ProxyEventManagerGuard) -> Result<()> {
         let callback_waker = Arc::clone(&self.waker_storage);
         let waker_callback = move || {
@@ -480,7 +482,7 @@ impl<T: CommData + Debug> SubscriberImpl<T> {
         // and the lifetime of the callback is managed by Rust, it will not outlive the scope of
         // this function call.
         unsafe {
-            bridge_ffi_rs::set_event_receive_handler(event_guard.deref_mut(), &fat_ptr, T::ID);
+            B::set_event_receive_handler(event_guard.deref_mut(), &fat_ptr, T::ID);
         }
         Ok(())
     }
@@ -519,12 +521,12 @@ impl<T: CommData + Debug> SubscriberImpl<T> {
     }
 }
 
-impl<T> Subscription<T, LolaRuntimeImpl> for SubscriberImpl<T>
+impl<T, B: FFIBridge> Subscription<T, LolaRuntimeImpl<B>> for SubscriberImpl<T, B>
 where
     T: CommData + Debug,
 {
-    type Subscriber = SubscribableImpl<T>;
-    type Sample<'a> = Sample<T>;
+    type Subscriber = SubscribableImpl<T, B>;
+    type Sample<'a> = Sample<T, B>;
 
     /// The unsubscribe method consumes the subscription and returns the subscribable instance.
     /// Calling `unsubscribe` while a `SampleContainer` holding samples whose lifetime
@@ -565,7 +567,7 @@ where
         scratch: &'_ mut SampleContainer<Self::Sample<'a>>,
         max_samples: usize,
     ) -> Result<usize> {
-        try_receive_samples::<T>(
+        try_receive_samples::<T, B>(
             self.event.get_proxy_event().deref_mut(),
             scratch,
             self.max_num_samples,
@@ -635,19 +637,19 @@ where
 // a waker storage for async notifications, and parameters for managing the receive operation.
 // The Future implementation for ReceiveFuture defines the polling logic,
 // which attempts to receive samples and manages the state of the receive operation.
-struct ReceiveFuture<'a, T: CommData + Debug, F: Future<Output = ()>> {
+struct ReceiveFuture<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBridge> {
     event_guard: Option<ProxyEventManagerGuard<'a>>,
     waker_storage: Arc<AtomicWaker>,
     max_num_samples: usize,
-    scratch: Option<SampleContainer<Sample<T>>>,
+    scratch: Option<SampleContainer<Sample<T, B>>>,
     new_samples: usize,
     max_samples: usize,
     total_received: usize,
     cancellation: Pin<&'a mut F>,
 }
 
-impl<'a, T: CommData + Debug, F: Future<Output = ()>> Future for ReceiveFuture<'a, T, F> {
-    type Output = (SampleContainer<Sample<T>>, Result<usize>);
+impl<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBridge> Future for ReceiveFuture<'a, T, F, B> {
+    type Output = (SampleContainer<Sample<T, B>>, Result<usize>);
 
     fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
         // Extract all immutable values upfront to avoid borrow conflicts with self in the callback
@@ -675,7 +677,7 @@ impl<'a, T: CommData + Debug, F: Future<Output = ()>> Future for ReceiveFuture<'
             // when passing to try_receive_samples
             if let Some(mut scratch) = self.scratch.take() {
                 if let Some(event_guard) = self.event_guard.as_mut() {
-                    let result = try_receive_samples::<T>(
+                    let result = try_receive_samples::<T, B>(
                         event_guard.deref_mut(),
                         &mut scratch,
                         max_num_samples,
@@ -801,26 +803,28 @@ impl std::fmt::Debug for DiscoveryStateData {
     }
 }
 
-pub struct LolaConsumerDiscovery<I> {
+pub struct SampleConsumerDiscovery<I, B: FFIBridge> {
     pub instance_specifier: InstanceSpecifier,
     pub _interface: PhantomData<I>,
+    pub _bridge: PhantomData<B>,
 }
 
-impl<I: Interface> LolaConsumerDiscovery<I> {
-    pub fn new(_runtime: &LolaRuntimeImpl, instance_specifier: InstanceSpecifier) -> Self {
+impl<I: Interface, B: FFIBridge> SampleConsumerDiscovery<I, B> {
+    pub fn new(_runtime: &LolaRuntimeImpl<B>, instance_specifier: InstanceSpecifier) -> Self {
         Self {
             instance_specifier,
             _interface: PhantomData,
+            _bridge: PhantomData,
         }
     }
 }
 
-impl<I: Interface + Send> ServiceDiscovery<I, LolaRuntimeImpl> for LolaConsumerDiscovery<I>
+impl<I: Interface + Send, B: FFIBridge> ServiceDiscovery<I, LolaRuntimeImpl<B>> for SampleConsumerDiscovery<I, B>
 where
-    LolaConsumerBuilder<I>: ConsumerBuilder<I, LolaRuntimeImpl>,
+    SampleConsumerBuilder<I, B>: ConsumerBuilder<I, LolaRuntimeImpl<B>>,
 {
-    type ConsumerBuilder = LolaConsumerBuilder<I>;
-    type ServiceEnumerator = Vec<LolaConsumerBuilder<I>>;
+    type ConsumerBuilder = SampleConsumerBuilder<I, B>;
+    type ServiceEnumerator = Vec<SampleConsumerBuilder<I, B>>;
 
     fn get_available_instances(&self) -> Result<Self::ServiceEnumerator> {
         //If ANY Support is added in Lola, then we need to return all available instances
@@ -839,6 +843,7 @@ where
                     handle_container: Arc::clone(&service_handle_arc),
                     handle_index,
                     interface_id: I::INTERFACE_ID,
+                    _marker: PhantomData,
                 };
                 LolaConsumerBuilder {
                     instance_info,
@@ -906,7 +911,7 @@ where
             // instance specifier is valid. The returned handle is stored
             // synchronously — before any async polling — guaranteeing
             // stop_find_service is always called in Drop.
-            let raw_handle = unsafe { bridge_ffi_rs::start_find_service(&fat_ptr, spec) };
+            let raw_handle = unsafe { B::start_find_service(&fat_ptr, spec) };
             if raw_handle.is_null() {
                 Err(Error::ServiceError(
                     ServiceFailedReason::FailedToStartDiscovery,
@@ -927,6 +932,7 @@ where
                 discovery_state,
                 waker_storage,
                 _interface: PhantomData,
+                _bridge: PhantomData,
             }
             .await
         }
@@ -940,29 +946,30 @@ where
 /// resources.
 /// Stop find service in Drop implementation to ensure that we clean up the find service if the
 /// future is dropped before completion
-struct ServiceDiscoveryFuture<I: Interface> {
+struct ServiceDiscoveryFuture<I: Interface, B: FFIBridge> {
     find_handle: bridge_ffi_rs::NativeFindServiceHandle,
     discovery_state: Arc<std::sync::Mutex<DiscoveryStateData>>,
     waker_storage: Arc<futures::task::AtomicWaker>,
     _interface: PhantomData<I>,
+    _bridge: PhantomData<B>,
 }
 
-impl<I: Interface> Drop for ServiceDiscoveryFuture<I> {
+impl<I: Interface, B: FFIBridge> Drop for ServiceDiscoveryFuture<I, B> {
     fn drop(&mut self) {
         // SAFETY: find_handle is always valid here — it was stored synchronously
         // from start_find_service return value before any async polling began.
         // This unconditional call ensures the C++ discovery operation is always
         // cleaned up, even when the future is dropped before the callback fires.
         unsafe {
-            bridge_ffi_rs::stop_find_service(
+            B::stop_find_service(
                 self.find_handle.as_mut() as *mut bridge_ffi_rs::FindServiceHandle
             );
         }
     }
 }
 
-impl<I: Interface> Future for ServiceDiscoveryFuture<I> {
-    type Output = Result<Vec<LolaConsumerBuilder<I>>>;
+impl<I: Interface, B: FFIBridge> Future for ServiceDiscoveryFuture<I, B> {
+    type Output = Result<Vec<SampleConsumerBuilder<I, B>>>;
 
     fn poll(
         self: std::pin::Pin<&mut Self>,
@@ -994,6 +1001,7 @@ impl<I: Interface> Future for ServiceDiscoveryFuture<I> {
                         handle_container: Arc::clone(&service_handle_arc),
                         handle_index,
                         interface_id: I::INTERFACE_ID,
+                        _marker: PhantomData,
                     };
                     LolaConsumerBuilder {
                         instance_info,
@@ -1009,20 +1017,20 @@ impl<I: Interface> Future for ServiceDiscoveryFuture<I> {
     }
 }
 
-impl<I: Interface> ConsumerBuilder<I, LolaRuntimeImpl> for LolaConsumerBuilder<I> {}
+impl<I: Interface, B: FFIBridge> ConsumerBuilder<I, LolaRuntimeImpl<B>> for SampleConsumerBuilder<I, B> {}
 
-impl<I: Interface> Builder<I::Consumer<LolaRuntimeImpl>> for LolaConsumerBuilder<I> {
-    fn build(self) -> Result<I::Consumer<LolaRuntimeImpl>> {
+impl<I: Interface, B: FFIBridge> Builder<I::Consumer<LolaRuntimeImpl<B>>> for SampleConsumerBuilder<I, B> {
+    fn build(self) -> Result<I::Consumer<LolaRuntimeImpl<B>>> {
         Ok(Consumer::new(self.instance_info))
     }
 }
 
-pub struct LolaConsumerBuilder<I: Interface> {
-    pub instance_info: LolaConsumerInfo,
+pub struct SampleConsumerBuilder<I: Interface, B: FFIBridge> {
+    pub instance_info: LolaConsumerInfo<B>,
     pub _interface: PhantomData<I>,
 }
 
-impl<I: Interface> ConsumerDescriptor<LolaRuntimeImpl> for LolaConsumerBuilder<I> {
+impl<I: Interface, B: FFIBridge> ConsumerDescriptor<LolaRuntimeImpl<B>> for SampleConsumerBuilder<I, B> {
     fn get_instance_identifier(&self) -> &InstanceSpecifier {
         //if InstanceSpecifier::ANY support enable by lola
         //then this API should get InstanceSpecifier from FFI Call
@@ -1043,9 +1051,9 @@ impl<I: Interface> ConsumerDescriptor<LolaRuntimeImpl> for LolaConsumerBuilder<I
 /// * `scratch` - Mutable reference to the sample container
 /// * `max_num_samples` - Maximum allowed samples for this subscription
 /// * `max_samples` - How many samples to fetch in this call
-fn try_receive_samples<T: CommData + Debug>(
+fn try_receive_samples<T: CommData + Debug, B: FFIBridge>(
     event: &mut ProxyEventBase,
-    scratch: &mut SampleContainer<Sample<T>>,
+    scratch: &mut SampleContainer<Sample<T, B>>,
     max_num_samples: usize,
     max_samples: usize,
 ) -> Result<usize> {
@@ -1066,7 +1074,7 @@ fn try_receive_samples<T: CommData + Debug>(
         ));
     }
     // Create a callback that will be called by the C++ side for each new sample arrival
-    let mut callback = create_sample_callback(scratch, max_samples);
+    let mut callback = create_sample_callback::<T, B>(scratch, max_samples);
     // Convert closure to FatPtr for C++ callback
     let dyn_callback: &mut dyn FnMut(*mut sample_ptr_rs::SamplePtr<T>) = &mut callback;
     // SAFETY: it is safe to transmute the closure reference to a FatPtr because
@@ -1075,7 +1083,7 @@ fn try_receive_samples<T: CommData + Debug>(
     // SAFETY: event is a valid ProxyEventBase pointer obtained during subscription.
     // The lifetime of the callback is managed by Rust and will not outlive this function call.
     let count = unsafe {
-        bridge_ffi_rs::get_samples_from_event(
+        B::get_samples_from_event(
             event as *mut ProxyEventBase,
             T::ID,
             &fat_ptr,
@@ -1106,8 +1114,8 @@ fn try_receive_samples<T: CommData + Debug>(
 /// # Parameters
 /// * `scratch` - Mutable reference to the sample container
 /// * `max_samples` - Maximum number of samples to maintain in the container
-pub fn create_sample_callback<'a, T: CommData + Debug>(
-    scratch: &'a mut SampleContainer<Sample<T>>,
+pub fn create_sample_callback<'a, T: CommData + Debug, B: FFIBridge>(
+    scratch: &'a mut SampleContainer<Sample<T, B>>,
     max_samples: usize,
 ) -> impl FnMut(*mut sample_ptr_rs::SamplePtr<T>) + 'a {
     move |raw_sample: *mut sample_ptr_rs::SamplePtr<T>| {
@@ -1122,6 +1130,7 @@ pub fn create_sample_callback<'a, T: CommData + Debug>(
                 id: ID_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
                 inner: LolaBinding {
                     data: ManuallyDrop::new(sample_ptr),
+                    _bridge: PhantomData,
                 },
             };
 

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -22,9 +22,6 @@
 //! The implementation ensures proper memory management and resource handling
 //! through Rust's ownership model and FFI safety practices.
 
-// Cloning to bridge is fine here because LolaFFIBridge is ZST and has no internal state,
-// so all clones are identical and stateless.
-
 //lifetime warning for all the Sample struct impl block, it is required for the Sample struct
 // event lifetime parameter
 // and mentaining lifetime of instances and data reference
@@ -61,7 +58,9 @@ pub struct LolaConsumerInfo<B: FFIBridge> {
     handle_container: Arc<mw_com::proxy::HandleContainer>,
     handle_index: usize,
     interface_id: &'static str,
-    bridge: B,
+    // Bridge is Arc-wrapped at creation for optimized cloning throughout the consumer lifecycle.
+    // For LolaFFIBridge (ZST), Arc overhead is minimal rather than cloning directly.
+    bridge: Arc<B>,
 }
 
 impl<B: FFIBridge> LolaConsumerInfo<B> {
@@ -81,7 +80,7 @@ where
     T: CommData + Debug,
 {
     data: ManuallyDrop<sample_ptr_rs::SamplePtr<T>>,
-    bridge: B,
+    bridge: Arc<B>,
 }
 
 impl<T, B: FFIBridge> Drop for LolaBinding<T, B>
@@ -315,8 +314,11 @@ impl<T: CommData + Debug, B: FFIBridge> Subscriber<T, LolaRuntimeImpl<B>>
         let handle = instance_info.get_handle().ok_or(Error::ConsumerError(
             ConsumerFailedReason::ServiceHandleNotFound,
         ))?;
-        let native_proxy =
-            NativeProxyBase::new(&instance_info.bridge, instance_info.interface_id, handle)?;
+        let native_proxy = NativeProxyBase::new(
+            instance_info.bridge.as_ref(),
+            instance_info.interface_id,
+            handle,
+        )?;
         let proxy_instance = ProxyInstanceManager(Arc::new(native_proxy));
         Ok(Self {
             identifier,
@@ -704,10 +706,7 @@ impl<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBridge> Future for R
         let new_samples = self.new_samples;
         let max_num_samples = self.max_num_samples;
         let total_received = self.total_received;
-        // Clone bridge to avoid borrow checker conflict:
-        // We need an immutable reference to bridge while also mutably borrowing self.scratch and self.event_guard.
-        // For LolaFFIBridge (ZST), clone is free.
-        let bridge = self.bridge.clone();
+        let bridge = Arc::clone(&self.bridge);
 
         // Poll the cancellation future first to ensure prompt handling of cancellation requests.
         if self.cancellation.as_mut().poll(ctx).is_ready() {
@@ -890,13 +889,14 @@ where
             .map_err(|_| Error::ServiceError(ServiceFailedReason::ServiceNotFound))?;
 
         let service_handle_arc = Arc::new(service_handle);
+        let bridge_arc = Arc::new(self.bridge.clone());
         let available_instances = (0..service_handle_arc.len())
             .map(|handle_index| {
                 let instance_info = LolaConsumerInfo {
                     handle_container: Arc::clone(&service_handle_arc),
                     handle_index,
                     interface_id: I::INTERFACE_ID,
-                    bridge: self.bridge.clone(),
+                    bridge: Arc::clone(&bridge_arc),
                 };
                 LolaConsumerBuilder {
                     instance_info,
@@ -1049,13 +1049,14 @@ impl<I: Interface, B: FFIBridge> Future for ServiceDiscoveryFuture<I, B> {
             //create Arc for service handle to share between instances
             let service_handle_arc = Arc::new(service_handle);
             // Build the response from discovered handles
+            let bridge_arc = Arc::new(self.bridge.clone());
             let available_instances = (0..service_handle_arc.len())
                 .map(|handle_index| {
                     let instance_info = LolaConsumerInfo {
                         handle_container: Arc::clone(&service_handle_arc),
                         handle_index,
                         interface_id: I::INTERFACE_ID,
-                        bridge: self.bridge.clone(),
+                        bridge: Arc::clone(&bridge_arc),
                     };
                     LolaConsumerBuilder {
                         instance_info,
@@ -1113,7 +1114,7 @@ impl<I: Interface, B: FFIBridge> ConsumerDescriptor<LolaRuntimeImpl<B>>
 /// * `max_num_samples` - Maximum allowed samples for this subscription
 /// * `max_samples` - How many samples to fetch in this call
 fn try_receive_samples<T: CommData + Debug, B: FFIBridge>(
-    bridge: &B,
+    bridge: &Arc<B>,
     event: &mut ProxyEventBase,
     scratch: &mut SampleContainer<Sample<T, B>>,
     max_num_samples: usize,
@@ -1177,10 +1178,11 @@ fn try_receive_samples<T: CommData + Debug, B: FFIBridge>(
 /// * `scratch` - Mutable reference to the sample container
 /// * `max_samples` - Maximum number of samples to maintain in the container
 pub fn create_sample_callback<'a, T: CommData + Debug, B: FFIBridge>(
-    bridge: &'a B,
+    bridge: &Arc<B>,
     scratch: &'a mut SampleContainer<Sample<T, B>>,
     max_samples: usize,
 ) -> impl FnMut(*mut sample_ptr_rs::SamplePtr<T>) + 'a {
+    let bridge = Arc::clone(bridge);
     move |raw_sample: *mut sample_ptr_rs::SamplePtr<T>| {
         if !raw_sample.is_null() {
             //SAFETY: It is safe to read the sample pointer because
@@ -1193,7 +1195,7 @@ pub fn create_sample_callback<'a, T: CommData + Debug, B: FFIBridge>(
                 id: ID_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
                 inner: LolaBinding {
                     data: ManuallyDrop::new(sample_ptr),
-                    bridge: bridge.clone(),
+                    bridge: Arc::clone(&bridge),
                 },
             };
 
@@ -1246,7 +1248,7 @@ mod test {
             handle_container: MockFFIBridge::make_handle_container(),
             handle_index: 0,
             interface_id: "TestInterface",
-            bridge: MockFFIBridge,
+            bridge: Arc::new(MockFFIBridge),
         }
     }
 
@@ -1266,7 +1268,7 @@ mod test {
                 data: ManuallyDrop::new(unsafe {
                     core::mem::zeroed::<sample_ptr_rs::SamplePtr<TestData>>()
                 }),
-                bridge: MockFFIBridge,
+                bridge: Arc::new(MockFFIBridge),
             },
         };
         assert_eq!(sample.id, 1);
@@ -1301,7 +1303,6 @@ mod test {
             waker_storage: Arc::new(AtomicWaker::new()),
             async_init_status: std::sync::OnceLock::new(),
             _proxy: make_proxy_instance("TestInterface"),
-            bridge: MockFFIBridge,
             _phantom: PhantomData,
         };
         let mut sample_container = SampleContainer::new(5);

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -64,7 +64,9 @@ pub struct LolaConsumerInfo<B: FFIBridge> {
 impl<B: FFIBridge> LolaConsumerInfo<B> {
     /// Get a reference to the handle, guaranteed valid as long as this struct exists
     pub fn get_handle(&self) -> Option<&HandleType> {
-        self.handle_container.get(self.handle_index)
+        // SAFETY: handle_container was produced by the bridge or a trusted mock;
+        // both implementations uphold the contract of handle_container_get_at.
+        unsafe { B::handle_container_get_at(&self.handle_container, self.handle_index) }
     }
 }
 
@@ -201,7 +203,7 @@ impl<B: FFIBridge> std::fmt::Debug for ProxyInstanceManager<B> {
 /// it must not expose any mutable access to the proxy instance
 /// Or must not provide any method to access the proxy instance directly
 pub struct NativeProxyBase<B: FFIBridge> {
-   proxy: NonNull<ProxyBase>, // Stores the proxy instance
+    proxy: NonNull<ProxyBase>, // Stores the proxy instance
     _marker: PhantomData<B>,
 }
 
@@ -237,7 +239,10 @@ impl<B: FFIBridge> NativeProxyBase<B> {
         let proxy = std::ptr::NonNull::new(raw_proxy_ptr).ok_or(Error::ConsumerError(
             ConsumerFailedReason::ProxyCreationFailed,
         ))?;
-        Ok(Self { proxy, _marker: PhantomData })
+        Ok(Self {
+            proxy,
+            _marker: PhantomData,
+        })
     }
 }
 
@@ -259,7 +264,11 @@ pub struct NativeProxyEventBase {
 unsafe impl Send for NativeProxyEventBase {}
 
 impl NativeProxyEventBase {
-    pub fn new<B: FFIBridge>(proxy: &NonNull<ProxyBase>, interface_id: &str, identifier: &str) -> Result<Self> {
+    pub fn new<B: FFIBridge>(
+        proxy: &NonNull<ProxyBase>,
+        interface_id: &str,
+        identifier: &str,
+    ) -> Result<Self> {
         //SAFETY: It is safe as we are passing valid proxy pointer and interface id to get event
         // proxy pointer is created during consumer creation
         let raw_event_ptr =

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -58,9 +58,11 @@ pub struct LolaConsumerInfo<B: FFIBridge> {
     handle_container: Arc<mw_com::proxy::HandleContainer>,
     handle_index: usize,
     interface_id: &'static str,
-    // Bridge is Arc-wrapped at creation for optimized cloning throughout the consumer lifecycle.
-    // For LolaFFIBridge (ZST), Arc overhead is minimal rather than cloning directly.
-    bridge: Arc<B>,
+    // LolaFFIBridge (Production case) is a ZST, so cloning it is not overhead,
+    // But if in future we add some state in the bridge type then we need to ensure that
+    // it is properly cloned and does not cause any overhead.
+    // In that case suggested to implement Arc for the type or FFIBridge itself.
+    bridge: B,
 }
 
 impl<B: FFIBridge> LolaConsumerInfo<B> {
@@ -80,7 +82,7 @@ where
     T: CommData + Debug,
 {
     data: ManuallyDrop<sample_ptr_rs::SamplePtr<T>>,
-    bridge: Arc<B>,
+    bridge: B,
 }
 
 impl<T, B: FFIBridge> Drop for LolaBinding<T, B>
@@ -314,11 +316,8 @@ impl<T: CommData + Debug, B: FFIBridge> Subscriber<T, LolaRuntimeImpl<B>>
         let handle = instance_info.get_handle().ok_or(Error::ConsumerError(
             ConsumerFailedReason::ServiceHandleNotFound,
         ))?;
-        let native_proxy = NativeProxyBase::new(
-            instance_info.bridge.as_ref(),
-            instance_info.interface_id,
-            handle,
-        )?;
+        let native_proxy =
+            NativeProxyBase::new(&instance_info.bridge, instance_info.interface_id, handle)?;
         let proxy_instance = ProxyInstanceManager(Arc::new(native_proxy));
         Ok(Self {
             identifier,
@@ -693,7 +692,10 @@ struct ReceiveFuture<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBrid
     new_samples: usize,
     max_samples: usize,
     total_received: usize,
+<<<<<<< HEAD
     cancellation: Pin<&'a mut F>,
+=======
+>>>>>>> d1f2a252 (Rust::com Update FFI mock)
     bridge: B,
 }
 
@@ -706,7 +708,7 @@ impl<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBridge> Future for R
         let new_samples = self.new_samples;
         let max_num_samples = self.max_num_samples;
         let total_received = self.total_received;
-        let bridge = Arc::clone(&self.bridge);
+        let bridge = self.bridge.clone();
 
         // Poll the cancellation future first to ensure prompt handling of cancellation requests.
         if self.cancellation.as_mut().poll(ctx).is_ready() {
@@ -889,14 +891,13 @@ where
             .map_err(|_| Error::ServiceError(ServiceFailedReason::ServiceNotFound))?;
 
         let service_handle_arc = Arc::new(service_handle);
-        let bridge_arc = Arc::new(self.bridge.clone());
         let available_instances = (0..service_handle_arc.len())
             .map(|handle_index| {
                 let instance_info = LolaConsumerInfo {
                     handle_container: Arc::clone(&service_handle_arc),
                     handle_index,
                     interface_id: I::INTERFACE_ID,
-                    bridge: Arc::clone(&bridge_arc),
+                    bridge: self.bridge.clone(),
                 };
                 LolaConsumerBuilder {
                     instance_info,
@@ -1049,14 +1050,13 @@ impl<I: Interface, B: FFIBridge> Future for ServiceDiscoveryFuture<I, B> {
             //create Arc for service handle to share between instances
             let service_handle_arc = Arc::new(service_handle);
             // Build the response from discovered handles
-            let bridge_arc = Arc::new(self.bridge.clone());
             let available_instances = (0..service_handle_arc.len())
                 .map(|handle_index| {
                     let instance_info = LolaConsumerInfo {
                         handle_container: Arc::clone(&service_handle_arc),
                         handle_index,
                         interface_id: I::INTERFACE_ID,
-                        bridge: Arc::clone(&bridge_arc),
+                        bridge: self.bridge.clone(),
                     };
                     LolaConsumerBuilder {
                         instance_info,
@@ -1114,7 +1114,7 @@ impl<I: Interface, B: FFIBridge> ConsumerDescriptor<LolaRuntimeImpl<B>>
 /// * `max_num_samples` - Maximum allowed samples for this subscription
 /// * `max_samples` - How many samples to fetch in this call
 fn try_receive_samples<T: CommData + Debug, B: FFIBridge>(
-    bridge: &Arc<B>,
+    bridge: &B,
     event: &mut ProxyEventBase,
     scratch: &mut SampleContainer<Sample<T, B>>,
     max_num_samples: usize,
@@ -1178,11 +1178,11 @@ fn try_receive_samples<T: CommData + Debug, B: FFIBridge>(
 /// * `scratch` - Mutable reference to the sample container
 /// * `max_samples` - Maximum number of samples to maintain in the container
 pub fn create_sample_callback<'a, T: CommData + Debug, B: FFIBridge>(
-    bridge: &Arc<B>,
+    bridge: &B,
     scratch: &'a mut SampleContainer<Sample<T, B>>,
     max_samples: usize,
 ) -> impl FnMut(*mut sample_ptr_rs::SamplePtr<T>) + 'a {
-    let bridge = Arc::clone(bridge);
+    let bridge = bridge.clone();
     move |raw_sample: *mut sample_ptr_rs::SamplePtr<T>| {
         if !raw_sample.is_null() {
             //SAFETY: It is safe to read the sample pointer because
@@ -1195,7 +1195,7 @@ pub fn create_sample_callback<'a, T: CommData + Debug, B: FFIBridge>(
                 id: ID_COUNTER.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
                 inner: LolaBinding {
                     data: ManuallyDrop::new(sample_ptr),
-                    bridge: Arc::clone(&bridge),
+                    bridge: bridge.clone(),
                 },
             };
 
@@ -1248,7 +1248,7 @@ mod test {
             handle_container: MockFFIBridge::make_handle_container(),
             handle_index: 0,
             interface_id: "TestInterface",
-            bridge: Arc::new(MockFFIBridge),
+            bridge: MockFFIBridge,
         }
     }
 
@@ -1268,7 +1268,7 @@ mod test {
                 data: ManuallyDrop::new(unsafe {
                     core::mem::zeroed::<sample_ptr_rs::SamplePtr<TestData>>()
                 }),
-                bridge: Arc::new(MockFFIBridge),
+                bridge: MockFFIBridge,
             },
         };
         assert_eq!(sample.id, 1);

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
@@ -500,16 +500,16 @@ impl<I: Interface, B: FFIBridge> Builder<I::Producer<LolaRuntimeImpl<B>>>
 #[cfg(test)]
 mod test {
     use super::*;
-    use bridge_ffi_mock::{MockFFIBridge, SharedMockBridge};
+    use bridge_ffi_mock::{MockFFIBridge, MockPointerAllocator, SharedMockBridge};
     use com_api_concept::InstanceSpecifier;
     use mockall::predicate::*;
+    use mockall::Sequence;
     // Bring trait methods into scope without shadowing local struct names.
     use com_api_concept::Publisher as _;
     use com_api_concept::SampleMaybeUninit as _;
     use com_api_concept::SampleMut as _;
-    use std::sync::Mutex;
 
-    #[derive(Debug)]
+    #[derive(Debug, Default)]
     #[repr(C)]
     struct TestData {
         value: i32,
@@ -546,28 +546,34 @@ mod test {
     #[test]
     fn test_provider_info_offer_service() {
         let mut mock = MockFFIBridge::new();
-        let skeleton_vec = Arc::new(Mutex::new(Vec::new()));
-        let skeleton_vec_clone = skeleton_vec.clone();
-        mock.expect_create_skeleton().returning(move |_, _| {
-            let mut skeleton = skeleton_vec_clone
-                .lock()
-                .expect("not able to acquire lock on skeleton_vec");
-            skeleton.push(Box::<SkeletonBase>::default());
-            skeleton.last_mut().unwrap().as_mut() as *mut SkeletonBase
-        });
-        mock.expect_skeleton_offer_service().returning(|_| true);
-        mock.expect_skeleton_stop_offer_service().returning(|_| ());
-        let skeleton = skeleton_vec.clone();
-        mock.expect_destroy_skeleton().returning(move |ptr| {
-            let mut skeleton = skeleton
-                .lock()
-                .expect("not able to acquire lock on skeleton_vec");
-            let pos = skeleton
-                .iter_mut()
-                .position(|s| s.as_mut() as *mut SkeletonBase == ptr)
-                .expect("destroyed skeleton handle should exist in skeleton_vec");
-            skeleton.remove(pos);
-        });
+        let mut seq = Sequence::new();
+
+        // Use MockPointerAllocator for cleaner pointer management
+        let skeleton_alloc = MockPointerAllocator::<SkeletonBase>::new();
+
+        let skel = skeleton_alloc.clone();
+        mock.expect_create_skeleton()
+            .in_sequence(&mut seq)
+            .returning(move |_, _| skel.allocate());
+
+        mock.expect_skeleton_offer_service()
+            .in_sequence(&mut seq)
+            .returning(|_| true);
+
+        mock.expect_skeleton_stop_offer_service()
+            .in_sequence(&mut seq)
+            .returning(|_| ());
+
+        let skel_cleanup = skeleton_alloc.clone();
+        mock.expect_destroy_skeleton()
+            .in_sequence(&mut seq)
+            .returning(move |ptr| {
+                assert!(
+                    skel_cleanup.free(ptr),
+                    "destroy_skeleton called with unknown pointer"
+                );
+            });
+
         let bridge = SharedMockBridge::new(mock);
         let provider_info = make_provider_info("TestInterface", &bridge);
         assert!(
@@ -578,16 +584,33 @@ mod test {
             provider_info.stop_offer_service().is_ok(),
             "stop_offer_service should always succeed in the mock"
         );
+
+        // Drop provider_info to remove the skeleton instance and trigger destroy_skeleton cleanup
+        drop(provider_info);
+
+        // Verify all allocations were cleaned up
+        skeleton_alloc.assert_all_freed();
     }
 
     #[test]
     fn test_publisher_allocate_and_send() {
+        let skeleton_alloc = MockPointerAllocator::<SkeletonBase>::new();
+        let event_alloc = MockPointerAllocator::<SkeletonEventBase>::new();
+        let data_alloc = MockPointerAllocator::<TestData>::new();
+        let mut seq = Sequence::new();
         let mut mock = MockFFIBridge::new();
+
+        let skeleton_alloc_clone = skeleton_alloc.clone();
+        let event_alloc_clone = event_alloc.clone();
         mock.expect_create_skeleton()
-            .returning(|_, _| Box::into_raw(Box::default()));
+            .in_sequence(&mut seq)
+            .returning(move |_, _| skeleton_alloc_clone.allocate());
         mock.expect_get_event_from_skeleton()
-            .returning(|_, _, _| Box::into_raw(Box::default()));
+            .in_sequence(&mut seq)
+            .returning(move |_, _, _| event_alloc_clone.allocate());
+
         mock.expect_get_allocatee_ptr()
+            .in_sequence(&mut seq)
             .returning(|_, allocatee_ptr, _| {
                 // SAFETY: Write a zeroed SampleAllocateePtr to the out-parameter for testing
                 unsafe {
@@ -598,17 +621,26 @@ mod test {
                 }
                 true
             });
-        mock.expect_get_allocatee_data_ptr().returning(move |_, _| {
-            // Return a valid heap-allocated TestData pointer for the test to write to
-            Box::into_raw(Box::new(TestData { value: 0 })) as *mut std::ffi::c_void
-        });
+        let data = data_alloc.clone();
+        mock.expect_get_allocatee_data_ptr()
+            .in_sequence(&mut seq)
+            .returning(move |_, _| data.allocate() as *mut std::ffi::c_void);
         mock.expect_skeleton_event_send_sample_allocatee()
+            .in_sequence(&mut seq)
             .returning(|_, _, _| true);
-        mock.expect_delete_allocatee_ptr().returning(|_, _| ());
-        mock.expect_destroy_skeleton().returning(|_| ());
+        mock.expect_delete_allocatee_ptr()
+            .in_sequence(&mut seq)
+            .returning(move |allocatee_ptr, _| {
+                data_alloc.free(allocatee_ptr as *mut TestData);
+            });
+
+        mock.expect_destroy_skeleton()
+            .in_sequence(&mut seq)
+            .returning(move |ptr| {
+                skeleton_alloc.free(ptr);
+            });
 
         let bridge = SharedMockBridge::new(mock);
-
         let spec = mw_com::InstanceSpecifier::try_from("/test_instance")
             .expect("valid instance specifier");
         let skeleton_handle =

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
@@ -102,7 +102,8 @@ where
     }
 }
 
-impl<T, B: FFIBridge> AsRef<sample_allocatee_ptr_rs::SampleAllocateePtr<T>> for AllocateePtrWrapper<T, B>
+impl<T, B: FFIBridge> AsRef<sample_allocatee_ptr_rs::SampleAllocateePtr<T>>
+    for AllocateePtrWrapper<T, B>
 where
     T: CommData + Debug,
 {
@@ -334,7 +335,10 @@ pub struct NativeSkeletonEventBase {
 unsafe impl Send for NativeSkeletonEventBase {}
 
 impl NativeSkeletonEventBase {
-    pub fn new<B: FFIBridge>(instance_info: &LolaProviderInfo<B>, identifier: &str) -> Result<Self> {
+    pub fn new<B: FFIBridge>(
+        instance_info: &LolaProviderInfo<B>,
+        identifier: &str,
+    ) -> Result<Self> {
         //SAFETY: It is safe as we are passing valid skeleton handle and interface id to get event
         // skeleton handle is created during producer offer call
         let raw_event_ptr = unsafe {
@@ -423,13 +427,13 @@ where
     }
 }
 
-pub struct SampleProducerBuilder<I: Interface, B: FFIBridge> {
+pub struct LolaProducerBuilder<I: Interface, B: FFIBridge> {
     pub instance_specifier: InstanceSpecifier,
     pub _interface: PhantomData<I>,
     pub _bridge: PhantomData<B>,
 }
 
-impl<I: Interface, B: FFIBridge> SampleProducerBuilder<I, B> {
+impl<I: Interface, B: FFIBridge> LolaProducerBuilder<I, B> {
     pub fn new(_runtime: &LolaRuntimeImpl<B>, instance_specifier: InstanceSpecifier) -> Self {
         Self {
             instance_specifier,
@@ -439,9 +443,14 @@ impl<I: Interface, B: FFIBridge> SampleProducerBuilder<I, B> {
     }
 }
 
-impl<I: Interface, B: FFIBridge> ProducerBuilder<I, LolaRuntimeImpl<B>> for SampleProducerBuilder<I, B> {}
+impl<I: Interface, B: FFIBridge> ProducerBuilder<I, LolaRuntimeImpl<B>>
+    for LolaProducerBuilder<I, B>
+{
+}
 
-impl<I: Interface, B: FFIBridge> Builder<I::Producer<LolaRuntimeImpl<B>>> for SampleProducerBuilder<I, B> {
+impl<I: Interface, B: FFIBridge> Builder<I::Producer<LolaRuntimeImpl<B>>>
+    for LolaProducerBuilder<I, B>
+{
     fn build(self) -> Result<I::Producer<LolaRuntimeImpl<B>>> {
         //Once FFI layer error handling is in place (SWP-253124), we should convert this error to a proper FFI error instead of using map_err here
         let instance_specifier_runtime = mw_com::InstanceSpecifier::try_from(
@@ -463,22 +472,60 @@ impl<I: Interface, B: FFIBridge> Builder<I::Producer<LolaRuntimeImpl<B>>> for Sa
 
 #[cfg(test)]
 mod test {
-    use com_api_concept::CommData;
-    use std::fmt::Debug;
+    use super::*;
+    use bridge_ffi_mock::MockFFIBridge;
+    use com_api_concept::InstanceSpecifier;
+    // Bring trait methods into scope without shadowing local struct names.
+    use com_api_concept::Publisher as _;
+    use com_api_concept::SampleMaybeUninit as _;
+    use com_api_concept::SampleMut as _;
 
-    #[derive(Debug, Clone, Copy)]
+    #[derive(Debug)]
     #[repr(C)]
-    struct TestData(u32);
+    struct TestData {
+        value: i32,
+    }
 
     unsafe impl com_api_concept::Reloc for TestData {}
 
-    impl CommData for TestData {
+    impl com_api_concept::CommData for TestData {
         const ID: &'static str = "TestData";
     }
 
+    // Creates a `NativeSkeletonHandle<MockFFIBridge>` .
+    fn make_skeleton_handle() -> NativeSkeletonHandle<MockFFIBridge> {
+        let spec = mw_com::InstanceSpecifier::try_from("/test_instance")
+            .expect("valid instance specifier");
+        NativeSkeletonHandle::<MockFFIBridge>::new("", &spec)
+            .expect("MockFFIBridge::create_skeleton should not fail")
+    }
+
+    // Creates a `LolaProviderInfo<MockFFIBridge>` with a valid heap-backed skeleton handle.
+    fn make_provider_info(interface_id: &'static str) -> LolaProviderInfo<MockFFIBridge> {
+        LolaProviderInfo {
+            instance_specifier: InstanceSpecifier::new("/test_instance")
+                .expect("valid instance specifier"),
+            interface_id,
+            skeleton_handle: SkeletonInstanceManager(Arc::new(make_skeleton_handle())),
+        }
+    }
+
     #[test]
-    #[ignore] // Test will be update with Ticket-242140
-    fn send_stuff() {
-        let _test_data = TestData(42);
+    fn test_provider_info_offer_service() {
+        let provider_info = make_provider_info("TestInterface");
+        let _ = provider_info.offer_service();
+        let _ = provider_info.stop_offer_service();
+    }
+
+    #[test]
+    fn test_publisher_allocate_and_send() {
+        let instance_info = make_provider_info("TestData");
+        let publisher: Publisher<TestData, MockFFIBridge> =
+            Publisher::<TestData, MockFFIBridge>::new("TestEvent", instance_info)
+                .expect("Failed to create publisher");
+        let sample = publisher.allocate().expect("Failed to allocate sample");
+        let test_data = TestData { value: 42 };
+        let sample_mut = sample.write(test_data);
+        sample_mut.send().expect("Failed to send sample");
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
@@ -477,7 +477,7 @@ impl<I: Interface, B: FFIBridge> Builder<I::Producer<LolaRuntimeImpl<B>>>
 #[cfg(test)]
 mod test {
     use super::*;
-    use bridge_ffi_mock::MockFFIBridge;
+    use bridge_ffi_mock::{MockFFIBridge, MockFFIBridgeGuard};
     use com_api_concept::InstanceSpecifier;
     // Bring trait methods into scope without shadowing local struct names.
     use com_api_concept::Publisher as _;
@@ -517,14 +517,20 @@ mod test {
     #[test]
     fn test_provider_info_offer_service() {
         let provider_info = make_provider_info("TestInterface");
-        let _ = provider_info.offer_service();
-        let _ = provider_info.stop_offer_service();
+        assert!(
+            provider_info.offer_service().is_ok(),
+            "offer_service should succeed when the mock returns a non-null skeleton sentinel"
+        );
+        assert!(
+            provider_info.stop_offer_service().is_ok(),
+            "stop_offer_service should always succeed in the mock"
+        );
     }
 
     #[test]
     fn test_publisher_allocate_and_send() {
-        // Register T so get_allocatee_ptr zero-fills the SampleAllocateePtr slot
-        // (safe assume_init) and get_allocatee_data_ptr returns real T-backed storage.
+        //this is for cleanup of thread local state.
+        let _guard = MockFFIBridgeGuard;
         MockFFIBridge::set_alloc_backing::<TestData>();
         let instance_info = make_provider_info("TestData");
         let publisher: Publisher<TestData, MockFFIBridge> =
@@ -533,6 +539,10 @@ mod test {
         let sample = publisher.allocate().expect("Failed to allocate sample");
         let test_data = TestData { value: 42 };
         let sample_mut = sample.write(test_data);
+        assert_eq!(
+            sample_mut.value, 42,
+            "written value should be readable back through SampleMut before sending"
+        );
         sample_mut.send().expect("Failed to send sample");
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
@@ -53,9 +53,11 @@ pub struct LolaProviderInfo<B: FFIBridge> {
     instance_specifier: InstanceSpecifier,
     interface_id: &'static str,
     skeleton_handle: SkeletonInstanceManager<B>,
-    // Bridge is Arc-wrapped at creation for optimized cloning throughout the producer lifecycle.
-    // For LolaFFIBridge (ZST), Arc overhead is minimal rather than cloning directly.
-    bridge: Arc<B>,
+    // LolaFFIBridge (Production case) is a ZST, so cloning it is not overhead,
+    // But if in future we add some state in the bridge type then we need to ensure that
+    // it is properly cloned and does not cause any overhead.
+    // In that case suggested to implement Arc for the type or FFIBridge itself.
+    bridge: B,
 }
 
 impl<B: FFIBridge> ProviderInfo for LolaProviderInfo<B> {
@@ -93,7 +95,7 @@ where
     T: CommData + Debug,
 {
     pub inner: ManuallyDrop<sample_allocatee_ptr_rs::SampleAllocateePtr<T>>,
-    pub bridge: Arc<B>,
+    pub bridge: B,
 }
 
 impl<T, B: FFIBridge> Drop for AllocateePtrWrapper<T, B>
@@ -395,7 +397,6 @@ pub struct Publisher<T, B: FFIBridge> {
     skeleton_event: NativeSkeletonEventBase,
     _data: PhantomData<T>,
     skeleton_instance: SkeletonInstanceManager<B>,
-    bridge: Arc<B>,
 }
 
 impl<T, B: FFIBridge> com_api_concept::Publisher<T, LolaRuntimeImpl<B>> for Publisher<T, B>
@@ -433,7 +434,7 @@ where
             skeleton_event: self.skeleton_event.clone(),
             allocatee_ptr: AllocateePtrWrapper {
                 inner: ManuallyDrop::new(allocatee_ptr),
-                bridge: Arc::clone(&self.bridge),
+                bridge: self.skeleton_instance.0.bridge.clone(),
             },
             lifetime: PhantomData,
         })
@@ -445,7 +446,6 @@ where
             skeleton_event,
             _data: PhantomData,
             skeleton_instance: instance_info.skeleton_handle.clone(),
-            bridge: Arc::clone(&instance_info.bridge),
         })
     }
 }
@@ -490,7 +490,7 @@ impl<I: Interface, B: FFIBridge> Builder<I::Producer<LolaRuntimeImpl<B>>>
             instance_specifier: self.instance_specifier,
             interface_id: I::INTERFACE_ID,
             skeleton_handle: SkeletonInstanceManager::<B>(Arc::new(skeleton_handle)),
-            bridge: Arc::new(self.bridge),
+            bridge: self.bridge,
         };
 
         I::Producer::new(instance_info)
@@ -535,7 +535,7 @@ mod test {
                 .expect("valid instance specifier"),
             interface_id,
             skeleton_handle: SkeletonInstanceManager(Arc::new(make_skeleton_handle())),
-            bridge: Arc::new(MockFFIBridge),
+            bridge: MockFFIBridge,
         }
     }
 

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
@@ -48,16 +48,22 @@ use crate::LolaRuntimeImpl;
 
 #[derive(Clone, Debug)]
 pub struct LolaProviderInfo<B: FFIBridge> {
-    pub instance_specifier: InstanceSpecifier,
-    pub interface_id: &'static str,
-    pub skeleton_handle: SkeletonInstanceManager<B>,
+    //instance_specifier is currently not used in LolaProviderInfo but it will be used in future for better error handling and logging
+    #[allow(unused)]
+    instance_specifier: InstanceSpecifier,
+    interface_id: &'static str,
+    skeleton_handle: SkeletonInstanceManager<B>,
+    bridge: B,
 }
 
 impl<B: FFIBridge> ProviderInfo for LolaProviderInfo<B> {
     fn offer_service(&self) -> Result<()> {
         //SAFETY: it is safe as we are passing valid skeleton handle to offer service
         // the skeleton handle is created during building the provider info instance
-        let status = unsafe { B::skeleton_offer_service(self.skeleton_handle.0.handle.as_ptr()) };
+        let status = unsafe {
+            self.bridge
+                .skeleton_offer_service(self.skeleton_handle.0.handle.as_ptr())
+        };
         if !status {
             return Err(Error::ServiceError(ServiceFailedReason::OfferServiceFailed));
         }
@@ -67,7 +73,10 @@ impl<B: FFIBridge> ProviderInfo for LolaProviderInfo<B> {
     fn stop_offer_service(&self) -> Result<()> {
         //SAFETY: it is safe as we are passing valid skeleton handle to stop offer service
         // the skeleton handle is created during building the provider info instance
-        unsafe { B::skeleton_stop_offer_service(self.skeleton_handle.0.handle.as_ptr()) };
+        unsafe {
+            self.bridge
+                .skeleton_stop_offer_service(self.skeleton_handle.0.handle.as_ptr())
+        };
         Ok(())
     }
 }
@@ -82,7 +91,7 @@ where
     T: CommData + Debug,
 {
     pub inner: ManuallyDrop<sample_allocatee_ptr_rs::SampleAllocateePtr<T>>,
-    pub _bridge: PhantomData<B>,
+    pub bridge: B,
 }
 
 impl<T, B: FFIBridge> Drop for AllocateePtrWrapper<T, B>
@@ -94,7 +103,7 @@ where
         //SampleAllocateePtr created by FFI
         unsafe {
             let mut allocatee_ptr = ManuallyDrop::take(&mut self.inner);
-            B::delete_allocatee_ptr(
+            self.bridge.delete_allocatee_ptr(
                 std::ptr::from_mut(&mut allocatee_ptr) as *mut std::ffi::c_void,
                 T::ID,
             );
@@ -130,7 +139,7 @@ where
         //SAFETY: allocatee_ptr is valid which is created using get_allocatee_ptr() and
         // it will be again type casted to T type pointer in cpp side so valid to send as void pointer
         unsafe {
-            let data_ptr = B::get_allocatee_data_ptr(
+            let data_ptr = self.allocatee_ptr.bridge.get_allocatee_data_ptr(
                 std::ptr::from_ref(&(*self.allocatee_ptr.inner)) as *const std::ffi::c_void,
                 T::ID,
             );
@@ -142,7 +151,7 @@ where
         //SAFETY: allocatee_ptr is valid which is created using get_allocatee_ptr() and
         // it will be again type casted to T type pointer in cpp side so valid to send as void pointer
         unsafe {
-            let data_ptr = B::get_allocatee_data_ptr(
+            let data_ptr = self.allocatee_ptr.bridge.get_allocatee_data_ptr(
                 std::ptr::from_mut(&mut (*self.allocatee_ptr.inner)) as *mut std::ffi::c_void,
                 T::ID,
             );
@@ -183,11 +192,13 @@ where
         // We've taken ownership via self (consumed, not borrowed), and
         // FFI call will complete before drop run on AllocateePtrWrapper and NativeSkeletonEventBase
         let status = unsafe {
-            B::skeleton_event_send_sample_allocatee(
-                self.skeleton_event.skeleton_event_ptr.as_ptr(),
-                T::ID,
-                std::ptr::from_ref(self.allocatee_ptr.as_ref()) as *const std::ffi::c_void,
-            )
+            self.allocatee_ptr
+                .bridge
+                .skeleton_event_send_sample_allocatee(
+                    self.skeleton_event.skeleton_event_ptr.as_ptr(),
+                    T::ID,
+                    std::ptr::from_ref(self.allocatee_ptr.as_ref()) as *const std::ffi::c_void,
+                )
         };
         if !status {
             return Err(Error::EventError(EventFailedReason::SendingDataFailed));
@@ -214,7 +225,7 @@ where
         //SAFETY: allocatee_ptr is valid which is created using get_allocatee_ptr() and
         // it will be again type casted to T type pointer in cpp side so valid to send as void pointer
         let data_ptr = unsafe {
-            B::get_allocatee_data_ptr(
+            self.allocatee_ptr.bridge.get_allocatee_data_ptr(
                 std::ptr::from_ref(self.allocatee_ptr.as_ref()) as *const std::ffi::c_void,
                 T::ID,
             ) as *mut core::mem::MaybeUninit<T>
@@ -290,7 +301,7 @@ impl<B: FFIBridge> std::fmt::Debug for SkeletonInstanceManager<B> {
 /// As it has Send and Sync unsafe impls, it must not expose any mutable access to the skeleton handle
 pub struct NativeSkeletonHandle<B: FFIBridge> {
     handle: NonNull<SkeletonBase>,
-    _marker: PhantomData<B>,
+    bridge: B,
 }
 
 //SAFETY: NativeSkeletonHandle is safe to share between threads because:
@@ -301,16 +312,20 @@ unsafe impl<B: FFIBridge> Sync for NativeSkeletonHandle<B> {}
 unsafe impl<B: FFIBridge> Send for NativeSkeletonHandle<B> {}
 
 impl<B: FFIBridge> NativeSkeletonHandle<B> {
-    pub fn new(interface_id: &str, instance_specifier: &mw_com::InstanceSpecifier) -> Result<Self> {
+    pub fn new(
+        bridge: &B,
+        interface_id: &str,
+        instance_specifier: &mw_com::InstanceSpecifier,
+    ) -> Result<Self> {
         //SAFETY: It is safe as we are passing valid type id and instance specifier to create skeleton
         let raw_handle =
-            unsafe { B::create_skeleton(interface_id, instance_specifier.as_native()) };
+            unsafe { bridge.create_skeleton(interface_id, instance_specifier.as_native()) };
         let handle = std::ptr::NonNull::new(raw_handle).ok_or(Error::ProducerError(
             ProducerFailedReason::SkeletonCreationFailed,
         ))?;
         Ok(Self {
             handle,
-            _marker: PhantomData,
+            bridge: bridge.clone(),
         })
     }
 }
@@ -320,7 +335,7 @@ impl<B: FFIBridge> Drop for NativeSkeletonHandle<B> {
         //SAFETY: It is safe as we are passing valid skeleton handle to destroy skeleton
         // the handle was created using create_skeleton
         unsafe {
-            B::destroy_skeleton(self.handle.as_ptr());
+            self.bridge.destroy_skeleton(self.handle.as_ptr());
         }
     }
 }
@@ -346,7 +361,7 @@ impl NativeSkeletonEventBase {
         //SAFETY: It is safe as we are passing valid skeleton handle and interface id to get event
         // skeleton handle is created during producer offer call
         let raw_event_ptr = unsafe {
-            B::get_event_from_skeleton(
+            instance_info.bridge.get_event_from_skeleton(
                 instance_info.skeleton_handle.0.handle.as_ptr(),
                 instance_info.interface_id,
                 identifier,
@@ -377,7 +392,7 @@ impl std::fmt::Debug for NativeSkeletonEventBase {
 pub struct Publisher<T, B: FFIBridge> {
     skeleton_event: NativeSkeletonEventBase,
     _data: PhantomData<T>,
-    _skeleton_instance: SkeletonInstanceManager<B>,
+    skeleton_instance: SkeletonInstanceManager<B>,
 }
 
 impl<T, B: FFIBridge> com_api_concept::Publisher<T, LolaRuntimeImpl<B>> for Publisher<T, B>
@@ -398,7 +413,7 @@ where
         let allocatee_ptr = unsafe {
             let mut sample =
                 core::mem::MaybeUninit::<sample_allocatee_ptr_rs::SampleAllocateePtr<T>>::uninit();
-            let status = B::get_allocatee_ptr(
+            let status = self.skeleton_instance.0.bridge.get_allocatee_ptr(
                 self.skeleton_event.skeleton_event_ptr.as_ptr(),
                 sample.as_mut_ptr() as *mut std::ffi::c_void,
                 T::ID,
@@ -415,7 +430,7 @@ where
             skeleton_event: self.skeleton_event.clone(),
             allocatee_ptr: AllocateePtrWrapper {
                 inner: ManuallyDrop::new(allocatee_ptr),
-                _bridge: PhantomData,
+                bridge: self.skeleton_instance.0.bridge.clone(),
             },
             lifetime: PhantomData,
         })
@@ -426,7 +441,7 @@ where
         Ok(Self {
             skeleton_event,
             _data: PhantomData,
-            _skeleton_instance: instance_info.skeleton_handle.clone(),
+            skeleton_instance: instance_info.skeleton_handle.clone(),
         })
     }
 }
@@ -434,15 +449,15 @@ where
 pub struct LolaProducerBuilder<I: Interface, B: FFIBridge> {
     pub instance_specifier: InstanceSpecifier,
     pub _interface: PhantomData<I>,
-    pub _bridge: PhantomData<B>,
+    pub bridge: B,
 }
 
 impl<I: Interface, B: FFIBridge> LolaProducerBuilder<I, B> {
-    pub fn new(_runtime: &LolaRuntimeImpl<B>, instance_specifier: InstanceSpecifier) -> Self {
+    pub fn new(runtime: &LolaRuntimeImpl<B>, instance_specifier: InstanceSpecifier) -> Self {
         Self {
             instance_specifier,
             _interface: PhantomData,
-            _bridge: PhantomData,
+            bridge: runtime.bridge.clone(),
         }
     }
 }
@@ -462,12 +477,16 @@ impl<I: Interface, B: FFIBridge> Builder<I::Producer<LolaRuntimeImpl<B>>>
         )
         .map_err(|_| Error::ProducerError(ProducerFailedReason::InstanceSpecifierInvalid))?;
 
-        let skeleton_handle =
-            NativeSkeletonHandle::<B>::new(I::INTERFACE_ID, &instance_specifier_runtime)?;
+        let skeleton_handle = NativeSkeletonHandle::<B>::new(
+            &self.bridge,
+            I::INTERFACE_ID,
+            &instance_specifier_runtime,
+        )?;
         let instance_info = LolaProviderInfo {
             instance_specifier: self.instance_specifier,
             interface_id: I::INTERFACE_ID,
             skeleton_handle: SkeletonInstanceManager::<B>(Arc::new(skeleton_handle)),
+            bridge: self.bridge,
         };
 
         I::Producer::new(instance_info)
@@ -477,7 +496,7 @@ impl<I: Interface, B: FFIBridge> Builder<I::Producer<LolaRuntimeImpl<B>>>
 #[cfg(test)]
 mod test {
     use super::*;
-    use bridge_ffi_mock::{MockFFIBridge, MockFFIBridgeGuard};
+    use bridge_ffi_mock::MockFFIBridge;
     use com_api_concept::InstanceSpecifier;
     // Bring trait methods into scope without shadowing local struct names.
     use com_api_concept::Publisher as _;
@@ -498,9 +517,10 @@ mod test {
 
     // Creates a `NativeSkeletonHandle<MockFFIBridge>` .
     fn make_skeleton_handle() -> NativeSkeletonHandle<MockFFIBridge> {
+        let bridge = MockFFIBridge;
         let spec = mw_com::InstanceSpecifier::try_from("/test_instance")
             .expect("valid instance specifier");
-        NativeSkeletonHandle::<MockFFIBridge>::new("", &spec)
+        NativeSkeletonHandle::<MockFFIBridge>::new(&bridge, "", &spec)
             .expect("MockFFIBridge::create_skeleton should not fail")
     }
 
@@ -511,6 +531,7 @@ mod test {
                 .expect("valid instance specifier"),
             interface_id,
             skeleton_handle: SkeletonInstanceManager(Arc::new(make_skeleton_handle())),
+            bridge: MockFFIBridge,
         }
     }
 
@@ -530,7 +551,7 @@ mod test {
     #[test]
     fn test_publisher_allocate_and_send() {
         //this is for cleanup of thread local state.
-        let _guard = MockFFIBridgeGuard;
+        // MockFFIBridge instance will clean up automatically on drop
         MockFFIBridge::set_alloc_backing::<TestData>();
         let instance_info = make_provider_info("TestData");
         let publisher: Publisher<TestData, MockFFIBridge> =

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
@@ -500,8 +500,9 @@ impl<I: Interface, B: FFIBridge> Builder<I::Producer<LolaRuntimeImpl<B>>>
 #[cfg(test)]
 mod test {
     use super::*;
-    use bridge_ffi_mock::MockFFIBridge;
+    use bridge_ffi_mock::{MockFFIBridge, SharedMockBridge};
     use com_api_concept::InstanceSpecifier;
+    use mockall::predicate::*;
     // Bring trait methods into scope without shadowing local struct names.
     use com_api_concept::Publisher as _;
     use com_api_concept::SampleMaybeUninit as _;
@@ -519,29 +520,38 @@ mod test {
         const ID: &'static str = "TestData";
     }
 
-    // Creates a `NativeSkeletonHandle<MockFFIBridge>` .
-    fn make_skeleton_handle() -> NativeSkeletonHandle<MockFFIBridge> {
-        let bridge = MockFFIBridge::new();
+    // Creates a `NativeSkeletonHandle<SharedMockBridge>` .
+    fn make_skeleton_handle(bridge: &SharedMockBridge) -> NativeSkeletonHandle<SharedMockBridge> {
         let spec = mw_com::InstanceSpecifier::try_from("/test_instance")
             .expect("valid instance specifier");
-        NativeSkeletonHandle::<MockFFIBridge>::new(&bridge, "", &spec)
-            .expect("MockFFIBridge::create_skeleton should not fail")
+        NativeSkeletonHandle::<SharedMockBridge>::new(&bridge, "", &spec)
+            .expect("SharedMockBridge::create_skeleton should not fail")
     }
 
-    // Creates a `LolaProviderInfo<MockFFIBridge>` with a valid heap-backed skeleton handle.
-    fn make_provider_info(interface_id: &'static str) -> LolaProviderInfo<MockFFIBridge> {
+    // Creates a `LolaProviderInfo<SharedMockBridge>` with a valid heap-backed skeleton handle.
+    fn make_provider_info(
+        interface_id: &'static str,
+        bridge: &SharedMockBridge,
+    ) -> LolaProviderInfo<SharedMockBridge> {
         LolaProviderInfo {
             instance_specifier: InstanceSpecifier::new("/test_instance")
                 .expect("valid instance specifier"),
             interface_id,
-            skeleton_handle: SkeletonInstanceManager(Arc::new(make_skeleton_handle())),
-            bridge: MockFFIBridge::new(),
+            skeleton_handle: SkeletonInstanceManager(Arc::new(make_skeleton_handle(&bridge))),
+            bridge: bridge.clone(),
         }
     }
 
     #[test]
     fn test_provider_info_offer_service() {
-        let provider_info = make_provider_info("TestInterface");
+        let mut mock = MockFFIBridge::new();
+        mock.expect_create_skeleton()
+            .returning(|_, _| Box::into_raw(Box::default()));
+        mock.expect_skeleton_offer_service().returning(|_| true);
+        mock.expect_skeleton_stop_offer_service().returning(|_| ());
+        mock.expect_destroy_skeleton().returning(|_| ());
+        let bridge = SharedMockBridge::new(mock);
+        let provider_info = make_provider_info("TestInterface", &bridge);
         assert!(
             provider_info.offer_service().is_ok(),
             "offer_service should succeed when the mock returns a non-null skeleton sentinel"
@@ -554,18 +564,38 @@ mod test {
 
     #[test]
     fn test_publisher_allocate_and_send() {
-        //this is for cleanup of thread local state.
-        // MockFFIBridge instance will clean up automatically on drop
-        let bridge = MockFFIBridge::new();
-        // Use T::ID ("TestData") as the key for allocatee backing
-        bridge.set_allocatee_backing::<TestData>("TestData", TestData { value: 0 });
+        let mut mock = MockFFIBridge::new();
+        mock.expect_create_skeleton()
+            .returning(|_, _| Box::into_raw(Box::default()));
+        mock.expect_get_event_from_skeleton()
+            .returning(|_, _, _| Box::into_raw(Box::default()));
+        mock.expect_get_allocatee_ptr()
+            .returning(|_, allocatee_ptr, _| {
+                // SAFETY: Write a zeroed SampleAllocateePtr to the out-parameter for testing
+                unsafe {
+                    std::ptr::write(
+                        allocatee_ptr as *mut sample_allocatee_ptr_rs::SampleAllocateePtr<TestData>,
+                        std::mem::zeroed(),
+                    );
+                }
+                true
+            });
+        mock.expect_get_allocatee_data_ptr().returning(move |_, _| {
+            // Return a valid heap-allocated TestData pointer for the test to write to
+            Box::into_raw(Box::new(TestData { value: 0 })) as *mut std::ffi::c_void
+        });
+        mock.expect_skeleton_event_send_sample_allocatee()
+            .returning(|_, _, _| true);
+        mock.expect_delete_allocatee_ptr().returning(|_, _| ());
+        mock.expect_destroy_skeleton().returning(|_| ());
 
-        // Create provider info with the same bridge instance
+        let bridge = SharedMockBridge::new(mock);
+
         let spec = mw_com::InstanceSpecifier::try_from("/test_instance")
             .expect("valid instance specifier");
         let skeleton_handle =
-            NativeSkeletonHandle::<MockFFIBridge>::new(&bridge, "TestData", &spec)
-                .expect("MockFFIBridge::create_skeleton should not fail");
+            NativeSkeletonHandle::<SharedMockBridge>::new(&bridge, "TestData", &spec)
+                .expect("SharedMockBridge::create_skeleton should not fail");
 
         let instance_info = LolaProviderInfo {
             instance_specifier: InstanceSpecifier::new("/test_instance")
@@ -575,16 +605,12 @@ mod test {
             bridge: bridge.clone(),
         };
 
-        let publisher: Publisher<TestData, MockFFIBridge> =
-            Publisher::<TestData, MockFFIBridge>::new("TestEvent", instance_info)
+        let publisher: Publisher<TestData, SharedMockBridge> =
+            Publisher::<TestData, SharedMockBridge>::new("TestEvent", instance_info)
                 .expect("Failed to create publisher");
         let sample = publisher.allocate().expect("Failed to allocate sample");
         let test_data = TestData { value: 42 };
         let sample_mut = sample.write(test_data);
-        assert_eq!(
-            sample_mut.value, 42,
-            "written value should be readable back through SampleMut before sending"
-        );
-        sample_mut.send().expect("Failed to send sample");
+        assert!(sample_mut.send().is_ok(), "Failed to send sample");
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
@@ -33,7 +33,7 @@ use crate::Debug;
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
 use core::ops::{Deref, DerefMut};
-use std::ptr::NonNull;
+use core::ptr::NonNull;
 use std::sync::Arc;
 
 use com_api_concept::{
@@ -507,6 +507,7 @@ mod test {
     use com_api_concept::Publisher as _;
     use com_api_concept::SampleMaybeUninit as _;
     use com_api_concept::SampleMut as _;
+    use std::sync::Mutex;
 
     #[derive(Debug)]
     #[repr(C)]
@@ -545,11 +546,28 @@ mod test {
     #[test]
     fn test_provider_info_offer_service() {
         let mut mock = MockFFIBridge::new();
-        mock.expect_create_skeleton()
-            .returning(|_, _| Box::into_raw(Box::default()));
+        let skeleton_vec = Arc::new(Mutex::new(Vec::new()));
+        let skeleton_vec_clone = skeleton_vec.clone();
+        mock.expect_create_skeleton().returning(move |_, _| {
+            let mut skeleton = skeleton_vec_clone
+                .lock()
+                .expect("not able to acquire lock on skeleton_vec");
+            skeleton.push(Box::<SkeletonBase>::default());
+            skeleton.last_mut().unwrap().as_mut() as *mut SkeletonBase
+        });
         mock.expect_skeleton_offer_service().returning(|_| true);
         mock.expect_skeleton_stop_offer_service().returning(|_| ());
-        mock.expect_destroy_skeleton().returning(|_| ());
+        let skeleton = skeleton_vec.clone();
+        mock.expect_destroy_skeleton().returning(move |ptr| {
+            let mut skeleton = skeleton
+                .lock()
+                .expect("not able to acquire lock on skeleton_vec");
+            let pos = skeleton
+                .iter_mut()
+                .position(|s| s.as_mut() as *mut SkeletonBase == ptr)
+                .expect("destroyed skeleton handle should exist in skeleton_vec");
+            skeleton.remove(pos);
+        });
         let bridge = SharedMockBridge::new(mock);
         let provider_info = make_provider_info("TestInterface", &bridge);
         assert!(

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
@@ -521,7 +521,7 @@ mod test {
 
     // Creates a `NativeSkeletonHandle<MockFFIBridge>` .
     fn make_skeleton_handle() -> NativeSkeletonHandle<MockFFIBridge> {
-        let bridge = MockFFIBridge;
+        let bridge = MockFFIBridge::new();
         let spec = mw_com::InstanceSpecifier::try_from("/test_instance")
             .expect("valid instance specifier");
         NativeSkeletonHandle::<MockFFIBridge>::new(&bridge, "", &spec)
@@ -535,7 +535,7 @@ mod test {
                 .expect("valid instance specifier"),
             interface_id,
             skeleton_handle: SkeletonInstanceManager(Arc::new(make_skeleton_handle())),
-            bridge: MockFFIBridge,
+            bridge: MockFFIBridge::new(),
         }
     }
 
@@ -556,8 +556,25 @@ mod test {
     fn test_publisher_allocate_and_send() {
         //this is for cleanup of thread local state.
         // MockFFIBridge instance will clean up automatically on drop
-        MockFFIBridge::set_alloc_backing::<TestData>();
-        let instance_info = make_provider_info("TestData");
+        let bridge = MockFFIBridge::new();
+        // Use T::ID ("TestData") as the key for allocatee backing
+        bridge.set_allocatee_backing::<TestData>("TestData", TestData { value: 0 });
+
+        // Create provider info with the same bridge instance
+        let spec = mw_com::InstanceSpecifier::try_from("/test_instance")
+            .expect("valid instance specifier");
+        let skeleton_handle =
+            NativeSkeletonHandle::<MockFFIBridge>::new(&bridge, "TestData", &spec)
+                .expect("MockFFIBridge::create_skeleton should not fail");
+
+        let instance_info = LolaProviderInfo {
+            instance_specifier: InstanceSpecifier::new("/test_instance")
+                .expect("valid instance specifier"),
+            interface_id: "TestData",
+            skeleton_handle: SkeletonInstanceManager(Arc::new(skeleton_handle)),
+            bridge: bridge.clone(),
+        };
+
         let publisher: Publisher<TestData, MockFFIBridge> =
             Publisher::<TestData, MockFFIBridge>::new("TestEvent", instance_info)
                 .expect("Failed to create publisher");

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
@@ -53,7 +53,9 @@ pub struct LolaProviderInfo<B: FFIBridge> {
     instance_specifier: InstanceSpecifier,
     interface_id: &'static str,
     skeleton_handle: SkeletonInstanceManager<B>,
-    bridge: B,
+    // Bridge is Arc-wrapped at creation for optimized cloning throughout the producer lifecycle.
+    // For LolaFFIBridge (ZST), Arc overhead is minimal rather than cloning directly.
+    bridge: Arc<B>,
 }
 
 impl<B: FFIBridge> ProviderInfo for LolaProviderInfo<B> {
@@ -91,7 +93,7 @@ where
     T: CommData + Debug,
 {
     pub inner: ManuallyDrop<sample_allocatee_ptr_rs::SampleAllocateePtr<T>>,
-    pub bridge: B,
+    pub bridge: Arc<B>,
 }
 
 impl<T, B: FFIBridge> Drop for AllocateePtrWrapper<T, B>
@@ -393,6 +395,7 @@ pub struct Publisher<T, B: FFIBridge> {
     skeleton_event: NativeSkeletonEventBase,
     _data: PhantomData<T>,
     skeleton_instance: SkeletonInstanceManager<B>,
+    bridge: Arc<B>,
 }
 
 impl<T, B: FFIBridge> com_api_concept::Publisher<T, LolaRuntimeImpl<B>> for Publisher<T, B>
@@ -430,7 +433,7 @@ where
             skeleton_event: self.skeleton_event.clone(),
             allocatee_ptr: AllocateePtrWrapper {
                 inner: ManuallyDrop::new(allocatee_ptr),
-                bridge: self.skeleton_instance.0.bridge.clone(),
+                bridge: Arc::clone(&self.bridge),
             },
             lifetime: PhantomData,
         })
@@ -442,6 +445,7 @@ where
             skeleton_event,
             _data: PhantomData,
             skeleton_instance: instance_info.skeleton_handle.clone(),
+            bridge: Arc::clone(&instance_info.bridge),
         })
     }
 }
@@ -486,7 +490,7 @@ impl<I: Interface, B: FFIBridge> Builder<I::Producer<LolaRuntimeImpl<B>>>
             instance_specifier: self.instance_specifier,
             interface_id: I::INTERFACE_ID,
             skeleton_handle: SkeletonInstanceManager::<B>(Arc::new(skeleton_handle)),
-            bridge: self.bridge,
+            bridge: Arc::new(self.bridge),
         };
 
         I::Producer::new(instance_info)
@@ -531,7 +535,7 @@ mod test {
                 .expect("valid instance specifier"),
             interface_id,
             skeleton_handle: SkeletonInstanceManager(Arc::new(make_skeleton_handle())),
-            bridge: MockFFIBridge,
+            bridge: Arc::new(MockFFIBridge),
         }
     }
 

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
@@ -47,19 +47,17 @@ use bridge_ffi_rs::*;
 use crate::LolaRuntimeImpl;
 
 #[derive(Clone, Debug)]
-pub struct LolaProviderInfo {
+pub struct LolaProviderInfo<B: FFIBridge> {
     pub instance_specifier: InstanceSpecifier,
     pub interface_id: &'static str,
-    pub skeleton_handle: SkeletonInstanceManager,
+    pub skeleton_handle: SkeletonInstanceManager<B>,
 }
 
-impl ProviderInfo for LolaProviderInfo {
+impl<B: FFIBridge> ProviderInfo for LolaProviderInfo<B> {
     fn offer_service(&self) -> Result<()> {
         //SAFETY: it is safe as we are passing valid skeleton handle to offer service
         // the skeleton handle is created during building the provider info instance
-        let status = unsafe {
-            bridge_ffi_rs::skeleton_offer_service(self.skeleton_handle.0.handle.as_ptr())
-        };
+        let status = unsafe { B::skeleton_offer_service(self.skeleton_handle.0.handle.as_ptr()) };
         if !status {
             return Err(Error::ServiceError(ServiceFailedReason::OfferServiceFailed));
         }
@@ -69,9 +67,7 @@ impl ProviderInfo for LolaProviderInfo {
     fn stop_offer_service(&self) -> Result<()> {
         //SAFETY: it is safe as we are passing valid skeleton handle to stop offer service
         // the skeleton handle is created during building the provider info instance
-        unsafe {
-            bridge_ffi_rs::skeleton_stop_offer_service(self.skeleton_handle.0.handle.as_ptr())
-        };
+        unsafe { B::skeleton_stop_offer_service(self.skeleton_handle.0.handle.as_ptr()) };
         Ok(())
     }
 }
@@ -81,14 +77,15 @@ impl ProviderInfo for LolaProviderInfo {
 /// Safe to move between SampleMaybeUninit and SampleMut because
 /// the Drop impl guarantees cleanup exactly once.
 #[derive(Debug)]
-pub struct AllocateePtrWrapper<T>
+pub struct AllocateePtrWrapper<T, B: FFIBridge>
 where
     T: CommData + Debug,
 {
     pub inner: ManuallyDrop<sample_allocatee_ptr_rs::SampleAllocateePtr<T>>,
+    pub _bridge: PhantomData<B>,
 }
 
-impl<T> Drop for AllocateePtrWrapper<T>
+impl<T, B: FFIBridge> Drop for AllocateePtrWrapper<T, B>
 where
     T: CommData + Debug,
 {
@@ -97,7 +94,7 @@ where
         //SampleAllocateePtr created by FFI
         unsafe {
             let mut allocatee_ptr = ManuallyDrop::take(&mut self.inner);
-            bridge_ffi_rs::delete_allocatee_ptr(
+            B::delete_allocatee_ptr(
                 std::ptr::from_mut(&mut allocatee_ptr) as *mut std::ffi::c_void,
                 T::ID,
             );
@@ -105,7 +102,7 @@ where
     }
 }
 
-impl<T> AsRef<sample_allocatee_ptr_rs::SampleAllocateePtr<T>> for AllocateePtrWrapper<T>
+impl<T, B: FFIBridge> AsRef<sample_allocatee_ptr_rs::SampleAllocateePtr<T>> for AllocateePtrWrapper<T, B>
 where
     T: CommData + Debug,
 {
@@ -115,16 +112,16 @@ where
 }
 
 #[derive(Debug)]
-pub struct SampleMut<'a, T>
+pub struct SampleMut<'a, T, B: FFIBridge>
 where
     T: CommData + Debug,
 {
     skeleton_event: NativeSkeletonEventBase,
-    allocatee_ptr: AllocateePtrWrapper<T>,
+    allocatee_ptr: AllocateePtrWrapper<T, B>,
     lifetime: PhantomData<&'a T>,
 }
 
-impl<'a, T> SampleMut<'a, T>
+impl<'a, T, B: FFIBridge> SampleMut<'a, T, B>
 where
     T: CommData + Debug,
 {
@@ -132,7 +129,7 @@ where
         //SAFETY: allocatee_ptr is valid which is created using get_allocatee_ptr() and
         // it will be again type casted to T type pointer in cpp side so valid to send as void pointer
         unsafe {
-            let data_ptr = bridge_ffi_rs::get_allocatee_data_ptr(
+            let data_ptr = B::get_allocatee_data_ptr(
                 std::ptr::from_ref(&(*self.allocatee_ptr.inner)) as *const std::ffi::c_void,
                 T::ID,
             );
@@ -144,7 +141,7 @@ where
         //SAFETY: allocatee_ptr is valid which is created using get_allocatee_ptr() and
         // it will be again type casted to T type pointer in cpp side so valid to send as void pointer
         unsafe {
-            let data_ptr = bridge_ffi_rs::get_allocatee_data_ptr(
+            let data_ptr = B::get_allocatee_data_ptr(
                 std::ptr::from_mut(&mut (*self.allocatee_ptr.inner)) as *mut std::ffi::c_void,
                 T::ID,
             );
@@ -153,7 +150,7 @@ where
     }
 }
 
-impl<'a, T> Deref for SampleMut<'a, T>
+impl<'a, T, B: FFIBridge> Deref for SampleMut<'a, T, B>
 where
     T: CommData + Debug,
 {
@@ -165,7 +162,7 @@ where
     }
 }
 
-impl<'a, T> DerefMut for SampleMut<'a, T>
+impl<'a, T, B: FFIBridge> DerefMut for SampleMut<'a, T, B>
 where
     T: CommData + Debug,
 {
@@ -175,7 +172,7 @@ where
     }
 }
 
-impl<'a, T> com_api_concept::SampleMut<T> for SampleMut<'a, T>
+impl<'a, T, B: FFIBridge> com_api_concept::SampleMut<T> for SampleMut<'a, T, B>
 where
     T: CommData + Debug,
 {
@@ -185,7 +182,7 @@ where
         // We've taken ownership via self (consumed, not borrowed), and
         // FFI call will complete before drop run on AllocateePtrWrapper and NativeSkeletonEventBase
         let status = unsafe {
-            bridge_ffi_rs::skeleton_event_send_sample_allocatee(
+            B::skeleton_event_send_sample_allocatee(
                 self.skeleton_event.skeleton_event_ptr.as_ptr(),
                 T::ID,
                 std::ptr::from_ref(self.allocatee_ptr.as_ref()) as *const std::ffi::c_void,
@@ -199,16 +196,16 @@ where
 }
 
 #[derive(Debug)]
-pub struct SampleMaybeUninit<'a, T>
+pub struct SampleMaybeUninit<'a, T, B: FFIBridge>
 where
     T: CommData + Debug,
 {
     skeleton_event: NativeSkeletonEventBase,
-    allocatee_ptr: AllocateePtrWrapper<T>,
+    allocatee_ptr: AllocateePtrWrapper<T, B>,
     lifetime: PhantomData<&'a T>,
 }
 
-impl<'a, T> SampleMaybeUninit<'a, T>
+impl<'a, T, B: FFIBridge> SampleMaybeUninit<'a, T, B>
 where
     T: CommData + Debug,
 {
@@ -216,7 +213,7 @@ where
         //SAFETY: allocatee_ptr is valid which is created using get_allocatee_ptr() and
         // it will be again type casted to T type pointer in cpp side so valid to send as void pointer
         let data_ptr = unsafe {
-            bridge_ffi_rs::get_allocatee_data_ptr(
+            B::get_allocatee_data_ptr(
                 std::ptr::from_ref(self.allocatee_ptr.as_ref()) as *const std::ffi::c_void,
                 T::ID,
             ) as *mut core::mem::MaybeUninit<T>
@@ -225,13 +222,13 @@ where
     }
 }
 
-impl<'a, T> com_api_concept::SampleMaybeUninit<T> for SampleMaybeUninit<'a, T>
+impl<'a, T, B: FFIBridge> com_api_concept::SampleMaybeUninit<T> for SampleMaybeUninit<'a, T, B>
 where
     T: CommData + Debug,
 {
-    type SampleMut = SampleMut<'a, T>;
+    type SampleMut = SampleMut<'a, T, B>;
 
-    fn write(mut self, val: T) -> SampleMut<'a, T> {
+    fn write(mut self, val: T) -> SampleMut<'a, T, B> {
         let data_ptr = self
             .get_allocatee_data_ptr()
             .expect("Allocatee data pointer is null");
@@ -247,7 +244,7 @@ where
         }
     }
 
-    unsafe fn assume_init(self) -> SampleMut<'a, T> {
+    unsafe fn assume_init(self) -> SampleMut<'a, T, B> {
         SampleMut {
             skeleton_event: self.skeleton_event,
             allocatee_ptr: self.allocatee_ptr,
@@ -256,7 +253,7 @@ where
     }
 }
 
-impl<'a, T> AsMut<core::mem::MaybeUninit<T>> for SampleMaybeUninit<'a, T>
+impl<'a, T, B: FFIBridge> AsMut<core::mem::MaybeUninit<T>> for SampleMaybeUninit<'a, T, B>
 where
     T: CommData + Debug,
 {
@@ -268,15 +265,15 @@ where
 
 /// Manages the lifetime of the native skeleton instance, user should clone this to share between threads
 /// Always use this struct to manage the skeleton instance pointer
-pub struct SkeletonInstanceManager(pub Arc<NativeSkeletonHandle>);
+pub struct SkeletonInstanceManager<B: FFIBridge>(pub Arc<NativeSkeletonHandle<B>>);
 
-impl Clone for SkeletonInstanceManager {
+impl<B: FFIBridge> Clone for SkeletonInstanceManager<B> {
     fn clone(&self) -> Self {
         Self(Arc::clone(&self.0))
     }
 }
 
-impl std::fmt::Debug for SkeletonInstanceManager {
+impl<B: FFIBridge> std::fmt::Debug for SkeletonInstanceManager<B> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SkeletonInstanceManager").finish()
     }
@@ -290,34 +287,35 @@ impl std::fmt::Debug for SkeletonInstanceManager {
 /// If any additional method is required to be added, ensure that the safety of the skeleton handle is maintained
 /// And the lifetime is managed correctly
 /// As it has Send and Sync unsafe impls, it must not expose any mutable access to the skeleton handle
-pub struct NativeSkeletonHandle {
+pub struct NativeSkeletonHandle<B: FFIBridge> {
     handle: NonNull<SkeletonBase>,
+    _marker: PhantomData<B>,
 }
 
 //SAFETY: NativeSkeletonHandle is safe to share between threads because:
 // It is created by FFI call and no mutable access is provided to the underlying skeleton handle
 // Access is controlled through Arc which provides atomic reference counting
 // The skeleton lifetime is managed safely through new and Drop
-unsafe impl Sync for NativeSkeletonHandle {}
-unsafe impl Send for NativeSkeletonHandle {}
+unsafe impl<B: FFIBridge> Sync for NativeSkeletonHandle<B> {}
+unsafe impl<B: FFIBridge> Send for NativeSkeletonHandle<B> {}
 
-impl NativeSkeletonHandle {
+impl<B: FFIBridge> NativeSkeletonHandle<B> {
     pub fn new(interface_id: &str, instance_specifier: &mw_com::InstanceSpecifier) -> Result<Self> {
         //SAFETY: It is safe as we are passing valid type id and instance specifier to create skeleton
         let raw_handle =
-            unsafe { bridge_ffi_rs::create_skeleton(interface_id, instance_specifier.as_native()) };
+            unsafe { B::create_skeleton(interface_id, instance_specifier.as_native()) };
         let handle = std::ptr::NonNull::new(raw_handle)
             .ok_or(Error::ProducerError(ProducerFailedReason::SkeletonCreationFailed))?;
-        Ok(Self { handle })
+        Ok(Self { handle, _marker: PhantomData })
     }
 }
 
-impl Drop for NativeSkeletonHandle {
+impl<B: FFIBridge> Drop for NativeSkeletonHandle<B> {
     fn drop(&mut self) {
         //SAFETY: It is safe as we are passing valid skeleton handle to destroy skeleton
         // the handle was created using create_skeleton
         unsafe {
-            bridge_ffi_rs::destroy_skeleton(self.handle.as_ptr());
+            B::destroy_skeleton(self.handle.as_ptr());
         }
     }
 }
@@ -336,11 +334,11 @@ pub struct NativeSkeletonEventBase {
 unsafe impl Send for NativeSkeletonEventBase {}
 
 impl NativeSkeletonEventBase {
-    pub fn new(instance_info: &LolaProviderInfo, identifier: &str) -> Result<Self> {
+    pub fn new<B: FFIBridge>(instance_info: &LolaProviderInfo<B>, identifier: &str) -> Result<Self> {
         //SAFETY: It is safe as we are passing valid skeleton handle and interface id to get event
         // skeleton handle is created during producer offer call
         let raw_event_ptr = unsafe {
-            bridge_ffi_rs::get_event_from_skeleton(
+            B::get_event_from_skeleton(
                 instance_info.skeleton_handle.0.handle.as_ptr(),
                 instance_info.interface_id,
                 identifier,
@@ -368,18 +366,18 @@ impl std::fmt::Debug for NativeSkeletonEventBase {
 }
 
 #[derive(Debug)]
-pub struct Publisher<T> {
+pub struct Publisher<T, B: FFIBridge> {
     skeleton_event: NativeSkeletonEventBase,
     _data: PhantomData<T>,
-    _skeleton_instance: SkeletonInstanceManager,
+    _skeleton_instance: SkeletonInstanceManager<B>,
 }
 
-impl<T> com_api_concept::Publisher<T, LolaRuntimeImpl> for Publisher<T>
+impl<T, B: FFIBridge> com_api_concept::Publisher<T, LolaRuntimeImpl<B>> for Publisher<T, B>
 where
     T: CommData + Debug,
 {
     type SampleMaybeUninit<'a>
-        = SampleMaybeUninit<'a, T>
+        = SampleMaybeUninit<'a, T, B>
     where
         Self: 'a;
 
@@ -392,7 +390,7 @@ where
         let allocatee_ptr = unsafe {
             let mut sample =
                 core::mem::MaybeUninit::<sample_allocatee_ptr_rs::SampleAllocateePtr<T>>::uninit();
-            let status = bridge_ffi_rs::get_allocatee_ptr(
+            let status = B::get_allocatee_ptr(
                 self.skeleton_event.skeleton_event_ptr.as_ptr(),
                 sample.as_mut_ptr() as *mut std::ffi::c_void,
                 T::ID,
@@ -409,13 +407,14 @@ where
             skeleton_event: self.skeleton_event.clone(),
             allocatee_ptr: AllocateePtrWrapper {
                 inner: ManuallyDrop::new(allocatee_ptr),
+                _bridge: PhantomData,
             },
             lifetime: PhantomData,
         })
     }
 
-    fn new(identifier: &str, instance_info: LolaProviderInfo) -> Result<Self> {
-        let skeleton_event = NativeSkeletonEventBase::new(&instance_info, identifier)?;
+    fn new(identifier: &str, instance_info: LolaProviderInfo<B>) -> Result<Self> {
+        let skeleton_event = NativeSkeletonEventBase::new::<B>(&instance_info, identifier)?;
         Ok(Self {
             skeleton_event,
             _data: PhantomData,
@@ -424,24 +423,26 @@ where
     }
 }
 
-pub struct LolaProducerBuilder<I: Interface> {
+pub struct SampleProducerBuilder<I: Interface, B: FFIBridge> {
     pub instance_specifier: InstanceSpecifier,
     pub _interface: PhantomData<I>,
+    pub _bridge: PhantomData<B>,
 }
 
-impl<I: Interface> LolaProducerBuilder<I> {
-    pub fn new(_runtime: &LolaRuntimeImpl, instance_specifier: InstanceSpecifier) -> Self {
+impl<I: Interface, B: FFIBridge> SampleProducerBuilder<I, B> {
+    pub fn new(_runtime: &LolaRuntimeImpl<B>, instance_specifier: InstanceSpecifier) -> Self {
         Self {
             instance_specifier,
             _interface: PhantomData,
+            _bridge: PhantomData,
         }
     }
 }
 
-impl<I: Interface> ProducerBuilder<I, LolaRuntimeImpl> for LolaProducerBuilder<I> {}
+impl<I: Interface, B: FFIBridge> ProducerBuilder<I, LolaRuntimeImpl<B>> for SampleProducerBuilder<I, B> {}
 
-impl<I: Interface> Builder<I::Producer<LolaRuntimeImpl>> for LolaProducerBuilder<I> {
-    fn build(self) -> Result<I::Producer<LolaRuntimeImpl>> {
+impl<I: Interface, B: FFIBridge> Builder<I::Producer<LolaRuntimeImpl<B>>> for SampleProducerBuilder<I, B> {
+    fn build(self) -> Result<I::Producer<LolaRuntimeImpl<B>>> {
         //Once FFI layer error handling is in place (SWP-253124), we should convert this error to a proper FFI error instead of using map_err here
         let instance_specifier_runtime = mw_com::InstanceSpecifier::try_from(
             self.instance_specifier.as_ref(),
@@ -449,11 +450,11 @@ impl<I: Interface> Builder<I::Producer<LolaRuntimeImpl>> for LolaProducerBuilder
         .map_err(|_| Error::ProducerError(ProducerFailedReason::InstanceSpecifierInvalid))?;
 
         let skeleton_handle =
-            NativeSkeletonHandle::new(I::INTERFACE_ID, &instance_specifier_runtime)?;
+            NativeSkeletonHandle::<B>::new(I::INTERFACE_ID, &instance_specifier_runtime)?;
         let instance_info = LolaProviderInfo {
             instance_specifier: self.instance_specifier,
             interface_id: I::INTERFACE_ID,
-            skeleton_handle: SkeletonInstanceManager(Arc::new(skeleton_handle)),
+            skeleton_handle: SkeletonInstanceManager::<B>(Arc::new(skeleton_handle)),
         };
 
         I::Producer::new(instance_info)

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
@@ -305,9 +305,13 @@ impl<B: FFIBridge> NativeSkeletonHandle<B> {
         //SAFETY: It is safe as we are passing valid type id and instance specifier to create skeleton
         let raw_handle =
             unsafe { B::create_skeleton(interface_id, instance_specifier.as_native()) };
-        let handle = std::ptr::NonNull::new(raw_handle)
-            .ok_or(Error::ProducerError(ProducerFailedReason::SkeletonCreationFailed))?;
-        Ok(Self { handle, _marker: PhantomData })
+        let handle = std::ptr::NonNull::new(raw_handle).ok_or(Error::ProducerError(
+            ProducerFailedReason::SkeletonCreationFailed,
+        ))?;
+        Ok(Self {
+            handle,
+            _marker: PhantomData,
+        })
     }
 }
 
@@ -519,6 +523,9 @@ mod test {
 
     #[test]
     fn test_publisher_allocate_and_send() {
+        // Register T so get_allocatee_ptr zero-fills the SampleAllocateePtr slot
+        // (safe assume_init) and get_allocatee_data_ptr returns real T-backed storage.
+        MockFFIBridge::set_alloc_backing::<TestData>();
         let instance_info = make_provider_info("TestData");
         let publisher: Publisher<TestData, MockFFIBridge> =
             Publisher::<TestData, MockFFIBridge>::new("TestEvent", instance_info)

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/runtime.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/runtime.rs
@@ -30,9 +30,9 @@ pub struct LolaRuntimeImpl<B: FFIBridge = LolaFFIBridge> {
 }
 
 impl<B: FFIBridge> Runtime for LolaRuntimeImpl<B> {
-    type ServiceDiscovery<I: Interface + Send> = SampleConsumerDiscovery<I, B>;
+    type ServiceDiscovery<I: Interface + Send> = LolaConsumerDiscovery<I, B>;
     type Subscriber<T: CommData + Debug> = SubscribableImpl<T, B>;
-    type ProducerBuilder<I: Interface> = SampleProducerBuilder<I, B>;
+    type ProducerBuilder<I: Interface> = LolaProducerBuilder<I, B>;
     type Publisher<T: CommData + Debug> = Publisher<T, B>;
     type ProviderInfo = LolaProviderInfo<B>;
     type ConsumerInfo = LolaConsumerInfo<B>;

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/runtime.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/runtime.rs
@@ -23,7 +23,8 @@ use com_api_concept::{
     Builder, CommData, FindServiceSpecifier, InstanceSpecifier, Interface, Result, Runtime,
 };
 
-use bridge_ffi_rs::{FFIBridge, LolaFFIBridge};
+use bridge_ffi_rs::FFIBridge;
+use bridge_ffi_lola::LolaFFIBridge;
 
 pub struct LolaRuntimeImpl<B: FFIBridge = LolaFFIBridge> {
     _marker: PhantomData<B>,

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/runtime.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/runtime.rs
@@ -16,18 +16,18 @@ use core::marker::PhantomData;
 use std::path::{Path, PathBuf};
 
 use crate::{
-    LolaConsumerInfo, LolaProviderInfo, Publisher, LolaConsumerDiscovery, LolaProducerBuilder,
+    LolaConsumerDiscovery, LolaConsumerInfo, LolaProducerBuilder, LolaProviderInfo, Publisher,
     SubscribableImpl,
 };
 use com_api_concept::{
     Builder, CommData, FindServiceSpecifier, InstanceSpecifier, Interface, Result, Runtime,
 };
 
-use bridge_ffi_rs::FFIBridge;
 use bridge_ffi_lola::LolaFFIBridge;
+use bridge_ffi_rs::FFIBridge;
 
 pub struct LolaRuntimeImpl<B: FFIBridge = LolaFFIBridge> {
-    _marker: PhantomData<B>,
+    pub(crate) bridge: B,
 }
 
 impl<B: FFIBridge> Runtime for LolaRuntimeImpl<B> {
@@ -51,7 +51,7 @@ impl<B: FFIBridge> Runtime for LolaRuntimeImpl<B> {
                 FindServiceSpecifier::Specific(spec) => spec,
             },
             _interface: PhantomData,
-            _bridge: PhantomData,
+            bridge: self.bridge.clone(),
         }
     }
 
@@ -72,7 +72,7 @@ impl<B: FFIBridge> Builder<LolaRuntimeImpl<B>> for RuntimeBuilderImpl<B> {
     fn build(self) -> Result<LolaRuntimeImpl<B>> {
         mw_com::initialize(self.config_path.as_deref());
         Ok(LolaRuntimeImpl {
-            _marker: PhantomData,
+            bridge: B::default(),
         })
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/runtime.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/runtime.rs
@@ -23,15 +23,19 @@ use com_api_concept::{
     Builder, CommData, FindServiceSpecifier, InstanceSpecifier, Interface, Result, Runtime,
 };
 
-pub struct LolaRuntimeImpl {}
+use bridge_ffi_rs::{FFIBridge, LolaFFIBridge};
 
-impl Runtime for LolaRuntimeImpl {
-    type ServiceDiscovery<I: Interface + Send> = LolaConsumerDiscovery<I>;
-    type Subscriber<T: CommData + Debug> = SubscribableImpl<T>;
-    type ProducerBuilder<I: Interface> = LolaProducerBuilder<I>;
-    type Publisher<T: CommData + Debug> = Publisher<T>;
-    type ProviderInfo = LolaProviderInfo;
-    type ConsumerInfo = LolaConsumerInfo;
+pub struct LolaRuntimeImpl<B: FFIBridge = LolaFFIBridge> {
+    _marker: PhantomData<B>,
+}
+
+impl<B: FFIBridge> Runtime for LolaRuntimeImpl<B> {
+    type ServiceDiscovery<I: Interface + Send> = SampleConsumerDiscovery<I, B>;
+    type Subscriber<T: CommData + Debug> = SubscribableImpl<T, B>;
+    type ProducerBuilder<I: Interface> = SampleProducerBuilder<I, B>;
+    type Publisher<T: CommData + Debug> = Publisher<T, B>;
+    type ProviderInfo = LolaProviderInfo<B>;
+    type ConsumerInfo = LolaConsumerInfo<B>;
 
     fn find_service<I: Interface + Send>(
         &self,
@@ -46,6 +50,7 @@ impl Runtime for LolaRuntimeImpl {
                 FindServiceSpecifier::Specific(spec) => spec,
             },
             _interface: PhantomData,
+            _bridge: PhantomData,
         }
     }
 
@@ -57,33 +62,39 @@ impl Runtime for LolaRuntimeImpl {
     }
 }
 
-pub struct RuntimeBuilderImpl {
+pub struct RuntimeBuilderImpl<B: FFIBridge = LolaFFIBridge> {
     config_path: Option<PathBuf>,
+    _marker: PhantomData<B>,
 }
 
-impl Builder<LolaRuntimeImpl> for RuntimeBuilderImpl {
-    fn build(self) -> Result<LolaRuntimeImpl> {
+impl<B: FFIBridge> Builder<LolaRuntimeImpl<B>> for RuntimeBuilderImpl<B> {
+    fn build(self) -> Result<LolaRuntimeImpl<B>> {
         mw_com::initialize(self.config_path.as_deref());
-        Ok(LolaRuntimeImpl {})
+        Ok(LolaRuntimeImpl {
+            _marker: PhantomData,
+        })
     }
 }
 
-impl com_api_concept::RuntimeBuilder<LolaRuntimeImpl> for RuntimeBuilderImpl {
+impl<B: FFIBridge> com_api_concept::RuntimeBuilder<LolaRuntimeImpl<B>> for RuntimeBuilderImpl<B> {
     fn load_config(&mut self, config: &Path) -> &mut Self {
         self.config_path = Some(config.to_path_buf());
         self
     }
 }
 
-impl Default for RuntimeBuilderImpl {
+impl<B: FFIBridge> Default for RuntimeBuilderImpl<B> {
     fn default() -> Self {
         Self::new()
     }
 }
 
-impl RuntimeBuilderImpl {
+impl<B: FFIBridge> RuntimeBuilderImpl<B> {
     /// Creates a new instance of the default implementation of the com layer
     pub fn new() -> Self {
-        Self { config_path: None }
+        Self {
+            config_path: None,
+            _marker: PhantomData,
+        }
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-mock/BUILD
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-mock/BUILD
@@ -16,6 +16,7 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 rust_library(
     name = "com-api-runtime-mock",
     srcs = ["runtime.rs"],
+    edition = "2024",
     visibility = [
         "//visibility:public",  # platform_only
     ],

--- a/score/mw/com/impl/rust/com-api/com-api/BUILD
+++ b/score/mw/com/impl/rust/com-api/com-api/BUILD
@@ -18,6 +18,7 @@ rust_library(
     name = "com-api",
     srcs = ["com_api.rs"],
     crate_name = "com_api",
+    edition = "2024",
     visibility = [
         "//visibility:public",  # platform_only
     ],

--- a/score/mw/com/impl/rust/proxy_bridge.rs
+++ b/score/mw/com/impl/rust/proxy_bridge.rs
@@ -54,6 +54,7 @@ mod ffi {
     /// `::score::mw::com::ServiceHandleContainer`<`::score::mw::com::impl::HandleType`> as an opaque
     /// struct. Note that this struct is empty as we only use references to it on Rust side.
     #[repr(C)]
+    #[derive(Default)]
     pub struct NativeHandleContainer {
         _dummy: [u8; 0],
     }
@@ -69,6 +70,7 @@ mod ffi {
     /// This type represents `score::mw::com::impl::ProxyEventBase` as an opaque struct.
     /// Note that this struct is empty as we only use references to it on Rust side.
     #[repr(C)]
+    #[derive(Default)]
     pub struct ProxyEventBase {
         _dummy: [u8; 0],
     }
@@ -76,6 +78,7 @@ mod ffi {
     /// This type represents `score::mw::com::impl::ProxyEvent` as an opaque struct.
     /// Note that this struct is empty as we only use references to it on Rust side.
     #[repr(C)]
+    #[derive(Default)]
     pub struct ProxyEvent<T> {
         pub(crate) base: ProxyEventBase,
         _data: PhantomData<T>,
@@ -84,6 +87,7 @@ mod ffi {
     /// This type represents `score::mw::com::impl::HandleType` as an opaque struct.
     /// Note that this struct is empty as we only use references to it on Rust side.
     #[repr(C)]
+    #[derive(Default)]
     pub struct HandleType {
         _dummy: [u8; 0],
     }

--- a/score/mw/com/test/basic_rust_api/consumer_async_apis/consumer_app.rs
+++ b/score/mw/com/test/basic_rust_api/consumer_async_apis/consumer_app.rs
@@ -55,7 +55,7 @@ async fn async_main() {
     );
 
     // Initialise the Lola runtime.
-    let mut runtime_builder = LolaRuntimeBuilderImpl::new();
+    let mut runtime_builder: LolaRuntimeBuilderImpl = LolaRuntimeBuilderImpl::new();
     runtime_builder.load_config(Path::new(CONFIG_PATH));
     let runtime = runtime_builder
         .build()

--- a/score/mw/com/test/basic_rust_api/consumer_sync_apis/consumer_app.rs
+++ b/score/mw/com/test/basic_rust_api/consumer_sync_apis/consumer_app.rs
@@ -317,7 +317,7 @@ fn main() {
     let num_cycles = args.num_cycles;
 
     // Initialise the Lola runtime.
-    let mut runtime_builder = LolaRuntimeBuilderImpl::new();
+    let mut runtime_builder: LolaRuntimeBuilderImpl = LolaRuntimeBuilderImpl::new();
     runtime_builder.load_config(Path::new(CONFIG_PATH));
     let runtime = runtime_builder
         .build()

--- a/score/mw/com/test/basic_rust_api/producer_app/producer_app.rs
+++ b/score/mw/com/test/basic_rust_api/producer_app/producer_app.rs
@@ -199,7 +199,7 @@ fn main() {
     let num_cycles = args.num_cycles;
 
     // Initialise the Lola runtime.
-    let mut runtime_builder = LolaRuntimeBuilderImpl::new();
+    let mut runtime_builder: LolaRuntimeBuilderImpl = LolaRuntimeBuilderImpl::new();
     runtime_builder.load_config(Path::new(CONFIG_PATH));
     let runtime = runtime_builder
         .build()


### PR DESCRIPTION
- Added a native FFI bridge and a mock FFI bridge for deterministic local testing.
- Runtime, consumer, and producer APIs are now pluggable via a bridge abstraction to support interchangeable backends.
- Added an explicit error for requests that exceed the maximum allowed sample count.
- Added mock-backed tests 