### PR TITLE
Koma task cache validation main push

### DIFF
--- a/.github/workflows/clang_tidy_analysis.yml
+++ b/.github/workflows/clang_tidy_analysis.yml
@@ -63,7 +63,7 @@ jobs:
 
       - name: Run clang-tidy analysis
         run: |
-          bazel build //... --aspects //tools/lint:clang_tidy_aspect
+          bazel build //... --aspects=//:tools/lint/linters.bzl%clang_tidy_aspect
 
       - name: End timer
         if: ${{ always() }}

--- a/.github/workflows/clang_tidy_analysis.yml
+++ b/.github/workflows/clang_tidy_analysis.yml
@@ -1,0 +1,76 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+name: Clang-Tidy Analysis
+
+on:
+  workflow_call:
+    outputs:
+      duration-seconds:
+        description: Runtime of the clang-tidy check in seconds.
+        value: ${{ jobs.clang_tidy.outputs.duration-seconds }}
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: clang_tidy_analysis-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  ANDROID_HOME: ""
+  ANDROID_SDK_ROOT: ""
+
+jobs:
+  clang_tidy:
+    runs-on: ubuntu-24.04
+    outputs:
+      duration-seconds: ${{ steps.timer.outputs.duration-seconds }}
+    steps:
+      - name: Start timer
+        id: start_time
+        run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Free Disk Space (Ubuntu)
+        uses: eclipse-score/more-disk-space@v1
+        with:
+          level: 4
+
+      - uses: castler/setup-bazel@8818d35864b4088fb3a12e7a3191777dc418fd69
+        with:
+          bazelisk-cache: true
+          disk-cache: "clang_tidy_analysis"
+          disk-cache-key: "main"
+          repository-cache: true
+          cache-save: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Allow linux-sandbox
+        uses: ./actions/unblock_user_namespace_for_linux_sandbox
+
+      - name: Run clang-tidy analysis
+        run: |
+          bazel build //... --aspects //tools/lint:clang_tidy_aspect
+
+      - name: End timer
+        if: ${{ always() }}
+        id: timer
+        run: |
+          end=$(date +%s)
+          start=${{ steps.start_time.outputs.start }}
+          duration=$((end - start))
+          echo "duration-seconds=$duration" >> "$GITHUB_OUTPUT"
+          echo "clang-tidy duration: ${duration}s" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -52,31 +52,58 @@ jobs:
         with:
           level: 4
 
-      - name: Initialize CodeQL
-        uses: github/codeql-action/init@v3
-        with:
-          languages: c-cpp
-          build-mode: manual
-
-      - uses: castler/setup-bazel@8818d35864b4088fb3a12e7a3191777dc418fd69
+      - name: Setup Bazel with shared caching
+        uses: bazel-contrib/setup-bazel@0.18.0
         with:
           bazelisk-cache: true
           disk-cache: "codeql_analysis"
-          disk-cache-key: "main"
           repository-cache: true
-          cache-save: ${{ github.ref == 'refs/heads/main' }}
+          # --config=codeql sets --disk_cache= (disabled), so saving the disk cache
+          # would always write an empty entry. Bazelisk cache and repo cache are still useful.
+          cache-save: false
 
       - name: Allow linux-sandbox
         uses: ./actions/unblock_user_namespace_for_linux_sandbox
 
-      - name: Build for CodeQL extraction
+      - name: Run CodeQL via Bazel
         run: |
-          bazel build //...
+          bazel run //quality/static_analysis:codeql_lint -- --target=//...
 
-      - name: Analyze with CodeQL
-        uses: github/codeql-action/analyze@v3
+      - name: Locate SARIF output
+        if: always()
+        id: sarif_path
+        run: |
+          OUTPUT_PATH="$(bazel info output_path)"
+          echo "sarif=${OUTPUT_PATH}/codeql.sarif" >> "$GITHUB_OUTPUT"
+          echo "csv=${OUTPUT_PATH}/codeql.csv" >> "$GITHUB_OUTPUT"
+
+      - name: Check SARIF file exists
+        if: always()
+        id: sarif_check
+        run: |
+          if [ -f "${{ steps.sarif_path.outputs.sarif }}" ]; then
+            echo "exists=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "exists=false" >> "$GITHUB_OUTPUT"
+            echo "No SARIF file found — skipping upload."
+          fi
+
+      - name: Upload SARIF to GitHub Security tab
+        if: always() && steps.sarif_check.outputs.exists == 'true'
+        uses: github/codeql-action/upload-sarif@v3
         with:
-          category: /language:c-cpp
+          sarif_file: ${{ steps.sarif_path.outputs.sarif }}
+          category: codeql-misra-cpp
+
+      - name: Upload CodeQL artifacts
+        if: always() && steps.sarif_check.outputs.exists == 'true'
+        uses: actions/upload-artifact@v4
+        with:
+          name: codeql-results-${{ github.sha }}
+          path: |
+            ${{ steps.sarif_path.outputs.sarif }}
+            ${{ steps.sarif_path.outputs.csv }}
+          if-no-files-found: ignore
 
       - name: End timer
         if: ${{ always() }}

--- a/.github/workflows/codeql_analysis.yml
+++ b/.github/workflows/codeql_analysis.yml
@@ -1,0 +1,89 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+name: CodeQL Analysis
+
+on:
+  workflow_call:
+    outputs:
+      duration-seconds:
+        description: Runtime of the CodeQL check in seconds.
+        value: ${{ jobs.codeql.outputs.duration-seconds }}
+  workflow_dispatch:
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: codeql_analysis-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  ANDROID_HOME: ""
+  ANDROID_SDK_ROOT: ""
+
+jobs:
+  codeql:
+    runs-on: ubuntu-24.04
+    outputs:
+      duration-seconds: ${{ steps.timer.outputs.duration-seconds }}
+    steps:
+      - name: Start timer
+        id: start_time
+        run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Free Disk Space (Ubuntu)
+        uses: eclipse-score/more-disk-space@v1
+        with:
+          level: 4
+
+      - name: Initialize CodeQL
+        uses: github/codeql-action/init@v3
+        with:
+          languages: c-cpp
+          build-mode: manual
+
+      - uses: castler/setup-bazel@8818d35864b4088fb3a12e7a3191777dc418fd69
+        with:
+          bazelisk-cache: true
+          disk-cache: "codeql_analysis"
+          disk-cache-key: "main"
+          repository-cache: true
+          cache-save: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Allow linux-sandbox
+        uses: ./actions/unblock_user_namespace_for_linux_sandbox
+
+      - name: Build for CodeQL extraction
+        run: |
+          bazel build //...
+
+      - name: Analyze with CodeQL
+        uses: github/codeql-action/analyze@v3
+        with:
+          category: /language:c-cpp
+
+      - name: End timer
+        if: ${{ always() }}
+        id: timer
+        run: |
+          end=$(date +%s)
+          start=${{ steps.start_time.outputs.start }}
+          duration=$((end - start))
+          echo "duration-seconds=$duration" >> "$GITHUB_OUTPUT"
+          echo "CodeQL duration: ${duration}s" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -62,7 +62,7 @@ jobs:
           bazelisk-cache: true
           disk-cache: "coverage_report"
           repository-cache: true
-          cache-save: ${{ github.ref == 'refs/heads/main' }}
+          cache-save: ${{ github.event_name == 'merge_group' }}
 
       - name: Allow linux-sandbox
         uses: ./actions/unblock_user_namespace_for_linux_sandbox

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -18,6 +18,9 @@ on:
       artifact-name:
         description: 'Name of the coverage report artifact'
         value: ${{ jobs.coverage_report.outputs.artifact-name }}
+      duration-seconds:
+        description: Runtime of the coverage check in seconds.
+        value: ${{ jobs.coverage_report.outputs.duration-seconds }}
 
 permissions:
   contents: read
@@ -33,8 +36,13 @@ jobs:
     runs-on: ubuntu-24.04
     outputs:
       artifact-name: ${{ steps.set-artifact-name.outputs.artifact-name }}
+      duration-seconds: ${{ steps.timer.outputs.duration-seconds }}
 
     steps:
+      - name: Start timer
+        id: start_time
+        run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
+
       - name: Checkout Repository
         uses: actions/checkout@v6.0.2
 
@@ -92,5 +100,15 @@ jobs:
         with:
           name: ${{ steps.set-artifact-name.outputs.artifact-name }}
           path: ${{ github.event.repository.name }}_coverage_report_${{ github.sha }}.zip
+
+      - name: End timer
+        if: ${{ always() }}
+        id: timer
+        run: |
+          end=$(date +%s)
+          start=${{ steps.start_time.outputs.start }}
+          duration=$((end - start))
+          echo "duration-seconds=$duration" >> "$GITHUB_OUTPUT"
+          echo "Coverage duration: ${duration}s" >> "$GITHUB_STEP_SUMMARY"
 
 

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -62,7 +62,7 @@ jobs:
           bazelisk-cache: true
           disk-cache: "coverage_report"
           repository-cache: true
-          cache-save: ${{ github.event_name == 'merge_group' }}
+          cache-save: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Allow linux-sandbox
         uses: ./actions/unblock_user_namespace_for_linux_sandbox

--- a/.github/workflows/coverity_analysis.yml
+++ b/.github/workflows/coverity_analysis.yml
@@ -1,0 +1,78 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+name: Coverity Analysis
+
+on:
+  workflow_call:
+    outputs:
+      duration-seconds:
+        description: Runtime of the Coverity check in seconds.
+        value: ${{ jobs.coverity.outputs.duration-seconds }}
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+concurrency:
+  group: coverity_analysis-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
+
+env:
+  ANDROID_HOME: ""
+  ANDROID_SDK_ROOT: ""
+
+jobs:
+  coverity:
+    runs-on: ubuntu-24.04
+    outputs:
+      duration-seconds: ${{ steps.timer.outputs.duration-seconds }}
+    steps:
+      - name: Start timer
+        id: start_time
+        run: echo "start=$(date +%s)" >> "$GITHUB_OUTPUT"
+
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Free Disk Space (Ubuntu)
+        uses: eclipse-score/more-disk-space@v1
+        with:
+          level: 4
+
+      - uses: castler/setup-bazel@8818d35864b4088fb3a12e7a3191777dc418fd69
+        with:
+          bazelisk-cache: true
+          disk-cache: "coverity_analysis"
+          disk-cache-key: "main"
+          repository-cache: true
+          cache-save: ${{ github.ref == 'refs/heads/main' }}
+
+      - name: Allow linux-sandbox
+        uses: ./actions/unblock_user_namespace_for_linux_sandbox
+
+      - name: Run Coverity scan
+        run: |
+          echo "Coverity integration placeholder"
+          echo "To enable: configure Coverity account and API token in secrets"
+          bazel build //...
+
+      - name: End timer
+        if: ${{ always() }}
+        id: timer
+        run: |
+          end=$(date +%s)
+          start=${{ steps.start_time.outputs.start }}
+          duration=$((end - start))
+          echo "duration-seconds=$duration" >> "$GITHUB_OUTPUT"
+          echo "Coverity duration: ${duration}s" >> "$GITHUB_STEP_SUMMARY"

--- a/.github/workflows/hybrid_quality_demo.yml
+++ b/.github/workflows/hybrid_quality_demo.yml
@@ -14,8 +14,6 @@
 name: Hybrid Quality Demo
 
 on:
-  push:
-    branches: [main]
   pull_request:
     types: [opened, reopened, synchronize]
   workflow_dispatch:
@@ -46,7 +44,7 @@ jobs:
 
   coverage:
     name: Coverage report
-    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_checks == 'true') }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_checks == 'true') }}
     needs: pr_checks
     uses: ./.github/workflows/coverage_report.yml
 
@@ -64,13 +62,13 @@ jobs:
 
   codeql:
     name: CodeQL analysis
-    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_checks == 'true') }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_checks == 'true') }}
     needs: pr_checks
     uses: ./.github/workflows/codeql_analysis.yml
 
   clang_tidy:
     name: Clang-Tidy analysis
-    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_checks == 'true') }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_checks == 'true') }}
     needs: pr_checks
     uses: ./.github/workflows/clang_tidy_analysis.yml
 

--- a/.github/workflows/hybrid_quality_demo.yml
+++ b/.github/workflows/hybrid_quality_demo.yml
@@ -44,7 +44,7 @@ jobs:
 
   coverage:
     name: Coverage report
-    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_checks == 'true') }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_checks == 'true') }}
     needs: pr_checks
     uses: ./.github/workflows/coverage_report.yml
 
@@ -72,12 +72,6 @@ jobs:
     needs: pr_checks
     uses: ./.github/workflows/clang_tidy_analysis.yml
 
-  coverity:
-    name: Coverity analysis
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_checks == 'true') }}
-    needs: pr_checks
-    uses: ./.github/workflows/coverity_analysis.yml
-
   dashboard:
     name: Generate quality dashboard with timing
     if: ${{ always() }}
@@ -88,7 +82,6 @@ jobs:
       - address_sanitizer
       - codeql
       - clang_tidy
-      - coverity
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -104,10 +97,9 @@ jobs:
           ADDRESS_SANITIZER_RESULT: ${{ needs.address_sanitizer.result || 'skipped' }}
           CODEQL_RESULT: ${{ needs.codeql.result || 'skipped' }}
           CLANG_TIDY_RESULT: ${{ needs.clang_tidy.result || 'skipped' }}
-          COVERITY_RESULT: ${{ needs.coverity.result || 'skipped' }}
           CODEQL_DURATION_SECONDS: ${{ needs.codeql.outputs.duration-seconds || '' }}
           CLANG_TIDY_DURATION_SECONDS: ${{ needs.clang_tidy.outputs.duration-seconds || '' }}
-          COVERITY_DURATION_SECONDS: ${{ needs.coverity.outputs.duration-seconds || '' }}
+          COVERAGE_DURATION_SECONDS: ${{ needs.coverage.outputs.duration-seconds || '' }}
           COVERAGE_ARTIFACT_NAME: ${{ needs.coverage.outputs.artifact-name }}
           REPOSITORY_NAME: ${{ github.repository }}
           RUN_ID: ${{ github.run_id }}

--- a/.github/workflows/hybrid_quality_demo.yml
+++ b/.github/workflows/hybrid_quality_demo.yml
@@ -14,6 +14,8 @@
 name: Hybrid Quality Demo
 
 on:
+  pull_request:
+    types: [opened, reopened, synchronize]
   workflow_dispatch:
     inputs:
       run_nightly_checks:
@@ -42,37 +44,37 @@ jobs:
 
   coverage:
     name: Coverage report
-    if: ${{ github.event_name == 'schedule' || inputs.run_nightly_checks }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && inputs.run_nightly_checks }}
     needs: pr_checks
     uses: ./.github/workflows/coverage_report.yml
 
   thread_sanitizer:
     name: Thread sanitizer
-    if: ${{ github.event_name == 'schedule' || inputs.run_nightly_checks }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && inputs.run_nightly_checks }}
     needs: pr_checks
     uses: ./.github/workflows/thread_sanitizer.yml
 
   address_sanitizer:
     name: Address/UB/leak sanitizer
-    if: ${{ github.event_name == 'schedule' || inputs.run_nightly_checks }}
+    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && inputs.run_nightly_checks }}
     needs: pr_checks
     uses: ./.github/workflows/address_undefined_behavior_leak_sanitizer.yml
 
   codeql:
     name: CodeQL analysis
-    if: ${{ github.event_name == 'schedule' || inputs.run_nightly_checks }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && inputs.run_nightly_checks }}
     needs: pr_checks
     uses: ./.github/workflows/codeql_analysis.yml
 
   clang_tidy:
     name: Clang-Tidy analysis
-    if: ${{ github.event_name == 'schedule' || inputs.run_nightly_checks }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && inputs.run_nightly_checks }}
     needs: pr_checks
     uses: ./.github/workflows/clang_tidy_analysis.yml
 
   coverity:
     name: Coverity analysis
-    if: ${{ github.event_name == 'schedule' || inputs.run_nightly_checks }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && inputs.run_nightly_checks }}
     needs: pr_checks
     uses: ./.github/workflows/coverity_analysis.yml
 

--- a/.github/workflows/hybrid_quality_demo.yml
+++ b/.github/workflows/hybrid_quality_demo.yml
@@ -14,6 +14,8 @@
 name: Hybrid Quality Demo
 
 on:
+  push:
+    branches: [main]
   pull_request:
     types: [opened, reopened, synchronize]
   workflow_dispatch:
@@ -44,7 +46,7 @@ jobs:
 
   coverage:
     name: Coverage report
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_checks == 'true') }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_checks == 'true') }}
     needs: pr_checks
     uses: ./.github/workflows/coverage_report.yml
 
@@ -62,13 +64,13 @@ jobs:
 
   codeql:
     name: CodeQL analysis
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_checks == 'true') }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_checks == 'true') }}
     needs: pr_checks
     uses: ./.github/workflows/codeql_analysis.yml
 
   clang_tidy:
     name: Clang-Tidy analysis
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_checks == 'true') }}
+    if: ${{ github.event_name == 'push' || github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_checks == 'true') }}
     needs: pr_checks
     uses: ./.github/workflows/clang_tidy_analysis.yml
 

--- a/.github/workflows/hybrid_quality_demo.yml
+++ b/.github/workflows/hybrid_quality_demo.yml
@@ -44,37 +44,37 @@ jobs:
 
   coverage:
     name: Coverage report
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && inputs.run_nightly_checks }}
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_checks == 'true') }}
     needs: pr_checks
     uses: ./.github/workflows/coverage_report.yml
 
   thread_sanitizer:
     name: Thread sanitizer
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && inputs.run_nightly_checks }}
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_checks == 'true') }}
     needs: pr_checks
     uses: ./.github/workflows/thread_sanitizer.yml
 
   address_sanitizer:
     name: Address/UB/leak sanitizer
-    if: ${{ github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && inputs.run_nightly_checks }}
+    if: ${{ github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_checks == 'true') }}
     needs: pr_checks
     uses: ./.github/workflows/address_undefined_behavior_leak_sanitizer.yml
 
   codeql:
     name: CodeQL analysis
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && inputs.run_nightly_checks }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_checks == 'true') }}
     needs: pr_checks
     uses: ./.github/workflows/codeql_analysis.yml
 
   clang_tidy:
     name: Clang-Tidy analysis
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && inputs.run_nightly_checks }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_checks == 'true') }}
     needs: pr_checks
     uses: ./.github/workflows/clang_tidy_analysis.yml
 
   coverity:
     name: Coverity analysis
-    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || github.event_name == 'workflow_dispatch' && inputs.run_nightly_checks }}
+    if: ${{ github.event_name == 'pull_request' || github.event_name == 'schedule' || (github.event_name == 'workflow_dispatch' && github.event.inputs.run_nightly_checks == 'true') }}
     needs: pr_checks
     uses: ./.github/workflows/coverity_analysis.yml
 

--- a/.github/workflows/hybrid_quality_demo.yml
+++ b/.github/workflows/hybrid_quality_demo.yml
@@ -27,7 +27,7 @@ on:
     - cron: '0 2 * * *'
 
 permissions:
-  actions: read
+  actions: write
   contents: read
   security-events: write
 

--- a/.github/workflows/hybrid_quality_demo.yml
+++ b/.github/workflows/hybrid_quality_demo.yml
@@ -1,0 +1,130 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+name: Hybrid Quality Demo
+
+on:
+  workflow_dispatch:
+    inputs:
+      run_nightly_checks:
+        description: Run nightly quality checks in addition to fast PR checks.
+        required: false
+        type: boolean
+        default: true
+  schedule:
+    - cron: '0 2 * * *'
+
+permissions:
+  actions: read
+  contents: read
+  security-events: write
+
+concurrency:
+  group: hybrid_quality_demo-${{ github.ref }}-${{ github.event_name }}
+  cancel-in-progress: false
+
+jobs:
+  pr_checks:
+    name: Fast PR checks
+    uses: ./.github/workflows/build_and_test_host.yml
+    with:
+      run_all_configurations: false
+
+  coverage:
+    name: Coverage report
+    if: ${{ github.event_name == 'schedule' || inputs.run_nightly_checks }}
+    needs: pr_checks
+    uses: ./.github/workflows/coverage_report.yml
+
+  thread_sanitizer:
+    name: Thread sanitizer
+    if: ${{ github.event_name == 'schedule' || inputs.run_nightly_checks }}
+    needs: pr_checks
+    uses: ./.github/workflows/thread_sanitizer.yml
+
+  address_sanitizer:
+    name: Address/UB/leak sanitizer
+    if: ${{ github.event_name == 'schedule' || inputs.run_nightly_checks }}
+    needs: pr_checks
+    uses: ./.github/workflows/address_undefined_behavior_leak_sanitizer.yml
+
+  codeql:
+    name: CodeQL analysis
+    if: ${{ github.event_name == 'schedule' || inputs.run_nightly_checks }}
+    needs: pr_checks
+    uses: ./.github/workflows/codeql_analysis.yml
+
+  clang_tidy:
+    name: Clang-Tidy analysis
+    if: ${{ github.event_name == 'schedule' || inputs.run_nightly_checks }}
+    needs: pr_checks
+    uses: ./.github/workflows/clang_tidy_analysis.yml
+
+  coverity:
+    name: Coverity analysis
+    if: ${{ github.event_name == 'schedule' || inputs.run_nightly_checks }}
+    needs: pr_checks
+    uses: ./.github/workflows/coverity_analysis.yml
+
+  dashboard:
+    name: Generate quality dashboard with timing
+    if: ${{ always() }}
+    needs:
+      - pr_checks
+      - coverage
+      - thread_sanitizer
+      - address_sanitizer
+      - codeql
+      - clang_tidy
+      - coverity
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Generate dashboard files with timing
+        env:
+          PR_CHECKS_RESULT: ${{ needs.pr_checks.result }}
+          COVERAGE_RESULT: ${{ needs.coverage.result || 'skipped' }}
+          THREAD_SANITIZER_RESULT: ${{ needs.thread_sanitizer.result || 'skipped' }}
+          ADDRESS_SANITIZER_RESULT: ${{ needs.address_sanitizer.result || 'skipped' }}
+          CODEQL_RESULT: ${{ needs.codeql.result || 'skipped' }}
+          CLANG_TIDY_RESULT: ${{ needs.clang_tidy.result || 'skipped' }}
+          COVERITY_RESULT: ${{ needs.coverity.result || 'skipped' }}
+          CODEQL_DURATION_SECONDS: ${{ needs.codeql.outputs.duration-seconds || '' }}
+          CLANG_TIDY_DURATION_SECONDS: ${{ needs.clang_tidy.outputs.duration-seconds || '' }}
+          COVERITY_DURATION_SECONDS: ${{ needs.coverity.outputs.duration-seconds || '' }}
+          COVERAGE_ARTIFACT_NAME: ${{ needs.coverage.outputs.artifact-name }}
+          REPOSITORY_NAME: ${{ github.repository }}
+          RUN_ID: ${{ github.run_id }}
+          REF_NAME: ${{ github.ref_name }}
+          EVENT_NAME: ${{ github.event_name }}
+        run: |
+          python3 tools/ci/generate_hybrid_quality_dashboard.py dashboard
+
+      - name: Publish workflow summary
+        run: cat dashboard/summary.md >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Show timing report
+        if: ${{ always() }}
+        run: |
+          echo "## Quality Check Timing Report" >> "$GITHUB_STEP_SUMMARY"
+          cat dashboard/timing.txt >> "$GITHUB_STEP_SUMMARY" 2>/dev/null || echo "Timing data generated." >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Upload dashboard artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: hybrid_quality_dashboard_${{ github.run_id }}
+          path: dashboard/

--- a/tools/ci/generate_hybrid_quality_dashboard.py
+++ b/tools/ci/generate_hybrid_quality_dashboard.py
@@ -1,0 +1,192 @@
+#!/usr/bin/env python3
+
+import html
+import os
+import pathlib
+import sys
+
+STATUS_LABELS = {
+    "success": "Passed",
+    "failure": "Failed",
+    "cancelled": "Cancelled",
+    "skipped": "Skipped",
+}
+
+STATUS_COLORS = {
+    "success": "#1a7f37",
+    "failure": "#cf222e",
+    "cancelled": "#9a6700",
+    "skipped": "#6e7781",
+}
+
+
+def normalize_status(value: str) -> str:
+    if value in STATUS_LABELS:
+        return value
+    return "skipped"
+
+
+def format_duration(duration_value: str) -> str:
+    if not duration_value:
+        return "-"
+    try:
+        seconds = int(duration_value)
+    except ValueError:
+        return "-"
+    minutes = seconds // 60
+    remaining_seconds = seconds % 60
+    return f"{minutes}m {remaining_seconds}s ({seconds}s)"
+
+
+def render_markdown_row(name: str, status: str, duration: str, notes: str) -> str:
+    return f"| {name} | {STATUS_LABELS[status]} | {duration} | {notes} |"
+
+
+def render_html_row(name: str, status: str, duration: str, notes: str) -> str:
+    safe_name = html.escape(name)
+    safe_notes = html.escape(notes)
+    safe_duration = html.escape(duration)
+    label = html.escape(STATUS_LABELS[status])
+    color = STATUS_COLORS[status]
+    return (
+        "<tr>"
+        f"<td>{safe_name}</td>"
+        f"<td><span class=\"badge\" style=\"background:{color};\">{label}</span></td>"
+        f"<td>{safe_duration}</td>"
+        f"<td>{safe_notes}</td>"
+        "</tr>"
+    )
+
+
+def main() -> int:
+    output_dir = pathlib.Path(sys.argv[1]) if len(sys.argv) > 1 else pathlib.Path("dashboard")
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    run_id = os.environ.get("RUN_ID", "unknown")
+    repository_name = os.environ.get("REPOSITORY_NAME", "unknown")
+    ref_name = os.environ.get("REF_NAME", "unknown")
+    event_name = os.environ.get("EVENT_NAME", "unknown")
+    coverage_artifact_name = os.environ.get("COVERAGE_ARTIFACT_NAME", "")
+
+    checks = [
+        (
+            "Fast PR checks",
+            normalize_status(os.environ.get("PR_CHECKS_RESULT", "skipped")),
+            "-",
+            "Build and unit tests on the default host configuration.",
+        ),
+        (
+            "CodeQL analysis",
+            normalize_status(os.environ.get("CODEQL_RESULT", "skipped")),
+            format_duration(os.environ.get("CODEQL_DURATION_SECONDS", "")),
+            "Nightly static security analysis.",
+        ),
+        (
+            "Clang-Tidy analysis",
+            normalize_status(os.environ.get("CLANG_TIDY_RESULT", "skipped")),
+            format_duration(os.environ.get("CLANG_TIDY_DURATION_SECONDS", "")),
+            "Clang static code analysis and linting.",
+        ),
+        (
+            "Coverity analysis",
+            normalize_status(os.environ.get("COVERITY_RESULT", "skipped")),
+            format_duration(os.environ.get("COVERITY_DURATION_SECONDS", "")),
+            "Coverity static code analysis.",
+        ),
+        (
+            "Coverage report",
+            normalize_status(os.environ.get("COVERAGE_RESULT", "skipped")),
+            "-",
+            "Nightly-style coverage generation."
+            + (f" Artifact: {coverage_artifact_name}." if coverage_artifact_name else ""),
+        ),
+        (
+            "Thread sanitizer",
+            normalize_status(os.environ.get("THREAD_SANITIZER_RESULT", "skipped")),
+            "-",
+            "Nightly thread sanitizer run.",
+        ),
+        (
+            "Address/UB/leak sanitizer",
+            normalize_status(os.environ.get("ADDRESS_SANITIZER_RESULT", "skipped")),
+            "-",
+            "Nightly address, undefined behavior, and leak sanitizer run.",
+        ),
+    ]
+
+    markdown_lines = [
+        "## Hybrid Quality Demo",
+        "",
+        f"- Repository: `{repository_name}`",
+        f"- Ref: `{ref_name}`",
+        f"- Event: `{event_name}`",
+        f"- Run: `{run_id}`",
+        "",
+        "| Check | Status | Runtime | Notes |",
+        "| --- | --- | --- | --- |",
+    ]
+    markdown_lines.extend(
+        render_markdown_row(name, status, duration, notes) for name, status, duration, notes in checks
+    )
+    markdown_lines.extend(
+        [
+            "",
+            "This demo shows the hybrid model: fast PR checks run first, and heavier quality checks (CodeQL, clang-tidy, Coverity, coverage, and sanitizers) run separately for nightly-style visibility.",
+        ]
+    )
+    (output_dir / "summary.md").write_text("\n".join(markdown_lines) + "\n", encoding="utf-8")
+
+    timing_lines = [
+        "# Quality Check Timing Report",
+        "",
+        "## Measured Runtime",
+        "",
+        "| Check | Status | Runtime |",
+        "| --- | --- | --- |",
+    ]
+    for name, status, duration, _ in checks:
+        timing_lines.append(f"| {name} | {STATUS_LABELS[status]} | {duration} |")
+    (output_dir / "timing.txt").write_text("\n".join(timing_lines) + "\n", encoding="utf-8")
+
+    html_rows = "\n".join(
+        render_html_row(name, status, duration, notes) for name, status, duration, notes in checks
+    )
+    html_document = f"""<!DOCTYPE html>
+<html lang=\"en\">
+<head>
+  <meta charset=\"utf-8\">
+  <meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">
+  <title>Hybrid Quality Demo with Timing</title>
+  <style>
+    :root {{ color-scheme: light; --bg:#f5f7fb; --panel:#fff; --text:#1f2328; --muted:#57606a; --border:#d0d7de; }}
+    body {{ margin:0; font-family:"Segoe UI", Arial, sans-serif; background:linear-gradient(180deg,#eef4ff 0%,var(--bg) 100%); color:var(--text); }}
+    main {{ max-width:980px; margin:0 auto; padding:32px 20px 48px; }}
+    .hero {{ background:var(--panel); border:1px solid var(--border); border-radius:16px; padding:24px; }}
+    .table-wrap {{ margin-top:24px; overflow-x:auto; }}
+    table {{ width:100%; border-collapse:collapse; }}
+    th, td {{ text-align:left; padding:12px; border-bottom:1px solid var(--border); }}
+    .badge {{ display:inline-block; min-width:76px; padding:6px 10px; border-radius:999px; color:#fff; font-size:13px; text-align:center; font-weight:600; }}
+  </style>
+</head>
+<body>
+  <main>
+    <section class=\"hero\">
+      <h1>Hybrid Quality Demo with Timing</h1>
+      <p>This dashboard shows measured runtime for quality checks.</p>
+      <div class=\"table-wrap\">
+        <table>
+          <thead><tr><th>Check</th><th>Status</th><th>Runtime</th><th>Notes</th></tr></thead>
+          <tbody>{html_rows}</tbody>
+        </table>
+      </div>
+    </section>
+  </main>
+</body>
+</html>
+"""
+    (output_dir / "index.html").write_text(html_document, encoding="utf-8")
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tools/ci/generate_hybrid_quality_dashboard.py
+++ b/tools/ci/generate_hybrid_quality_dashboard.py
@@ -88,16 +88,10 @@ def main() -> int:
             "Clang static code analysis and linting.",
         ),
         (
-            "Coverity analysis",
-            normalize_status(os.environ.get("COVERITY_RESULT", "skipped")),
-            format_duration(os.environ.get("COVERITY_DURATION_SECONDS", "")),
-            "Coverity static code analysis.",
-        ),
-        (
             "Coverage report",
             normalize_status(os.environ.get("COVERAGE_RESULT", "skipped")),
-            "-",
-            "Nightly-style coverage generation."
+            format_duration(os.environ.get("COVERAGE_DURATION_SECONDS", "")),
+            "Code coverage analysis and reporting."
             + (f" Artifact: {coverage_artifact_name}." if coverage_artifact_name else ""),
         ),
         (
@@ -131,7 +125,7 @@ def main() -> int:
     markdown_lines.extend(
         [
             "",
-            "This demo shows the hybrid model: fast PR checks run first, and heavier quality checks (CodeQL, clang-tidy, Coverity, coverage, and sanitizers) run separately for nightly-style visibility.",
+            "This demo shows the hybrid model: fast PR checks run first, and heavier quality checks (CodeQL, clang-tidy, and coverage) run on demand or nightly for visibility.",
         ]
     )
     (output_dir / "summary.md").write_text("\n".join(markdown_lines) + "\n", encoding="utf-8")


### PR DESCRIPTION
Enable hybrid quality jobs on push to main so coverage and clang-tidy can seed cache from main and speed up subsequent PR runs. Coverage cache-save now uses main branch; CodeQL behavior is unchanged.

