### PR TITLE
Migrate to rulesfs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -52,7 +52,7 @@ common:linux_aarch64_score_gcc_12_2_0_posix --extra_toolchains=@score_toolchains
 # the acceptance page once.
 common:qnx_x86_64 --credential_helper_timeout="60s" # QNX credential helper can be slow
 common:qnx_x86_64 --platforms=@score_bazel_platforms//:x86_64-qnx-sdp_8.0.0-posix
-common:qnx_x86_64 --extra_toolchains=@toolchains_qnx_ifs//:ifs_x86_64
+common:qnx_x86_64 --extra_toolchains=@score_qnx_x86_64_ifs_toolchain//:ifs-x86_64-qnx-sdp_8.0.0
 common:qnx_x86_64 --extra_toolchains=@score_qcc_x86_64_toolchain//:x86_64-qnx-sdp_8.0.0
 common:qnx_x86_64 --extra_toolchains=@score_toolchains_rust//toolchains/ferrocene:ferrocene_x86_64_pc_nto_qnx800
 common:qnx_x86_64 --credential_helper=*.qnx.com=%workspace%/third_party/qnx_credential_helper.py
@@ -60,7 +60,7 @@ common:qnx_x86_64 --sandbox_writable_path=/var/tmp
 
 common:qnx_arm64 --credential_helper_timeout="60s" # QNX credential helper can be slow
 common:qnx_arm64 --platforms=@score_bazel_platforms//:aarch64-qnx-sdp_8.0.0-posix
-common:qnx_arm64 --extra_toolchains=@toolchains_qnx_ifs//:ifs_aarch64
+common:qnx_arm64 --extra_toolchains=@score_qnx_aarch64_ifs_toolchain//:ifs-aarch64-qnx-sdp_8.0.0
 common:qnx_arm64 --extra_toolchains=@score_qcc_aarch64_toolchain//:aarch64-qnx-sdp_8.0.0
 common:qnx_arm64 --extra_toolchains=@score_toolchains_rust//toolchains/ferrocene:ferrocene_aarch64_unknown_nto_qnx800
 common:qnx_arm64 --credential_helper=*.qnx.com=%workspace%/third_party/qnx_credential_helper.py

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -112,26 +112,30 @@ use_repo(
     "score_gcc_aarch64_toolchain",
     "score_gcc_x86_64_toolchain",
     "score_qcc_aarch64_toolchain",
+    "score_qcc_aarch64_toolchain_pkg",
     "score_qcc_x86_64_toolchain",
+    "score_qcc_x86_64_toolchain_pkg",
 )
 
 bazel_dep(name = "score_itf", version = "0.3.0", dev_dependency = True)
+bazel_dep(name = "score_rules_imagefs", version = "0.0.3", dev_dependency = True)
 
-# For the moment we still need the old toolchain for ifs generation.
-# Migrate once rules_imagefs is ready to be used (https://github.com/eclipse-score/rules_imagefs/pull/1).
-bazel_dep(name = "score_toolchains_qnx", version = "0.0.7", dev_dependency = True)
-
-toolchains_qnx = use_extension(
-    "@score_toolchains_qnx//:extensions.bzl",
-    "toolchains_qnx",
-    dev_dependency = True,
+imagefs = use_extension("@score_rules_imagefs//extensions:imagefs.bzl", "imagefs", dev_dependency = True)
+imagefs.toolchain(
+    name = "score_qnx_x86_64_ifs_toolchain",
+    sdp_to_import = "@score_qcc_x86_64_toolchain_pkg",
+    target_cpu = "x86_64",
+    target_os = "qnx",
+    type = "ifs",
 )
-toolchains_qnx.sdp(
-    sha256 = "9039fd6a4a639f06ea977afb93963a6fe8f8c46db727066709370d999c7232e0",
-    strip_prefix = "",
-    url = "https://www.qnx.com/download/download/87174/installation_qnx_803_260305.tar.xz",
+imagefs.toolchain(
+    name = "score_qnx_aarch64_ifs_toolchain",
+    sdp_to_import = "@score_qcc_aarch64_toolchain_pkg",
+    target_cpu = "aarch64",
+    target_os = "qnx",
+    type = "ifs",
 )
-use_repo(toolchains_qnx, "toolchains_qnx_ifs")
+use_repo(imagefs, "score_qnx_aarch64_ifs_toolchain", "score_qnx_x86_64_ifs_toolchain")
 
 bazel_dep(name = "toolchains_llvm", version = "1.5.0", dev_dependency = True)
 

--- a/quality/integration_testing/environments/qnx8_qemu/BUILD
+++ b/quality/integration_testing/environments/qnx8_qemu/BUILD
@@ -11,7 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_files")
 
 filegroup(
     name = "init_build",
@@ -30,9 +30,9 @@ filegroup(
     visibility = ["//:__subpackages__"],
 )
 
-pkg_tar(
+pkg_files(
     name = "qnx_config",
     srcs = ["qcrypto.conf"],
-    package_dir = "/etc",
+    prefix = "/etc",
     visibility = ["//:__subpackages__"],
 )

--- a/quality/integration_testing/environments/qnx8_qemu/init_x86_64.build
+++ b/quality/integration_testing/environments/qnx8_qemu/init_x86_64.build
@@ -407,9 +407,3 @@ UseDNS no
 MaxAuthTries 3
 LoginGraceTime 30
 }
-
-# Package provided filesystem to root
-/=${FOLDER}
-
-# QEMU environment configuration (qcrypto.conf for the random service)
-/etc/qcrypto.conf=${QEMU_CONFIG}/etc/qcrypto.conf

--- a/quality/integration_testing/integration_testing.bzl
+++ b/quality/integration_testing/integration_testing.bzl
@@ -12,8 +12,9 @@
 # *******************************************************************************
 
 load("@rules_oci//oci:defs.bzl", "oci_image", "oci_load")
+load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("@score_itf//:defs.bzl", "py_itf_test")
-load("@score_toolchains_qnx//rules/fs:ifs.bzl", "qnx_ifs")
+load("@score_rules_imagefs//rules/qnx:ifs.bzl", "qnx_ifs")
 
 def _extend_list_in_kwargs(kwargs, key, values):
     kwargs[key] = kwargs.get(key, []) + values
@@ -39,6 +40,11 @@ def integration_test(name, srcs, filesystem, **kwargs):
         "@platforms//os:linux",
     ]
 
+    pkg_tar(
+        name = "_oci_filesystem_{}".format(name),
+        srcs = [filesystem],
+    )
+
     oci_image(
         name = image_name,
         architecture = select({
@@ -51,7 +57,7 @@ def integration_test(name, srcs, filesystem, **kwargs):
             "//quality/sanitizer/flags:any_sanitizer": "//quality/sanitizer:absolute_env",
         }),
         tars = [
-            filesystem,
+            "_oci_filesystem_{}".format(name),
         ] + select({
             "//quality/sanitizer/flags:none": [],
             "//quality/sanitizer/flags:any_sanitizer": ["//quality/sanitizer:suppressions_pkg"],
@@ -80,10 +86,7 @@ def integration_test(name, srcs, filesystem, **kwargs):
         name = qemu_image,
         out = "init_ifs_{}".format(name),
         build_file = "//quality/integration_testing/environments/qnx8_qemu:init_build",
-        tars = {
-            "FOLDER": filesystem,
-            "QEMU_CONFIG": "//quality/integration_testing/environments/qnx8_qemu:qnx_config",
-        },
+        srcs = [filesystem, "//quality/integration_testing/environments/qnx8_qemu:qnx_config"],
         target_compatible_with = QNX_TARGET_COMPATIBLE_WITH,
     )
 

--- a/quality/integration_testing/test/BUILD
+++ b/quality/integration_testing/test/BUILD
@@ -11,7 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_attributes", "pkg_files")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
 
 cc_binary(
@@ -24,12 +24,16 @@ cc_binary(
     srcs = ["main2.cpp"],
 )
 
-pkg_tar(
+pkg_files(
     name = "example-app-pkg",
     srcs = [
         ":example-app",
         ":example-app2",
     ],
+    attributes = pkg_attributes(
+        mode = "0777",
+    ),
+    prefix = "/",
 )
 
 integration_test(

--- a/score/mw/com/test/basic_rust_api/consumer_async_apis/integration_test/BUILD
+++ b/score/mw/com/test/basic_rust_api/consumer_async_apis/integration_test/BUILD
@@ -10,15 +10,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/basic_rust_api/consumer_async_apis:bigdata-com-api-async-pkg",
-    ],
-)
 
 integration_test(
     name = "test_com_api_async",
@@ -26,5 +18,5 @@ integration_test(
     srcs = [
         "com_api_async_api_test.py",
     ],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/basic_rust_api/consumer_async_apis:bigdata-com-api-async-pkg",
 )

--- a/score/mw/com/test/basic_rust_api/consumer_sync_apis/integration_test/BUILD
+++ b/score/mw/com/test/basic_rust_api/consumer_sync_apis/integration_test/BUILD
@@ -10,15 +10,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/basic_rust_api/consumer_sync_apis:bigdata-com-api-sync-pkg",
-    ],
-)
 
 integration_test(
     name = "test_com_api_sync",
@@ -26,5 +18,5 @@ integration_test(
     srcs = [
         "com_api_sync_api_test.py",
     ],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/basic_rust_api/consumer_sync_apis:bigdata-com-api-sync-pkg",
 )

--- a/score/mw/com/test/bigdata/integration_test/BUILD
+++ b/score/mw/com/test/bigdata/integration_test/BUILD
@@ -10,15 +10,7 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/bigdata:bigdata-pkg",
-    ],
-)
 
 integration_test(
     name = "test_bigdata_exchange",
@@ -26,5 +18,5 @@ integration_test(
     srcs = [
         "test_bigdata.py",
     ],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/bigdata:bigdata-pkg",
 )

--- a/score/mw/com/test/check_values_created_from_config/integration_test/BUILD
+++ b/score/mw/com/test/check_values_created_from_config/integration_test/BUILD
@@ -11,19 +11,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/check_values_created_from_config:check_values_created_from_config-pkg",
-    ],
-)
 
 integration_test(
     name = "test_check_values_created_from_config",
     timeout = "moderate",
     srcs = ["test_check_values_created_from_config.py"],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/check_values_created_from_config:check_values_created_from_config-pkg",
 )

--- a/score/mw/com/test/concurrent_skeleton_creation/integration_test/BUILD
+++ b/score/mw/com/test/concurrent_skeleton_creation/integration_test/BUILD
@@ -11,19 +11,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/concurrent_skeleton_creation:concurrent_skeleton_creation-pkg",
-    ],
-)
 
 integration_test(
     name = "concurrent_skeleton_creation",
     timeout = "moderate",
     srcs = ["test_concurrent_skeleton_creation.py"],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/concurrent_skeleton_creation:concurrent_skeleton_creation-pkg",
 )

--- a/score/mw/com/test/data_slots_read_only/integration_test/BUILD
+++ b/score/mw/com/test/data_slots_read_only/integration_test/BUILD
@@ -11,19 +11,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/data_slots_read_only:data_slots_read_only-pkg",
-    ],
-)
 
 integration_test(
     name = "data_slots_read_only",
     timeout = "moderate",
     srcs = ["test_data_slots_read_only.py"],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/data_slots_read_only:data_slots_read_only-pkg",
 )

--- a/score/mw/com/test/field_initial_value/integration_test/BUILD
+++ b/score/mw/com/test/field_initial_value/integration_test/BUILD
@@ -10,12 +10,12 @@
 #
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
 
-pkg_tar(
+pkg_filegroup(
     name = "filesystem",
-    deps = [
+    srcs = [
         "//score/mw/com/test/field_initial_value:client-pkg",
         "//score/mw/com/test/field_initial_value:service-pkg",
     ],

--- a/score/mw/com/test/find_any_semantics/integration_test/BUILD
+++ b/score/mw/com/test/find_any_semantics/integration_test/BUILD
@@ -11,12 +11,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
 
-pkg_tar(
+pkg_filegroup(
     name = "filesystem",
-    deps = [
+    srcs = [
         "//score/mw/com/test/find_any_semantics:client-pkg",
         "//score/mw/com/test/find_any_semantics:service-pkg",
     ],

--- a/score/mw/com/test/generic_proxy/integration_test/BUILD
+++ b/score/mw/com/test/generic_proxy/integration_test/BUILD
@@ -11,19 +11,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/generic_proxy:generic_proxy-pkg",
-    ],
-)
 
 integration_test(
     name = "generic_proxy",
     timeout = "moderate",
     srcs = ["test_generic_proxy.py"],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/generic_proxy:generic_proxy-pkg",
 )

--- a/score/mw/com/test/inotify/integration_test/BUILD
+++ b/score/mw/com/test/inotify/integration_test/BUILD
@@ -11,18 +11,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/inotify:inotify-test-pkg",
-    ],
-)
 
 integration_test(
     name = "inotify",
     srcs = ["test_inotify.py"],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/inotify:inotify-test-pkg",
 )

--- a/score/mw/com/test/methods/basic_acceptance_test/integration_test/BUILD
+++ b/score/mw/com/test/methods/basic_acceptance_test/integration_test/BUILD
@@ -11,27 +11,20 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "same_processes_filesystem",
-    deps = [
-        "//score/mw/com/test/methods/basic_acceptance_test:main_consumer_and_provider-pkg",
-    ],
-)
 
 integration_test(
     name = "basic_acceptance_same_process_test",
     srcs = [
         "basic_acceptance_same_process_test.py",
     ],
-    filesystem = ":same_processes_filesystem",
+    filesystem = "//score/mw/com/test/methods/basic_acceptance_test:main_consumer_and_provider-pkg",
 )
 
-pkg_tar(
+pkg_filegroup(
     name = "different_processes_filesystem",
-    deps = [
+    srcs = [
         "//score/mw/com/test/methods/basic_acceptance_test:main_consumer-pkg",
         "//score/mw/com/test/methods/basic_acceptance_test:main_provider-pkg",
     ],

--- a/score/mw/com/test/methods/non_trivial_constructors/integration_test/BUILD
+++ b/score/mw/com/test/methods/non_trivial_constructors/integration_test/BUILD
@@ -11,12 +11,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
 
-pkg_tar(
+pkg_filegroup(
     name = "filesystem",
-    deps = [
+    srcs = [
         "//score/mw/com/test/methods/non_trivial_constructors:main_consumer-pkg",
         "//score/mw/com/test/methods/non_trivial_constructors:main_provider-pkg",
     ],

--- a/score/mw/com/test/methods/signature_variations/integration_test/BUILD
+++ b/score/mw/com/test/methods/signature_variations/integration_test/BUILD
@@ -11,12 +11,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
 
-pkg_tar(
+pkg_filegroup(
     name = "filesystem",
-    deps = [
+    srcs = [
         "//score/mw/com/test/methods/signature_variations:main_consumer-pkg",
         "//score/mw/com/test/methods/signature_variations:main_provider-pkg",
     ],

--- a/score/mw/com/test/multiple_proxies/integration_test/BUILD
+++ b/score/mw/com/test/multiple_proxies/integration_test/BUILD
@@ -11,19 +11,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/multiple_proxies:multiple_proxies-pkg",
-    ],
-)
 
 integration_test(
     name = "multiple_proxies",
     timeout = "moderate",
     srcs = ["test_multiple_proxies.py"],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/multiple_proxies:multiple_proxies-pkg",
 )

--- a/score/mw/com/test/partial_restart/checks_number_of_allocations/integration_test/BUILD
+++ b/score/mw/com/test/partial_restart/checks_number_of_allocations/integration_test/BUILD
@@ -11,19 +11,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/partial_restart/checks_number_of_allocations:check_number_of_allocations-pkg",
-    ],
-)
 
 integration_test(
     name = "check_number_of_allocations",
     timeout = "moderate",
     srcs = ["test_check_number_of_allocations.py"],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/partial_restart/checks_number_of_allocations:check_number_of_allocations-pkg",
 )

--- a/score/mw/com/test/partial_restart/consumer_restart/integration_test/BUILD
+++ b/score/mw/com/test/partial_restart/consumer_restart/integration_test/BUILD
@@ -11,15 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/partial_restart/consumer_restart:consumer_restart-pkg",
-    ],
-)
 
 integration_test(
     name = "consumer_restart_graceful",
@@ -28,7 +20,7 @@ integration_test(
         "consumer_restart_test_fixture.py",
         "test_consumer_restart_graceful.py",
     ],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/partial_restart/consumer_restart:consumer_restart-pkg",
     # Disabled for thread sanitizer because of detected race (Ticket-246892)
     target_compatible_with = ["//quality/sanitizer/constraints:no_tsan"],
 )
@@ -40,7 +32,7 @@ integration_test(
         "consumer_restart_test_fixture.py",
         "test_consumer_restart_kill.py",
     ],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/partial_restart/consumer_restart:consumer_restart-pkg",
     # Flaky: after SIGKILL, CreateNewClient may not reach kReady within its
     # 500 ms budget under ASAN/LSan, causing the fire-and-forget
     # RegisterEventNotificationMessage to fail.  The consumer then waits

--- a/score/mw/com/test/partial_restart/provider_restart/integration_test/BUILD
+++ b/score/mw/com/test/partial_restart/provider_restart/integration_test/BUILD
@@ -11,15 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/partial_restart/provider_restart:provider_restart-pkg",
-    ],
-)
 
 integration_test(
     name = "provider_restart_graceful_no_proxy",
@@ -28,7 +20,7 @@ integration_test(
         "provider_restart_test_fixture.py",
         "test_provider_restart_graceful_no_proxy.py",
     ],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/partial_restart/provider_restart:provider_restart-pkg",
     # Disabled for thread sanitizer because of detected race (Ticket-246892)
     target_compatible_with = ["//quality/sanitizer/constraints:no_tsan"],
 )
@@ -40,7 +32,7 @@ integration_test(
         "provider_restart_test_fixture.py",
         "test_provider_restart_graceful.py",
     ],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/partial_restart/provider_restart:provider_restart-pkg",
     # Disabled for thread sanitizer because of detected race (Ticket-246892)
     target_compatible_with = ["//quality/sanitizer/constraints:no_tsan"],
 )
@@ -52,7 +44,7 @@ integration_test(
         "provider_restart_test_fixture.py",
         "test_provider_restart_kill_no_proxy.py",
     ],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/partial_restart/provider_restart:provider_restart-pkg",
     # Disabled for thread sanitizer because of detected race (Ticket-246892)
     target_compatible_with = ["//quality/sanitizer/constraints:no_tsan"],
 )
@@ -64,7 +56,7 @@ integration_test(
         "provider_restart_test_fixture.py",
         "test_provider_restart_kill.py",
     ],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/partial_restart/provider_restart:provider_restart-pkg",
     # Disabled for thread sanitizer because of detected race (Ticket-246892)
     target_compatible_with = ["//quality/sanitizer/constraints:no_tsan"],
 )

--- a/score/mw/com/test/partial_restart/provider_restart_max_subscribers/integration_test/BUILD
+++ b/score/mw/com/test/partial_restart/provider_restart_max_subscribers/integration_test/BUILD
@@ -11,15 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/partial_restart/provider_restart_max_subscribers:provider_restart_max_subscribers-pkg",
-    ],
-)
 
 integration_test(
     name = "provider_restart_max_subscribers_no_proxy",
@@ -28,7 +20,7 @@ integration_test(
         "provider_restart_max_subscribers_test_fixture.py",
         "test_provider_restart_max_subscribers_no_proxy.py",
     ],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/partial_restart/provider_restart_max_subscribers:provider_restart_max_subscribers-pkg",
     # Disabled for thread sanitizer because of detected race (Ticket-246892)
     target_compatible_with = ["//quality/sanitizer/constraints:no_tsan"],
 )
@@ -40,7 +32,7 @@ integration_test(
         "provider_restart_max_subscribers_test_fixture.py",
         "test_provider_restart_max_subscribers_with_proxy.py",
     ],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/partial_restart/provider_restart_max_subscribers:provider_restart_max_subscribers-pkg",
     # Disabled for thread sanitizer because of detected race (Ticket-246892)
     target_compatible_with = ["//quality/sanitizer/constraints:no_tsan"],
 )

--- a/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/integration_test/BUILD
+++ b/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/integration_test/BUILD
@@ -11,15 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies:proxy_restart_shall_not_affect_other_proxies-pkg",
-    ],
-)
 
 integration_test(
     name = "proxy_restart_shall_not_affect_other_proxies_graceful",
@@ -28,7 +20,7 @@ integration_test(
         "proxy_restart_shall_not_affect_other_proxies_test_fixture.py",
         "test_proxy_restart_shall_not_affect_other_proxies_graceful.py",
     ],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies:proxy_restart_shall_not_affect_other_proxies-pkg",
 )
 
 integration_test(
@@ -38,5 +30,5 @@ integration_test(
         "proxy_restart_shall_not_affect_other_proxies_test_fixture.py",
         "test_proxy_restart_shall_not_affect_other_proxies_kill.py",
     ],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies:proxy_restart_shall_not_affect_other_proxies-pkg",
 )

--- a/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/integration_test/proxy_restart_shall_not_affect_other_proxies_test_fixture.py
+++ b/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/integration_test/proxy_restart_shall_not_affect_other_proxies_test_fixture.py
@@ -15,7 +15,7 @@
 def proxy_restart_shall_not_affect_other_proxies(target, number_of_consumer_restarts, kill_consumer, **kwargs):
     args = ["--kill", f"{kill_consumer}", "--number-consumer-restarts", f"{number_of_consumer_restarts}"]
     return target.wrap_exec(
-        "bin/proxy_restart_shall_not_affect_other_proxies",
+        "./bin/proxy_restart_shall_not_affect_other_proxies",
         args,
         cwd="/opt/proxy_restart_shall_not_affect_other_proxies",
         wait_on_exit=True,

--- a/score/mw/com/test/pkg_application.bzl
+++ b/score/mw/com/test/pkg_application.bzl
@@ -39,11 +39,12 @@ def pkg_application(name, app_name, bin = [], etc = [], etc_deps = [], **kwargs)
         prefix = "/opt/{}/etc".format(app_name),
     )
 
-    pkg_tar(
+    pkg_filegroup(
         name = name,
         srcs = [
             "{}_binary".format(name),
             "{}_etc".format(name),
         ],
+        prefix = "/",
         **kwargs
     )

--- a/score/mw/com/test/receive_handler_unsubscribe/integration_test/BUILD
+++ b/score/mw/com/test/receive_handler_unsubscribe/integration_test/BUILD
@@ -11,19 +11,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/receive_handler_unsubscribe:receive_handler_unsubscribe-pkg",
-    ],
-)
 
 integration_test(
     name = "receive_handler_unsubscribe",
     timeout = "moderate",
     srcs = ["test_receive_handler_unsubscribe.py"],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/receive_handler_unsubscribe:receive_handler_unsubscribe-pkg",
 )

--- a/score/mw/com/test/receive_handler_usage/integration_test/BUILD
+++ b/score/mw/com/test/receive_handler_usage/integration_test/BUILD
@@ -11,19 +11,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/receive_handler_usage:receive_handler_usage-pkg",
-    ],
-)
 
 integration_test(
     name = "test_receive_handler_usage",
     timeout = "moderate",
     srcs = ["test_receive_handler_usage.py"],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/receive_handler_usage:receive_handler_usage-pkg",
 )

--- a/score/mw/com/test/reserving_skeleton_slots/integration_test/BUILD
+++ b/score/mw/com/test/reserving_skeleton_slots/integration_test/BUILD
@@ -11,19 +11,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/reserving_skeleton_slots:reserving_skeleton_slots-pkg",
-    ],
-)
 
 integration_test(
     name = "reserving_skeleton_slots",
     timeout = "moderate",
     srcs = ["test_reserving_skeleton_slots.py"],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/reserving_skeleton_slots:reserving_skeleton_slots-pkg",
 )

--- a/score/mw/com/test/separate_reception_threads/integration_test/BUILD
+++ b/score/mw/com/test/separate_reception_threads/integration_test/BUILD
@@ -11,19 +11,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/separate_reception_threads:separate_reception_threads-pkg",
-    ],
-)
 
 integration_test(
     name = "separate_reception_threads",
     timeout = "moderate",
     srcs = ["test_separate_reception_threads.py"],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/separate_reception_threads:separate_reception_threads-pkg",
 )

--- a/score/mw/com/test/service_discovery_during_consumer_crash/integration_test/BUILD
+++ b/score/mw/com/test/service_discovery_during_consumer_crash/integration_test/BUILD
@@ -11,7 +11,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
 
 # NOTE: This target requires visibility fix in the main BUILD file
@@ -22,14 +21,7 @@ integration_test(
     name = "service_discovery_during_consumer_crash",
     timeout = "moderate",
     srcs = ["test_service_discovery_during_consumer_crash.py"],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/service_discovery_during_consumer_crash:service_discovery_during_consumer_crash-pkg",
     # Disabled for thread sanitizer because of detected race (Ticket-246892)
     target_compatible_with = ["//quality/sanitizer/constraints:no_tsan"],
-)
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/service_discovery_during_consumer_crash:service_discovery_during_consumer_crash-pkg",
-    ],
 )

--- a/score/mw/com/test/service_discovery_during_provider_crash/integration_test/BUILD
+++ b/score/mw/com/test/service_discovery_during_provider_crash/integration_test/BUILD
@@ -11,7 +11,6 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
 
 # NOTE: This target requires visibility fix in the main BUILD file
@@ -22,12 +21,5 @@ integration_test(
     name = "service_discovery_during_provider_crash",
     timeout = "moderate",
     srcs = ["test_service_discovery_during_provider_crash.py"],
-    filesystem = ":filesystem",
-)
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/service_discovery_during_provider_crash:service_discovery_during_provider_crash-pkg",
-    ],
+    filesystem = "//score/mw/com/test/service_discovery_during_provider_crash:service_discovery_during_provider_crash-pkg",
 )

--- a/score/mw/com/test/service_discovery_offer_and_search/integration_test/BUILD
+++ b/score/mw/com/test/service_discovery_offer_and_search/integration_test/BUILD
@@ -11,12 +11,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
 
-pkg_tar(
+pkg_filegroup(
     name = "filesystem",
-    deps = [
+    srcs = [
         "//score/mw/com/test/service_discovery_offer_and_search:client-pkg",
         "//score/mw/com/test/service_discovery_offer_and_search:service-pkg",
     ],

--- a/score/mw/com/test/service_discovery_search_and_offer/integration_test/BUILD
+++ b/score/mw/com/test/service_discovery_search_and_offer/integration_test/BUILD
@@ -11,12 +11,12 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
 
-pkg_tar(
+pkg_filegroup(
     name = "filesystem",
-    deps = [
+    srcs = [
         "//score/mw/com/test/service_discovery_search_and_offer:client-pkg",
         "//score/mw/com/test/service_discovery_search_and_offer:service-pkg",
     ],

--- a/score/mw/com/test/shared_memory_storage/integration_test/BUILD
+++ b/score/mw/com/test/shared_memory_storage/integration_test/BUILD
@@ -11,19 +11,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/shared_memory_storage:shared_memory_storage-pkg",
-    ],
-)
 
 integration_test(
     name = "shared_memory_storage",
     timeout = "moderate",
     srcs = ["test_shared_memory_storage.py"],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/shared_memory_storage:shared_memory_storage-pkg",
 )

--- a/score/mw/com/test/subscribe_handler/integration_test/BUILD
+++ b/score/mw/com/test/subscribe_handler/integration_test/BUILD
@@ -11,19 +11,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/subscribe_handler:subscribe_handler-pkg",
-    ],
-)
 
 integration_test(
     name = "subscribe_handler",
     timeout = "moderate",
     srcs = ["test_subscribe_handler.py"],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/subscribe_handler:subscribe_handler-pkg",
 )

--- a/score/mw/com/test/unsubscribe_deadlock/integration_test/BUILD
+++ b/score/mw/com/test/unsubscribe_deadlock/integration_test/BUILD
@@ -11,19 +11,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_pkg//pkg:tar.bzl", "pkg_tar")
 load("//quality/integration_testing:integration_testing.bzl", "integration_test")
-
-pkg_tar(
-    name = "filesystem",
-    deps = [
-        "//score/mw/com/test/unsubscribe_deadlock:unsubscribe_deadlock-pkg",
-    ],
-)
 
 integration_test(
     name = "unsubscribe_deadlock",
     timeout = "moderate",
     srcs = ["test_unsubscribe_deadlock.py"],
-    filesystem = ":filesystem",
+    filesystem = "//score/mw/com/test/unsubscribe_deadlock:unsubscribe_deadlock-pkg",
 )


### PR DESCRIPTION
With this commit, we go away of the deprecated IFS rules, towards the in future maintained once.

This will also enable, that we will only depend on one ifs ruleset, once we make QNX UnitTests run.