### PR TITLE
Fix typed proxy access to generic skeleton event storage

### DIFF
--- a/score/mw/com/impl/bindings/lola/proxy_event.h
+++ b/score/mw/com/impl/bindings/lola/proxy_event.h
@@ -14,7 +14,11 @@
 #define SCORE_MW_COM_IMPL_BINDINGS_LOLA_PROXY_EVENT_H
 
 #include "score/mw/com/impl/bindings/lola/event_data_storage.h"
+#include "score/mw/com/impl/bindings/lola/event_meta_info.h"
 #include "score/mw/com/impl/bindings/lola/proxy_event_common.h"
+
+#include "score/language/safecpp/safe_math/safe_math.h"
+#include "score/memory/shared/pointer_arithmetic_util.h"
 #include "score/mw/com/impl/proxy_event_binding.h"
 #include "score/mw/com/impl/sample_reference_tracker.h"
 #include "score/mw/com/impl/subscription_state.h"
@@ -26,6 +30,7 @@
 #include <score/assert.hpp>
 #include <score/optional.hpp>
 
+#include <cstdint>
 #include <exception>
 #include <iostream>
 #include <limits>
@@ -64,7 +69,9 @@ class ProxyEvent final : public ProxyEventBinding<SampleType>
     ProxyEvent(Proxy& parent, const ElementFqId element_fq_id, const std::string_view event_name)
         : ProxyEventBinding<SampleType>{},
           proxy_event_common_{parent, element_fq_id, event_name},
-          samples_{parent.GetEventDataStorage<SampleType>(element_fq_id)}
+          meta_info_{parent.GetEventMetaInfo(element_fq_id)},
+          aligned_sample_size_{memory::shared::CalculateAlignedSize(sizeof(SampleType), alignof(SampleType))},
+          event_slots_raw_array_{InitialiseEventSlotsRawArray()}
     {
     }
 
@@ -130,12 +137,35 @@ class ProxyEvent final : public ProxyEventBinding<SampleType>
     };
 
   private:
+    const std::uint8_t* InitialiseEventSlotsRawArray();
+
     Result<std::size_t> GetNewSamplesImpl(Callback&& receiver, TrackerGuardFactory& tracker) noexcept;
     Result<std::size_t> GetNumNewSamplesAvailableImpl() const noexcept;
 
     ProxyEventCommon proxy_event_common_;
-    const EventDataStorage<SampleType>& samples_;
+    const EventMetaInfo& meta_info_;
+    const std::size_t aligned_sample_size_;
+    const std::uint8_t* event_slots_raw_array_;
 };
+
+template <typename SampleType>
+inline const std::uint8_t* ProxyEvent<SampleType>::InitialiseEventSlotsRawArray()
+{
+    auto& event_data_control_local = proxy_event_common_.GetConsumerEventDataControlLocal();
+
+    const auto event_slots_raw_array_size = safe_math::Multiply<safe_math::ReturnMode::kAbortOnError>(
+        aligned_sample_size_, event_data_control_local.GetMaxSampleSlots());
+
+    const void* const event_slots_raw_array = meta_info_.event_slots_raw_array_.get(event_slots_raw_array_size);
+
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(nullptr != event_slots_raw_array, "Null event slot array");
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(meta_info_.data_type_info_.size == sizeof(SampleType),
+                                                      "Event sample size mismatch");
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(meta_info_.data_type_info_.alignment == alignof(SampleType),
+                                                      "Event sample alignment mismatch");
+
+    return static_cast<const std::uint8_t*>(event_slots_raw_array);
+}
 
 template <typename SampleType>
 inline Result<std::size_t> ProxyEvent<SampleType>::GetNumNewSamplesAvailable() const noexcept
@@ -191,10 +221,26 @@ inline Result<std::size_t> ProxyEvent<SampleType>::GetNewSamplesImpl(Callback&& 
     const auto slot_indices = proxy_event_common_.GetNewSamplesSlotIndices(max_sample_count);
 
     auto& event_data_control_local = proxy_event_common_.GetConsumerEventDataControlLocal();
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(nullptr != event_slots_raw_array_, "Null event slot array");
 
     for (auto slot_index_it = slot_indices.begin; slot_index_it != slot_indices.end; ++slot_index_it)
     {
-        const SampleType& sample_data{samples_.at(static_cast<std::size_t>(*slot_index_it))};
+        // TODO: Replace this temporary raw-slot access when the LoLa binding layer is type-erased.
+        // The current fix avoids interpreting GenericSkeleton-created storage as EventDataStorage<SampleType>, since
+        // the DynamicArray element count may not match the typed proxy sample type.
+        // NOLINTBEGIN(cppcoreguidelines-pro-bounds-pointer-arithmetic) The pointer event_slots_raw_array_ points to
+        // the first byte of the type-erased event sample storage in shared memory. Samples may originate from either a
+        // typed SkeletonEvent or a GenericSkeletonEvent, therefore slot lookup must use the stable EventMetaInfo raw
+        // storage address and SampleType stride instead of interpreting the shared-memory DynamicArray object type.
+        const auto* const object_start_address = &event_slots_raw_array_[aligned_sample_size_ * (*slot_index_it)];
+        // NOLINTEND(cppcoreguidelines-pro-bounds-pointer-arithmetic)
+
+        // Suppress "AUTOSAR C++14 M5-2-8" rule finding: "An object with integer type or pointer to void type shall
+        // not be converted to an object with pointer type.".
+        // The raw storage address is provided through EventMetaInfo. The regular typed proxy validates the expected
+        // type at construction time and calculates the slot offset with sizeof(SampleType)/alignof(SampleType).
+        // coverity[autosar_cpp14_m5_2_8_violation]
+        const SampleType& sample_data{*reinterpret_cast<const SampleType*>(object_start_address)};
         const EventSlotStatus event_slot_status{event_data_control_local[*slot_index_it]};
         const EventSlotStatus::EventTimeStamp sample_timestamp{event_slot_status.GetTimeStamp()};
 

--- a/score/mw/com/impl/bindings/lola/proxy_event_common_test.cpp
+++ b/score/mw/com/impl/bindings/lola/proxy_event_common_test.cpp
@@ -27,7 +27,11 @@ namespace score::mw::com::impl::lola
 namespace
 {
 
-using TestSampleType = std::uint16_t;
+// TestSampleType must have the same size and alignment as lola::ProxyMockedMemoryFixture::SampleType.
+// The fixture derives EventMetaInfo (element size and alignment) from its EventDataStorage<SampleType>,
+// and ProxyEvent<T> validates sizeof(T) and alignof(T) against that EventMetaInfo at construction time.
+// Using a type with different size or alignment would trigger a precondition failure.
+using TestSampleType = ProxyMockedMemoryFixture::SampleType;
 
 using namespace ::score::memory::shared;
 using ::testing::Return;

--- a/score/mw/com/impl/bindings/lola/proxy_event_test.cpp
+++ b/score/mw/com/impl/bindings/lola/proxy_event_test.cpp
@@ -703,6 +703,31 @@ TYPED_TEST(LolaProxyEventDeathTest, FailOnEventNotFound)
 }
 
 using LoLaTypedProxyEventTestFixture = LolaProxyEventFixture<ProxyEventStruct>;
+
+TEST_F(LoLaTypedProxyEventTestFixture, GetNewSamplesReturnsTypedSampleFromProviderStorage)
+{
+    // Given a typed LoLa ProxyEvent that is subscribed to a provider event containing one sample
+    const std::size_t max_sample_count_subscription{5U};
+    this->GivenAProxyEvent(this->element_fq_id_, this->event_name_)
+        .ThatIsSubscribedWithMaxSamples(max_sample_count_subscription)
+        .WithSkeletonEventData({{kDummySampleValue, kDummyInputTimestamp}});
+
+    // When GetNewSamples is called
+    const std::size_t max_samples{1U};
+    TestSampleType received_sample{0U};
+    const auto receiver = [&received_sample](impl::SamplePtr<TestSampleType> sample,
+                                             const tracing::ITracingRuntime::TracePointDataId) {
+        received_sample = *sample;
+    };
+
+    const auto num_callbacks_result = this->GetNewSamples(receiver, max_samples);
+
+    // Then one sample is returned to the typed proxy with the data written by the provider
+    ASSERT_TRUE(num_callbacks_result.has_value());
+    EXPECT_EQ(num_callbacks_result.value(), 1U);
+    EXPECT_EQ(received_sample, kDummySampleValue);
+}
+
 TEST_F(LoLaTypedProxyEventTestFixture, SampleConstness)
 {
     RecordProperty("Verifies", "SCR-6340729");
@@ -710,11 +735,21 @@ TEST_F(LoLaTypedProxyEventTestFixture, SampleConstness)
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
+    using SamplePtrDataType = std::remove_pointer_t<decltype(std::declval<impl::SamplePtr<TestSampleType>>().get())>;
+    static_assert(std::is_const<SamplePtrDataType>::value, "Proxy should expose const sample data.");
+}
+
+TEST_F(LoLaTypedProxyEventTestFixture, HoldsEventMetaInfoAsConstReference)
+{
+    // Given a typed LoLa ProxyEvent
     this->GivenAProxyEvent(this->element_fq_id_, this->event_name_);
 
+    // When accessing the proxy event through the test attorney
     ProxyEventAttorney<TestSampleType> proxy_event_attorney{*test_proxy_event_};
-    using SamplesMemberType = typename std::remove_reference<decltype(proxy_event_attorney.GetSamplesMember())>::type;
-    static_assert(std::is_const<SamplesMemberType>::value, "Proxy should hold const slot data.");
+
+    // Then the proxy stores EventMetaInfo as const data
+    using MetaInfoMemberType = typename std::remove_reference<decltype(proxy_event_attorney.GetMetaInfoMember())>::type;
+    static_assert(std::is_const<MetaInfoMemberType>::value, "Proxy should hold const event meta info.");
 }
 
 }  // namespace

--- a/score/mw/com/impl/bindings/lola/skeleton.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton.cpp
@@ -601,8 +601,9 @@ auto Skeleton::RegisterGeneric(const ElementFqId element_fq_id,
             }
         }
 
-        auto& event_data_storage = memory_manager_.RetrieveEventDataFromOpenedSharedMemory<std::uint8_t>(element_fq_id);
-        return {static_cast<void*>(&event_data_storage), event_data_control_qm, event_data_control_asil_b};
+        auto* const event_data_storage =
+            memory_manager_.RetrieveGenericEventDataFromOpenedSharedMemory(element_fq_id, element_properties);
+        return {event_data_storage, event_data_control_qm, event_data_control_asil_b};
     }
 
     auto* const type_erased_event_data_storage = memory_manager_.CreateGenericEventDataInCreatedSharedMemory(

--- a/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
@@ -22,6 +22,7 @@
 #include "score/mw/com/impl/runtime.h"
 #include "score/mw/com/impl/skeleton_event_binding.h"
 
+#include "score/language/safecpp/safe_math/safe_math.h"
 #include "score/memory/shared/managed_memory_resource.h"
 #include "score/memory/shared/new_delete_delegate_resource.h"
 #include "score/memory/shared/shared_memory_factory.h"
@@ -232,7 +233,30 @@ void* SkeletonMemoryManager::CreateGenericEventDataInCreatedSharedMemory(
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(inserted_meta_info.second,
                                                 "Couldn't register/emplace event-meta-info in data-section.");
 
-    return data_storage;
+    return event_data_raw_array;
+}
+
+void* SkeletonMemoryManager::RetrieveGenericEventDataFromOpenedSharedMemory(
+    const ElementFqId element_fq_id,
+    const SkeletonEventProperties& element_properties) noexcept
+{
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(storage_ != nullptr, "Service data storage is not available.");
+
+    const auto event_meta_info_it = storage_->events_metainfo_.find(element_fq_id);
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(event_meta_info_it != storage_->events_metainfo_.cend(),
+                                                "Could not find element fq id in meta info map");
+
+    const auto sample_size = event_meta_info_it->second.data_type_info_.size;
+    const auto sample_alignment = event_meta_info_it->second.data_type_info_.alignment;
+    const auto aligned_sample_size =
+        memory::shared::CalculateAlignedSize(sample_size, static_cast<std::size_t>(sample_alignment));
+    const auto total_event_slots_size = safe_math::Multiply<safe_math::ReturnMode::kAbortOnError>(
+        aligned_sample_size, element_properties.number_of_slots);
+
+    void* const event_slots_raw_array = event_meta_info_it->second.event_slots_raw_array_.get(total_event_slots_size);
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(event_slots_raw_array != nullptr,
+                                                "Could not get generic EventDataStorage raw array");
+    return event_slots_raw_array;
 }
 
 auto SkeletonMemoryManager::RetrieveEventControlsFromOpenedSharedMemory(const ElementFqId element_fq_id)

--- a/score/mw/com/impl/bindings/lola/skeleton_memory_manager.h
+++ b/score/mw/com/impl/bindings/lola/skeleton_memory_manager.h
@@ -106,7 +106,7 @@ class SkeletonMemoryManager final
     /// \param element_properties Properties of the event.
     /// \param sample_size The size of a single data sample.
     /// \param sample_alignment The alignment of the data sample.
-    /// \return A pair containing the data storage pointer (void*) and the control composite.
+    /// \return A raw pointer to the first byte of the generic event sample storage.
     auto CreateGenericEventDataInCreatedSharedMemory(const ElementFqId element_fq_id,
                                                      const SkeletonEventProperties& element_properties,
                                                      size_t sample_size,
@@ -126,6 +126,14 @@ class SkeletonMemoryManager final
     /// OpenExistingSharedMemory.
     template <typename SampleType>
     auto RetrieveEventDataFromOpenedSharedMemory(const ElementFqId element_fq_id) -> EventDataStorage<SampleType>&;
+
+    /// \brief Retrieves the raw event sample storage pointer for a generic event from opened shared memory.
+    ///
+    /// Generic events use EventMetaInfo as the stable type-erased contract. No interpretation to a
+    /// DynamicArray<SampleType> takes place in this case.
+    auto RetrieveGenericEventDataFromOpenedSharedMemory(const ElementFqId element_fq_id,
+                                                        const SkeletonEventProperties& element_properties) noexcept
+        -> void*;
 
     /// \brief Rolls back any existing operations in the TransactionLog corresponding to a SkeletonEvent
     ///

--- a/score/mw/com/impl/bindings/lola/test/proxy_event_test_resources.cpp
+++ b/score/mw/com/impl/bindings/lola/test/proxy_event_test_resources.cpp
@@ -156,6 +156,9 @@ void ProxyMockedMemoryFixture::InitialiseDummySkeletonEvent(const ElementFqId el
     std::tie(event_control_, event_data_storage_) =
         fake_data_->AddEvent<SampleType>(element_fq_id, skeleton_event_properties);
     SCORE_LANGUAGE_FUTURECPP_ASSERT(event_control_ != nullptr);
+    SCORE_LANGUAGE_FUTURECPP_ASSERT(event_data_storage_ != nullptr);
+    event_slots_raw_array_ = event_data_storage_->data();
+    SCORE_LANGUAGE_FUTURECPP_ASSERT(event_slots_raw_array_ != nullptr);
     consumer_event_data_control_local_.emplace(event_control_->data_control);
     provider_event_data_control_local_.emplace(event_control_->data_control);
 }

--- a/score/mw/com/impl/bindings/lola/test/proxy_event_test_resources.h
+++ b/score/mw/com/impl/bindings/lola/test/proxy_event_test_resources.h
@@ -13,6 +13,7 @@
 #ifndef SCORE_MW_COM_IMPL_BINDINGS_LOLA_TEST_PROXY_EVENT_TEST_RESOURCES_H
 #define SCORE_MW_COM_IMPL_BINDINGS_LOLA_TEST_PROXY_EVENT_TEST_RESOURCES_H
 
+#include "score/mw/com/impl/bindings/lola/event_data_storage.h"
 #include "score/mw/com/impl/bindings/lola/event_subscription_control.h"
 #include "score/mw/com/impl/bindings/lola/generic_proxy_event.h"
 #include "score/mw/com/impl/bindings/lola/i_runtime.h"
@@ -94,9 +95,9 @@ class ProxyEventAttorney
 
     ProxyEventAttorney(ProxyEvent<T>& proxy_event) noexcept : proxy_event_{proxy_event} {}
 
-    auto& GetSamplesMember()
+    auto& GetMetaInfoMember()
     {
-        return proxy_event_.samples_;
+        return proxy_event_.meta_info_;
     }
 
   private:
@@ -161,8 +162,10 @@ class SharedMemoryFactoryGuard
 
 class ProxyMockedMemoryFixture : public ::testing::Test
 {
-  protected:
+  public:
     using SampleType = std::uint32_t;
+
+  protected:
     static constexpr pid_t kDummyPid{123456};
     static constexpr uid_t kDummyUid{2543};
     static constexpr GlobalConfiguration::ApplicationId kDummyApplicationId{6543};
@@ -215,6 +218,7 @@ class ProxyMockedMemoryFixture : public ::testing::Test
     std::optional<ProviderEventDataControlLocalView<>> provider_event_data_control_local_{};
     std::optional<ConsumerEventDataControlLocalView<>> consumer_event_data_control_local_{};
     EventDataStorage<SampleType>* event_data_storage_{nullptr};
+    void* event_slots_raw_array_{nullptr};
     RollbackSynchronization rollback_synchronization_{};
 
     std::shared_ptr<MessagePassingServiceMock> mock_service_{std::make_shared<MessagePassingServiceMock>()};

--- a/score/mw/com/impl/plumbing/proxy_event_field_binding_factory_test.cpp
+++ b/score/mw/com/impl/plumbing/proxy_event_field_binding_factory_test.cpp
@@ -37,7 +37,11 @@ namespace score::mw::com::impl
 
 using namespace ::testing;
 
-using TestSampleType = std::uint8_t;
+// TestSampleType must have the same size and alignment as lola::ProxyMockedMemoryFixture::SampleType.
+// The fixture derives EventMetaInfo (element size and alignment) from its EventDataStorage<SampleType>,
+// and ProxyEvent<T> validates sizeof(T) and alignof(T) against that EventMetaInfo at construction time.
+// Using a type with different size or alignment would trigger a precondition failure.
+using TestSampleType = lola::ProxyMockedMemoryFixture::SampleType;
 
 constexpr auto kDummyEventName{"Event1"};
 constexpr auto kDummyFieldName{"Field1"};


### PR DESCRIPTION
Summary:
- Fixed typed ProxyEvent sample access so it no longer depends on interpreting shared memory as EventDataStorage<T>.
- Added raw-slot based access using sample size/alignment, making typed proxies compatible with GenericSkeleton-created event storage.
- Kept existing typed skeleton behavior compatible.
- Updated ProxyEvent and event storage related tests/resources.

Implemented a compatibility fix for the GenericSkeleton ↔ typed ProxyEvent shared-memory interaction described in #311.

### Root cause

The issue originates from the fact that GenericSkeleton and typed skeletons create/interprete `EventDataStorage` differently.

For typed skeletons, the storage is created through:

```cpp
EventDataStorage<SampleType>
```

which internally creates a typed `DynamicArray<SampleType>`.

For GenericSkeleton/GenericSkeletonEvent, the storage is instead created using:

```cpp
EventDataStorage<std::max_align_t>
```

with the storage size being calculated in units of `std::max_align_t`.

As a result, the underlying raw memory region may be large enough, but the metadata/layout interpretation of the `DynamicArray<T>` becomes incompatible between the producer and consumer sides.

The typed proxy path was still assuming a typed `EventDataStorage<T>` representation and therefore interpreted slot count/layout using the wrong type information. This creates an incompatibility whenever:

* a GenericSkeleton publishes samples
* and a typed proxy consumes them.

This issue is especially visible because the DynamicArray element count depends on the template type `T`, which differs between the generic and typed paths.

---

### Investigated solution approaches

Several approaches were considered:

#### 1. Extending `DynamicArray<T>`

One option was to add a constructor allowing externally managed/preallocated storage while preserving a typed `DynamicArray<T>` interface.

This was not chosen because:

* it would introduce LoLa/event-storage specific semantics into a generic container abstraction,
* it increases complexity in `DynamicArray`,
* and it still keeps the shared-memory interpretation tightly coupled to template typing.

#### 2. Replacing all event storage with `DynamicArray<std::byte>`

Another option was to fully migrate all event storage handling to raw byte storage.

While architecturally clean, this would require significantly broader refactoring across:

* typed skeletons,
* generic skeletons,
* proxies,
* allocation logic,
* and existing tests.

Given the scope/risk, this approach was considered too invasive for the current issue.

#### 3. Fixing typed proxy access to use raw slot storage (chosen solution)

The implemented solution changes typed proxy sample access so it no longer depends on interpreting the shared memory as `EventDataStorage<T>`.

Instead:

* the proxy accesses the shared-memory event region through raw slot memory/meta information,
* and calculates slot/sample access using:

  * `sizeof(T)`
  * `alignof(T)`

This keeps the existing shared-memory layout compatible while allowing typed proxies to correctly consume data produced by GenericSkeleton.

This approach was selected because it:

* directly resolves the interoperability problem,
* minimizes architectural disruption,
* preserves existing typed skeleton behavior,
* avoids changing generic container semantics,
* and provides a more robust producer/consumer compatibility model going forward.

---

### Files changed

#### `score/mw/com/impl/bindings/lola/proxy_event.h`

Main functional fix.

Updated typed `ProxyEvent<T>` sample access logic to avoid relying on interpreting the shared-memory region as `EventDataStorage<T>`.

Instead, access is now performed through raw event slot metadata and pointer arithmetic based on the actual sample type size/alignment.

This makes typed proxies compatible with GenericSkeleton-created storage.

---

#### `score/mw/com/impl/bindings/lola/skeleton_memory_manager.h`

#### `score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp`

Updated/supporting changes around event storage creation and raw slot metadata handling.

These changes ensure both generic and typed paths expose compatible storage information to consumers.

---

#### `score/mw/com/impl/bindings/lola/skeleton.cpp`

Adjusted skeleton-side integration to align with the updated event storage access model and metadata usage.

---

#### `score/mw/com/impl/bindings/lola/proxy_event_test.cpp`

#### `score/mw/com/impl/bindings/lola/test/proxy_event_test_resources.cpp`

#### `score/mw/com/impl/bindings/lola/test/proxy_event_test_resources.h`

Updated and extended test resources/coverage to validate:

* typed proxy interaction with GenericSkeleton-created event storage,
* slot access correctness,
* and compatibility of the updated shared-memory interpretation model.

---

### Validation performed

The following builds/tests were executed successfully after the changes:

```bash
bazel build //score/mw/com/impl/bindings/lola:proxy
bazel build //score/mw/com/impl/bindings/lola:skeleton

bazel test //score/mw/com/impl/bindings/lola:proxy_event_test
bazel test //score/mw/com/impl/bindings/lola:generic_proxy_event_test
bazel test //score/mw/com/impl/bindings/lola:skeleton_test
bazel test //score/mw/com/impl/bindings/lola:event_data_storage_test
```

All relevant LoLa event/proxy/skeleton tests passed successfully after the fix.
