### PR TITLE
Extend service instance configuration for LoLa gateway

### DIFF
--- a/score/mw/com/impl/configuration/README.md
+++ b/score/mw/com/impl/configuration/README.md
@@ -341,6 +341,13 @@ dependent properties.
   some heuristics, configured in the  [global section](#shm-size-calc-mode).
   Using this property is not encouraged. It is rather a fallback, in case the preferred size calculation fails or in
   case the temporary heap-memory allocation done by the size calculation, needs to be avoided.
+- `interVmSupport`: This is a `SHM` `binding` specific optional setting, which controls whether the shared-memory 
+  objects for this instance are created so that they can be shared among VMs on the same ECU. In this case the SHM 
+  implementation potentially uses different mechanisms/path-names to create/open shm-objects. 
+- `interVmForwarded`: This is a `SHM` `binding` specific optional setting, which controls if the `service-instance` is 
+  expected to be shared between VM instances. In this case the provider of this service instance in the target 
+  gateway domain is not creating an SHM-object, but instead opens an SHM-object that has been created on the actual 
+  provider domain side. In order to use `interVmForwarded`, `interVmSupport` has to be enabled for this instance.
 
 ###### events and fields within an instance
 

--- a/score/mw/com/impl/configuration/config_parser.cpp
+++ b/score/mw/com/impl/configuration/config_parser.cpp
@@ -95,6 +95,8 @@ constexpr auto kTracingGloballyEnabledDefaultValue = false;
 constexpr auto kTracingApplicationInstanceIDKey = "applicationInstanceID"sv;
 constexpr auto kApplicationIdKey = "applicationID"sv;
 constexpr auto kTracingTraceFilterConfigPathKey = "traceFilterConfigPath"sv;
+constexpr auto kInterVmSupport = "interVmSupport"sv;
+constexpr auto kInterVmForwarded = "interVmForwarded"sv;
 constexpr auto kNumberOfIpcTracingSlotsKey = "numberOfIpcTracingSlots"sv;
 using NumberOfIpcTracingSlots_t = std::uint8_t;
 constexpr auto kNumberOfIpcTracingSlotsDefault = static_cast<NumberOfIpcTracingSlots_t>(0U);
@@ -657,6 +659,28 @@ auto ParseLolaServiceInstanceDeployment(const score::json::Object& json_map) -> 
                                                           "Configuration corrupted, check with json schema");
         const auto instance_id_value = instance_id_casted.value();
         service.instance_id_ = LolaServiceInstanceId{instance_id_value};
+    }
+
+    const auto& inter_vm_support = json_map.find(kInterVmSupport.data());
+    if (inter_vm_support != json_map.cend())
+    {
+        service.inter_vm_support_ = inter_vm_support->second.As<bool>().value();
+    }
+
+    // No need to check that binding is SHM for now, because this method is only called if binding is SHM.
+
+    const auto& inter_vm_forwarded = json_map.find(kInterVmForwarded.data());
+    if (inter_vm_forwarded != json_map.cend())
+    {
+        service.inter_vm_forwarded_ = inter_vm_forwarded->second.As<bool>().value();
+    }
+
+    if (service.inter_vm_forwarded_)
+    {
+        SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(
+            service.inter_vm_support_,
+            "Configuration corrupted: Service instance is interVmForwarded but is not "
+            "configured for interVmSupport");
     }
 
     ParseLolaEventInstanceDeployment(json_map, service);

--- a/score/mw/com/impl/configuration/config_parser_test.cpp
+++ b/score/mw/com/impl/configuration/config_parser_test.cpp
@@ -4728,5 +4728,181 @@ TEST_F(ConfigParserFixture, ParseWithMalformedPermissionChecksHandledGracefully)
     });
 }
 
+using ConfigParserFixtureDeathTest = ConfigParserFixture;
+TEST_F(ConfigParserFixtureDeathTest, InvalidInterVmConfigurationWillDie)
+{
+    // Given a JSON where service instance is configured to be inter-VM forwarded but is not configured to have
+    // interVM support, which is invalid
+    auto config_with_invalid_vm_configuration = R"(
+{
+    "serviceTypes": [
+        {
+            "serviceTypeName": "/bmw/ncar/services/TirePressureService",
+            "version": {
+                "major": 12,
+                "minor": 34
+            },
+            "bindings": [
+                {
+                    "binding": "SHM",
+                    "serviceId": 1234,
+                    "events": [
+                        {
+                            "eventName": "CurrentPressureFrontLeft",
+                            "eventId": 30
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "serviceInstances": [
+        {
+            "instanceSpecifier": "abc/abc/TirePressurePort",
+            "serviceTypeName": "/bmw/ncar/services/TirePressureService",
+            "version": {
+                "major": 12,
+                "minor": 34
+            },
+            "instances": [
+                {
+                    "instanceId": 1234,
+                    "asil-level": "QM",
+                    "binding": "SHM",
+                    "events": [
+                        {
+                            "eventName": "CurrentPressureFrontLeft"
+                        }
+                    ],
+                    "interVmSupport": false,
+                    "interVmForwarded": true
+                }
+            ]
+        }
+    ]
+}
+)"_json;
+    // When parsing the JSON
+    // That the application will terminate
+    SCORE_LANGUAGE_FUTURECPP_EXPECT_CONTRACT_VIOLATED(score::cpp::ignore = score::mw::com::impl::configuration::Parse(
+                                                          std::move(config_with_invalid_vm_configuration)));
+}
+
+TEST_F(ConfigParserFixtureDeathTest, NoInterVmSupportWillNotDie)
+{
+    // Given a JSON where service instance is not configured to have inter VM support is fine
+    auto config_with_inter_vm_support_disabled = R"(
+{
+    "serviceTypes": [
+        {
+            "serviceTypeName": "/bmw/ncar/services/TirePressureService",
+            "version": {
+                "major": 12,
+                "minor": 34
+            },
+            "bindings": [
+                {
+                    "binding": "SHM",
+                    "serviceId": 1234,
+                    "events": [
+                        {
+                            "eventName": "CurrentPressureFrontLeft",
+                            "eventId": 30
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "serviceInstances": [
+        {
+            "instanceSpecifier": "abc/abc/TirePressurePort",
+            "serviceTypeName": "/bmw/ncar/services/TirePressureService",
+            "version": {
+                "major": 12,
+                "minor": 34
+            },
+            "instances": [
+                {
+                    "instanceId": 1234,
+                    "asil-level": "QM",
+                    "binding": "SHM",
+                    "events": [
+                        {
+                            "eventName": "CurrentPressureFrontLeft"
+                        }
+                    ],
+                    "interVmSupport": false,
+                    "interVmForwarded": false
+                }
+            ]
+        }
+    ]
+}
+)"_json;
+    // When parsing the JSON
+    // That the application will not terminate
+    score::cpp::ignore = score::mw::com::impl::configuration::Parse(std::move(config_with_inter_vm_support_disabled));
+}
+
+TEST_F(ConfigParserFixtureDeathTest, InterVmSupportButNotInterVmForwardedWillNotDie)
+{
+    // Given a JSON where service instance is configured for inter VM support but will not forward it via inter VM is
+    // fine
+    auto config_with_inter_vm_support_no_vm_forwarding = R"(
+{
+    "serviceTypes": [
+        {
+            "serviceTypeName": "/bmw/ncar/services/TirePressureService",
+            "version": {
+                "major": 12,
+                "minor": 34
+            },
+            "bindings": [
+                {
+                    "binding": "SHM",
+                    "serviceId": 1234,
+                    "events": [
+                        {
+                            "eventName": "CurrentPressureFrontLeft",
+                            "eventId": 30
+                        }
+                    ]
+                }
+            ]
+        }
+    ],
+    "serviceInstances": [
+        {
+            "instanceSpecifier": "abc/abc/TirePressurePort",
+            "serviceTypeName": "/bmw/ncar/services/TirePressureService",
+            "version": {
+                "major": 12,
+                "minor": 34
+            },
+            "instances": [
+                {
+                    "instanceId": 1234,
+                    "asil-level": "QM",
+                    "binding": "SHM",
+                    "events": [
+                        {
+                            "eventName": "CurrentPressureFrontLeft"
+                        }
+                    ],
+                    "interVmSupport": true,
+                    "interVmForwarded": false
+                }
+            ]
+        }
+    ]
+}
+)"_json;
+    // When parsing the JSON
+    // That the application will not terminate
+    score::cpp::ignore =
+        score::mw::com::impl::configuration::Parse(std::move(config_with_inter_vm_support_no_vm_forwarding));
+}
+
 }  // namespace
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/configuration/configuration_test.cpp
+++ b/score/mw/com/impl/configuration/configuration_test.cpp
@@ -204,6 +204,8 @@ TEST_F(ConfigurationFixture, ConfigIsCorrectlyParsedFromFile)
     binding_info.shared_memory_size_ = shared_memory_size;
     binding_info.control_asil_b_memory_size_ = control_asil_b_memory_size;
     binding_info.control_qm_memory_size_ = control_qm_memory_size;
+    binding_info.inter_vm_support_ = true;
+    binding_info.inter_vm_forwarded_ = true;
     const QualityType asil_level{QualityType::kASIL_B};
 
     ServiceInstanceDeployment manual_service_instance(

--- a/score/mw/com/impl/configuration/example/mw_com_config.json
+++ b/score/mw/com/impl/configuration/example/mw_com_config.json
@@ -87,7 +87,9 @@
                         "B": [
                             15
                         ]
-                    }
+                    },
+                    "interVmSupport": true,
+                    "interVmForwarded": true
                 }
             ]
         }

--- a/score/mw/com/impl/configuration/lola_service_instance_deployment.cpp
+++ b/score/mw/com/impl/configuration/lola_service_instance_deployment.cpp
@@ -34,6 +34,8 @@ constexpr auto kMethodsKeyInstDepl = "methods";
 constexpr auto kStrictKeyInstDepl = "strict";
 constexpr auto kAllowedConsumerKeyInstDepl = "allowedConsumer";
 constexpr auto kAllowedProviderKeyInstDepl = "allowedProvider";
+constexpr auto kInterVmSupport = "interVmSupport";
+constexpr auto kInterVmForwarded = "interVmForwarded";
 
 // Note 1:
 // Suppress "AUTOSAR C++14 A15-5-3" rule finding. This rule states: "The std::terminate() function shall not be called
@@ -149,7 +151,9 @@ LolaServiceInstanceDeployment::LolaServiceInstanceDeployment(const score::json::
           ConvertJsonToServiceElementMap<MethodInstanceMapping>(json_object, kMethodsKeyInstDepl),
           GetValueFromJson<bool>(json_object, kStrictKeyInstDepl),
           ConvertJsonToUidMap(json_object, kAllowedConsumerKeyInstDepl),
-          ConvertJsonToUidMap(json_object, kAllowedProviderKeyInstDepl)}
+          ConvertJsonToUidMap(json_object, kAllowedProviderKeyInstDepl),
+          GetValueFromJson<bool>(json_object, kInterVmSupport),
+          GetValueFromJson<bool>(json_object, kInterVmForwarded)}
 {
     const auto serialization_version = GetValueFromJson<std::uint32_t>(json_object, kSerializationVersionKeyInstDepl);
     if (serialization_version != serializationVersion)
@@ -193,7 +197,9 @@ LolaServiceInstanceDeployment::LolaServiceInstanceDeployment(
     MethodInstanceMapping methods,
     const bool strict_permission,
     std::unordered_map<QualityType, std::vector<uid_t>> allowed_consumer,
-    std::unordered_map<QualityType, std::vector<uid_t>> allowed_provider) noexcept
+    std::unordered_map<QualityType, std::vector<uid_t>> allowed_provider,
+    const bool inter_vm_support,
+    const bool inter_vm_forwarded) noexcept
     : instance_id_{instance_id},
       shared_memory_size_{},
       control_asil_b_memory_size_{},
@@ -203,7 +209,9 @@ LolaServiceInstanceDeployment::LolaServiceInstanceDeployment(
       methods_{std::move(methods)},
       strict_permissions_{strict_permission},
       allowed_consumer_{std::move(allowed_consumer)},
-      allowed_provider_{std::move(allowed_provider)}
+      allowed_provider_{std::move(allowed_provider)},
+      inter_vm_support_{inter_vm_support},
+      inter_vm_forwarded_{inter_vm_forwarded}
 {
 }
 
@@ -237,6 +245,8 @@ score::json::Object LolaServiceInstanceDeployment::Serialize() const noexcept
     json_object[kMethodsKeyInstDepl] = ConvertServiceElementMapToJson(methods_);
 
     json_object[kStrictKeyInstDepl] = strict_permissions_;
+    json_object[kInterVmSupport] = inter_vm_support_;
+    json_object[kInterVmForwarded] = inter_vm_forwarded_;
 
     json_object[kAllowedConsumerKeyInstDepl] = ConvertUidMapToJson(allowed_consumer_);
     json_object[kAllowedProviderKeyInstDepl] = ConvertUidMapToJson(allowed_provider_);

--- a/score/mw/com/impl/configuration/lola_service_instance_deployment.h
+++ b/score/mw/com/impl/configuration/lola_service_instance_deployment.h
@@ -44,14 +44,15 @@ class LolaServiceInstanceDeployment
 
     LolaServiceInstanceDeployment() = default;
     explicit LolaServiceInstanceDeployment(const score::json::Object& json_object) noexcept;
-    explicit LolaServiceInstanceDeployment(
-        const score::cpp::optional<LolaServiceInstanceId> instance_id,
-        EventInstanceMapping events = {},
-        FieldInstanceMapping fields = {},
-        MethodInstanceMapping methods = {},
-        const bool strict_permission = false,
-        std::unordered_map<QualityType, std::vector<uid_t>> allowed_consumer = {},
-        std::unordered_map<QualityType, std::vector<uid_t>> allowed_provider = {}) noexcept;
+    explicit LolaServiceInstanceDeployment(const score::cpp::optional<LolaServiceInstanceId> instance_id,
+                                           EventInstanceMapping events = {},
+                                           FieldInstanceMapping fields = {},
+                                           MethodInstanceMapping methods = {},
+                                           const bool strict_permission = false,
+                                           std::unordered_map<QualityType, std::vector<uid_t>> allowed_consumer = {},
+                                           std::unordered_map<QualityType, std::vector<uid_t>> allowed_provider = {},
+                                           const bool inter_vm_support = false,
+                                           const bool inter_vm_forwarded = false) noexcept;
 
     // Finding States that: A project shall not contain instances of non-volatile variables being given values that are
     // not subsequently used.
@@ -81,6 +82,8 @@ class LolaServiceInstanceDeployment
     std::unordered_map<QualityType, std::vector<uid_t>> allowed_consumer_;
     // coverity[autosar_cpp14_m11_0_1_violation]
     std::unordered_map<QualityType, std::vector<uid_t>> allowed_provider_;
+    bool inter_vm_support_{false};
+    bool inter_vm_forwarded_{false};
 
     score::json::Object Serialize() const noexcept;
     bool ContainsEvent(const std::string& event_name) const noexcept;

--- a/score/mw/com/impl/configuration/lola_service_instance_deployment_test.cpp
+++ b/score/mw/com/impl/configuration/lola_service_instance_deployment_test.cpp
@@ -135,6 +135,30 @@ TEST(LolaServiceInstanceDeployment, ContainsFieldReturnsFalseIfEventMissing)
     EXPECT_FALSE(unit.ContainsField("def"));
 }
 
+TEST(LolaServiceInstanceDeployment, InterVMSupportReturnsFalseByDefault)
+{
+    LolaServiceInstanceDeployment unit{LolaServiceInstanceId{2U}};
+    EXPECT_FALSE(unit.inter_vm_support_);
+}
+
+TEST(LolaServiceInstanceDeployment, InterVMForwardedReturnsFalseByDefault)
+{
+    LolaServiceInstanceDeployment unit{LolaServiceInstanceId{2U}};
+    EXPECT_FALSE(unit.inter_vm_forwarded_);
+}
+
+TEST(LolaServiceInstanceDeployment, InterVMSupportConstructedAsExpected)
+{
+    LolaServiceInstanceDeployment unit{LolaServiceInstanceId{2U}, {}, {}, {}, false, {}, {}, true, false};
+    EXPECT_TRUE(unit.inter_vm_support_);
+}
+
+TEST(LolaServiceInstanceDeployment, InterVMForwardedConstructedAsExpected)
+{
+    LolaServiceInstanceDeployment unit{LolaServiceInstanceId{2U}, {}, {}, {}, false, {}, {}, false, true};
+    EXPECT_TRUE(unit.inter_vm_forwarded_);
+}
+
 TEST(LolaServiceInstanceDeployment, ContainsMethodReturnsTrueIfMethodPresent)
 {
     // Given a LolaServiceInstanceDeployment containing a method

--- a/score/mw/com/impl/configuration/mw_com_config_schema.json
+++ b/score/mw/com/impl/configuration/mw_com_config_schema.json
@@ -421,6 +421,18 @@
                                             }
                                         }
                                     }
+                                },
+                                "interVmSupport": {
+                                    "type": "boolean",
+                                    "title": "Enable inter VM support",
+                                    "description": "Optional parameter. interVmSupport property is only supported in case binding property is set to SHM. If it is set to true, then the provider/consumer of this instance expects, that shared-memory-objects used by this service instance are visible cross-VM. The SHM implementation potentially uses different mechanisms/path-names to create/open shm-objects.",
+                                    "default": false
+                                },
+                                "interVmForwarded": {
+                                    "type": "boolean",
+                                    "title": "Enable forwarding of service instance across VM boundaries",
+                                    "description": "Optional parameter. interVmForwarded property is only supported in case binding property is set to SHM. If it is set to true, then also interVmSupport has to be set to true. If it is set to true then a provider setting up the corresponding instance with SHM binding, will expect, that the underlying shm-objects already exist, because they have been created already in the source domain (VM) and only need to be opened in its own domain (VM).",
+                                    "default": false
                                 }
                             }
                         }


### PR DESCRIPTION
Extended the configuration for LoLa service instances so that it can be configured if a service instance shall support inter-VM communication and if it will be forwarded via that gateway.
These properties are relevant so that the underlying shared memory can be setup correctly, i.e. choose the correct shared memory and determine to open existing SHM instead of creating new objects.

Issue: https://github.com/eclipse-score/communication/issues/387