### PR TITLE
chore: Pin devcontainer version and add docker in docker

### DIFF
--- a/.devcontainer/devcontainer-lock.json
+++ b/.devcontainer/devcontainer-lock.json
@@ -1,0 +1,9 @@
+{
+  "features": {
+    "ghcr.io/devcontainers/features/docker-in-docker:2": {
+      "version": "2.17.0",
+      "resolved": "ghcr.io/devcontainers/features/docker-in-docker@sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c",
+      "integrity": "sha256:25b9f05705ffba7dbe503230ac76081419306f8c8bc88e0ce78c4ecd99a0c78c"
+    }
+  }
+}

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,7 +1,8 @@
 {
     "name": "eclipse-s-core",
-    "image": "ghcr.io/eclipse-score/devcontainer:1.0.0",
+    "image": "ghcr.io/eclipse-score/devcontainer:v1.5.0",
     "runArgs": [
         "--privileged"
-    ]
+    ],
+    "features": { "ghcr.io/devcontainers/features/docker-in-docker:2": {} }
 }


### PR DESCRIPTION
Using `main` as devcontainer version makes it very hard to figure out with which devcontainer image the code was build and tested 2 years ago.

The new integration tests require docker running inside the devcontainer. With the added feature all tests run via `bazel test //...` pass inside the devcontainer.