### PR TITLE
mw/com: Fix clang-tidy warnings in SkeletonField and SkeletonFieldBase

### DIFF
--- a/score/mw/com/impl/skeleton_field.h
+++ b/score/mw/com/impl/skeleton_field.h
@@ -120,7 +120,7 @@ class SkeletonField : public SkeletonFieldBase
     //         void(FieldType& new_value)
     //   - new_value : the value requested by the proxy. This value will be modified in place by the registered handler
     //   and the new value will be used to update the field.
-    template <bool ES = EnableSet, typename std::enable_if<ES, int>::type = 0, typename CallableType>
+    template <bool ES = EnableSet, std::enable_if_t<ES, int> = 0, typename CallableType>
     Result<void> RegisterSetHandler(CallableType&& set_handler)
     {
         static_assert(std::is_invocable_v<CallableType, FieldType&>,
@@ -179,7 +179,7 @@ class SkeletonField : public SkeletonFieldBase
                   std::unique_ptr<SkeletonMethod<GetMethodSignature>> skeleton_get_method_dispatch,
                   const std::string_view field_name);
 
-    bool IsInitialValueSaved() const noexcept override
+    [[nodiscard]] bool IsInitialValueSaved() const noexcept override
     {
         return initial_field_value_ != nullptr;
     }
@@ -191,7 +191,7 @@ class SkeletonField : public SkeletonFieldBase
 
     SkeletonEvent<FieldType>* GetTypedEvent() const noexcept;
 
-    bool IsSetHandlerMissing() const noexcept override
+    [[nodiscard]] bool IsSetHandlerMissing() const noexcept override
     {
         if constexpr (!EnableSet)
         {
@@ -304,7 +304,7 @@ SkeletonField<SampleDataType, EnableSet, EnableNotifier>::SkeletonField(Skeleton
       // coverity[autosar_cpp14_a12_8_3_violation] This is a false-positive.
       initial_field_value_{std::move(other.initial_field_value_)},
       skeleton_field_mock_{other.skeleton_field_mock_},
-      is_set_handler_registered_{std::move(other.is_set_handler_registered_)},
+      is_set_handler_registered_{other.is_set_handler_registered_},
       set_method_{std::move(other.set_method_)},
       get_method_{std::move(other.get_method_)}
 {
@@ -322,7 +322,7 @@ auto SkeletonField<SampleDataType, EnableSet, EnableNotifier>::operator=(Skeleto
 
         initial_field_value_ = std::move(other.initial_field_value_);
         skeleton_field_mock_ = std::move(other.skeleton_field_mock_);
-        is_set_handler_registered_ = std::move(other.is_set_handler_registered_);
+        is_set_handler_registered_ = other.is_set_handler_registered_;
         set_method_ = std::move(other.set_method_);
         get_method_ = std::move(other.get_method_);
         SkeletonBaseView skeleton_base_view{skeleton_base_.get()};

--- a/score/mw/com/impl/skeleton_field_base.h
+++ b/score/mw/com/impl/skeleton_field_base.h
@@ -50,6 +50,9 @@ class SkeletonFieldBase
 
     virtual ~SkeletonFieldBase() = default;
 
+    SkeletonFieldBase(const SkeletonFieldBase&) = delete;
+    SkeletonFieldBase& operator=(const SkeletonFieldBase&) & = delete;
+
     /// \brief Updates the reference to SkeletonBase held by the SkeletonField and also the owned methods.
     ///
     /// This must happen in the derived class since the derived class owns the methods (this is required since they are
@@ -94,10 +97,7 @@ class SkeletonFieldBase
             }
             return update_field_result;
         }
-        else
-        {
-            return skeleton_event_dispatch_->PrepareOffer();
-        }
+        return skeleton_event_dispatch_->PrepareOffer();
     }
 
     void PrepareStopOffer() noexcept
@@ -106,9 +106,6 @@ class SkeletonFieldBase
     }
 
   protected:
-    SkeletonFieldBase(const SkeletonFieldBase&) = delete;
-    SkeletonFieldBase& operator=(const SkeletonFieldBase&) & = delete;
-
     SkeletonFieldBase(SkeletonFieldBase&&) noexcept = default;
     SkeletonFieldBase& operator=(SkeletonFieldBase&&) & noexcept = default;
     // Suppress "AUTOSAR C++14 M11-0-1" rule findings. This rule states: "Member data in non-POD class types shall
@@ -130,11 +127,11 @@ class SkeletonFieldBase
 
   private:
     /// \brief Returns whether the initial value has been saved by the user to be used by DoDeferredUpdate
-    virtual bool IsInitialValueSaved() const noexcept = 0;
+    [[nodiscard]] virtual bool IsInitialValueSaved() const noexcept = 0;
 
     /// \brief Returns true if a setter has been enabled in the interface and a set handler was not registered via
     /// RegisterSetHandler. Otherwise, returns false.
-    virtual bool IsSetHandlerMissing() const noexcept = 0;
+    [[nodiscard]] virtual bool IsSetHandlerMissing() const noexcept = 0;
 
     /// \brief Sets the initial value of the field.
     ///


### PR DESCRIPTION
- Replace enable_if<>::type with enable_if_t<> (modernize-type-traits)
- Add [[nodiscard]] to IsInitialValueSaved() and IsSetHandlerMissing() (modernize-use-nodiscard)
- Remove redundant std::move() on trivially-copyable bool (performance-move-const-arg)
- Remove else-after-return in PrepareOffer() (readability-else-after-return)
- Move deleted copy /assignment operator to public section (modernize-use-equals-delete)