### PR TITLE
mw/com: Make ProxyBase::AreBindingsValid symmetrical with Skeleton side

### DIFF
--- a/score/mw/com/design/skeleton_proxy/README.md
+++ b/score/mw/com/design/skeleton_proxy/README.md
@@ -188,34 +188,23 @@ independent level.
 
 #### Binding level Registration of proxy events/fields at their parent proxy
 
-On the binding **specific** level things look different!
-I.e. the binding specific proxy needs to interact with its dependent/child proxy events of type `ProxyEventBindingBase`
+On the binding **specific** level things look similar:
+the binding specific proxy needs to interact with its dependent/child proxy events of type `ProxyEventBindingBase`
 (at least the `LoLa`/shared-memory specific does, so we introduced it on the `ProxyBinding` interface level) .
 
-Therefore, `impl::ProxyBinding` has a method `RegisterEventBinding` (and `UnregisterEventBinding`) and our `LoLa`
-binding specific proxy `lola::Proxy`, which implements `impl::ProxyBinding`, has a member `event_bindings_` (a map
-containing its child proxy events), which it populates in its implementation of `RegisterEventBinding` with its
-dependent proxy events.
-
-The call to `RegisterEventBinding` happens during creation of a binding independent `impl::ProxyEvent` via an `RAII`
-style member `event_binding_registration_guard_` of type `EventBindingRegistrationGuard`, which the `impl::ProxyEvent`
-owns.
-This `EventBindingRegistrationGuard` takes over two functionalities:
-
-- setting `ProxyBase::are_service_element_bindings_valid_` member of its parent ProxyBase instance (see previous chapter)
-- calling `RegisterEventBinding` on the underlying `ProxyBinding` of the given `ProxyBase` on construction of the
-  `EventBindingRegistrationGuard` and calling `UnregisterEventBinding` on destruction. Since
-  `event_binding_registration_guard_` is owned by the `impl::ProxyEvent`, the registration / unregistration is done on
-  construction / destruction of an `impl::ProxyEvent`.
+Therefore, when each `lola::ProxyEvent` gets created (as a member of the generated proxy class), it registers itself 
+at its parent `lola::Proxy` via `lola::Proxy::RegisterEvent()`. The `lola::Proxy` stores the reference to each 
+child `lola::ProxyEvent`s in a map which it can later use.
 
 So **after** construction of user facing generated proxy class instance (`DummyProxy`), we have the following structure
 in place:
 
 1. Only an instance of the generated proxy class gets returned from the call to `<DummyProxy>::Create()` in case its
    binding on proxy level (its `pImpl` target) implementing `ProxyBinding` could be constructed and also for **all** its
-   aggregated events/fields their related `ProxyEventBinding`s (`pImpl` targets) could be constructed.
+   aggregated events/fields their related `ProxyEventBinding`s (`pImpl` targets) could be constructed. If this is not 
+   the case, then an error will be returned from `<DummyProxy>::Create()`.
 2. The `ProxyBinding` (`ProxyBase::proxy_binding_`) has complete access to all its child events/fields as
-   `ProxyBinding::RegisterEventBinding` has been called for all contained events/fields.
+   `lola::Proxy::RegisterEvent()` has been called for all contained events/fields.
 
 
 #### Extract type agnostic code

--- a/score/mw/com/impl/bindings/lola/generic_proxy_event.cpp
+++ b/score/mw/com/impl/bindings/lola/generic_proxy_event.cpp
@@ -31,6 +31,7 @@ GenericProxyEvent::GenericProxyEvent(Proxy& parent, const ElementFqId element_fq
       proxy_event_common_{parent, element_fq_id, event_name},
       meta_info_{parent.GetEventMetaInfo(element_fq_id)}
 {
+    parent.RegisterEvent(event_name, *this);
 }
 
 Result<void> GenericProxyEvent::Subscribe(const std::size_t max_sample_count) noexcept

--- a/score/mw/com/impl/bindings/lola/proxy.cpp
+++ b/score/mw/com/impl/bindings/lola/proxy.cpp
@@ -600,32 +600,6 @@ bool Proxy::IsEventProvided(const std::string_view event_name) const noexcept
     return event_exists;
 }
 
-void Proxy::RegisterEventBinding(const std::string_view service_element_name,
-                                 ProxyEventBindingBase& proxy_event_binding) noexcept
-{
-    // Suppress Autosar C++14 A8-5-3 states that auto variables shall not be initialized using braced initialization.
-    // This is a false positive, we don't use auto here
-    // coverity[autosar_cpp14_a8_5_3_violation : FALSE]
-    std::lock_guard lock{proxy_event_registration_mutex_};
-    const auto insert_result = event_bindings_.emplace(service_element_name, proxy_event_binding);
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(insert_result.second,
-                                                "Failed to insert proxy event binding into event binding map.");
-    proxy_event_binding.NotifyServiceInstanceChangedAvailability(is_service_instance_available_, GetSourcePid());
-}
-
-void Proxy::UnregisterEventBinding(const std::string_view service_element_name) noexcept
-{
-    // Suppress Autosar C++14 A8-5-3 states that auto variables shall not be initialized using braced initialization.
-    // This is a false positive, we don't use auto here
-    // coverity[autosar_cpp14_a8_5_3_violation : FALSE]
-    std::lock_guard lock{proxy_event_registration_mutex_};
-    const auto number_of_elements_removed = event_bindings_.erase(service_element_name);
-    if (number_of_elements_removed == 0U)
-    {
-        score::mw::log::LogWarn("lola") << "UnregisterEventBinding that was never registered. Ignoring.";
-    }
-}
-
 score::Result<void> Proxy::SetupMethods()
 {
     auto enabled_method_data = GetMethodIdAndQueueSizeForEnabledMethods();
@@ -918,6 +892,16 @@ pid_t Proxy::GetSourcePid() const noexcept
                                                       "Proxy::GetSourcePid: Managed memory data pointer is Null");
     auto& service_data_storage = detail_proxy::GetServiceDataStorage(*data_);
     return service_data_storage.skeleton_pid_;
+}
+
+void Proxy::RegisterEvent(const std::string_view service_element_name,
+                          ProxyEventBindingBase& proxy_event_binding) noexcept
+{
+    std::lock_guard lock{proxy_event_registration_mutex_};
+    const auto insert_result = event_bindings_.emplace(service_element_name, proxy_event_binding);
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(insert_result.second,
+                                                "Failed to insert proxy event binding into event binding map.");
+    proxy_event_binding.NotifyServiceInstanceChangedAvailability(is_service_instance_available_, GetSourcePid());
 }
 
 void Proxy::RegisterMethod(const UniqueMethodIdentifier method_id, ProxyMethod& proxy_method) noexcept

--- a/score/mw/com/impl/bindings/lola/proxy.h
+++ b/score/mw/com/impl/bindings/lola/proxy.h
@@ -167,24 +167,6 @@ class Proxy : public ProxyBinding
     /// \return True if the event name exists, otherwise, false
     bool IsEventProvided(const std::string_view event_name) const noexcept override;
 
-    /// \brief Adds a reference to a Proxy service element binding to an internal map
-    ///
-    /// Will insert the provided ProxyEventBindingBase& into a map stored within the class which will be used to call
-    /// NotifyServiceInstanceChangedAvailability on all saved Proxy service elements by the FindServiceHandler of
-    /// find_service_guard_. It will then call NotifyServiceInstanceChangedAvailability on the provided
-    /// ProxyEventBindingBase. Since this function first locks proxy_event_registration_mutex_, it is ensured that the
-    /// provided Proxy service element will be notified synchronously about the availability of the provider and will
-    /// then be notified of any future changes via the callback, without missing any notifications.
-    void RegisterEventBinding(const std::string_view service_element_name,
-                              ProxyEventBindingBase& proxy_event_binding) noexcept override;
-
-    /// \brief Removes the reference to a Proxy service element binding from an internal map
-    ///
-    /// This must be called by a Proxy service element before destructing to ensure that the FindService handler in
-    /// find_service_guard_ does not call NotifyServiceInstanceChangedAvailability on a Proxy service element after it's
-    /// been destructed.
-    void UnregisterEventBinding(const std::string_view service_element_name) noexcept override;
-
     score::Result<void> SetupMethods() override;
 
     QualityType GetQualityType() const noexcept;
@@ -198,6 +180,8 @@ class Proxy : public ProxyBinding
         return proxy_instance_identifier_;
     }
 
+    void RegisterEvent(const std::string_view service_element_name,
+                       ProxyEventBindingBase& proxy_event_binding) noexcept;
     void RegisterMethod(const UniqueMethodIdentifier method_id, ProxyMethod& proxy_method) noexcept;
 
     /// \brief Stops auto-reconnect for this proxy and marks it ready for destruction.
@@ -243,7 +227,7 @@ class Proxy : public ProxyBinding
     HandleType handle_;
     std::unordered_map<std::string_view, std::reference_wrapper<ProxyEventBindingBase>> event_bindings_;
 
-    /// Mutex which synchronises registration of Proxy service elements via Proxy::RegisterEventBinding with the
+    /// Mutex which synchronises registration of Proxy service elements via Proxy::RegisterEvent with the
     /// FindServiceHandler in find_service_guard_ which will call NotifyServiceInstanceChangedAvailability on all
     /// currently registered Proxy service elements.
     std::mutex proxy_event_registration_mutex_;

--- a/score/mw/com/impl/bindings/lola/proxy_event.h
+++ b/score/mw/com/impl/bindings/lola/proxy_event.h
@@ -73,6 +73,7 @@ class ProxyEvent final : public ProxyEventBinding<SampleType>
           aligned_sample_size_{memory::shared::CalculateAlignedSize(sizeof(SampleType), alignof(SampleType))},
           event_slots_raw_array_{InitialiseEventSlotsRawArray()}
     {
+        parent.RegisterEvent(event_name, *this);
     }
 
     ProxyEvent(const ProxyEvent&) = delete;

--- a/score/mw/com/impl/bindings/lola/proxy_event_test.cpp
+++ b/score/mw/com/impl/bindings/lola/proxy_event_test.cpp
@@ -32,6 +32,21 @@
 
 namespace score::mw::com::impl::lola
 {
+
+class ProxyTestAttorney
+{
+  public:
+    explicit ProxyTestAttorney(Proxy& proxy) : proxy_{proxy} {}
+
+    const std::unordered_map<std::string_view, std::reference_wrapper<ProxyEventBindingBase>>& GetEvents() const
+    {
+        return proxy_.event_bindings_;
+    }
+
+  private:
+    Proxy& proxy_;
+};
+
 namespace
 {
 
@@ -163,6 +178,10 @@ using MyTypes = ::testing::Types<ProxyEventStruct, GenericProxyEventStruct>;
 TYPED_TEST_SUITE(LolaProxyEventFixture, MyTypes, );
 
 template <typename T>
+using LolaProxyEventConstructionFixture = LolaProxyEventFixture<T>;
+TYPED_TEST_SUITE(LolaProxyEventConstructionFixture, MyTypes, );
+
+template <typename T>
 using LolaProxyEventGetNewSamplesFixture = LolaProxyEventFixture<T>;
 TYPED_TEST_SUITE(LolaProxyEventGetNewSamplesFixture, MyTypes, );
 
@@ -173,6 +192,22 @@ TYPED_TEST_SUITE(LolaProxyEventGetNumNewSamplesAvailableFixture, MyTypes, );
 template <typename T>
 using LolaProxyEventDeathTest = LolaProxyEventFixture<T>;
 TYPED_TEST_SUITE(LolaProxyEventDeathTest, MyTypes, );
+
+TYPED_TEST(LolaProxyEventConstructionFixture, ConstructingRegistersEventWithParent)
+{
+    // Given a proxy with an events map which is initially empty
+    auto& events_map = ProxyTestAttorney(*this->proxy_).GetEvents();
+    ASSERT_EQ(events_map.size(), 0U);
+
+    // When constructing a ProxyEvent
+    this->GivenAProxyEvent(this->element_fq_id_, this->event_name_);
+
+    // Then the event should have been registered in the parent Proxy's map of events
+    EXPECT_EQ(events_map.size(), 1U);
+    auto registered_event_it = events_map.find(this->event_name_);
+    EXPECT_NE(registered_event_it, events_map.end());
+    EXPECT_EQ(&registered_event_it->second.get(), &(*this->test_proxy_event_));
+}
 
 TYPED_TEST(LolaProxyEventGetNewSamplesFixture, CallsReceiverForEachAccessibleSample)
 {

--- a/score/mw/com/impl/bindings/lola/proxy_test.cpp
+++ b/score/mw/com/impl/bindings/lola/proxy_test.cpp
@@ -429,14 +429,14 @@ TEST_F(ProxyAutoReconnectFixture, WhenStopFindServiceReturnsErrorOnProxyDestruct
     // Then the program does not terminate
 }
 
-TEST_F(ProxyAutoReconnectFixture, RegisterEventBindingCallsNotifyOnEventWithFalseWhenProviderInitiallyDoesNotExist)
+TEST_F(ProxyAutoReconnectFixture, RegisterEventCallsNotifyOnEventWithFalseWhenProviderInitiallyDoesNotExist)
 {
     const auto valid_find_service_handle = make_FindServiceHandle(10U);
     mock_binding::ProxyEvent<std::uint8_t> proxy_event{};
 
     // Expecting that StartFindService is called but the handler is not called since the provider does not exist
-    ON_CALL(service_discovery_mock_, StartFindService(_, EnrichedInstanceIdentifier{identifier_}))
-        .WillByDefault(Return(valid_find_service_handle));
+    EXPECT_CALL(service_discovery_mock_, StartFindService(_, EnrichedInstanceIdentifier{identifier_}))
+        .WillOnce(Return(valid_find_service_handle));
 
     // Then expecting that NotifyServiceInstanceChangedAvailability is called on the event with is_available false
     const bool is_available{false};
@@ -447,10 +447,10 @@ TEST_F(ProxyAutoReconnectFixture, RegisterEventBindingCallsNotifyOnEventWithFals
     EXPECT_NE(proxy_, nullptr);
 
     // and the ProxyEvent registers itself with the Proxy
-    proxy_->RegisterEventBinding("Event0", proxy_event);
+    proxy_->RegisterEvent("Event0", proxy_event);
 }
 
-TEST_F(ProxyAutoReconnectFixture, RegisterEventBindingCallsNotifyOnEventWithTrueWhenProviderInitiallyExists)
+TEST_F(ProxyAutoReconnectFixture, RegisterEventCallsNotifyOnEventWithTrueWhenProviderInitiallyExists)
 {
     const auto valid_find_service_handle = make_FindServiceHandle(10U);
     mock_binding::ProxyEvent<std::uint8_t> proxy_event{};
@@ -472,10 +472,10 @@ TEST_F(ProxyAutoReconnectFixture, RegisterEventBindingCallsNotifyOnEventWithTrue
     EXPECT_NE(proxy_, nullptr);
 
     // and the ProxyEvent registers itself with the Proxy
-    proxy_->RegisterEventBinding("Event0", proxy_event);
+    proxy_->RegisterEvent("Event0", proxy_event);
 }
 
-TEST_F(ProxyAutoReconnectFixture, RegisterEventBindingCallsNotifyOnEventWithLatestValueFromFindServiceHandler)
+TEST_F(ProxyAutoReconnectFixture, RegisterEventCallsNotifyOnEventWithLatestValueFromFindServiceHandler)
 {
     const auto valid_find_service_handle = make_FindServiceHandle(10U);
     mock_binding::ProxyEvent<std::uint8_t> proxy_event_0{};
@@ -525,14 +525,14 @@ TEST_F(ProxyAutoReconnectFixture, RegisterEventBindingCallsNotifyOnEventWithLate
     EXPECT_NE(proxy_, nullptr);
 
     // and the first ProxyEvent registers itself with the Proxy
-    proxy_->RegisterEventBinding("Event0", proxy_event_0);
+    proxy_->RegisterEvent("Event0", proxy_event_0);
 
     // And then the FindService handler is called with an empty service handle container
     ServiceHandleContainer<HandleType> empty_service_handle_container{};
     saved_find_service_handler(empty_service_handle_container, valid_find_service_handle);
 
     // and the second ProxyEvent registers itself with the Proxy
-    proxy_->RegisterEventBinding("Event1", proxy_event_1);
+    proxy_->RegisterEvent("Event1", proxy_event_1);
 
     // And then the FindService handler is called again with a non-empty service handle container
     ServiceHandleContainer<HandleType> filled_service_handle_container{make_HandleType(identifier_)};
@@ -618,8 +618,8 @@ TEST_F(ProxyEventBindingFixture, RegisteringEventBindingWillCallNotifyServiceIns
     // Expecting that NotifyServiceInstanceChangedAvailability will be called on the binding
     EXPECT_CALL(mock_proxy_event_base_binding, NotifyServiceInstanceChangedAvailability(_, _));
 
-    // When calling RegisterEventBinding
-    proxy_->RegisterEventBinding(kDummyEventName, mock_proxy_event_base_binding);
+    // When calling RegisterEvent
+    proxy_->RegisterEvent(kDummyEventName, mock_proxy_event_base_binding);
 }
 
 TEST_F(ProxyEventBindingFixture,
@@ -638,45 +638,12 @@ TEST_F(ProxyEventBindingFixture,
     InitialiseProxyWithCreate(identifier_);
 
     // and that two bindings are registered
-    proxy_->RegisterEventBinding(kDummyEventName, mock_proxy_event_base_binding);
-    proxy_->RegisterEventBinding("some_other_event", mock_proxy_event_base_binding_2);
+    proxy_->RegisterEvent(kDummyEventName, mock_proxy_event_base_binding);
+    proxy_->RegisterEvent("some_other_event", mock_proxy_event_base_binding_2);
 
     // When the find service handler is called
     const auto find_service_handler = find_service_handler_promise_.get_future().get();
     find_service_handler(ServiceHandleContainer<HandleType>{}, kDummyFindServiceHandle);
-}
-
-TEST_F(ProxyEventBindingFixture,
-       UnregisteringEventBindingAfterRegisteringWillMakeBindingUnavailableToServiceAvailabilityChangeHandler)
-{
-    mock_binding::ProxyEventBase mock_proxy_event_base_binding{};
-
-    // Expecting that NotifyServiceInstanceChangedAvailability will only be called on the binding once when it's
-    // registered and not again when the find service handler is called
-    EXPECT_CALL(mock_proxy_event_base_binding, NotifyServiceInstanceChangedAvailability(_, _));
-
-    // Given a constructed Proxy which registered an event binding
-    WhichCapturesFindServiceHandler(identifier_);
-    InitialiseProxyWithCreate(identifier_);
-    proxy_->RegisterEventBinding(kDummyEventName, mock_proxy_event_base_binding);
-
-    // and then unregistered the event binding
-    proxy_->UnregisterEventBinding(kDummyEventName);
-
-    // When the find service handler is called
-    const auto find_service_handler = find_service_handler_promise_.get_future().get();
-    find_service_handler(ServiceHandleContainer<HandleType>{}, kDummyFindServiceHandle);
-}
-
-TEST_F(ProxyEventBindingFixture, UnregisteringEventBindingBeforeRegisteringWillNotTerminate)
-{
-    // Given a constructed Proxy
-    InitialiseProxyWithCreate(identifier_);
-
-    // When calling UnregisterEventBinding when RegisterEventBinding was never called
-    proxy_->UnregisterEventBinding(kDummyEventName);
-
-    // Then we don't terminate
 }
 
 using ProxyGetEventMetaInfoFixture = ProxyMockedMemoryFixture;

--- a/score/mw/com/impl/bindings/lola/test/proxy_event_test_resources.cpp
+++ b/score/mw/com/impl/bindings/lola/test/proxy_event_test_resources.cpp
@@ -13,6 +13,7 @@
 #include "score/mw/com/impl/bindings/lola/test/proxy_event_test_resources.h"
 
 #include "score/memory/shared/memory_resource_registry.h"
+#include "score/mw/com/impl/find_service_handle.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -126,7 +127,18 @@ void ProxyMockedMemoryFixture::InitialiseProxyWithConstructor(const InstanceIden
 {
     EnrichedInstanceIdentifier enriched_instance_identifier{instance_identifier};
     ON_CALL(service_discovery_mock_, StartFindService(_, enriched_instance_identifier))
-        .WillByDefault(Return(make_FindServiceHandle(10U)));
+        .WillByDefault(
+            testing::WithArg<0>(testing::Invoke([this](auto find_service_handler) -> Result<FindServiceHandle> {
+                // In practice, if a service is available at the point in time when the Proxy is created then the find
+                // service handler will be called synchronously in the StartFindService call. We simulate this here by
+                // calling the handler with a handle.
+                auto find_service_handle = make_FindServiceHandle(10U);
+                auto handle = make_HandleType(identifier_);
+                auto found_service_handle_container = ServiceHandleContainer<HandleType>{handle};
+
+                std::invoke(find_service_handler, found_service_handle_container, find_service_handle);
+                return find_service_handle;
+            })));
 
     Proxy::EventNameToElementFqIdConverter event_name_to_element_fq_id_converter{lola_service_deployment_,
                                                                                  lola_service_instance_id_.GetId()};

--- a/score/mw/com/impl/bindings/mock_binding/proxy.h
+++ b/score/mw/com/impl/bindings/mock_binding/proxy.h
@@ -29,8 +29,6 @@ class Proxy : public ProxyBinding
     ~Proxy() override = default;
 
     MOCK_METHOD(bool, IsEventProvided, (const std::string_view), (const, noexcept, override));
-    MOCK_METHOD(void, RegisterEventBinding, (std::string_view, ProxyEventBindingBase&), (noexcept, override));
-    MOCK_METHOD(void, UnregisterEventBinding, (std::string_view), (noexcept, override));
     MOCK_METHOD(Result<void>, SetupMethods, (), (override));
     MOCK_METHOD(void, PrepareDeinitialize, (), (override));
     MOCK_METHOD(void, FinalizeDeinitialize, (), (override));
@@ -45,17 +43,6 @@ class ProxyFacade : public ProxyBinding
     bool IsEventProvided(const std::string_view event_name) const noexcept override
     {
         return proxy_.IsEventProvided(event_name);
-    }
-
-    void RegisterEventBinding(const std::string_view service_element_name,
-                              ProxyEventBindingBase& proxy_event_binding) noexcept override
-    {
-        proxy_.RegisterEventBinding(service_element_name, proxy_event_binding);
-    }
-
-    void UnregisterEventBinding(const std::string_view service_element_name) noexcept override
-    {
-        proxy_.UnregisterEventBinding(service_element_name);
     }
 
     Result<void> SetupMethods() override
@@ -76,6 +63,7 @@ class ProxyFacade : public ProxyBinding
   private:
     Proxy& proxy_;
 };
+
 }  // namespace score::mw::com::impl::mock_binding
 
 #endif  // SCORE_MW_COM_IMPL_BINDINGS_MOCK_BINDING_PROXY_H

--- a/score/mw/com/impl/proxy_binding.h
+++ b/score/mw/com/impl/proxy_binding.h
@@ -54,13 +54,6 @@ class ProxyBinding
     /// \return True if the event name exists, otherwise, false
     virtual bool IsEventProvided(const std::string_view event_name) const noexcept = 0;
 
-    /// Registers a ProxyEvent binding with its parent proxy
-    virtual void RegisterEventBinding(const std::string_view service_element_name,
-                                      ProxyEventBindingBase& proxy_event_binding) noexcept = 0;
-
-    /// Unregisters a ProxyEvent binding with its parent proxy
-    virtual void UnregisterEventBinding(const std::string_view service_element_name) noexcept = 0;
-
     virtual Result<void> SetupMethods() = 0;
 
     /// \brief Contains all cleanup logic for the binding that needs to be executed before any of the service elements

--- a/score/mw/com/impl/proxy_binding_test.cpp
+++ b/score/mw/com/impl/proxy_binding_test.cpp
@@ -29,8 +29,6 @@ class MyProxy final : public ProxyBinding
     {
         return true;
     }
-    void RegisterEventBinding(std::string_view, ProxyEventBindingBase&) noexcept override {}
-    void UnregisterEventBinding(std::string_view) noexcept override {}
     Result<void> SetupMethods() override
     {
         return {};

--- a/score/mw/com/impl/proxy_event_base.cpp
+++ b/score/mw/com/impl/proxy_event_base.cpp
@@ -34,45 +34,6 @@ namespace score::mw::com::impl
 // Initialization of static thread_local variables!
 thread_local bool ProxyEventBase::is_in_receive_handler_context = false;
 
-/// \brief Helper class which registers the ProxyEventBindingBase with its parent proxy (ProxyBinding) and unregisters
-/// on destruction
-///
-/// Since ProxyBase is moveable, we must ensure that this class does not store a reference or pointer to it. As if the
-/// Proxy is moved, then the pointer or reference would be invalidated. However, the ProxyBinding is not moveable, so
-/// storing a pointer to the ProxyBinding is safe.
-class EventBindingRegistrationGuard final
-{
-  public:
-    EventBindingRegistrationGuard(ProxyBinding* proxy_binding,
-                                  ProxyEventBindingBase* proxy_event_binding_base,
-                                  std::string_view event_name) noexcept
-        : proxy_binding_{proxy_binding}, proxy_event_binding_base_{proxy_event_binding_base}, event_name_{event_name}
-    {
-        if ((proxy_binding_ != nullptr) && (proxy_event_binding_base_ != nullptr))
-        {
-            proxy_binding_->RegisterEventBinding(event_name, *proxy_event_binding_base);
-        }
-    }
-
-    ~EventBindingRegistrationGuard() noexcept
-    {
-        if ((proxy_binding_ != nullptr) && (proxy_event_binding_base_ != nullptr))
-        {
-            proxy_binding_->UnregisterEventBinding(event_name_);
-        }
-    }
-
-    EventBindingRegistrationGuard(const EventBindingRegistrationGuard&) = delete;
-    EventBindingRegistrationGuard& operator=(const EventBindingRegistrationGuard&) = delete;
-    EventBindingRegistrationGuard(EventBindingRegistrationGuard&& other) = delete;
-    EventBindingRegistrationGuard& operator=(EventBindingRegistrationGuard&& other) = delete;
-
-  private:
-    ProxyBinding* proxy_binding_;
-    ProxyEventBindingBase* proxy_event_binding_base_;
-    std::string_view event_name_;
-};
-
 // Suppress "AUTOSAR C++14 A3-1-1", The rule states: "It shall be possible to include any header file
 // in multiple translation units without violating the One Definition Rule."
 // This is false positive. Function is declared only once.
@@ -86,8 +47,6 @@ ProxyEventBase::ProxyEventBase(std::string_view event_name,
       event_name_{event_name},
       tracker_{std::make_unique<SampleReferenceTracker>()},
       tracing_data_{},
-      event_binding_registration_guard_{
-          std::make_unique<EventBindingRegistrationGuard>(proxy_binding_ptr, binding_base_.get(), event_name)},
       proxy_event_base_mock_{nullptr},
       is_subscribed_flag_{false},
       receive_handler_scope_{}

--- a/score/mw/com/impl/proxy_event_base.h
+++ b/score/mw/com/impl/proxy_event_base.h
@@ -35,8 +35,6 @@
 namespace score::mw::com::impl
 {
 
-class EventBindingRegistrationGuard;
-
 /// \brief This is the user-visible class of an event that is part of a proxy. It contains ProxyEvent functionality that
 /// is agnostic of the data type that is transferred by the event.
 ///
@@ -187,8 +185,6 @@ class ProxyEventBase : public EnableReferenceToMoveableFromThis<ProxyEventBase>
     std::unique_ptr<SampleReferenceTracker> tracker_;
     // coverity[autosar_cpp14_m11_0_1_violation]
     tracing::ProxyEventTracingData tracing_data_;
-    // coverity[autosar_cpp14_m11_0_1_violation]
-    std::unique_ptr<EventBindingRegistrationGuard> event_binding_registration_guard_;
 
     IProxyEventBase* proxy_event_base_mock_;
 

--- a/score/mw/com/impl/proxy_event_base_test.cpp
+++ b/score/mw/com/impl/proxy_event_base_test.cpp
@@ -205,51 +205,6 @@ TYPED_TEST(ProxyEventBaseCreationFixture, CreatingServiceElementWithInvalidProxy
     EXPECT_FALSE(dummy_proxy.AreBindingsValid());
 }
 
-TYPED_TEST(ProxyEventBaseCreationFixture,
-           CreatingServiceElementWithValidProxyEventBindingWillRegisterAndUnregisterEventBinding)
-{
-    auto valid_proxy_binding = std::make_unique<mock_binding::Proxy>();
-    auto valid_proxy_event_binding =
-        std::make_unique<typename ProxyEventBaseCreationFixture<TypeParam>::MockServiceElementType>();
-
-    auto* const mock_proxy_binding = valid_proxy_binding.get();
-    ProxyEventBindingBase* const mock_proxy_event_binding = valid_proxy_event_binding.get();
-
-    // Expecting that the ProxyEvent will register and unregister itself with the parent Proxy
-    EXPECT_CALL(*mock_proxy_binding, RegisterEventBinding(kEventName, Ref(*mock_proxy_event_binding)));
-    EXPECT_CALL(*mock_proxy_binding, UnregisterEventBinding(kEventName));
-
-    // Given a proxy with a valid binding
-    DummyProxy dummy_proxy(std::move(valid_proxy_binding),
-                           make_HandleType(make_InstanceIdentifier(kEmptyInstanceDeployment, kEmptyTypeDeployment)));
-
-    // When creating a ProxyEvent with a valid binding
-    auto service_element = std::make_unique<typename ProxyEventBaseCreationFixture<TypeParam>::ServiceElementType>(
-        dummy_proxy, kEventName, std::move(valid_proxy_event_binding));
-}
-
-TYPED_TEST(ProxyEventBaseCreationFixture,
-           CreatingServiceElementWithInvalidProxyEventBindingWillNotRegisterOrUnregisterEventBinding)
-{
-    auto valid_proxy_binding = std::make_unique<mock_binding::Proxy>();
-
-    auto* const mock_proxy_binding = valid_proxy_binding.get();
-
-    // Expecting that the ProxyEvent will not register itself with the parent Proxy
-    EXPECT_CALL(*mock_proxy_binding, RegisterEventBinding(_, _)).Times(0);
-    EXPECT_CALL(*mock_proxy_binding, UnregisterEventBinding(_)).Times(0);
-
-    // Given a proxy with a valid binding
-    DummyProxy dummy_proxy(std::move(valid_proxy_binding),
-                           make_HandleType(make_InstanceIdentifier(kEmptyInstanceDeployment, kEmptyTypeDeployment)));
-
-    // When creating a ProxyEvent with an invalid binding
-    auto service_element = std::make_unique<typename ProxyEventBaseCreationFixture<TypeParam>::ServiceElementType>(
-        dummy_proxy,
-        kEventName,
-        std::unique_ptr<typename ProxyEventBaseCreationFixture<TypeParam>::MockServiceElementType>(nullptr));
-}
-
 TYPED_TEST(ProxyEventBaseUnsubscribeFixture, CallingUnsubscribeWhileSubscribedCallsUnsubscribeOnBinding)
 {
     this->RecordProperty("Verifies", "SCR-14033377, SCR-17292399, SCR-14137271, SCR-21286218");


### PR DESCRIPTION
Previously, ProxyBase::AreBindingsValid was implemented differently to avoid have to store a map of service elements (which also requires updating the map when moving a Proxy) in ProxyBase. However, we have since added these maps so there's no longer any reason to have the asymmetry in the implementations of AreBindingsValid.