### PR TITLE
Partial Restart Test: Remove setuid

### DIFF
--- a/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/BUILD
+++ b/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/BUILD
@@ -62,8 +62,22 @@ cc_library(
 )
 
 validate_json_schema_test(
-    name = "validate_mw_com_config_schema",
-    json = "mw_com_config.json",
+    name = "validate_mw_com_config_schema_provider",
+    json = "mw_com_config_provider.json",
+    schema = "//score/mw/com/impl/configuration:mw_com_config_schema",
+    tags = ["lint"],
+)
+
+validate_json_schema_test(
+    name = "validate_mw_com_config_schema_consumer_1",
+    json = "mw_com_config_consumer_1.json",
+    schema = "//score/mw/com/impl/configuration:mw_com_config_schema",
+    tags = ["lint"],
+)
+
+validate_json_schema_test(
+    name = "validate_mw_com_config_schema_consumer_2",
+    json = "mw_com_config_consumer_2.json",
     schema = "//score/mw/com/impl/configuration:mw_com_config_schema",
     tags = ["lint"],
 )
@@ -73,7 +87,9 @@ pkg_application(
     app_name = "proxy_restart_shall_not_affect_other_proxies",
     bin = [":proxy_restart_shall_not_affect_other_proxies"],
     etc = [
-        "mw_com_config.json",
+        "mw_com_config_consumer_1.json",
+        "mw_com_config_consumer_2.json",
+        "mw_com_config_provider.json",
         "logging.json",
     ],
     visibility = [

--- a/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/application.cpp
+++ b/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/application.cpp
@@ -35,6 +35,10 @@ const std::string_view kConsumer2CheckpointControlName = "Consumer_2";
 const std::string_view kProviderCheckpointControlName = "Skeleton";
 const std::chrono::seconds kMaxWaitTimeToReachCheckpoint{30U};
 
+const std::string_view kProviderConfigurationPath = "./etc/mw_com_config_provider.json";
+const std::string_view kConsumer1ConfigurationPath = "./etc/mw_com_config_consumer_1.json";
+const std::string_view kConsumer2ConfigurationPath = "./etc/mw_com_config_consumer_2.json";
+
 struct TestParameters
 {
     std::size_t number_consumer_restart{};
@@ -65,7 +69,7 @@ bool DoControllerActions(const TestParameters& test_parameters, score::cpp::stop
     //***************************************************
     auto provider_pid_guard = ForkProcessAndRunInChildProcess(
         "Controller Step (2):", "Provider:", [&provider_checkpoint_control, &stop_token]() {
-            PerformProviderActions(provider_checkpoint_control, stop_token);
+            PerformProviderActions(provider_checkpoint_control, kProviderConfigurationPath, stop_token);
         });
     if (!provider_pid_guard.has_value())
     {
@@ -93,7 +97,7 @@ bool DoControllerActions(const TestParameters& test_parameters, score::cpp::stop
     //***************************************************
     auto consumer_1_pid_guard = ForkProcessAndRunInChildProcess(
         "Controller Step (4):", "Consumer:", [&consumer_1_checkpoint_control, &stop_token]() {
-            PerformFirstConsumerActions(consumer_1_checkpoint_control, stop_token);
+            PerformFirstConsumerActions(consumer_1_checkpoint_control, kConsumer1ConfigurationPath, stop_token);
         });
     if (!consumer_1_pid_guard.has_value())
     {
@@ -133,8 +137,10 @@ bool DoControllerActions(const TestParameters& test_parameters, score::cpp::stop
     //***************************************************
     auto consumer_2_pid_guard = ForkProcessAndRunInChildProcess(
         "Controller Step (7):", "Consumer 2:", [&consumer_2_checkpoint_control, &stop_token, &test_parameters]() {
-            PerformSecondConsumerActions(
-                consumer_2_checkpoint_control, stop_token, test_parameters.number_consumer_restart + 1);
+            PerformSecondConsumerActions(consumer_2_checkpoint_control,
+                                         kConsumer2ConfigurationPath,
+                                         stop_token,
+                                         test_parameters.number_consumer_restart + 1);
         });
     if (!consumer_2_pid_guard.has_value())
     {
@@ -192,7 +198,7 @@ bool DoControllerActions(const TestParameters& test_parameters, score::cpp::stop
         //***************************************************
         consumer_1_pid_guard = ForkProcessAndRunInChildProcess(
             "Controller Step (11):", "Consumer 1:", [&consumer_1_checkpoint_control, &stop_token]() {
-                PerformFirstConsumerActions(consumer_1_checkpoint_control, stop_token);
+                PerformFirstConsumerActions(consumer_1_checkpoint_control, kConsumer1ConfigurationPath, stop_token);
             });
         if (!consumer_1_pid_guard.has_value())
         {

--- a/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/consumer.cpp
+++ b/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/consumer.cpp
@@ -11,6 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  *******************************************************************************/
 
+#include "score/mw/com/runtime.h"
 #include "score/mw/com/test/common_test_resources/check_point_control.h"
 #include "score/mw/com/test/common_test_resources/consumer_resources.h"
 #include "score/mw/com/test/common_test_resources/general_resources.h"
@@ -98,26 +99,17 @@ bool StartFindServiceAndWait(const std::string& tag,
 
 }  // namespace
 
-void PerformFirstConsumerActions(CheckPointControl& check_point_control, score::cpp::stop_token stop_token)
+void PerformFirstConsumerActions(CheckPointControl& check_point_control,
+                                 std::string_view mw_com_config_path,
+                                 score::cpp::stop_token stop_token)
 {
     //***************************************************
-    // Step (1)- setuid
+    // Step (1)- initialize mw::com Runtime with correct config
     //***************************************************
-    // LoLa requires that processes shall have distinct UIDs.
-    // After fork. Parent and child proccess will have same UID.
-    // setuid is used to make child proccess UID distinct.
-#if defined(__QNXNTO__)
-    // Grant pathspace ability for nonroot domain before setuid, so that
-    // resmgr_attach() (used by LoLa message passing) works after setuid.
-    procmgr_ability(0, PROCMGR_ADN_NONROOT | PROCMGR_AOP_ALLOW | PROCMGR_AID_PATHSPACE, PROCMGR_AID_EOL);
-#endif
-    const auto ret_setuid = setuid(kUidFirstConsumer);
-    if (ret_setuid != 0)
-    {
-        std::cerr << "set uid fails: " << errno << std::strerror(errno) << "\n";
-        check_point_control.ErrorOccurred();
-        return;
-    }
+    std::cout << "First Consumer Step(1) - mw_com_config_path: " << mw_com_config_path << std::endl;
+    // Initialize mw::com runtime with our explicit configuration
+    const char* argv[2U] = {"--service_instance_manifest", mw_com_config_path.data()};
+    runtime::InitializeRuntime(2U, argv);
     //***************************************************************************
     // Step (2)- start find service and wait till it is found.
     //***************************************************************************
@@ -194,27 +186,17 @@ void PerformFirstConsumerActions(CheckPointControl& check_point_control, score::
 }
 
 void PerformSecondConsumerActions(CheckPointControl& check_point_control,
+                                  std::string_view mw_com_config_path,
                                   score::cpp::stop_token stop_token,
                                   const size_t create_proxy_and_receive_M_times)
 {
     //***************************************************
-    // Step (1)- setuid
+    // Step (1)- initialize mw::com Runtime with correct config
     //***************************************************
-    // LoLa requires that processes shall have distinct UIDs.
-    // After fork. Parent and child proccess will have same UID.
-    // setuid is used to make child proccess UID distinct.
-#if defined(__QNXNTO__)
-    // Grant pathspace ability for nonroot domain before setuid, so that
-    // resmgr_attach() (used by LoLa message passing) works after setuid.
-    procmgr_ability(0, PROCMGR_ADN_NONROOT | PROCMGR_AOP_ALLOW | PROCMGR_AID_PATHSPACE, PROCMGR_AID_EOL);
-#endif
-    const auto ret_setuid = setuid(kUidSecondConsumer);
-    if (ret_setuid != 0)
-    {
-        std::cerr << "Second Consumer Step (1): set uid fails: " << errno << std::strerror(errno) << "\n";
-        check_point_control.ErrorOccurred();
-        return;
-    }
+    std::cout << "Second Consumer Step(1) - mw_com_config_path: " << mw_com_config_path << std::endl;
+    // Initialize mw::com runtime with our explicit configuration
+    const char* argv[2U] = {"--service_instance_manifest", mw_com_config_path.data()};
+    runtime::InitializeRuntime(2U, argv);
     //*********************************************************
     // Step (2)- start find service and wait till it is found.
     //*********************************************************

--- a/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/consumer.h
+++ b/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/consumer.h
@@ -17,9 +17,12 @@
 
 namespace score::mw::com::test
 {
-void PerformFirstConsumerActions(CheckPointControl& check_point_control, score::cpp::stop_token stop_token);
+void PerformFirstConsumerActions(CheckPointControl& check_point_control,
+                                 std::string_view mw_com_config_path,
+                                 score::cpp::stop_token stop_token);
 
 void PerformSecondConsumerActions(CheckPointControl& check_point_control,
+                                  std::string_view mw_com_config_path,
                                   score::cpp::stop_token stop_token,
                                   const size_t create_proxy_and_receive_M_times);
 }  // namespace score::mw::com::test

--- a/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/mw_com_config_consumer_1.json
+++ b/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/mw_com_config_consumer_1.json
@@ -1,0 +1,66 @@
+{
+  "serviceTypes": [
+    {
+      "serviceTypeName": "/score/mw/com/test/small",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "bindings": [
+        {
+          "binding": "SHM",
+          "serviceId": 8265,
+          "events": [
+            {
+              "eventName": "simple_event",
+              "eventId": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "serviceTypeName": "/bmw/adp/DummyServiceType",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "bindings": [
+        {
+          "binding": "SHM",
+          "serviceId": 6433,
+          "events": []
+        }
+      ]
+    }
+  ],
+  "serviceInstances": [
+    {
+      "instanceSpecifier": "partial_restart/small_but_great",
+      "serviceTypeName": "/score/mw/com/test/small",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "instances": [
+        {
+          "instanceId": 1,
+          "asil-level": "B",
+          "binding": "SHM",
+          "events": [
+            {
+              "eventName": "simple_event",
+              "numberOfSampleSlots": 21,
+              "maxSubscribers": 2,
+              "numberOfIpcTracingSlots": 1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "global": {
+    "asil-level": "B",
+    "applicationID": 40
+  }
+}

--- a/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/mw_com_config_consumer_2.json
+++ b/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/mw_com_config_consumer_2.json
@@ -60,6 +60,7 @@
     }
   ],
   "global": {
-    "asil-level": "B"
+    "asil-level": "B",
+    "applicationID": 41
   }
 }

--- a/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/mw_com_config_provider.json
+++ b/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/mw_com_config_provider.json
@@ -1,0 +1,66 @@
+{
+  "serviceTypes": [
+    {
+      "serviceTypeName": "/score/mw/com/test/small",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "bindings": [
+        {
+          "binding": "SHM",
+          "serviceId": 8265,
+          "events": [
+            {
+              "eventName": "simple_event",
+              "eventId": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "serviceTypeName": "/bmw/adp/DummyServiceType",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "bindings": [
+        {
+          "binding": "SHM",
+          "serviceId": 6433,
+          "events": []
+        }
+      ]
+    }
+  ],
+  "serviceInstances": [
+    {
+      "instanceSpecifier": "partial_restart/small_but_great",
+      "serviceTypeName": "/score/mw/com/test/small",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "instances": [
+        {
+          "instanceId": 1,
+          "asil-level": "B",
+          "binding": "SHM",
+          "events": [
+            {
+              "eventName": "simple_event",
+              "numberOfSampleSlots": 21,
+              "maxSubscribers": 2,
+              "numberOfIpcTracingSlots": 1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "global": {
+    "asil-level": "B",
+    "applicationID": 1
+  }
+}

--- a/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/provider.cpp
+++ b/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/provider.cpp
@@ -11,6 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  *******************************************************************************/
 
+#include "score/mw/com/runtime.h"
 #include "score/mw/com/test/common_test_resources/check_point_control.h"
 #include "score/mw/com/test/common_test_resources/general_resources.h"
 #include "score/mw/com/test/common_test_resources/provider_resources.h"
@@ -28,8 +29,15 @@ const auto kInstanceSpecifier =
 const std::chrono::milliseconds kDelayBetweenSendEvents{20U};
 }  // namespace
 
-void PerformProviderActions(CheckPointControl& check_point_control, score::cpp::stop_token stop_token)
+void PerformProviderActions(CheckPointControl& check_point_control,
+                            std::string_view mw_com_config_path,
+                            score::cpp::stop_token stop_token)
 {
+    std::cout << "Provider: Starting actions! mw_com_config_path: " << mw_com_config_path << std::endl;
+    // Initialize mw::com runtime with our explicit configuration
+    const char* argv[2U] = {"--service_instance_manifest", mw_com_config_path.data()};
+    runtime::InitializeRuntime(2, argv);
+
     //***************************************************
     // Step (1)- create and offer service
     //***************************************************

--- a/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/provider.h
+++ b/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/provider.h
@@ -18,6 +18,8 @@
 
 namespace score::mw::com::test
 {
-void PerformProviderActions(CheckPointControl& check_point_control, score::cpp::stop_token stop_token);
+void PerformProviderActions(CheckPointControl& check_point_control,
+                            std::string_view mw_com_config_path,
+                            score::cpp::stop_token stop_token);
 }
 #endif  // SCORE_MW_COM_TEST_PARTIAL_RESTART_PROXY_RESTART_SHALL_NOT_AFFECT_OTHER_PROXIES_PROVIDER_H


### PR DESCRIPTION
setuid calls are not needed anymore.
Instead we start test apps with distinct
applicationId