### PR TITLE
test(lola): verify skeleton event timestamp after reopen

### DIFF
--- a/score/mw/com/impl/bindings/lola/skeleton_event_test.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_event_test.cpp
@@ -445,5 +445,56 @@ TEST_F(SkeletonEventTimestampFixture, SendUpdatesTimestampInControlData)
         << "The second timestamp should be exactly one greater than the first.";
 }
 
+TEST_F(SkeletonEventTimestampFixture, PrepareOfferInitializesCurrentTimestampFromReopenedControlData)
+{
+    RecordProperty("Description",
+                   "Checks that a SkeletonEvent which reopens existing shared memory continues the timestamp sequence "
+                   "from the latest timestamp already present in the event control data.");
+    RecordProperty("TestType", "Unit Test");
+
+    constexpr bool enforce_max_samples{true};
+    constexpr SlotIndexType existing_slot_index{0U};
+    constexpr EventSlotStatus::EventTimeStamp existing_latest_timestamp{42U};
+
+    auto existing_service_data_control_qm =
+        CreateServiceDataControlWithEvent(fake_element_fq_id_, QualityType::kASIL_QM);
+    auto existing_service_data_control_asil_b =
+        CreateServiceDataControlWithEvent(fake_element_fq_id_, QualityType::kASIL_B);
+    auto existing_service_data_storage = CreateServiceDataStorageWithEvent<test::TestSampleType>(fake_element_fq_id_);
+
+    auto& existing_event_control_qm =
+        GetEventControlFromServiceDataControl(fake_element_fq_id_, *existing_service_data_control_qm);
+    auto& existing_event_control_asil_b =
+        GetEventControlFromServiceDataControl(fake_element_fq_id_, *existing_service_data_control_asil_b);
+    ProviderEventDataControlLocalView<> existing_provider_control_qm{existing_event_control_qm.data_control};
+    ProviderEventDataControlLocalView<> existing_provider_control_asil_b{existing_event_control_asil_b.data_control};
+    existing_provider_control_qm.EventReady(existing_slot_index, existing_latest_timestamp);
+    existing_provider_control_asil_b.EventReady(existing_slot_index, existing_latest_timestamp);
+
+    ExpectControlSegmentOpened(*existing_service_data_control_qm, existing_service_data_control_asil_b.get());
+    ExpectDataSegmentOpened(existing_service_data_storage);
+    WithAlreadyConnectedProxy();
+
+    InitialiseSkeletonEvent(fake_element_fq_id_, fake_event_name_, max_samples_, max_subscribers_, enforce_max_samples);
+
+    std::ignore = skeleton_event_->PrepareOffer();
+
+    auto allocated_slot_result = skeleton_event_->Allocate();
+    ASSERT_TRUE(allocated_slot_result.has_value());
+    auto allocated_slot = std::move(allocated_slot_result).value();
+
+    const impl::SampleAllocateePtrView<test::TestSampleType> allocated_slot_view{allocated_slot};
+    const auto* const lola_allocated_slot =
+        allocated_slot_view.template As<lola::SampleAllocateePtr<test::TestSampleType>>();
+    ASSERT_NE(lola_allocated_slot, nullptr);
+    const auto allocated_slot_index = lola_allocated_slot->GetReferencedSlot();
+
+    const auto send_result = skeleton_event_->Send(std::move(allocated_slot), std::nullopt);
+    ASSERT_TRUE(send_result.has_value());
+
+    const EventSlotStatus final_slot_status{existing_provider_control_qm[allocated_slot_index]};
+    EXPECT_EQ(final_slot_status.GetTimeStamp(), existing_latest_timestamp + 1U);
+}
+
 }  // namespace
 }  // namespace score::mw::com::impl::lola

--- a/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.cpp
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.cpp
@@ -313,6 +313,32 @@ void SkeletonMockedMemoryFixture::ExpectServiceUsageMarkerFileCreatedOrOpenedAnd
     EXPECT_CALL(*unistd_mock_, unlink(StrEq(test::kServiceInstanceUsageFilePath))).Times(0);
 }
 
+void SkeletonMockedMemoryFixture::ExpectControlSegmentOpened(
+    ServiceDataControl& service_data_control_qm,
+    ServiceDataControl* const service_data_control_asil_b) noexcept
+{
+    ON_CALL(*control_qm_shared_memory_resource_mock_, getUsableBaseAddress())
+        .WillByDefault(Return(static_cast<void*>(&service_data_control_qm)));
+    ON_CALL(shared_memory_factory_mock_, Open(test::kControlChannelPathQm, true, _))
+        .WillByDefault(Return(control_qm_shared_memory_resource_mock_));
+
+    if (service_data_control_asil_b != nullptr)
+    {
+        ON_CALL(*control_asil_b_shared_memory_resource_mock_, getUsableBaseAddress())
+            .WillByDefault(Return(static_cast<void*>(service_data_control_asil_b)));
+        ON_CALL(shared_memory_factory_mock_, Open(test::kControlChannelPathAsilB, true, _))
+            .WillByDefault(Return(control_asil_b_shared_memory_resource_mock_));
+    }
+}
+
+void SkeletonMockedMemoryFixture::ExpectDataSegmentOpened(ServiceDataStorage& service_data_storage) noexcept
+{
+    ON_CALL(*data_shared_memory_resource_mock_, getUsableBaseAddress())
+        .WillByDefault(Return(static_cast<void*>(&service_data_storage)));
+    ON_CALL(shared_memory_factory_mock_, Open(test::kDataChannelPath, true, _))
+        .WillByDefault(Return(data_shared_memory_resource_mock_));
+}
+
 std::unique_ptr<ServiceDataControl> SkeletonMockedMemoryFixture::CreateServiceDataControlWithEvent(
     ElementFqId element_fq_id,
     QualityType quality_type) noexcept

--- a/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h
@@ -436,6 +436,11 @@ class SkeletonMockedMemoryFixture : public ::testing::Test
 
     void ExpectServiceUsageMarkerFileCreatedOrOpenedAndClosed() noexcept;
 
+    void ExpectControlSegmentOpened(ServiceDataControl& service_data_control_qm,
+                                    ServiceDataControl* service_data_control_asil_b = nullptr) noexcept;
+
+    void ExpectDataSegmentOpened(ServiceDataStorage& service_data_storage) noexcept;
+
     std::unique_ptr<ServiceDataControl> CreateServiceDataControlWithEvent(ElementFqId element_fq_id,
                                                                           QualityType quality_type) noexcept;
     static EventControl& GetEventControlFromServiceDataControl(ElementFqId element_fq_id,


### PR DESCRIPTION
What
Add a test that check that current_timestamp_ is set correctly.
It should be possible to inject your own EventDataControl which has some preset slot values using ExpectControlSegmentOpened() in the SkeletonMockedMemoryFixture.

How
No response

Estimates for realization
Effort low
No impact on users expected
Category

Affects Detailed Design



Summary:
This PR addresses issue #87: “Add unit test in skeleton_event.h for checking timestamp”.

The ticket asks for unit-test coverage to verify that current_timestamp_ is set correctly. The important scenario is not only the normal Send() path, but also the reopened/shared-memory path where existing EventDataControl already contains preset slot timestamp values. The test validates that SkeletonEvent correctly continues the timestamp sequence from the existing slot data.

link: https://github.com/eclipse-score/communication/issues/87

Changes made:
1. Updated:
   score/mw/com/impl/bindings/lola/skeleton_event_test.cpp

   Added a new unit test:
   SkeletonEventTimestampFixture.PrepareOfferInitializesCurrentTimestampFromReopenedControlData

   This test:
   - Creates preset QM and ASIL-B ServiceDataControl objects.
   - Sets an existing event slot as ready with timestamp 42.
   - Injects these preset controls through the mocked shared-memory open path.
   - Calls PrepareOffer().
   - Allocates and sends a new sample.
   - Verifies that the newly sent sample gets timestamp 43.

2. Updated:
   score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h

   Added helper declarations:
   - ExpectControlSegmentOpened(...)
   - ExpectDataSegmentOpened(...)

3. Updated:
   score/mw/com/impl/bindings/lola/test/skeleton_test_resources.cpp

   Added helper implementations to allow SkeletonMockedMemoryFixture tests to inject existing control/data shared-memory objects instead of always creating fresh memory objects.

Why the changes were made:
The existing timestamp coverage only checked normal timestamp incrementing during Send(). That proves the fresh/default case, but it does not prove the ticket requirement: that current_timestamp_ is initialized correctly when existing EventDataControl with preset slot values is reopened.

This new test covers the intended partial-restart/reopen scenario. If the existing shared-memory slot has timestamp 42, the next sent event must use timestamp 43. This verifies that timestamp continuity is preserved.

Alternatives considered:
1. Test only normal Send() timestamp increments.
   - Rejected because this path was already covered and does not validate injected/preset EventDataControl slot values.

2. Directly expose or read current_timestamp_ using friend access or an attorney helper.
   - Rejected because it would make the test tightly coupled to a private implementation detail.

3. Verify behavior through externally observable timestamp output after injecting preset control data.
   - Chosen because it follows the ticket request, uses the existing SkeletonMockedMemoryFixture pattern, and validates the real behavior without exposing internal state.

Build and test results:
The focused unit test was executed with:

bazel test //score/mw/com/impl/bindings/lola:skeleton_event_test \
  --test_filter=SkeletonEventTimestampFixture.PrepareOfferInitializesCurrentTimestampFromReopenedControlData \
  --test_output=all

Result:
- 1 test suite executed.
- 1 test executed.
- 1 test passed.
- Test runtime reported by Google Test: 32 ms total.
- Bazel reported: Build completed successfully, 8 total actions.
- Bazel reported: //score/mw/com/impl/bindings/lola:skeleton_event_test PASSED in 1.6s.
- Final result: Executed 1 out of 1 test: 1 test passes.

The LoLa package build was executed with:

bazel build //score/mw/com/impl/bindings/lola:all

Result:
- 117 targets found/analyzed.
- Build completed successfully.
- Bazel reported: Build completed successfully, 201 total actions.
- Elapsed time: 957.347s.
- Critical path: 90.34s.

The wider LoLa test suite was executed with:

bazel test //score/mw/com/impl/bindings/lola/... --test_output=errors

Result:
- 92 targets and 67 test targets found.
- Build completed successfully.
- Bazel reported: Build completed successfully, 25 total actions.
- Visible test output shows LoLa tests passing/cached, including event data control, event data storage, event slot status, partial restart path builder, and other related LoLa tests.

The wider COM test command was also run:

bazel test //score/mw/com/... --test_output=errors

Result:
- 962 targets and 248 test targets found.
- Build completed successfully.
- Bazel reported: Build completed successfully, 85 total actions.
- Visible output shows COM and LoLa related tests passing/cached.

Verification:
The new test verifies the required timestamp behavior by setting an existing slot timestamp to 42 and confirming that the next sent sample receives timestamp 43 after PrepareOffer(). This confirms that SkeletonEvent initializes/continues current_timestamp_ correctly from reopened EventDataControl state.

Branch used:
feature/87-skeleton-event-current-timestamp

Linked issue:
Closes #87