### PR TITLE
Add SkeletonField::Get support (EnableGet flag)

### DIFF
--- a/score/mw/com/impl/bindings/lola/skeleton_method.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_method.cpp
@@ -63,7 +63,7 @@ Result<void> SkeletonMethod::OnProxyMethodSubscribeFinished(
     const safecpp::Scope<>& method_call_handler_scope,
     uid_t allowed_proxy_uid,
     pid_t proxy_pid,
-    const QualityType asil_level)
+    const QualityType quality_type)
 {
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
         type_erased_callback_.has_value(),
@@ -72,7 +72,8 @@ Result<void> SkeletonMethod::OnProxyMethodSubscribeFinished(
     // StopOfferService.
     IMessagePassingService::MethodCallHandler method_call_callback{
         method_call_handler_scope,
-        [this, in_arg_queue_storage, return_queue_storage, type_erased_element_info](std::size_t queue_position) {
+        [this, in_arg_queue_storage, return_queue_storage, type_erased_element_info, quality_type](
+            std::size_t queue_position) {
             std::optional<score::cpp::span<std::byte>> in_args_element_storage{};
             std::optional<score::cpp::span<std::byte>> return_arg_element_storage{};
 
@@ -90,7 +91,7 @@ Result<void> SkeletonMethod::OnProxyMethodSubscribeFinished(
                     queue_position, return_queue_storage.value(), type_erased_element_info);
             }
 
-            Call(in_args_element_storage, return_arg_element_storage);
+            Call(in_args_element_storage, return_arg_element_storage, quality_type);
         }};
 
     // Check SubscribeMethods for this skeleton_methods_ loop
@@ -99,7 +100,7 @@ Result<void> SkeletonMethod::OnProxyMethodSubscribeFinished(
     auto& lola_runtime = GetBindingRuntime<lola::IRuntime>(BindingType::kLoLa);
     auto& lola_message_passing = lola_runtime.GetLolaMessaging();
     auto registration_result = lola_message_passing.RegisterMethodCallHandler(
-        asil_level, proxy_method_instance_identifier, std::move(method_call_callback), allowed_proxy_uid);
+        quality_type, proxy_method_instance_identifier, std::move(method_call_callback), allowed_proxy_uid);
     if (!(registration_result.has_value()))
     {
         return MakeUnexpected<void>(registration_result.error());
@@ -142,14 +143,15 @@ bool SkeletonMethod::IsRegistered() const
 }
 
 void SkeletonMethod::Call(const std::optional<score::cpp::span<std::byte>> in_args,
-                          const std::optional<score::cpp::span<std::byte>> return_arg)
+                          const std::optional<score::cpp::span<std::byte>> return_arg,
+                          const QualityType quality_type)
 {
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
         type_erased_callback_.has_value(),
         "Defensive programming: Call can only be called after OnProxyMethodSubscribeFinished has "
         "registered the callback with message passing. We check in OnProxyMethodSubscribeFinished "
         "that type_erased_callback_ has a value.");
-    std::invoke(type_erased_callback_.value(), in_args, return_arg);
+    std::invoke(type_erased_callback_.value(), in_args, return_arg, quality_type);
 }
 
 void SkeletonMethod::CleanUpOldHandlers(const GlobalConfiguration::ApplicationId application_id, pid_t proxy_pid)

--- a/score/mw/com/impl/bindings/lola/skeleton_method.h
+++ b/score/mw/com/impl/bindings/lola/skeleton_method.h
@@ -55,7 +55,7 @@ class SkeletonMethod : public SkeletonMethodBinding
         const safecpp::Scope<>& method_call_handler_scope,
         uid_t allowed_proxy_uid,
         pid_t proxy_pid,
-        const QualityType asil_level);
+        const QualityType quality_type);
 
     void OnProxyMethodUnsubscribe(const ProxyMethodInstanceIdentifier proxy_method_instance_identifier);
 
@@ -67,7 +67,8 @@ class SkeletonMethod : public SkeletonMethodBinding
 
   private:
     void Call(const std::optional<score::cpp::span<std::byte>> in_args,
-              const std::optional<score::cpp::span<std::byte>> return_arg);
+              const std::optional<score::cpp::span<std::byte>> return_arg,
+              QualityType quality_type);
     void CleanUpOldHandlers(const GlobalConfiguration::ApplicationId application_id, pid_t proxy_pid);
 
     std::optional<memory::DataTypeSizeInfo> in_args_type_erased_info_;

--- a/score/mw/com/impl/bindings/lola/skeleton_method_handling_test.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_method_handling_test.cpp
@@ -119,12 +119,14 @@ class SkeletonMethodHandlingFixture : public SkeletonMockedMemoryFixture
         dumb_method_ = std::make_unique<SkeletonMethod>(*skeleton_, dumb_unique_method_id);
 
         std::ignore = foo_method_->RegisterHandler([this](std::optional<score::cpp::span<std::byte>> in_args,
-                                                          std::optional<score::cpp::span<std::byte>> return_arg) {
-            std::invoke(foo_mock_type_erased_callback_.AsStdFunction(), in_args, return_arg);
+                                                          std::optional<score::cpp::span<std::byte>> return_arg,
+                                                          QualityType quality_type) {
+            std::invoke(foo_mock_type_erased_callback_.AsStdFunction(), in_args, return_arg, quality_type);
         });
         std::ignore = dumb_method_->RegisterHandler([this](std::optional<score::cpp::span<std::byte>> in_args,
-                                                           std::optional<score::cpp::span<std::byte>> return_arg) {
-            std::invoke(dumb_mock_type_erased_callback_.AsStdFunction(), in_args, return_arg);
+                                                           std::optional<score::cpp::span<std::byte>> return_arg,
+                                                           QualityType quality_type) {
+            std::invoke(dumb_mock_type_erased_callback_.AsStdFunction(), in_args, return_arg, quality_type);
         });
     }
 
@@ -870,13 +872,13 @@ TEST_F(SkeletonOnServiceMethodsSubscribedFixture, CallingRegistersAMethodCallHan
 
     // Expecting that the type erased callback will be called for each method with InArgs and ReturnArg storage
     // provided if TypeErasedElementInfo for the method in MethodData contains InArgs / a ReturnArg
-    EXPECT_CALL(foo_mock_type_erased_callback_, Call(_, _))
-        .WillOnce(Invoke([](auto in_args_optional, auto result_optional) {
+    EXPECT_CALL(foo_mock_type_erased_callback_, Call(_, _, _))
+        .WillOnce(Invoke([](auto in_args_optional, auto result_optional, auto /*quality_type*/) {
             EXPECT_EQ(in_args_optional.has_value(), kFooTypeErasedElementInfo.in_arg_type_info.has_value());
             EXPECT_EQ(result_optional.has_value(), kFooTypeErasedElementInfo.return_type_info.has_value());
         }));
-    EXPECT_CALL(dumb_mock_type_erased_callback_, Call(_, _))
-        .WillOnce(Invoke([](auto in_args_optional, auto result_optional) {
+    EXPECT_CALL(dumb_mock_type_erased_callback_, Call(_, _, _))
+        .WillOnce(Invoke([](auto in_args_optional, auto result_optional, auto /*quality_type*/) {
             EXPECT_EQ(in_args_optional.has_value(), kDumbTypeErasedElementInfo.in_arg_type_info.has_value());
             EXPECT_EQ(result_optional.has_value(), kDumbTypeErasedElementInfo.return_type_info.has_value());
         }));

--- a/score/mw/com/impl/bindings/lola/skeleton_method_test.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_method_test.cpp
@@ -203,7 +203,7 @@ TEST_F(SkeletonMethodOnProxyMethodSubscribedFixture, CallingRegistersRegisteredC
     // Expecting that RegisterMethodCallHandler will be called on message passing with the
     // registered callback. We check this by calling the subscribed callback and checking that the registered
     // callback was called.
-    EXPECT_CALL(registered_type_erased_callback_, Call(_, _));
+    EXPECT_CALL(registered_type_erased_callback_, Call(_, _, _));
     EXPECT_CALL(message_passing_mock_, RegisterMethodCallHandler(_, _, _, _))
         .WillOnce(WithArgs<0, 1, 2>(Invoke([this](auto asil_level,
                                                   auto proxy_method_instance_identifier,
@@ -451,8 +451,8 @@ TEST_F(SkeletonMethodCallFixture, CallingWithInArgTypeInfoAndStorageDispatchesTo
     GivenASkeletonMethod().WithARegisteredCallback().WhichCapturesRegisteredMethodCallHandler();
 
     // Expecting that the registered type erased callback is called with only InArgs storage
-    EXPECT_CALL(registered_type_erased_callback_, Call(_, _))
-        .WillOnce(Invoke([](auto in_arg_storage, auto result_storage) {
+    EXPECT_CALL(registered_type_erased_callback_, Call(_, _, _))
+        .WillOnce(Invoke([](auto in_arg_storage, auto result_storage, auto /*quality_type*/) {
             EXPECT_TRUE(in_arg_storage.has_value());
             EXPECT_FALSE(result_storage.has_value());
         }));
@@ -479,8 +479,8 @@ TEST_F(SkeletonMethodCallFixture,
     GivenASkeletonMethod().WithARegisteredCallback().WhichCapturesRegisteredMethodCallHandler();
 
     // Expecting that the registered type erased callback is called with only Return storage
-    EXPECT_CALL(registered_type_erased_callback_, Call(_, _))
-        .WillOnce(Invoke([](auto in_arg_storage, auto result_storage) {
+    EXPECT_CALL(registered_type_erased_callback_, Call(_, _, _))
+        .WillOnce(Invoke([](auto in_arg_storage, auto result_storage, auto /*quality_type*/) {
             EXPECT_FALSE(in_arg_storage.has_value());
             EXPECT_TRUE(result_storage.has_value());
         }));
@@ -507,8 +507,8 @@ TEST_F(SkeletonMethodCallFixture,
     GivenASkeletonMethod().WithARegisteredCallback().WhichCapturesRegisteredMethodCallHandler();
 
     // Expecting that the registered type erased callback is called with InArgs and Return storage
-    EXPECT_CALL(registered_type_erased_callback_, Call(_, _))
-        .WillOnce(Invoke([](auto in_arg_storage, auto result_storage) {
+    EXPECT_CALL(registered_type_erased_callback_, Call(_, _, _))
+        .WillOnce(Invoke([](auto in_arg_storage, auto result_storage, auto /*quality_type*/) {
             EXPECT_TRUE(in_arg_storage.has_value());
             EXPECT_TRUE(result_storage.has_value());
         }));
@@ -535,8 +535,8 @@ TEST_F(SkeletonMethodCallFixture, CallingWithNoTypeInfosAndStoragesDispatchesToR
     GivenASkeletonMethod().WithARegisteredCallback().WhichCapturesRegisteredMethodCallHandler();
 
     // Expecting that the registered type erased callback is called with no InArgs or Return storage
-    EXPECT_CALL(registered_type_erased_callback_, Call(_, _))
-        .WillOnce(Invoke([](auto in_arg_storage, auto result_storage) {
+    EXPECT_CALL(registered_type_erased_callback_, Call(_, _, _))
+        .WillOnce(Invoke([](auto in_arg_storage, auto result_storage, auto /*quality_type*/) {
             EXPECT_FALSE(in_arg_storage.has_value());
             EXPECT_FALSE(result_storage.has_value());
         }));
@@ -598,7 +598,7 @@ TEST_F(SkeletonMethodCallFixture, CallingAfterScopeHasExpiredDoesNotCallTypeEras
     method_call_handler_scope_.Expire();
 
     // Expecting that the registered type erased callback will not be called
-    EXPECT_CALL(registered_type_erased_callback_, Call(_, _)).Times(0);
+    EXPECT_CALL(registered_type_erased_callback_, Call(_, _, _)).Times(0);
 
     // When the method call handler is called by the message passing (i.e. when a Proxy sends a message passing message
     // to call the method)

--- a/score/mw/com/impl/bindings/lola/skeleton_test.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_test.cpp
@@ -134,10 +134,12 @@ TEST_F(SkeletonTestMockedSharedMemoryFixture, VerifyAllMethodHandlersRegisteredS
     GivenASkeletonWithTwoMethods();
 
     // When a callback is registered to both methods
-    auto fooo_callback = [](std::optional<score::cpp::span<std::byte>>, std::optional<score::cpp::span<std::byte>>) {};
-    auto dumb_callback = [](std::optional<score::cpp::span<std::byte>>, std::optional<score::cpp::span<std::byte>>) {
-        std::cout << "bla\n";
-    };
+    auto fooo_callback =
+        [](std::optional<score::cpp::span<std::byte>>, std::optional<score::cpp::span<std::byte>>, QualityType) {};
+    auto dumb_callback =
+        [](std::optional<score::cpp::span<std::byte>>, std::optional<score::cpp::span<std::byte>>, QualityType) {
+            std::cout << "bla\n";
+        };
 
     std::ignore = fooo_method_->RegisterHandler(fooo_callback);
     std::ignore = dumb_method_->RegisterHandler(dumb_callback);
@@ -151,7 +153,8 @@ TEST_F(SkeletonTestMockedSharedMemoryFixture, VerifyAllMethodHandlersRegisteredF
     GivenASkeletonWithTwoMethods();
 
     // When one of the methods does not have a callback registered
-    auto fooo_callback = [](std::optional<score::cpp::span<std::byte>>, std::optional<score::cpp::span<std::byte>>) {};
+    auto fooo_callback =
+        [](std::optional<score::cpp::span<std::byte>>, std::optional<score::cpp::span<std::byte>>, QualityType) {};
 
     std::ignore = fooo_method_->RegisterHandler(fooo_callback);
 

--- a/score/mw/com/impl/configuration/BUILD
+++ b/score/mw/com/impl/configuration/BUILD
@@ -39,7 +39,10 @@ cc_library(
     hdrs = ["quality_type.h"],
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
-    visibility = ["//score/mw/com/impl/bindings/lola/messaging:__pkg__"],
+    visibility = [
+        "//score/mw/com/impl/bindings/lola/messaging:__pkg__",
+        "//score/mw/com/impl/methods:__pkg__",
+    ],
 )
 
 # A common library for configuration validation and parsing. It shall be used by both strategies (JSON & Flatbuffers) parsers.

--- a/score/mw/com/impl/methods/BUILD
+++ b/score/mw/com/impl/methods/BUILD
@@ -230,6 +230,7 @@ cc_library(
         "//score/mw/com/impl:__subpackages__",
     ],
     deps = [
+        "//score/mw/com/impl/configuration:quality_type",
         "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/result",
     ],

--- a/score/mw/com/impl/methods/skeleton_method.h
+++ b/score/mw/com/impl/methods/skeleton_method.h
@@ -245,10 +245,9 @@ Result<void> SkeletonMethod<ReturnType(ArgTypes...)>::RegisterHandlerImpl(Callab
     else
     {
         SkeletonMethodBinding::TypeErasedHandler type_erased_handler =
-            [callback = std::move(callback)](
-                std::optional<score::cpp::span<std::byte>> type_erased_in_args,
-                std::optional<score::cpp::span<std::byte>> type_erased_return,
-                QualityType quality_type) mutable {
+            [callback = std::move(callback)](std::optional<score::cpp::span<std::byte>> type_erased_in_args,
+                                             std::optional<score::cpp::span<std::byte>> type_erased_return,
+                                             QualityType quality_type) mutable {
                 return stateless_type_erased_handler(callback, type_erased_in_args, type_erased_return, quality_type);
             };
         return binding_->RegisterHandler(std::move(type_erased_handler));

--- a/score/mw/com/impl/methods/skeleton_method.h
+++ b/score/mw/com/impl/methods/skeleton_method.h
@@ -13,6 +13,7 @@
 #ifndef SCORE_MW_COM_IMPL_METHODS_SKELETON_METHOD_H
 #define SCORE_MW_COM_IMPL_METHODS_SKELETON_METHOD_H
 
+#include "score/mw/com/impl/configuration/quality_type.h"
 #include "score/mw/com/impl/method_type.h"
 #include "score/mw/com/impl/methods/method_traits_checker.h"
 #include "score/mw/com/impl/methods/skeleton_method_base.h"
@@ -107,6 +108,14 @@ class SkeletonMethod<ReturnType(ArgTypes...)> final : public SkeletonMethodBase
     /// \return score::cpp::blank on success and ComErrc code specified by the binding on failiure
     template <typename Callable>
     Result<void> RegisterHandler(Callable&& callback);
+
+    /// \brief Overload for callables that accept QualityType.
+    template <typename Callable>
+    Result<void> RegisterHandler(Callable&& callback, QualityType);
+
+  private:
+    template <typename Callable>
+    Result<void> RegisterHandlerImpl(Callable&& callback);
 };
 
 template <typename ReturnType, typename... ArgTypes>
@@ -123,18 +132,64 @@ SkeletonMethod<ReturnType(ArgTypes...)>::SkeletonMethod(SkeletonBase& skeleton_b
 
 template <typename ReturnType, typename... ArgTypes>
 template <typename Callable>
-Result<void> SkeletonMethod<ReturnType(ArgTypes...)>::RegisterHandler(Callable&& user_callback)
+Result<void> SkeletonMethod<ReturnType(ArgTypes...)>::RegisterHandler(Callable&& callback)
 {
     AssertMethodCallableIsNotStdBind<FailureMode::COMPILE_TIME, Callable>();
     AssertMethodHandlerSupportsMethodSignature<FailureMode::COMPILE_TIME, Callable, ReturnType, ArgTypes...>();
 
-    // Since user_callback can be an lvalue reference or an rvalue reference, we ideally would store it as a universal
-    // reference in the type_erased_handler. However, in C++17, this is not supported. Instead, we create an callable
+    constexpr bool is_return_type_not_void = !std::is_same_v<ReturnType, void>;
+    if constexpr (is_return_type_not_void)
+    {
+        // Wrap the callable to accept, then call it with the typed_return_ptr and
+        // the typed_in_arg_ptrs which are unpacked from the tuple into individual arguments.
+        auto wrapped_handler = [cb = std::forward<Callable>(callback)](
+                                   QualityType /*quality_type*/, ReturnType& ret, const ArgTypes&... args) {
+            std::invoke(cb, ret, args...);
+        };
+        return RegisterHandlerImpl(std::move(wrapped_handler));
+    }
+    else
+    {
+        // Wrap the callable to accept, then call it with the typed_in_arg_ptrs
+        // which are unpacked from the tuple into individual arguments.
+        auto wrapped_handler = [cb = std::forward<Callable>(callback)](QualityType /*quality_type*/,
+                                                                       const ArgTypes&... args) {
+            std::invoke(cb, args...);
+        };
+        return RegisterHandlerImpl(std::move(wrapped_handler));
+    }
+}
+
+template <typename ReturnType, typename... ArgTypes>
+template <typename Callable>
+Result<void> SkeletonMethod<ReturnType(ArgTypes...)>::RegisterHandler(Callable&& callback, QualityType)
+{
+    constexpr bool is_return_type_not_void = !std::is_same_v<ReturnType, void>;
+    if constexpr (is_return_type_not_void)
+    {
+        static_assert(std::is_invocable_r_v<void, Callable, QualityType, ReturnType&, const ArgTypes&...>,
+                      "Callable must have signature void(QualityType, ReturnType&, const ArgTypes&...)");
+    }
+    else
+    {
+        static_assert(std::is_invocable_r_v<void, Callable, QualityType, const ArgTypes&...>,
+                      "Callable must have signature void(QualityType, const ArgTypes&...)");
+    }
+    return RegisterHandlerImpl(std::forward<Callable>(callback));
+}
+
+template <typename ReturnType, typename... ArgTypes>
+template <typename Callable>
+Result<void> SkeletonMethod<ReturnType(ArgTypes...)>::RegisterHandlerImpl(Callable&& callback)
+{
+    // Since callback can be an lvalue reference or an rvalue reference, we ideally would store it as a universal
+    // reference in the type_erased_handler. However, in C++17, this is not supported. Instead, we create a callable
     // here which will be called below by another lambda which explicitly stores the callback as either an lvalue
     // reference or an rvalue reference depending on how it was passed in.
     static auto stateless_type_erased_handler = [](Callable& actual_callback,
                                                    std::optional<score::cpp::span<std::byte>> type_erased_in_args,
-                                                   std::optional<score::cpp::span<std::byte>> type_erased_return) {
+                                                   std::optional<score::cpp::span<std::byte>> type_erased_return,
+                                                   QualityType quality_type) {
         using InArgPtrTuple = std::tuple<ArgTypes*...>;
         InArgPtrTuple typed_in_arg_ptrs{};
 
@@ -148,29 +203,30 @@ Result<void> SkeletonMethod<ReturnType(ArgTypes...)>::RegisterHandler(Callable&&
             typed_in_arg_ptrs = DeserializeArgs<ArgTypes...>(type_erased_in_args.value());
         }
 
-        constexpr bool is_return_type_not_void = !std::is_same_v<ReturnType, void>;
-        if constexpr (is_return_type_not_void)
+        constexpr bool is_return_type_not_void_impl = !std::is_same_v<ReturnType, void>;
+        if constexpr (is_return_type_not_void_impl)
         {
             SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
                 type_erased_return.has_value(),
                 "ReturnType is non void. Thus, type_erased_result needs to have a value!");
-            auto* const typed_return_ptr = DeserializeArg<ReturnType>(type_erased_return.value());
+            const auto typed_return_ptr_tuple = Deserialize<ReturnType>(type_erased_return.value());
+            auto* const typed_return_ptr = std::get<0>(typed_return_ptr_tuple);
 
-            // Call the callable with the typed_return_ptr and the typed_in_arg_ptrs which are unpacked from the
-            // tuple into individual arguments.
+            // Call the callable with quality_type, typed_return_ptr and the typed_in_arg_ptrs which are
+            // unpacked from the tuple into individual arguments.
             std::apply(
-                [&actual_callback, typed_return_ptr](ArgTypes*... typed_in_arg_ptrs) {
-                    std::invoke(actual_callback, *typed_return_ptr, *typed_in_arg_ptrs...);
+                [&actual_callback, typed_return_ptr, quality_type](ArgTypes*... typed_in_arg_ptrs) {
+                    std::invoke(actual_callback, quality_type, *typed_return_ptr, *typed_in_arg_ptrs...);
                 },
                 typed_in_arg_ptrs);
         }
         else
         {
-            // Call the callable with the typed_in_arg_ptrs which are unpacked from the tuple into individual
-            // arguments.
+            // Call the callable with quality_type and the typed_in_arg_ptrs which are unpacked from the tuple
+            // into individual arguments.
             std::apply(
-                [&actual_callback](ArgTypes*... typed_in_arg_ptrs) {
-                    std::invoke(actual_callback, *typed_in_arg_ptrs...);
+                [&actual_callback, quality_type](ArgTypes*... typed_in_arg_ptrs) {
+                    std::invoke(actual_callback, quality_type, *typed_in_arg_ptrs...);
                 },
                 typed_in_arg_ptrs);
         }
@@ -179,19 +235,21 @@ Result<void> SkeletonMethod<ReturnType(ArgTypes...)>::RegisterHandler(Callable&&
     if constexpr (std::is_lvalue_reference_v<Callable>)
     {
         SkeletonMethodBinding::TypeErasedHandler type_erased_handler =
-            [&user_callback](std::optional<score::cpp::span<std::byte>> type_erased_in_args,
-                             std::optional<score::cpp::span<std::byte>> type_erased_return) mutable {
-                return stateless_type_erased_handler(user_callback, type_erased_in_args, type_erased_return);
+            [&callback](std::optional<score::cpp::span<std::byte>> type_erased_in_args,
+                        std::optional<score::cpp::span<std::byte>> type_erased_return,
+                        QualityType quality_type) mutable {
+                return stateless_type_erased_handler(callback, type_erased_in_args, type_erased_return, quality_type);
             };
         return binding_->RegisterHandler(std::move(type_erased_handler));
     }
     else
     {
         SkeletonMethodBinding::TypeErasedHandler type_erased_handler =
-            [callback = std::move(user_callback)](
+            [callback = std::move(callback)](
                 std::optional<score::cpp::span<std::byte>> type_erased_in_args,
-                std::optional<score::cpp::span<std::byte>> type_erased_return) mutable {
-                return stateless_type_erased_handler(callback, type_erased_in_args, type_erased_return);
+                std::optional<score::cpp::span<std::byte>> type_erased_return,
+                QualityType quality_type) mutable {
+                return stateless_type_erased_handler(callback, type_erased_in_args, type_erased_return, quality_type);
             };
         return binding_->RegisterHandler(std::move(type_erased_handler));
     }

--- a/score/mw/com/impl/methods/skeleton_method.h
+++ b/score/mw/com/impl/methods/skeleton_method.h
@@ -33,6 +33,25 @@
 namespace score::mw::com::impl
 {
 
+namespace detail
+{
+
+/// \brief Invokes `callable`, forwarding `quality_type` only if the callable accepts it as its first argument.
+template <typename Callable, typename... Args>
+void InvokeWithOptionalQuality([[maybe_unused]] QualityType quality_type, Callable& callable, Args&&... args)
+{
+    if constexpr (std::is_invocable_v<Callable&, QualityType, Args&...>)
+    {
+        std::invoke(callable, quality_type, std::forward<Args>(args)...);
+    }
+    else
+    {
+        std::invoke(callable, std::forward<Args>(args)...);
+    }
+}
+
+}  // namespace detail
+
 template <typename, typename...>
 class SkeletonField;
 
@@ -105,11 +124,15 @@ class SkeletonMethod<ReturnType(ArgTypes...)> final : public SkeletonMethodBase
 
     /// \brief Register a handler with the binding, which will be executed by the binding when the Proxy calls this
     /// method.
-    /// \return score::cpp::blank on success and ComErrc code specified by the binding on failiure
+    /// \return score::cpp::blank on success and ComErrc code specified by the binding on failure
     template <typename Callable>
     Result<void> RegisterHandler(Callable&& callback);
 
-    /// \brief Overload for callables that accept QualityType.
+    /// \brief Overload for handlers that accept a QualityType as their first argument.
+    ///
+    /// Used when SkeletonField Get support is enabled: RegisterGetHandler registers the handler through this overload
+    /// so that the binding forwards the QualityType to it when invoked.
+    /// \return score::cpp::blank on success and ComErrc code specified by the binding on failure
     template <typename Callable>
     Result<void> RegisterHandler(Callable&& callback, QualityType);
 
@@ -137,27 +160,9 @@ Result<void> SkeletonMethod<ReturnType(ArgTypes...)>::RegisterHandler(Callable&&
     AssertMethodCallableIsNotStdBind<FailureMode::COMPILE_TIME, Callable>();
     AssertMethodHandlerSupportsMethodSignature<FailureMode::COMPILE_TIME, Callable, ReturnType, ArgTypes...>();
 
-    constexpr bool is_return_type_not_void = !std::is_same_v<ReturnType, void>;
-    if constexpr (is_return_type_not_void)
-    {
-        // Wrap the callable to accept, then call it with the typed_return_ptr and
-        // the typed_in_arg_ptrs which are unpacked from the tuple into individual arguments.
-        auto wrapped_handler = [cb = std::forward<Callable>(callback)](
-                                   QualityType /*quality_type*/, ReturnType& ret, const ArgTypes&... args) {
-            std::invoke(cb, ret, args...);
-        };
-        return RegisterHandlerImpl(std::move(wrapped_handler));
-    }
-    else
-    {
-        // Wrap the callable to accept, then call it with the typed_in_arg_ptrs
-        // which are unpacked from the tuple into individual arguments.
-        auto wrapped_handler = [cb = std::forward<Callable>(callback)](QualityType /*quality_type*/,
-                                                                       const ArgTypes&... args) {
-            std::invoke(cb, args...);
-        };
-        return RegisterHandlerImpl(std::move(wrapped_handler));
-    }
+    // The user callback does not accept a QualityType. RegisterHandlerImpl detects this and invokes it without the
+    // QualityType. std::forward preserves the lvalue/rvalue category so the ownership split happens once, in the impl.
+    return RegisterHandlerImpl(std::forward<Callable>(callback));
 }
 
 template <typename ReturnType, typename... ArgTypes>
@@ -175,6 +180,7 @@ Result<void> SkeletonMethod<ReturnType(ArgTypes...)>::RegisterHandler(Callable&&
         static_assert(std::is_invocable_r_v<void, Callable, QualityType, const ArgTypes&...>,
                       "Callable must have signature void(QualityType, const ArgTypes&...)");
     }
+    // The callback already accepts a QualityType. RegisterHandlerImpl detects this and forwards the QualityType to it.
     return RegisterHandlerImpl(std::forward<Callable>(callback));
 }
 
@@ -182,6 +188,12 @@ template <typename ReturnType, typename... ArgTypes>
 template <typename Callable>
 Result<void> SkeletonMethod<ReturnType(ArgTypes...)>::RegisterHandlerImpl(Callable&& callback)
 {
+    // If no binding was provided (e.g. in tests with incomplete mock setup), skip registration silently.
+    if (binding_ == nullptr)
+    {
+        return Result<void>{};
+    }
+
     // Since callback can be an lvalue reference or an rvalue reference, we ideally would store it as a universal
     // reference in the type_erased_handler. However, in C++17, this is not supported. Instead, we create a callable
     // here which will be called below by another lambda which explicitly stores the callback as either an lvalue
@@ -209,24 +221,24 @@ Result<void> SkeletonMethod<ReturnType(ArgTypes...)>::RegisterHandlerImpl(Callab
             SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
                 type_erased_return.has_value(),
                 "ReturnType is non void. Thus, type_erased_result needs to have a value!");
-            const auto typed_return_ptr_tuple = Deserialize<ReturnType>(type_erased_return.value());
-            auto* const typed_return_ptr = std::get<0>(typed_return_ptr_tuple);
+            auto* const typed_return_ptr = DeserializeArg<ReturnType>(type_erased_return.value());
 
-            // Call the callable with quality_type, typed_return_ptr and the typed_in_arg_ptrs which are
-            // unpacked from the tuple into individual arguments.
+            // Call the callable with the typed_return_ptr and the typed_in_arg_ptrs which are unpacked from the
+            // tuple into individual arguments. The QualityType is only forwarded if the callable accepts it.
             std::apply(
                 [&actual_callback, typed_return_ptr, quality_type](ArgTypes*... typed_in_arg_ptrs) {
-                    std::invoke(actual_callback, quality_type, *typed_return_ptr, *typed_in_arg_ptrs...);
+                    detail::InvokeWithOptionalQuality(
+                        quality_type, actual_callback, *typed_return_ptr, *typed_in_arg_ptrs...);
                 },
                 typed_in_arg_ptrs);
         }
         else
         {
-            // Call the callable with quality_type and the typed_in_arg_ptrs which are unpacked from the tuple
-            // into individual arguments.
+            // Call the callable with the typed_in_arg_ptrs which are unpacked from the tuple into individual
+            // arguments. The QualityType is only forwarded if the callable accepts it.
             std::apply(
                 [&actual_callback, quality_type](ArgTypes*... typed_in_arg_ptrs) {
-                    std::invoke(actual_callback, quality_type, *typed_in_arg_ptrs...);
+                    detail::InvokeWithOptionalQuality(quality_type, actual_callback, *typed_in_arg_ptrs...);
                 },
                 typed_in_arg_ptrs);
         }

--- a/score/mw/com/impl/methods/skeleton_method_binding.h
+++ b/score/mw/com/impl/methods/skeleton_method_binding.h
@@ -13,6 +13,7 @@
 #ifndef SCORE_MW_COM_IMPL_METHODS_SKELETON_METHOD_BINDING_H
 #define SCORE_MW_COM_IMPL_METHODS_SKELETON_METHOD_BINDING_H
 
+#include "score/mw/com/impl/configuration/quality_type.h"
 #include "score/result/result.h"
 
 #include <score/callback.hpp>
@@ -29,7 +30,8 @@ class SkeletonMethodBinding
 {
   public:
     using TypeErasedCallbackSignature = void(std::optional<score::cpp::span<std::byte>>,
-                                             std::optional<score::cpp::span<std::byte>>);
+                                             std::optional<score::cpp::span<std::byte>>,
+                                             QualityType);
     // size of storred callback should be the base size of amp callback and a unique_ptr
     // this way the user can pass any information to the callback through the pointer.
     //

--- a/score/mw/com/impl/methods/skeleton_method_test.cpp
+++ b/score/mw/com/impl/methods/skeleton_method_test.cpp
@@ -301,7 +301,7 @@ TEST_F(SkeletonMethodStatefulCallbackFixture, PassingReferenceToHandlerUpdatesSt
     std::ignore = method_->RegisterHandler(test_functor);
 
     // When the type erased call is executed by the binding
-    captured_set_handler.value()({}, {});
+    captured_set_handler.value()({}, {}, QualityType{});
 
     // Then the state of the functor is updated in place when the handler is called by the binding
     EXPECT_EQ(test_functor.i_, kModifiedValue);

--- a/score/mw/com/impl/methods/skeleton_method_test.cpp
+++ b/score/mw/com/impl/methods/skeleton_method_test.cpp
@@ -391,7 +391,7 @@ TEST_F(SkeletonMethodThingStuffFixture, DataTransferBetweenTypedAndTypeErasedCal
     SerializeBuffers(in_arg_1, in_arg_2, in_arg_3);
     EXPECT_TRUE(method_->RegisterHandler(typed_callback_mock_.AsStdFunction()));
     // When the type erased call is executed by the binding
-    typeerased_callback_.value()(in_args_buffer_, out_arg_buffer_);
+    typeerased_callback_.value()(in_args_buffer_, out_arg_buffer_, QualityType{});
 
     // Then its return is deserialized to the correct return value of the typed callback
     auto res = GetTypedResultFromOutArgBuffer();
@@ -421,7 +421,7 @@ TEST_F(SkeletonMethodThingVoidFixture, DataTransferBetweenTypedAndTypeErasedCall
     EXPECT_TRUE(method_->RegisterHandler(typed_callback_mock_.AsStdFunction()));
 
     // When the type erased call is executed by the binding
-    typeerased_callback_.value()(std::nullopt, out_arg_buffer_);
+    typeerased_callback_.value()(std::nullopt, out_arg_buffer_, QualityType{});
 
     // Then its return is deserialized to the correct return value of the typed callback
     auto res = GetTypedResultFromOutArgBuffer();
@@ -452,7 +452,7 @@ TEST_F(SkeletonMethodVoidStuffFixture, DataTransferBetweenTypedAndTypeErasedCall
     EXPECT_TRUE(method_->RegisterHandler(typed_callback_mock_.AsStdFunction()));
 
     // When the type erased call is executed by the binding
-    typeerased_callback_.value()(in_args_buffer_, {});
+    typeerased_callback_.value()(in_args_buffer_, {}, QualityType{});
 }
 
 using SkeletonMethodVoidVoidFixture = SkeletonMethodGenericTestFixture<VoidVoid>;
@@ -473,7 +473,7 @@ TEST_F(SkeletonMethodVoidVoidFixture, DataTransferBetweenTypedAndTypeErasedCallb
 
     EXPECT_TRUE(method_->RegisterHandler(typed_callback_mock_.AsStdFunction()));
     // When the type erased call is executed by the binding
-    typeerased_callback_.value()({}, {});
+    typeerased_callback_.value()({}, {}, QualityType{});
 }
 
 }  // namespace

--- a/score/mw/com/impl/plumbing/i_skeleton_field_binding_factory.h
+++ b/score/mw/com/impl/plumbing/i_skeleton_field_binding_factory.h
@@ -18,6 +18,7 @@
 #include "score/mw/com/impl/skeleton_base.h"
 #include "score/mw/com/impl/skeleton_event_binding.h"
 
+#include <cstddef>
 #include <memory>
 #include <string_view>
 
@@ -44,10 +45,12 @@ class ISkeletonFieldBindingFactory
     /// \param identifier The instance identifier containing the binding information.
     /// \param parent A reference to the Skeleton which owns this event.
     /// \param field_name The binding unspecific name of the field inside the skeleton denoted by instance identifier.
+    /// \param additional_slots_for_field_get_set Additional slots to reserve on top of configured sample slots.
     /// \return An instance of SkeletonEventBinding or nullptr in case of an error.
     virtual auto CreateEventBinding(const InstanceIdentifier& identifier,
                                     SkeletonBinding& parent_binding,
-                                    const std::string_view field_name) noexcept
+                                    const std::string_view field_name,
+                                    std::size_t additional_slots_for_field_get_set = 0U) noexcept
         -> std::unique_ptr<SkeletonEventBinding<SampleType>> = 0;
 };
 

--- a/score/mw/com/impl/plumbing/i_skeleton_field_binding_factory.h
+++ b/score/mw/com/impl/plumbing/i_skeleton_field_binding_factory.h
@@ -46,11 +46,13 @@ class ISkeletonFieldBindingFactory
     /// \param parent A reference to the Skeleton which owns this event.
     /// \param field_name The binding unspecific name of the field inside the skeleton denoted by instance identifier.
     /// \param additional_slots_for_field_get_set Additional slots to reserve on top of configured sample slots.
+    /// \param field_getter_enabled Whether the field's getter method is enabled.
     /// \return An instance of SkeletonEventBinding or nullptr in case of an error.
     virtual auto CreateEventBinding(const InstanceIdentifier& identifier,
                                     SkeletonBinding& parent_binding,
                                     const std::string_view field_name,
-                                    std::size_t additional_slots_for_field_get_set = 0U) noexcept
+                                    std::size_t additional_slots_for_field_get_set = 0U,
+                                    bool field_getter_enabled = false) noexcept
         -> std::unique_ptr<SkeletonEventBinding<SampleType>> = 0;
 };
 

--- a/score/mw/com/impl/plumbing/skeleton_field_binding_factory.h
+++ b/score/mw/com/impl/plumbing/skeleton_field_binding_factory.h
@@ -22,6 +22,7 @@
 #include "score/mw/com/impl/skeleton_base.h"
 #include "score/mw/com/impl/skeleton_event_binding.h"
 
+#include <cstddef>
 #include <functional>
 #include <memory>
 #include <string_view>
@@ -37,11 +38,14 @@ class SkeletonFieldBindingFactory final
 {
   public:
     /// \brief See documentation in ISkeletonFieldBindingFactory.
-    static std::unique_ptr<SkeletonEventBinding<SampleType>> CreateEventBinding(const InstanceIdentifier& identifier,
-                                                                                SkeletonBinding& parent_binding,
-                                                                                const std::string_view field_name)
+    static std::unique_ptr<SkeletonEventBinding<SampleType>> CreateEventBinding(
+        const InstanceIdentifier& identifier,
+        SkeletonBinding& parent_binding,
+        const std::string_view field_name,
+        std::size_t additional_slots_for_field_get_set = 0U)
     {
-        return instance().CreateEventBinding(identifier, parent_binding, field_name);
+        return instance().CreateEventBinding(
+            identifier, parent_binding, field_name, additional_slots_for_field_get_set);
     }
 
     /// \brief Inject a mock ISkeletonFieldBindingFactory. If a mock is injected, then all calls on

--- a/score/mw/com/impl/plumbing/skeleton_field_binding_factory.h
+++ b/score/mw/com/impl/plumbing/skeleton_field_binding_factory.h
@@ -42,10 +42,11 @@ class SkeletonFieldBindingFactory final
         const InstanceIdentifier& identifier,
         SkeletonBinding& parent_binding,
         const std::string_view field_name,
-        std::size_t additional_slots_for_field_get_set = 0U)
+        std::size_t additional_slots_for_field_get_set = 0U,
+        bool field_getter_enabled = false)
     {
         return instance().CreateEventBinding(
-            identifier, parent_binding, field_name, additional_slots_for_field_get_set);
+            identifier, parent_binding, field_name, additional_slots_for_field_get_set, field_getter_enabled);
     }
 
     /// \brief Inject a mock ISkeletonFieldBindingFactory. If a mock is injected, then all calls on

--- a/score/mw/com/impl/plumbing/skeleton_field_binding_factory_impl.h
+++ b/score/mw/com/impl/plumbing/skeleton_field_binding_factory_impl.h
@@ -21,6 +21,7 @@
 #include "score/mw/com/impl/skeleton_base.h"
 #include "score/mw/com/impl/skeleton_event_binding.h"
 
+#include <cstddef>
 #include <memory>
 #include <string_view>
 
@@ -36,7 +37,8 @@ class SkeletonFieldBindingFactoryImpl : public ISkeletonFieldBindingFactory<Samp
     std::unique_ptr<SkeletonEventBinding<SampleType>> CreateEventBinding(
         const InstanceIdentifier& identifier,
         SkeletonBinding& parent_binding,
-        const std::string_view field_name) noexcept override;
+        const std::string_view field_name,
+        std::size_t additional_slots_for_field_get_set = 0U) noexcept override;
 };
 
 template <typename SampleType>
@@ -48,16 +50,18 @@ template <typename SampleType>
 // an exception.
 // This suppression should be removed after fixing [Ticket-173043](broken_link_j/Ticket-173043)
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-auto SkeletonFieldBindingFactoryImpl<SampleType>::CreateEventBinding(const InstanceIdentifier& identifier,
-                                                                     SkeletonBinding& parent_binding,
-                                                                     const std::string_view field_name) noexcept
-    -> std::unique_ptr<SkeletonEventBinding<SampleType>>
+auto SkeletonFieldBindingFactoryImpl<SampleType>::CreateEventBinding(
+    const InstanceIdentifier& identifier,
+    SkeletonBinding& parent_binding,
+    const std::string_view field_name,
+    std::size_t additional_slots_for_field_get_set) noexcept -> std::unique_ptr<SkeletonEventBinding<SampleType>>
 {
     // TODO: Currently field_getter_enabled is hard coded to false, will add support
     //  when getter functionality of field is implemented.
     return CreateSkeletonEventOrField<SkeletonEventBinding<SampleType>,
                                       lola::SkeletonEvent<SampleType>,
-                                      ServiceElementType::FIELD>(identifier, parent_binding, field_name, false);
+                                      ServiceElementType::FIELD>(
+        identifier, parent_binding, field_name, additional_slots_for_field_get_set, false);
 }
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/skeleton_field_binding_factory_impl.h
+++ b/score/mw/com/impl/plumbing/skeleton_field_binding_factory_impl.h
@@ -34,11 +34,11 @@ template <typename SampleType>
 class SkeletonFieldBindingFactoryImpl : public ISkeletonFieldBindingFactory<SampleType>
 {
   public:
-    std::unique_ptr<SkeletonEventBinding<SampleType>> CreateEventBinding(
-        const InstanceIdentifier& identifier,
-        SkeletonBinding& parent_binding,
-        const std::string_view field_name,
-        std::size_t additional_slots_for_field_get_set = 0U) noexcept override;
+    std::unique_ptr<SkeletonEventBinding<SampleType>> CreateEventBinding(const InstanceIdentifier& identifier,
+                                                                         SkeletonBinding& parent_binding,
+                                                                         const std::string_view field_name,
+                                                                         std::size_t additional_slots_for_field_get_set,
+                                                                         bool field_getter_enabled) noexcept override;
 };
 
 template <typename SampleType>
@@ -50,18 +50,17 @@ template <typename SampleType>
 // an exception.
 // This suppression should be removed after fixing [Ticket-173043](broken_link_j/Ticket-173043)
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-auto SkeletonFieldBindingFactoryImpl<SampleType>::CreateEventBinding(
-    const InstanceIdentifier& identifier,
-    SkeletonBinding& parent_binding,
-    const std::string_view field_name,
-    std::size_t additional_slots_for_field_get_set) noexcept -> std::unique_ptr<SkeletonEventBinding<SampleType>>
+auto SkeletonFieldBindingFactoryImpl<SampleType>::CreateEventBinding(const InstanceIdentifier& identifier,
+                                                                     SkeletonBinding& parent_binding,
+                                                                     const std::string_view field_name,
+                                                                     std::size_t additional_slots_for_field_get_set,
+                                                                     bool field_getter_enabled) noexcept
+    -> std::unique_ptr<SkeletonEventBinding<SampleType>>
 {
-    // TODO: Currently field_getter_enabled is hard coded to false, will add support
-    //  when getter functionality of field is implemented.
     return CreateSkeletonEventOrField<SkeletonEventBinding<SampleType>,
                                       lola::SkeletonEvent<SampleType>,
                                       ServiceElementType::FIELD>(
-        identifier, parent_binding, field_name, additional_slots_for_field_get_set, false);
+        identifier, parent_binding, field_name, additional_slots_for_field_get_set, field_getter_enabled);
 }
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/skeleton_field_binding_factory_mock.h
+++ b/score/mw/com/impl/plumbing/skeleton_field_binding_factory_mock.h
@@ -17,6 +17,8 @@
 
 #include <gmock/gmock.h>
 
+#include <cstddef>
+
 namespace score::mw::com::impl
 {
 
@@ -28,6 +30,16 @@ class SkeletonFieldBindingFactoryMock : public ISkeletonFieldBindingFactory<Samp
                 CreateEventBinding,
                 (const InstanceIdentifier&, SkeletonBinding&, const std::string_view),
                 (noexcept, override));
+
+    auto CreateEventBinding(const InstanceIdentifier& identifier,
+                            SkeletonBinding& parent_binding,
+                            const std::string_view field_name,
+                            std::size_t additional_slots_for_field_get_set) noexcept
+        -> std::unique_ptr<SkeletonEventBinding<SampleType>> override
+    {
+        static_cast<void>(additional_slots_for_field_get_set);
+        return CreateEventBinding(identifier, parent_binding, field_name);
+    }
 };
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/skeleton_field_binding_factory_mock.h
+++ b/score/mw/com/impl/plumbing/skeleton_field_binding_factory_mock.h
@@ -28,18 +28,8 @@ class SkeletonFieldBindingFactoryMock : public ISkeletonFieldBindingFactory<Samp
   public:
     MOCK_METHOD(std::unique_ptr<SkeletonEventBinding<SampleType>>,
                 CreateEventBinding,
-                (const InstanceIdentifier&, SkeletonBinding&, const std::string_view),
+                (const InstanceIdentifier&, SkeletonBinding&, const std::string_view, std::size_t, bool),
                 (noexcept, override));
-
-    auto CreateEventBinding(const InstanceIdentifier& identifier,
-                            SkeletonBinding& parent_binding,
-                            const std::string_view field_name,
-                            std::size_t additional_slots_for_field_get_set) noexcept
-        -> std::unique_ptr<SkeletonEventBinding<SampleType>> override
-    {
-        static_cast<void>(additional_slots_for_field_get_set);
-        return CreateEventBinding(identifier, parent_binding, field_name);
-    }
 };
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_impl.h
+++ b/score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_impl.h
@@ -30,6 +30,7 @@
 #include <score/overload.hpp>
 
 #include <chrono>
+#include <cstddef>
 #include <exception>
 #include <memory>
 #include <string>
@@ -44,7 +45,8 @@ namespace detail
 {
 
 inline lola::SkeletonEventProperties GetSkeletonEventProperties(
-    const LolaEventInstanceDeployment& lola_event_instance_deployment)
+    const LolaEventInstanceDeployment& lola_event_instance_deployment,
+    std::size_t additional_slots_for_field_get_set = 0U)
 {
     if (!lola_event_instance_deployment.GetNumberOfSampleSlots().has_value())
     {
@@ -61,15 +63,21 @@ inline lola::SkeletonEventProperties GetSkeletonEventProperties(
                "not specified in the configuration. Terminating.";
         std::terminate();
     }
-    return lola::SkeletonEventProperties{lola_event_instance_deployment.GetNumberOfSampleSlots().value(),
+    const auto number_of_slots =
+        static_cast<std::size_t>(lola_event_instance_deployment.GetNumberOfSampleSlots().value()) +
+        additional_slots_for_field_get_set;
+
+    return lola::SkeletonEventProperties{number_of_slots,
                                          lola_event_instance_deployment.max_subscribers_.value(),
                                          lola_event_instance_deployment.enforce_max_samples_};
 }
 
 inline lola::SkeletonEventProperties GetSkeletonEventProperties(
-    const LolaFieldInstanceDeployment& lola_field_instance_deployment)
+    const LolaFieldInstanceDeployment& lola_field_instance_deployment,
+    std::size_t additional_slots_for_field_get_set = 0U)
 {
-    return GetSkeletonEventProperties(lola_field_instance_deployment.lola_event_instance_deployment_);
+    return GetSkeletonEventProperties(lola_field_instance_deployment.lola_event_instance_deployment_,
+                                      additional_slots_for_field_get_set);
 }
 
 }  // namespace detail
@@ -86,7 +94,9 @@ template <typename SkeletonServiceElementBinding, typename SkeletonServiceElemen
 auto CreateSkeletonEventOrField(const InstanceIdentifier& identifier,
                                 SkeletonBinding& parent_binding,
                                 const std::string_view service_element_name,
-                                bool field_getter_enabled) noexcept -> std::unique_ptr<SkeletonServiceElementBinding>
+                                std::size_t additional_slots_for_field_get_set = 0U,
+                                bool field_getter_enabled = false) noexcept
+    -> std::unique_ptr<SkeletonServiceElementBinding>
 {
     static_assert((element_type == ServiceElementType::EVENT) || (element_type == ServiceElementType::FIELD));
 
@@ -94,8 +104,11 @@ auto CreateSkeletonEventOrField(const InstanceIdentifier& identifier,
 
     using ReturnType = std::unique_ptr<SkeletonServiceElementBinding>;
     auto visitor = score::cpp::overload(
-        [identifier_view, &parent_binding, &service_element_name, field_getter_enabled](
-            const LolaServiceTypeDeployment& lola_service_type_deployment) -> ReturnType {
+        [identifier_view,
+         &parent_binding,
+         &service_element_name,
+         additional_slots_for_field_get_set,
+         field_getter_enabled](const LolaServiceTypeDeployment& lola_service_type_deployment) -> ReturnType {
             auto* const lola_parent = dynamic_cast<lola::Skeleton*>(&parent_binding);
             if (lola_parent == nullptr)
             {
@@ -111,8 +124,8 @@ auto CreateSkeletonEventOrField(const InstanceIdentifier& identifier,
             const std::string service_element_name_str{service_element_name};
             const auto& lola_service_element_instance_deployment = GetServiceElementInstanceDeployment<element_type>(
                 lola_service_instance_deployment, service_element_name_str);
-            const lola::SkeletonEventProperties skeleton_event_properties =
-                detail::GetSkeletonEventProperties(lola_service_element_instance_deployment);
+            const lola::SkeletonEventProperties skeleton_event_properties = detail::GetSkeletonEventProperties(
+                lola_service_element_instance_deployment, additional_slots_for_field_get_set);
 
             const auto lola_service_element_id =
                 GetServiceElementId<element_type>(lola_service_type_deployment, service_element_name_str);

--- a/score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_test.cpp
+++ b/score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_test.cpp
@@ -126,7 +126,9 @@ TEST_P(SkeletonServiceElementBindingFactoryParamaterisedFixture, CanConstructFix
 class SkeletonServiceElementBindingFactoryFixture : public ::testing::Test
 {
   protected:
-    const LolaFieldInstanceDeployment field_deployment_{{2U}, {3U}, 1U, true, 0U};
+    const LolaFieldInstanceDeployment field_deployment_{LolaEventInstanceDeployment{{2U}, {3U}, {1U}, true, 0U},
+                                                        false,
+                                                        false};
 
     auto GetSkeletonEventProperties(const std::size_t additional_slots_for_field_get_set = 0U) const
     {

--- a/score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_test.cpp
+++ b/score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_test.cpp
@@ -123,6 +123,31 @@ INSTANTIATE_TEST_CASE_P(SkeletonServiceElementBindingFactoryParamaterisedDeathTe
 
 TEST_P(SkeletonServiceElementBindingFactoryParamaterisedFixture, CanConstructFixture) {}
 
+class SkeletonServiceElementBindingFactoryFixture : public ::testing::Test
+{
+  protected:
+    const LolaFieldInstanceDeployment field_deployment_{{2U}, {3U}, 1U, true, 0U};
+
+    auto GetSkeletonEventProperties(const std::size_t additional_slots_for_field_get_set = 0U) const
+    {
+        return detail::GetSkeletonEventProperties(field_deployment_, additional_slots_for_field_get_set);
+    }
+};
+
+TEST_F(SkeletonServiceElementBindingFactoryFixture, AdditionalSlotsAreAddedToConfiguredNumberOfSlots)
+{
+    const auto skeleton_event_properties = GetSkeletonEventProperties(1U);
+
+    EXPECT_EQ(skeleton_event_properties.number_of_slots, 3U);
+}
+
+TEST_F(SkeletonServiceElementBindingFactoryFixture, DefaultAdditionalSlotsKeepsConfiguredNumberOfSlots)
+{
+    const auto skeleton_event_properties = GetSkeletonEventProperties();
+
+    EXPECT_EQ(skeleton_event_properties.number_of_slots, 2U);
+}
+
 TEST_P(SkeletonServiceElementBindingFactoryParamaterisedFixture, CanConstructServiceElement)
 {
     RecordProperty("Verifies", "SCR-21803701, SCR-21803702, SCR-5898925");

--- a/score/mw/com/impl/skeleton_base_test.cpp
+++ b/score/mw/com/impl/skeleton_base_test.cpp
@@ -117,7 +117,7 @@ class SkeletonBaseFixture : public ::testing::Test
                     Create(instance_identifier, _, kDummyEventName2))
             .WillOnce(Return(ByMove(std::move(skeleton_event_mock_ptr_2))));
         EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_,
-                    CreateEventBinding(instance_identifier, _, kDummyFieldName))
+                    CreateEventBinding(instance_identifier, _, kDummyFieldName, _, _))
             .WillOnce(Return(ByMove(std::move(skeleton_field_mock_ptr))));
 
         EXPECT_CALL(*event_binding_mock_1_, GetBindingType()).WillOnce(Return(BindingType::kLoLa));
@@ -620,7 +620,7 @@ TEST_F(SkeletonBaseOfferFixture, NoStopOfferOnErrorIdentifier)
                 Create(instance_identifier, _, kDummyEventName2))
         .Times(0);
     EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_,
-                CreateEventBinding(GetInstanceIdentifierWithoutBinding(), _, kDummyFieldName))
+                CreateEventBinding(GetInstanceIdentifierWithoutBinding(), _, kDummyFieldName, _, _))
         .Times(0);
 
     // Given a constructed Skeleton with a invalid identifier

--- a/score/mw/com/impl/skeleton_field.h
+++ b/score/mw/com/impl/skeleton_field.h
@@ -303,12 +303,22 @@ class SkeletonFieldImpl : public SkeletonFieldBase
             {
                 return;
             }
-            const auto result = get_method_->RegisterHandler([this]() -> Result<FieldType> {
-                // need to serialize access to Get. In case of concurrent Get calls,
-                // we want to ensure that they are processed sequentially.
-                std::lock_guard<std::mutex> lock{get_handler_mutex_};
-                return SkeletonEventView<FieldType>{*GetTypedEvent()}.GetLatestSample();
-            });
+            const auto result = get_method_->RegisterHandler(
+                [this](QualityType quality_type, FieldType& return_value) {
+                    // need to serialize access to Get. In case of concurrent Get calls,
+                    // we want to ensure that they are processed sequentially.
+                    std::lock_guard<std::mutex> lock{get_handler_mutex_};
+                    const auto sample_ptr_result =
+                        SkeletonEventView<FieldType>{*GetTypedEvent()}.GetLatestSample(quality_type);
+                    if (!sample_ptr_result.has_value())
+                    {
+                        score::mw::log::LogError("lola")
+                            << "Get handler: failed to get latest sample: " << sample_ptr_result.error();
+                        return;
+                    }
+                    return_value = *sample_ptr_result.value();
+                },
+                QualityType{});
             if (!result.has_value())
             {
                 score::mw::log::LogError("lola")

--- a/score/mw/com/impl/skeleton_field.h
+++ b/score/mw/com/impl/skeleton_field.h
@@ -248,7 +248,8 @@ class SkeletonFieldImpl : public SkeletonFieldBase
                 skeleton_base_view.GetAssociatedInstanceIdentifier(),
                 skeleton_base_view.GetBinding(),
                 field_name,
-                (kHasGetter || kHasSetter) ? 1U : 0U),
+                (kHasGetter || kHasSetter) ? 1U : 0U,
+                kHasGetter),
             typename SkeletonEvent<FieldType>::FieldOnlyConstructorEnabler{});
     }
 
@@ -303,13 +304,19 @@ class SkeletonFieldImpl : public SkeletonFieldBase
             {
                 return;
             }
+            auto field_ref =
+                std::make_unique<std::reference_wrapper<ReferenceToMoveable<SkeletonFieldBase>::Reference>>(
+                    GetReferenceToMoveable());
+            auto mutex = std::make_unique<std::mutex>();
             const auto result = get_method_->RegisterHandler(
-                [this](QualityType quality_type, FieldType& return_value) {
+                [field_ref = std::move(field_ref), mutex = std::move(mutex)](QualityType quality_type,
+                                                                             FieldType& return_value) {
                     // need to serialize access to Get. In case of concurrent Get calls,
                     // we want to ensure that they are processed sequentially.
-                    std::lock_guard<std::mutex> lock{get_handler_mutex_};
+                    std::lock_guard<std::mutex> lock{*mutex};
+                    auto& typed_field = static_cast<SkeletonFieldImpl&>(field_ref->get().Get());
                     const auto sample_ptr_result =
-                        SkeletonEventView<FieldType>{*GetTypedEvent()}.GetLatestSample(quality_type);
+                        SkeletonEventView<FieldType>{typed_field.GetTypedEvent()}.GetLatestSample(quality_type);
                     if (!sample_ptr_result.has_value())
                     {
                         score::mw::log::LogError("lola")
@@ -350,13 +357,6 @@ class SkeletonFieldImpl : public SkeletonFieldBase
     /// This mutex must be allocated on the heap since SkeletonField must be moveable (and a std::mutex is not
     /// moveable).
     std::unique_ptr<std::mutex> set_handler_mutex_{};
-    
-    // Zero-cost storage: only a real mutex when kHasGetter=true, otherwise an empty zero-size type.
-    struct NullMutex
-    {
-    };
-    using GetHandlerMutexType = std::conditional_t<kHasGetter, std::mutex, NullMutex>;
-    GetHandlerMutexType get_handler_mutex_{};
 
     std::unique_ptr<SkeletonMethod<SetMethodSignature>> set_method_;
     std::unique_ptr<SkeletonMethod<GetMethodSignature>> get_method_;

--- a/score/mw/com/impl/skeleton_field.h
+++ b/score/mw/com/impl/skeleton_field.h
@@ -245,7 +245,10 @@ class SkeletonFieldImpl : public SkeletonFieldBase
             parent,
             field_name,
             SkeletonFieldBindingFactory<SampleDataType>::CreateEventBinding(
-                skeleton_base_view.GetAssociatedInstanceIdentifier(), skeleton_base_view.GetBinding(), field_name),
+                skeleton_base_view.GetAssociatedInstanceIdentifier(),
+                skeleton_base_view.GetBinding(),
+                field_name,
+                (kHasGetter || kHasSetter) ? 1U : 0U),
             typename SkeletonEvent<FieldType>::FieldOnlyConstructorEnabler{});
     }
 
@@ -302,7 +305,7 @@ class SkeletonFieldImpl : public SkeletonFieldBase
             }
             const auto result = get_method_->RegisterHandler([this]() -> Result<FieldType> {
                 // need to serialize access to Get. In case of concurrent Get calls,
-                // we want to ensure that they are processed sequentially.    
+                // we want to ensure that they are processed sequentially.
                 std::lock_guard<std::mutex> lock{get_handler_mutex_};
                 return SkeletonEventView<FieldType>{*GetTypedEvent()}.GetLatestSample();
             });
@@ -339,7 +342,9 @@ class SkeletonFieldImpl : public SkeletonFieldBase
     std::unique_ptr<std::mutex> set_handler_mutex_{};
     
     // Zero-cost storage: only a real mutex when kHasGetter=true, otherwise an empty zero-size type.
-    struct NullMutex {};
+    struct NullMutex
+    {
+    };
     using GetHandlerMutexType = std::conditional_t<kHasGetter, std::mutex, NullMutex>;
     GetHandlerMutexType get_handler_mutex_{};
 

--- a/score/mw/com/impl/skeleton_field.h
+++ b/score/mw/com/impl/skeleton_field.h
@@ -291,6 +291,29 @@ class SkeletonFieldImpl : public SkeletonFieldBase
         }
     }
 
+    /// \brief Registers a get handler into get_method_ so that proxy Get() calls are served automatically.
+    void RegisterGetHandler()
+    {
+        if constexpr (kHasGetter)
+        {
+            if (get_method_ == nullptr)
+            {
+                return;
+            }
+            const auto result = get_method_->RegisterHandler([this]() -> Result<FieldType> {
+                // need to serialize access to Get. In case of concurrent Get calls,
+                // we want to ensure that they are processed sequentially.    
+                std::lock_guard<std::mutex> lock{get_handler_mutex_};
+                return SkeletonEventView<FieldType>{*GetTypedEvent()}.GetLatestSample();
+            });
+            if (!result.has_value())
+            {
+                score::mw::log::LogError("lola")
+                    << "RegisterGetHandler: failed to register get handler: " << result.error();
+            }
+        }
+    }
+
     /// \brief Single private delegating constructor. Both the production and test ctors funnel through here with
     ///        appropriate dispatches (real ones from the Make*IfEnabled helpers, or nullptr).
     SkeletonFieldImpl(SkeletonBase& parent,
@@ -314,6 +337,11 @@ class SkeletonFieldImpl : public SkeletonFieldBase
     /// This mutex must be allocated on the heap since SkeletonField must be moveable (and a std::mutex is not
     /// moveable).
     std::unique_ptr<std::mutex> set_handler_mutex_{};
+    
+    // Zero-cost storage: only a real mutex when kHasGetter=true, otherwise an empty zero-size type.
+    struct NullMutex {};
+    using GetHandlerMutexType = std::conditional_t<kHasGetter, std::mutex, NullMutex>;
+    GetHandlerMutexType get_handler_mutex_{};
 
     std::unique_ptr<SkeletonMethod<SetMethodSignature>> set_method_;
     std::unique_ptr<SkeletonMethod<GetMethodSignature>> get_method_;
@@ -336,6 +364,10 @@ SkeletonFieldImpl<SampleDataType, Tags...>::SkeletonFieldImpl(
 {
     SkeletonBaseView skeleton_base_view{parent};
     skeleton_base_view.RegisterField(field_name, GetReferenceToMoveable());
+    if constexpr (kHasGetter)
+    {
+        RegisterGetHandler();
+    }
 }
 
 /// \brief FieldType is allocated by the user and provided to the middleware to send. Dispatches to

--- a/score/mw/com/impl/skeleton_field_test.cpp
+++ b/score/mw/com/impl/skeleton_field_test.cpp
@@ -93,7 +93,7 @@ class SkeletonFieldTestFixture : public ::testing::Test
     void SetUp() override
     {
         ON_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_,
-                CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName))
+                CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName, _, _))
             .WillByDefault(InvokeWithoutArgs([this]() {
                 return std::make_unique<mock_binding::SkeletonEventFacade<TestSampleType>>(
                     skeleton_field_binding_mock_);
@@ -194,7 +194,7 @@ TEST(SkeletonFieldGetHandlerTest, RegisterGetHandlerInvokesGetLatestSampleOnBind
     SkeletonFieldBindingFactoryMockGuard<TestSampleType> skeleton_field_binding_factory_mock_guard{};
     auto skeleton_field_binding_mock_ptr = std::make_unique<mock_binding::SkeletonEvent<TestSampleType>>();
     ON_CALL(skeleton_field_binding_factory_mock_guard.factory_mock_,
-            CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName))
+            CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName, _, _))
         .WillByDefault(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
 
     SkeletonMethodBindingFactoryMockGuard skeleton_method_binding_factory_mock_guard{};
@@ -729,7 +729,7 @@ TEST(SkeletonFieldInitialValueTest, MoveAssigningFieldBeforePrepareOfferWillKeep
     auto skeleton_field_binding_mock_ptr = std::make_unique<mock_binding::SkeletonEvent<TestSampleType>>();
     auto& skeleton_field_binding_mock = *skeleton_field_binding_mock_ptr;
     EXPECT_CALL(skeleton_field_binding_factory_mock_guard.factory_mock_,
-                CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName))
+                CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName, _, _))
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
 
     EXPECT_CALL(skeleton_field_binding_mock, GetBindingType()).WillOnce(Return(BindingType::kLoLa));
@@ -760,7 +760,8 @@ TEST(SkeletonFieldInitialValueTest, MoveAssigningFieldBeforePrepareOfferWillKeep
     // and Expecting that a second SkeletonField binding is created
     auto skeleton_field_binding_mock_ptr_2 = std::make_unique<mock_binding::SkeletonEvent<TestSampleType>>();
     auto& skeleton_field_binding_mock_2 = *skeleton_field_binding_mock_ptr_2;
-    EXPECT_CALL(skeleton_field_binding_factory_mock_guard.factory_mock_, CreateEventBinding(identifier2, _, kFieldName))
+    EXPECT_CALL(skeleton_field_binding_factory_mock_guard.factory_mock_,
+                CreateEventBinding(identifier2, _, kFieldName, _, _))
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr_2))));
 
     EXPECT_CALL(skeleton_field_binding_mock_2, GetBindingType()).WillOnce(Return(BindingType::kLoLa));
@@ -875,7 +876,7 @@ TEST_F(SkeletonFieldDeathTest, DestroyingSkeletonFieldWhileHoldingSampleAllocate
     auto skeleton_field_binding_mock_ptr = std::make_unique<mock_binding::SkeletonEvent<TestSampleType>>();
     auto& skeleton_field_binding_mock = *skeleton_field_binding_mock_ptr;
     EXPECT_CALL(skeleton_field_binding_factory_mock_guard.factory_mock_,
-                CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName))
+                CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName, _, _))
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
 
     // and that PrepareOffer() is called once on the field binding

--- a/score/mw/com/impl/skeleton_field_test.cpp
+++ b/score/mw/com/impl/skeleton_field_test.cpp
@@ -1115,7 +1115,7 @@ TEST_F(SkeletonFieldSetHandlerTest, CallingMethodHandlerInvokesUserCallback)
     // When calling the set handler that was captured by the method binding
     auto [in_span, out_span] =
         CreateFieldSetterInArgAndReturnSpans(kDummySetValue, score::Result<TestSampleType>{kDummySetValue});
-    captured_set_handler_.value()(in_span, out_span);
+    captured_set_handler_.value()(in_span, out_span, QualityType{});
 }
 
 TEST_F(SkeletonFieldSetHandlerTest, CallingMethodHandlerInvokesLatestRegisteredUserCallback)
@@ -1148,7 +1148,7 @@ TEST_F(SkeletonFieldSetHandlerTest, CallingMethodHandlerInvokesLatestRegisteredU
     // When calling the set handler that was captured by the method binding
     auto [in_span, out_span] =
         CreateFieldSetterInArgAndReturnSpans(kDummySetValue, score::Result<TestSampleType>{kDummySetValue});
-    captured_set_handler_.value()(in_span, out_span);
+    captured_set_handler_.value()(in_span, out_span, QualityType{});
 }
 
 TEST_F(SkeletonFieldSetHandlerTest, CallingMethodHandlerCallsSend)
@@ -1168,7 +1168,7 @@ TEST_F(SkeletonFieldSetHandlerTest, CallingMethodHandlerCallsSend)
     // When calling the set handler that was captured by the method binding
     auto [in_span, out_span] =
         CreateFieldSetterInArgAndReturnSpans(kDummySetValue, score::Result<TestSampleType>{kDummySetValue});
-    captured_set_handler_.value()(in_span, out_span);
+    captured_set_handler_.value()(in_span, out_span, QualityType{});
 }
 
 TEST_F(SkeletonFieldSetHandlerTest, MethodHandlerDoesNotTerminateWhenSendFails)
@@ -1189,7 +1189,7 @@ TEST_F(SkeletonFieldSetHandlerTest, MethodHandlerDoesNotTerminateWhenSendFails)
     // When calling the set handler that was captured by the method binding
     auto [in_span, out_span] =
         CreateFieldSetterInArgAndReturnSpans(kDummySetValue, score::Result<TestSampleType>{kDummySetValue});
-    captured_set_handler_.value()(in_span, out_span);
+    captured_set_handler_.value()(in_span, out_span, QualityType{});
 
     // Then the out span contains an error indicating that the binding failed
     const auto& return_value = *reinterpret_cast<score::Result<TestSampleType>*>(out_span.data());
@@ -1223,7 +1223,7 @@ TEST_F(SkeletonFieldSetHandlerTest, CallingMethodHandlerCallsSendWithValueModifi
     // When calling the set handler that was captured by the method binding
     auto [in_span, out_span] =
         CreateFieldSetterInArgAndReturnSpans(kDummySetValue, score::Result<TestSampleType>{kDummySetValue});
-    captured_set_handler_.value()(in_span, out_span);
+    captured_set_handler_.value()(in_span, out_span, QualityType{});
 }
 
 TEST_F(SkeletonFieldSetHandlerTest, PassingReferenceToHandlerUpdatesStateInPlace)
@@ -1252,7 +1252,7 @@ TEST_F(SkeletonFieldSetHandlerTest, PassingReferenceToHandlerUpdatesStateInPlace
     // When calling the set handler that was captured by the method binding
     auto [in_span, out_span] =
         CreateFieldSetterInArgAndReturnSpans(kDummySetValue, score::Result<TestSampleType>{kDummySetValue});
-    captured_set_handler_.value()(in_span, out_span);
+    captured_set_handler_.value()(in_span, out_span, QualityType{});
 
     // Then the state of the functor is updated in place when the handler is called by the binding
     EXPECT_EQ(test_functor.i_, kModifiedValue);
@@ -1305,7 +1305,7 @@ TEST_F(SkeletonFieldMoveConstructionFixture,
     // When calling the set handler that was captured by the method binding
     auto [in_span, out_span] =
         CreateFieldSetterInArgAndReturnSpans(kDummySetValue, score::Result<TestSampleType>{kDummySetValue});
-    captured_set_handler_.value()(in_span, out_span);
+    captured_set_handler_.value()(in_span, out_span, QualityType{});
 }
 
 }  // namespace

--- a/score/mw/com/impl/skeleton_field_test.cpp
+++ b/score/mw/com/impl/skeleton_field_test.cpp
@@ -25,6 +25,7 @@
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
+#include <array>
 #include <cstdint>
 #include <functional>
 #include <memory>
@@ -123,6 +124,14 @@ class SkeletonFieldTestFixture : public ::testing::Test
     mock_binding::SkeletonMethod skeleton_field_set_binding_mock_{};
 };
 
+class MyGetEnabledSkeleton : public SkeletonBase
+{
+  public:
+    using SkeletonBase::SkeletonBase;
+
+    SkeletonField<TestSampleType, WithGetter> my_get_field_{*this, kFieldName};
+};
+
 TEST(SkeletonFieldTest, NotCopyable)
 {
     RecordProperty("Verifies", "SCR-18221574");
@@ -173,6 +182,32 @@ TEST(SkeletonFieldTest, SkeletonFieldContainsPublicSampleType)
     static_assert(std::is_same<typename SkeletonField<TestSampleType, WithGetter, WithNotifier, WithSetter>::FieldType,
                                TestSampleType>::value,
                   "Incorrect FieldType.");
+}
+
+TEST(SkeletonFieldGetHandlerTest, RegisterGetHandlerInvokesGetLatestSampleOnBinding)
+{
+    // Given a runtime, an event binding factory returning a mock event binding,
+    // and a method binding factory returning a mock method binding
+    RuntimeMockGuard runtime_mock_guard{};
+    ON_CALL(runtime_mock_guard.runtime_mock_, GetTracingFilterConfig()).WillByDefault(Return(nullptr));
+
+    SkeletonFieldBindingFactoryMockGuard<TestSampleType> skeleton_field_binding_factory_mock_guard{};
+    auto skeleton_field_binding_mock_ptr = std::make_unique<mock_binding::SkeletonEvent<TestSampleType>>();
+    ON_CALL(skeleton_field_binding_factory_mock_guard.factory_mock_,
+            CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName))
+        .WillByDefault(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
+
+    SkeletonMethodBindingFactoryMockGuard skeleton_method_binding_factory_mock_guard{};
+    mock_binding::SkeletonMethod skeleton_method_binding_mock{};
+    ON_CALL(skeleton_method_binding_factory_mock_guard.factory_mock_, Create(kInstanceIdWithLolaBinding, _, _, _))
+        .WillByDefault(
+            Return(ByMove(std::make_unique<mock_binding::SkeletonMethodFacade>(skeleton_method_binding_mock))));
+
+    // Then RegisterHandler must be called on the get method binding exactly once during construction
+    EXPECT_CALL(skeleton_method_binding_mock, RegisterHandler(_)).WillOnce(Return(ResultBlank{}));
+
+    // When a skeleton with EnableGet=true field is constructed, RegisterHandler is called automatically
+    MyGetEnabledSkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
 }
 
 // When Ticket-104261 is implemented, the Update call does not have to be deferred until OfferService is called. This

--- a/score/mw/com/impl/traits_test.cpp
+++ b/score/mw/com/impl/traits_test.cpp
@@ -689,7 +689,7 @@ class SkeletonCreationFixture : public ::testing::Test
 
         // By default the Create call on the SkeletonFieldBindingFactory returns valid bindings.
         ON_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_,
-                CreateEventBinding(identifier_with_valid_binding_, _, kFieldName))
+                CreateEventBinding(identifier_with_valid_binding_, _, kFieldName, _, _))
             .WillByDefault(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
 
         // By default the Create call on the SkeletonMethodBindingFactory returns valid bindings.
@@ -761,7 +761,7 @@ TEST_F(GeneratedSkeletonCreationInstanceSpecifierTestFixture,
                 Create(identifier_with_valid_binding_, _, kEventName))
         .WillOnce(Return(ByMove(std::move(skeleton_event_binding_mock_ptr))));
     EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_,
-                CreateEventBinding(identifier_with_valid_binding_, _, kFieldName))
+                CreateEventBinding(identifier_with_valid_binding_, _, kFieldName, _, _))
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
     EXPECT_CALL(skeleton_method_binding_factory_mock_guard_.factory_mock_,
                 Create(identifier_with_valid_binding_, _, kFieldName, MethodType::kSet))
@@ -835,7 +835,7 @@ TEST_F(GeneratedSkeletonCreationInstanceSpecifierTestFixture, ReturnErrorWhenCre
 
     // Expecting that the Create call on the SkeletonFieldBindingFactory returns an invalid binding for the field.
     EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_,
-                CreateEventBinding(identifier_with_valid_binding_, _, kFieldName))
+                CreateEventBinding(identifier_with_valid_binding_, _, kFieldName, _, _))
         .WillOnce(Return(ByMove(nullptr)));
 
     // When constructing a skeleton with an InstanceSpecifier
@@ -914,7 +914,7 @@ TEST_F(GeneratedSkeletonCreationInstanceIdentifierTestFixture, ConstructingFromE
                 Create(identifier_with_valid_binding_, _, kEventName))
         .WillOnce(Return(ByMove(std::move(skeleton_event_binding_mock_ptr))));
     EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_,
-                CreateEventBinding(identifier_with_valid_binding_, _, kFieldName))
+                CreateEventBinding(identifier_with_valid_binding_, _, kFieldName, _, _))
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
 
     // When constructing a skeleton with an InstanceIdentifier
@@ -979,7 +979,7 @@ TEST_F(GeneratedSkeletonCreationInstanceIdentifierTestFixture, ConstructingFromI
 
     // Expecting that the Create call on the SkeletonFieldBindingFactory returns an invalid binding for the field.
     EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_,
-                CreateEventBinding(identifier_with_valid_binding_, _, kFieldName))
+                CreateEventBinding(identifier_with_valid_binding_, _, kFieldName, _, _))
         .WillOnce(Return(ByMove(nullptr)));
 
     // When constructing a skeleton with an InstanceIdentifier
@@ -1150,7 +1150,7 @@ class GeneratedSkeletonStopOfferServiceRaiiFixture : public SkeletonCreationFixt
         EXPECT_CALL(skeleton_event_binding_factory_mock_guard_.factory_mock_, Create(_, _, _))
             .WillOnce(Return(ByMove(
                 std::make_unique<mock_binding::SkeletonEventFacade<TestSampleType>>(skeleton_event_binding_mock_))));
-        EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_, CreateEventBinding(_, _, _))
+        EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_, CreateEventBinding(_, _, _, _, _))
             .WillOnce(Return(ByMove(
                 std::make_unique<mock_binding::SkeletonEventFacade<TestSampleType>>(skeleton_field_binding_mock_))));
         EXPECT_CALL(skeleton_method_binding_factory_mock_guard_.factory_mock_, Create(_, _, _, MethodType::kSet))
@@ -1168,7 +1168,7 @@ class GeneratedSkeletonStopOfferServiceRaiiFixture : public SkeletonCreationFixt
         EXPECT_CALL(skeleton_event_binding_factory_mock_guard_.factory_mock_, Create(_, _, _))
             .WillOnce(Return(ByMove(
                 std::make_unique<mock_binding::SkeletonEventFacade<TestSampleType>>(skeleton_event_binding_mock_2_))));
-        EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_, CreateEventBinding(_, _, _))
+        EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_, CreateEventBinding(_, _, _, _, _))
             .WillOnce(Return(ByMove(
                 std::make_unique<mock_binding::SkeletonEventFacade<TestSampleType>>(skeleton_field_binding_mock_2_))));
         EXPECT_CALL(skeleton_method_binding_factory_mock_guard_.factory_mock_, Create(_, _, _, MethodType::kSet))


### PR DESCRIPTION
mw/com/impl: introduces and implements SkeletonField::Get

- SkeletonField now includes a new template parameter, EnableGet.
- When EnableGet is true, a skeleton Get method attribute is added to SkeletonField.
- Constructors were updated to support all relevant EnableSet and EnableGet combinations.
- Automatically register a Get handler for fields with EnableGet.
- Serve Get requests by reading the latest field value and returning it through the Get method.
- Pass additional_slots through field binding creation.
- Compute additional_slots from EnableSet || EnableGet.
- Use configured_slots + additional_slots in event properties.
- Add unit tests for +1 and default (unchanged) slot count.