### PR TITLE
Create a KPI dashboard for quality numbers

### DIFF
--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -27,6 +27,7 @@ on:
 env:
   ANDROID_HOME: ""
   ANDROID_SDK_ROOT: ""
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   create-draft-release:

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -1,0 +1,179 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+# Reusable workflow: run clang-tidy via Bazel and upload the report as an artifact.
+#
+# Called by nightly_quality.yml. Uses the clang-tidy Bazel config defined in
+# quality/static_analysis/static_analysis.bazelrc:
+#   bazel test --config=clang-tidy //...
+
+name: Clang-Tidy
+
+on:
+  workflow_call:
+    outputs:
+      artifact-name:
+        description: "Name of the clang-tidy report artifact"
+        value: ${{ jobs.clang-tidy.outputs.artifact-name }}
+      conclusion:
+        description: "Job conclusion: success or failure"
+        value: ${{ jobs.clang-tidy.outputs.conclusion }}
+
+permissions:
+  contents: read
+
+env:
+  ANDROID_HOME: ""
+  ANDROID_SDK_ROOT: ""
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  clang-tidy:
+    runs-on: ubuntu-24.04
+    outputs:
+      artifact-name: ${{ steps.set-artifact-name.outputs.artifact-name }}
+      conclusion: ${{ steps.set-conclusion.outputs.conclusion }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Free Disk Space (Ubuntu)
+        uses: eclipse-score/more-disk-space@v1
+        with:
+          level: 4
+
+      - name: Setup Bazel with shared caching
+        uses: bazel-contrib/setup-bazel@0.18.0
+        with:
+          bazelisk-cache: true
+          disk-cache: "clang_tidy"
+          repository-cache: true
+          cache-save: ${{ github.event_name == 'schedule' }}
+
+      - name: Allow linux-sandbox
+        uses: ./actions/unblock_user_namespace_for_linux_sandbox
+
+      - name: Run clang-tidy via Bazel
+        id: run-clang-tidy
+        # Continue on error so we can collect and upload the report even on findings
+        continue-on-error: true
+        run: |
+          bazel test --config=clang-tidy //... \
+            2>&1 | tee clang_tidy_raw.log
+
+      - name: Collect clang-tidy reports
+        run: |
+          mkdir -p clang_tidy_report
+
+          # aspect_rules_lint v2 writes {label}.AspectRulesLintClangTidy.out per target.
+          # -L is required because bazel-bin is a symlink.
+          find -L bazel-bin -name "*.AspectRulesLintClangTidy.out" 2>/dev/null \
+            | xargs -I{} cp {} clang_tidy_report/ 2>/dev/null || true
+
+          # Also save the raw log
+          cp clang_tidy_raw.log clang_tidy_report/
+
+          # Count findings from the .out files (verbose=False means findings are only
+          # in the per-file .out files, not in the bazel terminal output)
+          FINDINGS=$(cat clang_tidy_report/*.AspectRulesLintClangTidy.out 2>/dev/null \
+            | grep -c "warning:\|error:" || true)
+          echo "Total clang-tidy findings: ${FINDINGS}"
+          echo "findings=${FINDINGS}" >> $GITHUB_OUTPUT
+
+          # Generate a simple HTML summary
+          python3 - << 'PYEOF'
+          import re, pathlib, html, datetime, glob
+
+          # Read all .out files (findings are per source file, not in bazel terminal output)
+          findings = []
+          for out_file in glob.glob("clang_tidy_report/*.AspectRulesLintClangTidy.out"):
+              log = pathlib.Path(out_file).read_text(errors="replace")
+              for m in re.finditer(
+                  r"^(.*?):(\d+):\d+:\s+(warning|error):\s+(.+?)(?:\s+\[.+?\])?$",
+                  log, re.MULTILINE):
+                  findings.append(m.groups())
+
+          rows = ""
+          for path, line, severity, msg in findings:
+              sev_cls = "error" if severity == "error" else "warning"
+              rows += (
+                  f"<tr class='{sev_cls}'>"
+                  f"<td>{html.escape(path)}:{html.escape(line)}</td>"
+                  f"<td>{html.escape(severity)}</td>"
+                  f"<td>{html.escape(msg)}</td></tr>\n"
+              )
+
+          total = len(findings)
+          errors   = sum(1 for _, _, s, _ in findings if s == "error")
+          warnings = total - errors
+          generated = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+
+          html_out = f"""<!DOCTYPE html>
+          <html lang="en"><head><meta charset="utf-8">
+          <title>Clang-Tidy Report</title>
+          <style>
+            body {{ font-family: -apple-system, sans-serif; max-width: 1100px;
+                   margin: 32px auto; padding: 0 16px; color: #24292e; }}
+            h1   {{ border-bottom: 2px solid #e1e4e8; padding-bottom: 8px; }}
+            .summary {{ display: flex; gap: 24px; margin: 16px 0 24px; }}
+            .stat {{ background: #f6f8fa; border: 1px solid #e1e4e8; border-radius: 6px;
+                    padding: 12px 20px; text-align: center; }}
+            .stat .num {{ font-size: 2em; font-weight: 700; }}
+            .stat.err .num {{ color: #d73a49; }}
+            .stat.warn .num {{ color: #e36209; }}
+            table {{ border-collapse: collapse; width: 100%; font-size: 0.88em; }}
+            th, td {{ text-align: left; padding: 6px 10px;
+                      border-bottom: 1px solid #e1e4e8; }}
+            th {{ background: #f6f8fa; font-weight: 600; }}
+            tr.error td {{ background: #fff0f0; }}
+            tr.warning td {{ background: #fffbf0; }}
+            .meta {{ color: #586069; font-size: 0.85em; margin-bottom: 16px; }}
+          </style></head><body>
+          <h1>Clang-Tidy Report</h1>
+          <p class="meta">Generated: {generated}</p>
+          <div class="summary">
+            <div class="stat err"><div class="num">{errors}</div>Errors</div>
+            <div class="stat warn"><div class="num">{warnings}</div>Warnings</div>
+            <div class="stat"><div class="num">{total}</div>Total findings</div>
+          </div>
+          <table>
+            <thead><tr><th>Location</th><th>Severity</th><th>Message</th></tr></thead>
+            <tbody>{rows if rows else "<tr><td colspan='3'>No findings.</td></tr>"}</tbody>
+          </table>
+          </body></html>"""
+
+          pathlib.Path("clang_tidy_report/index.html").write_text(html_out)
+          print(f"Report written: {total} findings ({errors} errors, {warnings} warnings)")
+          PYEOF
+
+      - name: Set artifact name
+        id: set-artifact-name
+        run: |
+          NAME="${{ github.event.repository.name }}_clang_tidy_${{ github.sha }}"
+          echo "artifact-name=${NAME}" >> $GITHUB_OUTPUT
+
+      - name: Set conclusion
+        id: set-conclusion
+        run: |
+          if [[ "${{ steps.run-clang-tidy.outcome }}" == "success" ]]; then
+            echo "conclusion=success" >> $GITHUB_OUTPUT
+          else
+            echo "conclusion=failure" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload clang-tidy report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.set-artifact-name.outputs.artifact-name }}
+          path: clang_tidy_report/

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -1,0 +1,188 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+# Reusable workflow: run CodeQL analysis and upload the SARIF report as an artifact.
+#
+# Called by nightly_quality.yml. Uses the codeql Bazel config defined in
+# quality/static_analysis/static_analysis.bazelrc and the CodeQL bundle from
+# the Bazel third_party integration.
+
+name: CodeQL Analysis
+
+on:
+  workflow_call:
+    outputs:
+      artifact-name:
+        description: "Name of the CodeQL report artifact"
+        value: ${{ jobs.codeql.outputs.artifact-name }}
+      conclusion:
+        description: "Job conclusion: success or failure"
+        value: ${{ jobs.codeql.outputs.conclusion }}
+
+permissions:
+  contents: read
+  security-events: write
+
+env:
+  ANDROID_HOME: ""
+  ANDROID_SDK_ROOT: ""
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  codeql:
+    runs-on: ubuntu-24.04
+    timeout-minutes: 180
+    outputs:
+      artifact-name: ${{ steps.set-artifact-name.outputs.artifact-name }}
+      conclusion: ${{ steps.set-conclusion.outputs.conclusion }}
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Free Disk Space (Ubuntu)
+        uses: eclipse-score/more-disk-space@v1
+        with:
+          level: 4
+
+      - name: Setup Bazel with shared caching
+        uses: bazel-contrib/setup-bazel@0.18.0
+        with:
+          bazelisk-cache: true
+          disk-cache: "codeql"
+          repository-cache: true
+          cache-save: ${{ github.event_name == 'schedule' }}
+
+      - name: Allow linux-sandbox
+        uses: ./actions/unblock_user_namespace_for_linux_sandbox
+
+      - name: Run CodeQL via Bazel
+        id: run-codeql
+        continue-on-error: true
+        run: |
+          bazel run --config=codeql //quality/static_analysis:codeql_lint \
+            -- --target //score/... 2>&1 | tee codeql_raw.log
+
+      - name: Collect CodeQL results
+        run: |
+          mkdir -p codeql_report
+
+          # Copy raw log
+          cp codeql_raw.log codeql_report/
+
+          # Find SARIF output.
+          # codeql_lint.py writes to {bazel output_path}/codeql.sarif (inside bazel-out/).
+          # Also search /var/tmp/codeql_databases as a fallback.
+          find ./bazel-out /var/tmp/codeql_databases /tmp \
+            -name "*.sarif" 2>/dev/null \
+            | xargs -I{} cp {} codeql_report/ 2>/dev/null || true
+
+          # Generate HTML summary from SARIF files (or raw log fallback)
+          python3 - << 'PYEOF'
+          import json, pathlib, html, datetime, glob
+
+          generated = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+          findings = []
+
+          for sarif_path in glob.glob("codeql_report/*.sarif"):
+              try:
+                  data = json.loads(pathlib.Path(sarif_path).read_text())
+                  for run in data.get("runs", []):
+                      rules = {r["id"]: r for r in
+                               run.get("tool", {}).get("driver", {}).get("rules", [])}
+                      for result in run.get("results", []):
+                          rule_id = result.get("ruleId", "unknown")
+                          rule = rules.get(rule_id, {})
+                          message = result.get("message", {}).get("text", "")
+                          severity = result.get("level", "warning")
+                          locs = result.get("locations", [{}])
+                          loc = locs[0].get("physicalLocation", {})
+                          uri = loc.get("artifactLocation", {}).get("uri", "")
+                          line = loc.get("region", {}).get("startLine", "")
+                          findings.append((uri, str(line), severity, rule_id, message))
+              except Exception:
+                  pass
+
+          rows = ""
+          for uri, line, severity, rule_id, msg in findings:
+              sev_cls = "error" if severity in ("error",) else "warning"
+              rows += (
+                  f"<tr class='{sev_cls}'>"
+                  f"<td>{html.escape(uri)}:{html.escape(line)}</td>"
+                  f"<td>{html.escape(severity)}</td>"
+                  f"<td>{html.escape(rule_id)}</td>"
+                  f"<td>{html.escape(msg[:120])}</td></tr>\n"
+              )
+
+          total   = len(findings)
+          errors  = sum(1 for *_, s, __, ___ in findings if s == "error")
+          warnings = total - errors
+
+          html_out = f"""<!DOCTYPE html>
+          <html lang="en"><head><meta charset="utf-8">
+          <title>CodeQL Report</title>
+          <style>
+            body {{ font-family: -apple-system, sans-serif; max-width: 1100px;
+                   margin: 32px auto; padding: 0 16px; color: #24292e; }}
+            h1   {{ border-bottom: 2px solid #e1e4e8; padding-bottom: 8px; }}
+            .summary {{ display: flex; gap: 24px; margin: 16px 0 24px; }}
+            .stat {{ background: #f6f8fa; border: 1px solid #e1e4e8; border-radius: 6px;
+                    padding: 12px 20px; text-align: center; }}
+            .stat .num {{ font-size: 2em; font-weight: 700; }}
+            .stat.err .num {{ color: #d73a49; }}
+            .stat.warn .num {{ color: #e36209; }}
+            table {{ border-collapse: collapse; width: 100%; font-size: 0.88em; }}
+            th, td {{ text-align: left; padding: 6px 10px;
+                      border-bottom: 1px solid #e1e4e8; }}
+            th {{ background: #f6f8fa; font-weight: 600; }}
+            tr.error td {{ background: #fff0f0; }}
+            tr.warning td {{ background: #fffbf0; }}
+            .meta {{ color: #586069; font-size: 0.85em; margin-bottom: 16px; }}
+          </style></head><body>
+          <h1>CodeQL Report</h1>
+          <p class="meta">Generated: {generated}</p>
+          <div class="summary">
+            <div class="stat err"><div class="num">{errors}</div>Errors</div>
+            <div class="stat warn"><div class="num">{warnings}</div>Warnings</div>
+            <div class="stat"><div class="num">{total}</div>Total findings</div>
+          </div>
+          <table>
+            <thead><tr><th>Location</th><th>Severity</th><th>Rule</th><th>Message</th></tr></thead>
+            <tbody>{rows if rows else "<tr><td colspan='4'>No SARIF findings. See codeql_raw.log for details.</td></tr>"}</tbody>
+          </table>
+          </body></html>"""
+
+          pathlib.Path("codeql_report/index.html").write_text(html_out)
+          print(f"CodeQL HTML report: {total} findings")
+          PYEOF
+
+      - name: Set artifact name
+        id: set-artifact-name
+        run: |
+          NAME="${{ github.event.repository.name }}_codeql_${{ github.sha }}"
+          echo "artifact-name=${NAME}" >> $GITHUB_OUTPUT
+
+      - name: Set conclusion
+        id: set-conclusion
+        run: |
+          if [[ "${{ steps.run-codeql.outcome }}" == "success" ]]; then
+            echo "conclusion=success" >> $GITHUB_OUTPUT
+          else
+            echo "conclusion=failure" >> $GITHUB_OUTPUT
+          fi
+
+      - name: Upload CodeQL report artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.set-artifact-name.outputs.artifact-name }}
+          path: codeql_report/

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -28,6 +28,7 @@ concurrency:
 env:
   ANDROID_HOME: ""
   ANDROID_SDK_ROOT: ""
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   coverage_report:
     runs-on: ubuntu-24.04
@@ -79,6 +80,10 @@ jobs:
           mkdir -p artifacts
           find bazel-testlogs/score/ -name 'test.xml' -print0 | xargs -0 -I{} cp --parents {} artifacts/
           cp -r cpp_coverage artifacts/
+          # Include raw LCOV .dat file so the quality dashboard can read actual
+          # line/function/branch percentages directly without re-running genhtml.
+          LCOV_DAT="$(bazel info output_path)/_coverage/_coverage_report.dat"
+          [ -f "$LCOV_DAT" ] && cp "$LCOV_DAT" artifacts/coverage_report.dat || true
           zip -r ${{ github.event.repository.name }}_coverage_report_${{ github.sha }}.zip artifacts/
         shell: bash
 

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -39,6 +39,7 @@ permissions:
 env:
   ANDROID_HOME: ""
   ANDROID_SDK_ROOT: ""
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build-and-deploy-docs:

--- a/.github/workflows/docs.yml
+++ b/.github/workflows/docs.yml
@@ -1,0 +1,179 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+# Workflow: Build and deploy Sphinx documentation to GitHub Pages.
+#
+# Triggers:
+#   - Push to main  → deploys to  <pages-url>/latest/
+#   - Release published → deploys to  <pages-url>/<tag>/  and  <pages-url>/stable/
+#   - workflow_dispatch → manual re-run (deploys as "latest")
+#
+# URL structure on GitHub Pages:
+#   https://<owner>.github.io/<repo>/              ← root redirect to latest/
+#   https://<owner>.github.io/<repo>/latest/       ← built from main
+#   https://<owner>.github.io/<repo>/stable/       ← copy of newest release
+#   https://<owner>.github.io/<repo>/v1.2.3/       ← per-release snapshot
+
+name: Build and Deploy Documentation
+
+on:
+  push:
+    branches: [main]
+  release:
+    types: [published]
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  ANDROID_HOME: ""
+  ANDROID_SDK_ROOT: ""
+
+jobs:
+  build-and-deploy-docs:
+    runs-on: ubuntu-24.04
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      # ------------------------------------------------------------------
+      # Determine deployment target (latest vs release tag)
+      # ------------------------------------------------------------------
+      - name: Set deployment variables
+        id: vars
+        run: |
+          OWNER="${{ github.repository_owner }}"
+          REPO="${{ github.event.repository.name }}"
+          BASE_URL="https://${OWNER}.github.io/${REPO}"
+
+          if [[ "${{ github.event_name }}" == "release" ]]; then
+            VERSION="${{ github.ref_name }}"
+            DEST_DIR="${{ github.ref_name }}"
+            IS_RELEASE="true"
+          else
+            VERSION="latest"
+            DEST_DIR="latest"
+            IS_RELEASE="false"
+          fi
+
+          echo "version=${VERSION}"   >> $GITHUB_OUTPUT
+          echo "dest_dir=${DEST_DIR}" >> $GITHUB_OUTPUT
+          echo "base_url=${BASE_URL}" >> $GITHUB_OUTPUT
+          echo "is_release=${IS_RELEASE}" >> $GITHUB_OUTPUT
+
+      # ------------------------------------------------------------------
+      # Build environment setup
+      # ------------------------------------------------------------------
+      - name: Free Disk Space (Ubuntu)
+        uses: eclipse-score/more-disk-space@v1
+        with:
+          level: 4
+
+      - name: Setup Bazel with shared caching
+        uses: bazel-contrib/setup-bazel@0.18.0
+        with:
+          bazelisk-cache: true
+          disk-cache: "docs"
+          repository-cache: true
+          cache-save: ${{ github.event_name != 'pull_request' }}
+
+      - name: Allow linux-sandbox
+        uses: ./actions/unblock_user_namespace_for_linux_sandbox
+
+      # ------------------------------------------------------------------
+      # Generate Sphinx artifacts via Bazel (mirrors .readthedocs.yaml)
+      # ------------------------------------------------------------------
+      - name: Generate documentation artifacts via Bazel
+        run: |
+          bazel build //docs/sphinx:generate_api_rst
+          cp -f score/mw/com/README.md docs/sphinx/README.md
+          mkdir -p docs/sphinx/generated
+          cp -f bazel-bin/docs/sphinx/generated/*.rst docs/sphinx/generated/
+          mkdir -p score/mw/com/design/doxygen_build/xml
+          cp -rf bazel-bin/score/mw/com/design/doxygen_build/xml/* \
+                 score/mw/com/design/doxygen_build/xml/
+
+      - name: Install Python dependencies
+        run: pip install -r requirements_lock.txt
+
+      # ------------------------------------------------------------------
+      # Build Sphinx HTML
+      # ------------------------------------------------------------------
+      - name: Build Sphinx documentation
+        env:
+          DOCS_VERSION: ${{ steps.vars.outputs.version }}
+          DOCS_BASE_URL: ${{ steps.vars.outputs.base_url }}
+        run: sphinx-build docs/sphinx _sphinx_output
+
+      # ------------------------------------------------------------------
+      # Assemble the deploy directory
+      #   _deploy/
+      #     <dest_dir>/        ← sphinx HTML output
+      #     stable/            ← copy of sphinx output (releases only)
+      #     versions.json      ← version list for the navbar switcher
+      #     index.html         ← root redirect to latest/
+      #     .nojekyll          ← disable GitHub Pages Jekyll processing
+      # ------------------------------------------------------------------
+      - name: Assemble deploy directory
+        env:
+          DEST_DIR: ${{ steps.vars.outputs.dest_dir }}
+          IS_RELEASE: ${{ steps.vars.outputs.is_release }}
+          BASE_URL: ${{ steps.vars.outputs.base_url }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          mkdir -p _deploy
+
+          # Sphinx output into the version subfolder
+          cp -r _sphinx_output _deploy/${DEST_DIR}
+
+          # For releases: also publish as stable/
+          if [[ "${IS_RELEASE}" == "true" ]]; then
+            cp -r _sphinx_output _deploy/stable
+          fi
+
+          # Root index.html: redirect to latest/
+          cat > _deploy/index.html << 'REDIRECT'
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <meta http-equiv="refresh" content="0; url=latest/">
+            <title>Redirecting to latest documentation...</title>
+          </head>
+          <body>
+            <p>Redirecting to <a href="latest/">latest documentation</a>...</p>
+          </body>
+          </html>
+          REDIRECT
+
+          # Prevent Jekyll from processing the site
+          touch _deploy/.nojekyll
+
+          # Generate versions.json for the pydata-sphinx-theme version switcher
+          python3 docs/sphinx/utils/update_versions_json.py \
+            --owner "${{ github.repository_owner }}" \
+            --repo  "${{ github.event.repository.name }}" \
+            --base-url "${BASE_URL}" \
+            --output _deploy/versions.json
+
+      # ------------------------------------------------------------------
+      # Deploy to gh-pages branch (keep_files preserves other versions)
+      # ------------------------------------------------------------------
+      - name: Deploy to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_deploy
+          keep_files: true

--- a/.github/workflows/nightly_quality.yml
+++ b/.github/workflows/nightly_quality.yml
@@ -13,21 +13,21 @@
 
 # Workflow: Run nightly quality jobs and publish results to GitHub Pages.
 #
-# Runs every night at midnight UTC (and on workflow_dispatch for manual runs).
+# Runs every night at midnight UTC. Three quality jobs run in parallel:
+#   - Coverage   : full C++ test suite with gcov/lcov → HTML report
+#   - CodeQL     : static security/MISRA analysis → HTML report
+#   - Clang-Tidy : C++ static analysis → HTML report
 #
-# Jobs:
-#   - coverage   : full C++ test suite with gcov/lcov → HTML report
-#   - codeql     : TODO – will be added when CodeQL workflow is available
-#   - clang-tidy : TODO – will be added when clang-tidy workflow is available
-#
-# After all quality jobs complete, a `deploy-quality-reports` job:
-#   1. Downloads the coverage HTML artifact
-#   2. Creates a quality dashboard index page
-#   3. Deploys everything to  <pages-url>/latest/quality/  on the gh-pages branch
+# After all three complete (pass or fail), a final deploy-quality-reports job:
+#   1. Downloads all three HTML artifacts
+#   2. Runs create_dashboard.py to produce the dashboard index page
+#   3. Deploys everything to <pages-url>/latest/quality/ on the gh-pages branch
 #
 # Deployed URL structure:
-#   https://<owner>.github.io/<repo>/latest/quality/index.html    ← dashboard
-#   https://<owner>.github.io/<repo>/latest/quality/coverage/     ← lcov HTML
+#   https://<owner>.github.io/<repo>/latest/quality/index.html         ← dashboard
+#   https://<owner>.github.io/<repo>/latest/quality/coverage/          ← lcov HTML
+#   https://<owner>.github.io/<repo>/latest/quality/codeql/            ← CodeQL HTML
+#   https://<owner>.github.io/<repo>/latest/quality/clang_tidy/        ← Clang-Tidy HTML
 
 name: Nightly Quality Jobs
 
@@ -42,34 +42,42 @@ permissions:
 env:
   ANDROID_HOME: ""
   ANDROID_SDK_ROOT: ""
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   # --------------------------------------------------------------------
-  # Quality job: Coverage
+  # Quality job 1: Coverage
   # --------------------------------------------------------------------
   run-coverage:
     uses: ./.github/workflows/coverage_report.yml
     permissions:
       contents: read
 
-  # TODO: add CodeQL job here once .github/workflows/codeql.yml exists
-  # run-codeql:
-  #   uses: ./.github/workflows/codeql.yml
-  #   permissions:
-  #     contents: read
-  #     security-events: write
-
-  # TODO: add clang-tidy job here once .github/workflows/clang_tidy.yml exists
-  # run-clang-tidy:
-  #   uses: ./.github/workflows/clang_tidy.yml
-  #   permissions:
-  #     contents: read
+  # --------------------------------------------------------------------
+  # Quality job 2: CodeQL
+  # --------------------------------------------------------------------
+  run-codeql:
+    uses: ./.github/workflows/codeql.yml
+    permissions:
+      contents: read
+      security-events: write
 
   # --------------------------------------------------------------------
-  # Collect results and deploy to GitHub Pages
+  # Quality job 3: Clang-Tidy
+  # --------------------------------------------------------------------
+  run-clang-tidy:
+    uses: ./.github/workflows/clang_tidy.yml
+    permissions:
+      contents: read
+
+  # --------------------------------------------------------------------
+  # Collect all results, build the dashboard, deploy to GitHub Pages
   # --------------------------------------------------------------------
   deploy-quality-reports:
-    needs: [run-coverage]
+    needs: [run-coverage, run-codeql, run-clang-tidy]
+    # Always run even if individual quality jobs fail, so the dashboard
+    # still reflects which jobs passed and which failed.
+    if: always()
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -78,13 +86,37 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2
 
+      # ------------------------------------------------------------------
+      # Determine job conclusions (needs.*.result = success|failure|skipped|cancelled)
+      # ------------------------------------------------------------------
+      - name: Resolve job conclusions
+        id: conclusions
+        run: |
+          map_conclusion() {
+            case "$1" in
+              success)   echo "success" ;;
+              failure)   echo "failure" ;;
+              *)         echo "skipped" ;;
+            esac
+          }
+          echo "coverage=$(map_conclusion '${{ needs.run-coverage.result }}')"     >> $GITHUB_OUTPUT
+          echo "codeql=$(map_conclusion '${{ needs.run-codeql.result }}')"         >> $GITHUB_OUTPUT
+          echo "clang_tidy=$(map_conclusion '${{ needs.run-clang-tidy.result }}')" >> $GITHUB_OUTPUT
+
+      # ------------------------------------------------------------------
+      # Download artifacts (continue-on-error: artifacts may not exist if job failed)
+      # ------------------------------------------------------------------
       - name: Download coverage artifact
+        if: needs.run-coverage.result == 'success'
+        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.run-coverage.outputs.artifact-name }}
           path: /tmp/coverage_zip
 
       - name: Extract coverage HTML report
+        if: needs.run-coverage.result == 'success'
+        continue-on-error: true
         run: |
           cd /tmp/coverage_zip
           unzip *.zip -d extracted
@@ -92,70 +124,62 @@ jobs:
           cp -r /tmp/coverage_zip/extracted/artifacts/cpp_coverage/. \
                 ${GITHUB_WORKSPACE}/_quality/coverage/
 
-      - name: Create quality dashboard index page
+      - name: Download CodeQL artifact
+        if: needs.run-codeql.result == 'success'
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.run-codeql.outputs.artifact-name }}
+          path: _quality/codeql
+
+      - name: Download Clang-Tidy artifact
+        if: needs.run-clang-tidy.result == 'success'
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.run-clang-tidy.outputs.artifact-name }}
+          path: _quality/clang_tidy
+
+      # ------------------------------------------------------------------
+      # Generate dashboard index page via generate_dashboard.py
+      # ------------------------------------------------------------------
+
+      # Install Jinja2 (already in requirements_lock.txt; just ensure it is
+      # available on the runner before running the dashboard script).
+      - name: Install dashboard dependencies
+        if: always() && steps.conclusions.outcome == 'success'
+        run: pip install jinja2 markupsafe
+
+      # Restore KPI history from the previous gh-pages deployment so the
+      # dashboard can show delta badges and trend sparklines across runs.
+      - name: Restore KPI history
+        if: always() && steps.conclusions.outcome == 'success'
         run: |
-          OWNER="${{ github.repository_owner }}"
-          REPO="${{ github.event.repository.name }}"
-          RUN_URL="https://github.com/${OWNER}/${REPO}/actions/runs/${{ github.run_id }}"
-          BUILD_DATE=$(date -u '+%Y-%m-%d %H:%M UTC')
+          mkdir -p _quality/data
+          git fetch origin gh-pages 2>/dev/null || true
+          git show origin/gh-pages:latest/quality/data/quality_history.json \
+            > _quality/data/quality_history.json 2>/dev/null || true
 
-          mkdir -p _quality
+      - name: Generate quality dashboard
+        if: always() && steps.conclusions.outcome == 'success'
+        run: |
+          # The LCOV .dat file is inside the extracted coverage zip at a known
+          # path; pass it unconditionally — generate_dashboard.py handles the
+          # case where the file is absent (returns empty coverage data).
+          python3 quality/dashboard/generate_dashboard.py \
+            --sarif-dir      _quality/codeql \
+            --clang-tidy-dir _quality/clang_tidy \
+            --lcov           /tmp/coverage_zip/extracted/artifacts/coverage_report.dat \
+            --history        _quality/data/quality_history.json \
+            --html           _quality/index.html \
+            --github-summary
 
-          cat > _quality/index.html << EOF
-          <!DOCTYPE html>
-          <html lang="en">
-          <head>
-            <meta charset="utf-8">
-            <title>Quality Reports — ${REPO}</title>
-            <style>
-              body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
-                     max-width: 860px; margin: 40px auto; padding: 0 20px; color: #24292e; }
-              h1   { border-bottom: 2px solid #e1e4e8; padding-bottom: 10px; }
-              .meta { color: #586069; font-size: 0.9em; margin: -10px 0 24px; }
-              table { border-collapse: collapse; width: 100%; }
-              th, td { text-align: left; padding: 10px 14px; border-bottom: 1px solid #e1e4e8; }
-              th    { background: #f6f8fa; font-weight: 600; }
-              a     { color: #0366d6; text-decoration: none; }
-              a:hover { text-decoration: underline; }
-              .badge-ok   { color: #28a745; font-weight: 600; }
-              .badge-todo { color: #6a737d; }
-            </style>
-          </head>
-          <body>
-            <h1>Nightly Quality Reports</h1>
-            <p class="meta">
-              Last updated: <strong>${BUILD_DATE}</strong> &mdash;
-              <a href="${RUN_URL}">View workflow run →</a>
-            </p>
-            <table>
-              <thead>
-                <tr><th>Job</th><th>Status</th><th>Report</th><th>Description</th></tr>
-              </thead>
-              <tbody>
-                <tr>
-                  <td>Coverage</td>
-                  <td class="badge-ok">&#10003; Available</td>
-                  <td><a href="coverage/index.html">Open report →</a></td>
-                  <td>Line &amp; branch coverage from C++ unit tests (gcov/lcov)</td>
-                </tr>
-                <tr>
-                  <td>CodeQL</td>
-                  <td class="badge-todo">Not yet configured</td>
-                  <td>—</td>
-                  <td>Static security and quality analysis</td>
-                </tr>
-                <tr>
-                  <td>Clang-Tidy</td>
-                  <td class="badge-todo">Not yet configured</td>
-                  <td>—</td>
-                  <td>C++ static analysis</td>
-                </tr>
-              </tbody>
-            </table>
-          </body>
-          </html>
-          EOF
+          echo "Dashboard generated. Contents of _quality/:"
+          find _quality -type f | sort
 
+      # ------------------------------------------------------------------
+      # Deploy to GitHub Pages
+      # ------------------------------------------------------------------
       - name: Deploy quality reports to GitHub Pages
         uses: peaceiris/actions-gh-pages@v4
         with:
@@ -163,3 +187,9 @@ jobs:
           publish_dir: ./_quality
           destination_dir: latest/quality
           keep_files: true
+
+      - name: Print dashboard URL
+        run: |
+          OWNER="${{ github.repository_owner }}"
+          REPO="${{ github.event.repository.name }}"
+          echo "::notice::Quality dashboard → https://${OWNER}.github.io/${REPO}/latest/quality/index.html"

--- a/.github/workflows/nightly_quality.yml
+++ b/.github/workflows/nightly_quality.yml
@@ -1,0 +1,165 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+# Workflow: Run nightly quality jobs and publish results to GitHub Pages.
+#
+# Runs every night at midnight UTC (and on workflow_dispatch for manual runs).
+#
+# Jobs:
+#   - coverage   : full C++ test suite with gcov/lcov → HTML report
+#   - codeql     : TODO – will be added when CodeQL workflow is available
+#   - clang-tidy : TODO – will be added when clang-tidy workflow is available
+#
+# After all quality jobs complete, a `deploy-quality-reports` job:
+#   1. Downloads the coverage HTML artifact
+#   2. Creates a quality dashboard index page
+#   3. Deploys everything to  <pages-url>/latest/quality/  on the gh-pages branch
+#
+# Deployed URL structure:
+#   https://<owner>.github.io/<repo>/latest/quality/index.html    ← dashboard
+#   https://<owner>.github.io/<repo>/latest/quality/coverage/     ← lcov HTML
+
+name: Nightly Quality Jobs
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # every day at midnight UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  ANDROID_HOME: ""
+  ANDROID_SDK_ROOT: ""
+
+jobs:
+  # --------------------------------------------------------------------
+  # Quality job: Coverage
+  # --------------------------------------------------------------------
+  run-coverage:
+    uses: ./.github/workflows/coverage_report.yml
+    permissions:
+      contents: read
+
+  # TODO: add CodeQL job here once .github/workflows/codeql.yml exists
+  # run-codeql:
+  #   uses: ./.github/workflows/codeql.yml
+  #   permissions:
+  #     contents: read
+  #     security-events: write
+
+  # TODO: add clang-tidy job here once .github/workflows/clang_tidy.yml exists
+  # run-clang-tidy:
+  #   uses: ./.github/workflows/clang_tidy.yml
+  #   permissions:
+  #     contents: read
+
+  # --------------------------------------------------------------------
+  # Collect results and deploy to GitHub Pages
+  # --------------------------------------------------------------------
+  deploy-quality-reports:
+    needs: [run-coverage]
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Download coverage artifact
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.run-coverage.outputs.artifact-name }}
+          path: /tmp/coverage_zip
+
+      - name: Extract coverage HTML report
+        run: |
+          cd /tmp/coverage_zip
+          unzip *.zip -d extracted
+          mkdir -p ${GITHUB_WORKSPACE}/_quality/coverage
+          cp -r /tmp/coverage_zip/extracted/artifacts/cpp_coverage/. \
+                ${GITHUB_WORKSPACE}/_quality/coverage/
+
+      - name: Create quality dashboard index page
+        run: |
+          OWNER="${{ github.repository_owner }}"
+          REPO="${{ github.event.repository.name }}"
+          RUN_URL="https://github.com/${OWNER}/${REPO}/actions/runs/${{ github.run_id }}"
+          BUILD_DATE=$(date -u '+%Y-%m-%d %H:%M UTC')
+
+          mkdir -p _quality
+
+          cat > _quality/index.html << EOF
+          <!DOCTYPE html>
+          <html lang="en">
+          <head>
+            <meta charset="utf-8">
+            <title>Quality Reports — ${REPO}</title>
+            <style>
+              body { font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+                     max-width: 860px; margin: 40px auto; padding: 0 20px; color: #24292e; }
+              h1   { border-bottom: 2px solid #e1e4e8; padding-bottom: 10px; }
+              .meta { color: #586069; font-size: 0.9em; margin: -10px 0 24px; }
+              table { border-collapse: collapse; width: 100%; }
+              th, td { text-align: left; padding: 10px 14px; border-bottom: 1px solid #e1e4e8; }
+              th    { background: #f6f8fa; font-weight: 600; }
+              a     { color: #0366d6; text-decoration: none; }
+              a:hover { text-decoration: underline; }
+              .badge-ok   { color: #28a745; font-weight: 600; }
+              .badge-todo { color: #6a737d; }
+            </style>
+          </head>
+          <body>
+            <h1>Nightly Quality Reports</h1>
+            <p class="meta">
+              Last updated: <strong>${BUILD_DATE}</strong> &mdash;
+              <a href="${RUN_URL}">View workflow run →</a>
+            </p>
+            <table>
+              <thead>
+                <tr><th>Job</th><th>Status</th><th>Report</th><th>Description</th></tr>
+              </thead>
+              <tbody>
+                <tr>
+                  <td>Coverage</td>
+                  <td class="badge-ok">&#10003; Available</td>
+                  <td><a href="coverage/index.html">Open report →</a></td>
+                  <td>Line &amp; branch coverage from C++ unit tests (gcov/lcov)</td>
+                </tr>
+                <tr>
+                  <td>CodeQL</td>
+                  <td class="badge-todo">Not yet configured</td>
+                  <td>—</td>
+                  <td>Static security and quality analysis</td>
+                </tr>
+                <tr>
+                  <td>Clang-Tidy</td>
+                  <td class="badge-todo">Not yet configured</td>
+                  <td>—</td>
+                  <td>C++ static analysis</td>
+                </tr>
+              </tbody>
+            </table>
+          </body>
+          </html>
+          EOF
+
+      - name: Deploy quality reports to GitHub Pages
+        uses: peaceiris/actions-gh-pages@v4
+        with:
+          github_token: ${{ secrets.GITHUB_TOKEN }}
+          publish_dir: ./_quality
+          destination_dir: latest/quality
+          keep_files: true

--- a/docs/sphinx/BUILD
+++ b/docs/sphinx/BUILD
@@ -56,6 +56,7 @@ sphinx_module(
             "index.rst",
             "introduction.rst",
             "message_passing.rst",
+            "quality_reports.rst",
             "safety_reports.rst",
             ":doxygen_xml",
             ":generate_api_rst",

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -28,11 +28,10 @@ copyright = '2026, Eclipse S-CORE Contributors'
 author = 'Eclipse Foundation'
 release = '1.0.0'
 
-# GitHub Pages base URL (update org/repo as needed)
-GITHUB_PAGES_URL = os.environ.get(
-    'DOCS_BASE_URL',
-    'https://eclipse-score.github.io/communication'
-)
+# Version and base URL injected by the docs.yml GitHub Actions workflow.
+# Falls back to sensible defaults for local builds.
+docs_version = os.environ.get('DOCS_VERSION', 'latest')
+docs_base_url = os.environ.get('DOCS_BASE_URL', '').rstrip('/')
 
 # -- General configuration ---
 extensions = [
@@ -75,6 +74,10 @@ exclude_patterns = ['_build', 'Thumbs.db', '.DS_Store']
 # -- Options for HTML output --
 html_theme = 'pydata_sphinx_theme'
 
+# Canonical base URL for this version (helps search engines and the switcher)
+if docs_base_url:
+    html_baseurl = f"{docs_base_url}/{docs_version}/"
+
 # Professional theme configuration inspired by modern open-source projects
 html_theme_options = {
     # Navigation settings
@@ -88,6 +91,12 @@ html_theme_options = {
     'navbar_start': ['navbar-logo'],
     'navbar_center': ['navbar-nav'],
     'navbar_end': ['version-switcher', 'navbar-icon-links', 'theme-switcher'],
+
+    # Version switcher — reads versions.json from the GitHub Pages root
+    'switcher': {
+        'json_url': f"{docs_base_url}/versions.json" if docs_base_url else '/versions.json',
+        'version_match': docs_version,
+    },
 
     # Search configuration
     'search_bar_text': 'Search documentation...',
@@ -113,11 +122,6 @@ html_theme_options = {
         }
     ],
 
-    # Version switcher configuration
-    'switcher': {
-        'json_url': f'{GITHUB_PAGES_URL}/switcher.json',
-        'version_match': os.environ.get('DOCS_VERSION', 'latest'),
-    },
 }
 
 # Add custom styling

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -27,6 +27,12 @@ including the LoLa (Low Latency) implementation and Message Passing library.
 
    safety_reports
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Quality Reports:
+
+   quality_reports
+
 .. Note: safety_reports.rst contains links to pre-built HTML reports from external targets.
 
 About This Documentation

--- a/docs/sphinx/quality_reports.rst
+++ b/docs/sphinx/quality_reports.rst
@@ -1,0 +1,32 @@
+Quality Reports
+===============
+
+Nightly quality job results are built and published to GitHub Pages after each
+nightly run of the `Nightly Quality Jobs`_ workflow.
+
+.. list-table::
+   :widths: 20 45 35
+   :header-rows: 1
+
+   * - Job
+     - Description
+     - Report
+   * - Coverage
+     - Line and branch coverage from C++ unit tests (gcov/lcov)
+     - `Coverage report <quality/coverage/index.html>`_
+   * - CodeQL
+     - Static security and quality analysis
+     - Not yet configured
+   * - Clang-Tidy
+     - C++ static analysis
+     - Not yet configured
+
+`Open Quality Dashboard <quality/index.html>`_
+
+.. note::
+
+   Quality reports are updated every night.  If a link returns a 404, the
+   first nightly run has not yet completed.  Check the `Nightly Quality Jobs`_
+   workflow page for the current run status.
+
+.. _Nightly Quality Jobs: https://github.com/ahmed0mousa/communication/actions/workflows/nightly_quality.yml

--- a/docs/sphinx/utils/update_versions_json.py
+++ b/docs/sphinx/utils/update_versions_json.py
@@ -1,0 +1,122 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+"""Generate versions.json for the pydata-sphinx-theme version switcher.
+
+Called from the docs.yml GitHub Actions workflow.  Reads published releases
+via the ``gh`` CLI and writes a JSON file consumed by the version-switcher
+component in the Sphinx navbar.
+
+Output format (pydata-sphinx-theme v0.15+):
+
+    [
+      {"name": "latest (main)", "version": "latest", "url": "…/latest/",  "preferred": true},
+      {"name": "stable (v2.1.0)", "version": "stable", "url": "…/stable/"},
+      {"name": "v2.1.0",          "version": "v2.1.0", "url": "…/v2.1.0/"},
+      …
+    ]
+
+Usage:
+    python3 update_versions_json.py \\
+        --owner eclipse-score \\
+        --repo  communication \\
+        --base-url https://eclipse-score.github.io/communication \\
+        --output versions.json
+"""
+
+import argparse
+import json
+import subprocess
+import sys
+
+
+def _fetch_releases(owner: str, repo: str) -> list[dict]:
+    """Return published (non-draft, non-prerelease) releases via the gh CLI."""
+    result = subprocess.run(
+        [
+            "gh", "release", "list",
+            "--repo", f"{owner}/{repo}",
+            "--json", "tagName,isDraft,isPrerelease",
+            "--limit", "50",
+        ],
+        capture_output=True,
+        text=True,
+        check=False,
+    )
+    if result.returncode != 0 or not result.stdout.strip():
+        # No releases yet or gh CLI not authenticated — return empty list
+        return []
+    return [
+        r for r in json.loads(result.stdout)
+        if not r.get("isDraft") and not r.get("isPrerelease")
+    ]
+
+
+def build_versions(base_url: str, releases: list[dict]) -> list[dict]:
+    """Build the versions list from the release data."""
+    base = base_url.rstrip("/")
+
+    versions = [
+        {
+            "name": "latest (main)",
+            "version": "latest",
+            "url": f"{base}/latest/",
+            "preferred": True,
+        }
+    ]
+
+    if releases:
+        newest_tag = releases[0]["tagName"]
+        versions.append(
+            {
+                "name": f"stable ({newest_tag})",
+                "version": "stable",
+                "url": f"{base}/stable/",
+            }
+        )
+        for release in releases:
+            tag = release["tagName"]
+            versions.append(
+                {
+                    "name": tag,
+                    "version": tag,
+                    "url": f"{base}/{tag}/",
+                }
+            )
+
+    return versions
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(
+        description="Generate versions.json for the pydata-sphinx-theme version switcher."
+    )
+    parser.add_argument("--owner",    required=True, help="GitHub organisation or user name")
+    parser.add_argument("--repo",     required=True, help="Repository name")
+    parser.add_argument("--base-url", required=True, help="Root GitHub Pages URL (no trailing slash)")
+    parser.add_argument("--output",   default="versions.json", help="Output file path")
+    args = parser.parse_args()
+
+    releases = _fetch_releases(args.owner, args.repo)
+    versions = build_versions(args.base_url, releases)
+
+    with open(args.output, "w", encoding="utf-8") as fh:
+        json.dump(versions, fh, indent=2)
+        fh.write("\n")
+
+    version_names = [v["version"] for v in versions]
+    print(f"Written {args.output} with {len(versions)} version(s): {version_names}")
+
+
+if __name__ == "__main__":
+    main()

--- a/quality/create_dashboard.py
+++ b/quality/create_dashboard.py
@@ -1,0 +1,248 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+"""Generate the nightly quality dashboard index.html.
+
+Called by the deploy-quality-reports job in nightly_quality.yml after all
+quality jobs complete.  Reads job conclusions and artifact paths passed as
+CLI arguments and writes a single-page HTML dashboard to stdout or a file.
+
+Usage:
+    python3 create_dashboard.py \\
+        --repo-url  https://github.com/<org>/<repo> \\
+        --pages-url https://<org>.github.io/<repo> \\
+        --run-id    <github.run_id> \\
+        --coverage-conclusion  success|failure|skipped \\
+        --codeql-conclusion    success|failure|skipped \\
+        --clang-tidy-conclusion success|failure|skipped \\
+        --output dashboard/index.html
+"""
+
+import argparse
+import datetime
+import html as html_mod
+import pathlib
+import sys
+
+
+_BADGE = {
+    "success": ('<span class="badge ok">&#10003; Passed</span>', "ok"),
+    "failure": ('<span class="badge fail">&#10007; Failed</span>', "fail"),
+    "skipped": ('<span class="badge skip">&#8212; Skipped</span>', "skip"),
+}
+
+_CSS = """
+body {
+  font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", Helvetica, Arial, sans-serif;
+  max-width: 900px;
+  margin: 48px auto;
+  padding: 0 20px;
+  color: #24292e;
+  background: #fff;
+}
+h1 { border-bottom: 2px solid #e1e4e8; padding-bottom: 10px; margin-bottom: 4px; }
+.run-meta { color: #586069; font-size: 0.88em; margin-bottom: 28px; }
+.run-meta a { color: #0366d6; text-decoration: none; }
+.run-meta a:hover { text-decoration: underline; }
+.cards { display: flex; gap: 20px; flex-wrap: wrap; margin-bottom: 36px; }
+.card {
+  flex: 1 1 220px;
+  border: 1px solid #e1e4e8;
+  border-radius: 8px;
+  padding: 20px 24px;
+  background: #f6f8fa;
+}
+.card h2 { margin: 0 0 10px; font-size: 1.05em; }
+.card p   { margin: 0 0 14px; font-size: 0.9em; color: #586069; }
+.card a.btn {
+  display: inline-block;
+  padding: 6px 14px;
+  background: #0366d6;
+  color: #fff;
+  border-radius: 4px;
+  font-size: 0.88em;
+  text-decoration: none;
+}
+.card a.btn:hover { background: #0256b5; }
+.card a.btn.disabled {
+  background: #e1e4e8;
+  color: #586069;
+  pointer-events: none;
+  cursor: default;
+}
+.badge {
+  display: inline-block;
+  padding: 3px 10px;
+  border-radius: 12px;
+  font-size: 0.82em;
+  font-weight: 600;
+  margin-bottom: 10px;
+}
+.badge.ok   { background: #dcffe4; color: #22863a; border: 1px solid #a2d8b3; }
+.badge.fail { background: #ffeef0; color: #b31d28; border: 1px solid #f5c0c0; }
+.badge.skip { background: #f1f3f4; color: #6a737d; border: 1px solid #d1d5da; }
+footer {
+  margin-top: 48px;
+  padding-top: 16px;
+  border-top: 1px solid #e1e4e8;
+  font-size: 0.82em;
+  color: #586069;
+}
+"""
+
+_CARD_TEMPLATE = """\
+<div class="card">
+  <h2>{title}</h2>
+  {badge}
+  <p>{description}</p>
+  {link}
+</div>
+"""
+
+
+def _badge(conclusion: str) -> tuple[str, str]:
+    return _BADGE.get(conclusion, _BADGE["skipped"])
+
+
+def _link_btn(url: str | None, label: str) -> str:
+    if url:
+        return f'<a class="btn" href="{html_mod.escape(url)}">{html_mod.escape(label)}</a>'
+    return '<a class="btn disabled">Not available</a>'
+
+
+def build_dashboard(
+    *,
+    repo_url: str,
+    pages_url: str,
+    run_id: str,
+    coverage_conclusion: str,
+    codeql_conclusion: str,
+    clang_tidy_conclusion: str,
+) -> str:
+    pages_url = pages_url.rstrip("/")
+    run_url = f"{repo_url}/actions/runs/{run_id}"
+    generated = datetime.datetime.utcnow().strftime("%Y-%m-%d %H:%M UTC")
+
+    # Overall status
+    conclusions = [coverage_conclusion, codeql_conclusion, clang_tidy_conclusion]
+    if all(c == "success" for c in conclusions):
+        overall_badge, overall_cls = _badge("success")
+    elif any(c == "failure" for c in conclusions):
+        overall_badge, overall_cls = _badge("failure")
+    else:
+        overall_badge, overall_cls = _badge("skipped")
+
+    # Build cards
+    coverage_badge, _ = _badge(coverage_conclusion)
+    codeql_badge, _   = _badge(codeql_conclusion)
+    clang_badge, _    = _badge(clang_tidy_conclusion)
+
+    coverage_link = (
+        _link_btn("coverage/index.html", "Open Coverage Report →")
+        if coverage_conclusion == "success" else
+        _link_btn(None, "Not available")
+    )
+    codeql_link = (
+        _link_btn("codeql/index.html", "Open CodeQL Report →")
+        if codeql_conclusion == "success" else
+        _link_btn(None, "Not available")
+    )
+    clang_link = (
+        _link_btn("clang_tidy/index.html", "Open Clang-Tidy Report →")
+        if clang_tidy_conclusion == "success" else
+        _link_btn(None, "Not available")
+    )
+
+    cards = (
+        _CARD_TEMPLATE.format(
+            title="Coverage",
+            badge=coverage_badge,
+            description="Line &amp; branch coverage from C++ unit tests (gcov/lcov).",
+            link=coverage_link,
+        )
+        + _CARD_TEMPLATE.format(
+            title="CodeQL",
+            badge=codeql_badge,
+            description="Static security and quality analysis (MISRA C++ coding standards).",
+            link=codeql_link,
+        )
+        + _CARD_TEMPLATE.format(
+            title="Clang-Tidy",
+            badge=clang_badge,
+            description="C++ static analysis via clang-tidy Bazel aspect.",
+            link=clang_link,
+        )
+    )
+
+    return f"""<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1">
+  <title>Nightly Quality Dashboard</title>
+  <style>{_CSS}</style>
+</head>
+<body>
+  <h1>Nightly Quality Dashboard</h1>
+  <p class="run-meta">
+    Overall: {overall_badge} &nbsp;|&nbsp;
+    Last updated: <strong>{html_mod.escape(generated)}</strong> &nbsp;|&nbsp;
+    <a href="{html_mod.escape(run_url)}">View workflow run &rarr;</a>
+  </p>
+  <div class="cards">
+    {cards}
+  </div>
+  <footer>
+    Generated by <a href="{html_mod.escape(repo_url)}">eclipse-score/communication</a>
+    nightly quality workflow. Reports are updated every night at midnight UTC.
+  </footer>
+</body>
+</html>
+"""
+
+
+def main() -> None:
+    parser = argparse.ArgumentParser(description="Generate nightly quality dashboard HTML.")
+    parser.add_argument("--repo-url",              required=True)
+    parser.add_argument("--pages-url",             required=True)
+    parser.add_argument("--run-id",                required=True)
+    parser.add_argument("--coverage-conclusion",   required=True,
+                        choices=["success", "failure", "skipped"])
+    parser.add_argument("--codeql-conclusion",     required=True,
+                        choices=["success", "failure", "skipped"])
+    parser.add_argument("--clang-tidy-conclusion", required=True,
+                        choices=["success", "failure", "skipped"])
+    parser.add_argument("--output",                default="-",
+                        help="Output file path, or '-' for stdout")
+    args = parser.parse_args()
+
+    dashboard_html = build_dashboard(
+        repo_url=args.repo_url,
+        pages_url=args.pages_url,
+        run_id=args.run_id,
+        coverage_conclusion=args.coverage_conclusion,
+        codeql_conclusion=args.codeql_conclusion,
+        clang_tidy_conclusion=args.clang_tidy_conclusion,
+    )
+
+    if args.output == "-":
+        sys.stdout.write(dashboard_html)
+    else:
+        out = pathlib.Path(args.output)
+        out.parent.mkdir(parents=True, exist_ok=True)
+        out.write_text(dashboard_html, encoding="utf-8")
+        print(f"Dashboard written to {out}")
+
+
+if __name__ == "__main__":
+    main()

--- a/quality/dashboard/dashboard.html.j2
+++ b/quality/dashboard/dashboard.html.j2
@@ -1,0 +1,303 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<title>Quality Dashboard</title>
+<style>
+  :root { --bg:#0d1117; --surface:#161b22; --border:#30363d; --text:#e6edf3; --muted:#8b949e; --accent:#58a6ff; }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  body { background:var(--bg); color:var(--text); font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; padding:2rem; }
+  h1 { font-size:1.6rem; margin-bottom:.25rem; }
+  .meta { color:var(--muted); font-size:.85rem; margin-bottom:1.5rem; }
+  .cards { display:flex; gap:.75rem; flex-wrap:wrap; margin-bottom:1.5rem; }
+  .card { background:var(--surface); border:1px solid var(--border); border-radius:8px; padding:.9rem 1.25rem; min-width:110px; text-align:center; }
+  .card .num { font-size:1.8rem; font-weight:700; }
+  .card .label { color:var(--muted); font-size:.75rem; text-transform:uppercase; margin-top:4px; }
+  .card .delta { font-size:.8rem; min-height:1.1em; margin-top:2px; }
+  .tabs { display:flex; border-bottom:2px solid var(--border); margin-bottom:1.5rem; }
+  .tab-btn { background:none; border:none; border-bottom:3px solid transparent; margin-bottom:-2px; padding:.6rem 1.25rem; color:var(--muted); cursor:pointer; font-size:.95rem; font-weight:500; }
+  .tab-btn.active { color:var(--accent); border-bottom-color:var(--accent); }
+  .tab-btn:hover { color:var(--text); }
+  .panel { display:none; } .panel.active { display:block; }
+  .controls { display:flex; gap:.75rem; flex-wrap:wrap; margin-bottom:.75rem; }
+  .controls input, .controls select { background:var(--surface); border:1px solid var(--border); border-radius:6px; color:var(--text); padding:.4rem .8rem; font-size:.9rem; }
+  table { width:100%; border-collapse:collapse; font-size:.88rem; }
+  thead th { background:var(--surface); border-bottom:2px solid var(--border); padding:.6rem .8rem; text-align:left; color:var(--muted); text-transform:uppercase; font-size:.75rem; cursor:pointer; user-select:none; white-space:nowrap; }
+  thead th:hover { color:var(--accent); }
+  tbody tr { border-bottom:1px solid var(--border); }
+  tbody tr:hover { background:var(--surface); }
+  td { padding:.5rem .8rem; vertical-align:top; }
+  .badge { display:inline-block; padding:2px 8px; border-radius:4px; font-size:.75rem; font-weight:600; color:#fff; white-space:nowrap; }
+  .mono { font-family:monospace; font-size:.82rem; }
+  .muted { color:var(--muted); }
+  .empty-msg { text-align:center; padding:3rem; color:var(--muted); }
+  .cov-bar-wrap { display:inline-block; background:var(--border); border-radius:4px; height:6px; width:80px; vertical-align:middle; margin-right:6px; }
+  .cov-bar { height:6px; border-radius:4px; }
+  .cov-summary { display:flex; gap:1rem; flex-wrap:wrap; margin-bottom:1.25rem; }
+  .cov-box { background:var(--surface); border:1px solid var(--border); border-radius:8px; padding:1rem 1.5rem; text-align:center; min-width:140px; }
+  .cov-box .big { font-size:2rem; font-weight:700; }
+  .cov-box .sub { color:var(--muted); font-size:.8rem; margin-top:2px; }
+  .cov-box .detail { color:var(--muted); font-size:.75rem; margin-top:2px; }
+  .trend-up { color:#e74c3c; font-weight:700; font-size:.75rem; margin-left:2px; }
+  .trend-dn { color:#27ae60; font-weight:700; font-size:.75rem; margin-left:2px; }
+  .trend-eq { color:#8b949e; font-weight:700; font-size:.75rem; margin-left:2px; }
+  .section-title { color:var(--muted); font-size:.85rem; text-transform:uppercase; letter-spacing:.05em; margin-bottom:.75rem; font-weight:600; margin-top:1.25rem; }
+  .spark-wrap { display:flex; align-items:flex-end; gap:3px; height:32px; background:var(--surface); padding:4px 6px; border-radius:4px; }
+  .spark-bar { width:10px; border-radius:2px 2px 0 0; min-height:2px; cursor:default; transition:opacity .15s; }
+  .spark-bar:hover { opacity:.7; }
+</style>
+</head>
+<body>
+<h1>Quality Dashboard</h1>
+<p class="meta">Generated: {{ timestamp }}</p>
+
+{# ── Summary cards ── #}
+<div class="cards">
+  {% for sev in ['critical','high','error','warning','medium','low','recommendation','note'] %}
+    {% set n = codeql_counts[sev] %}
+    {% if n %}
+      <div class="card">
+        <div class="num" style="color:{{ sev_colour(sev) }}">{{ n }}</div>
+        <div class="label">CodeQL {{ sev }}</div>
+      </div>
+    {% endif %}
+  {% endfor %}
+  {% if not codeql_rows %}
+    <div class="card">
+      <div class="num" style="color:#27ae60">0</div>
+      {% if prev %}<div class="delta">{{ delta(0, prev.codeql, false) }}</div>{% endif %}
+      <div class="label">CodeQL findings</div>
+    </div>
+  {% elif prev %}
+    <div class="card" style="border-style:dashed;min-width:80px">
+      <div class="num" style="font-size:1.25rem">{{ delta(codeql_rows|length, prev.codeql, false) }}</div>
+      <div class="label">CodeQL Δ</div>
+    </div>
+  {% endif %}
+
+  <div class="card">
+    <div class="num" style="color:{{ '#e74c3c' if clang_errors else ('#e67e22' if clang_rows else '#27ae60') }}">{{ clang_rows|length }}</div>
+    {% if prev %}<div class="delta">{{ delta(clang_rows|length, prev.clang_tidy, false) }}</div>{% endif %}
+    <div class="label">Clang-Tidy</div>
+  </div>
+
+  {% if cov %}
+    {% for key, hk, label in [('line_pct','line_cov','Line Cov'),('func_pct','func_cov','Func Cov'),('branch_pct','branch_cov','Branch Cov')] %}
+      <div class="card">
+        <div class="num" style="color:{{ cov_colour(cov[key]) }}">{{ '%.1f'|format(cov[key]) }}%</div>
+        {% if prev and prev[hk] is not none %}<div class="delta">{{ delta(cov[key], prev[hk], true) }}</div>{% endif %}
+        <div class="label">{{ label }}</div>
+      </div>
+    {% endfor %}
+  {% else %}
+    <div class="card"><div class="num" style="color:#95a5a6">N/A</div><div class="label">Coverage</div></div>
+  {% endif %}
+</div>
+
+<div class="tabs">
+  <button class="tab-btn active" onclick="showTab('codeql',this)">CodeQL ({{ codeql_rows|length }})</button>
+  <button class="tab-btn" onclick="showTab('clang',this)">Clang-Tidy ({{ clang_rows|length }})</button>
+  <button class="tab-btn" onclick="showTab('coverage',this)">Coverage ({{ ('%.1f'|format(cov.line_pct) ~ '%') if cov else 'N/A' }})</button>
+  <button class="tab-btn" onclick="showTab('kpi',this)">KPI / Trends ({{ history|length }} runs)</button>
+</div>
+
+{# ── CodeQL tab ── #}
+<div id="tab-codeql" class="panel active">
+  {% if codeql_rows %}
+  <div class="controls">
+    <input id="cq-search" type="text" placeholder="Search message or path…" oninput="cqFilter()" style="flex:1;min-width:200px"/>
+    <select id="cq-sev" onchange="cqFilter()">
+      <option value="">All severities</option>
+      {% for sev in ['critical','high','error','warning','medium','low','recommendation','note'] %}
+        {% if codeql_counts[sev] %}<option value="{{ sev }}">{{ sev|capitalize }} ({{ codeql_counts[sev] }})</option>{% endif %}
+      {% endfor %}
+    </select>
+  </div>
+  <table>
+    <thead><tr><th onclick="cqSort(0)">Severity &#8597;</th><th onclick="cqSort(1)">Rule &#8597;</th><th onclick="cqSort(2)">Message &#8597;</th><th onclick="cqSort(3)">Location &#8597;</th></tr></thead>
+    <tbody id="cq-tbody">
+      {% for r in codeql_rows %}
+      <tr data-sev="{{ r.severity|lower }}">
+        <td><span class="badge" style="background:{{ sev_colour(r.severity) }}">{{ r.severity|upper }}</span></td>
+        <td class="mono">{{ r.name }}</td>
+        <td>{{ r.message }}</td>
+        <td class="mono muted">{{ r.path }}{% if r.start_line %}:{{ r.start_line }}{% endif %}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="empty-msg">No CodeQL findings — clean code!</p>
+  {% endif %}
+</div>
+
+{# ── Clang-Tidy tab ── #}
+<div id="tab-clang" class="panel">
+  {% if clang_rows %}
+  <div class="controls">
+    <input id="ct-search" type="text" placeholder="Search message or check…" oninput="ctFilter()" style="flex:1;min-width:200px"/>
+    <select id="ct-sev" onchange="ctFilter()">
+      <option value="">All severities</option>
+      {% for sev in ['error','warning'] %}
+        {% if clang_counts[sev] %}<option value="{{ sev }}">{{ sev|capitalize }} ({{ clang_counts[sev] }})</option>{% endif %}
+      {% endfor %}
+    </select>
+  </div>
+  <table>
+    <thead><tr><th onclick="ctSort(0)">Severity &#8597;</th><th onclick="ctSort(1)">Check &#8597;</th><th onclick="ctSort(2)">Message &#8597;</th><th onclick="ctSort(3)">Location &#8597;</th></tr></thead>
+    <tbody id="ct-tbody">
+      {% for r in clang_rows %}
+      <tr data-sev="{{ r.severity|lower }}">
+        <td><span class="badge" style="background:{{ sev_colour(r.severity) }}">{{ r.severity|upper }}</span></td>
+        <td class="mono">{{ r.check }}</td>
+        <td>{{ r.message }}</td>
+        <td class="mono muted">{{ r.path }}{% if r.line %}:{{ r.line }}{% endif %}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% else %}
+  <p class="empty-msg">No Clang-Tidy warnings — clean code!</p>
+  {% endif %}
+</div>
+
+{# ── Coverage tab ── #}
+<div id="tab-coverage" class="panel">
+  {% if cov %}
+  <div class="cov-summary">
+    {% for key, label, detail_key in [('line_pct','Line Coverage','lines'),('func_pct','Function Coverage','funcs'),('branch_pct','Branch Coverage','branches')] %}
+    <div class="cov-box">
+      <div class="big" style="color:{{ cov_colour(cov[key]) }}">{{ '%.1f'|format(cov[key]) }}%</div>
+      <div class="sub">{{ label }}</div>
+      <div class="detail">{{ cov[detail_key] }}</div>
+    </div>
+    {% endfor %}
+  </div>
+  {% if cov_files %}
+  <table>
+    <thead><tr><th>File</th><th onclick="cvSort(1)" style="cursor:pointer">Lines &#8597;</th><th onclick="cvSort(2)" style="cursor:pointer">Functions &#8597;</th><th onclick="cvSort(3)" style="cursor:pointer">Branches &#8597;</th><th>Lines (hit/total)</th></tr></thead>
+    <tbody id="cv-tbody">
+      {% for f in cov_files %}
+      <tr>
+        <td class="mono">{{ f.file|basename }}</td>
+        <td data-val="{{ f.line_pct }}">
+          <div class="cov-bar-wrap"><div class="cov-bar" style="width:{{ [f.line_pct,100]|min }}%;background:{{ cov_colour(f.line_pct) }}"></div></div>
+          <span style="color:{{ cov_colour(f.line_pct) }};font-weight:600">{{ '%.1f'|format(f.line_pct) }}%</span>
+        </td>
+        <td data-val="{{ f.func_pct }}">
+          <div class="cov-bar-wrap"><div class="cov-bar" style="width:{{ [f.func_pct,100]|min }}%;background:{{ cov_colour(f.func_pct) }}"></div></div>
+          <span style="color:{{ cov_colour(f.func_pct) }};font-weight:600">{{ '%.1f'|format(f.func_pct) }}%</span>
+        </td>
+        <td data-val="{{ f.branch_pct }}">
+          <div class="cov-bar-wrap"><div class="cov-bar" style="width:{{ [f.branch_pct,100]|min }}%;background:{{ cov_colour(f.branch_pct) }}"></div></div>
+          <span style="color:{{ cov_colour(f.branch_pct) }};font-weight:600">{{ '%.1f'|format(f.branch_pct) }}%</span>
+        </td>
+        <td class="mono muted">{{ f.lh }}/{{ f.lf }}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% endif %}
+  {% else %}
+  <p class="empty-msg">No coverage data.<br>Run <code>bazel coverage //:calculator_test</code></p>
+  {% endif %}
+</div>
+
+{# ── KPI tab ── #}
+<div id="tab-kpi" class="panel">
+  {% if history|length < 2 %}
+  <p class="empty-msg">{{ history|length }} run(s) recorded. Trends appear after 2+ runs.</p>
+  {% else %}
+  <h3 class="section-title">Error Fix KPIs</h3>
+  <div class="cards" style="margin-bottom:2rem">
+    {% for label, key, hib, unit in [('CodeQL Findings','codeql',false,''),('Clang-Tidy Warnings','clang_tidy',false,''),('Line Coverage','line_cov',true,'%'),('Branch Coverage','branch_cov',true,'%')] %}
+    {% set curr = history[-1][key] %}
+    {% set prv  = history[-2][key] %}
+    {% set orig = history[0][key] %}
+    <div class="card">
+      <div class="num">{% if curr is not none %}{{ ('%.1f'|format(curr) ~ unit) if curr is float else (curr|string ~ unit) }}{% else %}N/A{% endif %}</div>
+      {% if curr is not none and prv is not none %}<div class="delta">{{ delta(curr, prv, hib) }} vs prev</div>{% endif %}
+      <div class="label">{{ label }}
+        {% if curr is not none and orig is not none and orig != 0 %}
+          {% set rate = ((orig - curr) / orig * 100) if not hib else ((curr - orig) / orig * 100) %}
+          <br><span style="color:{{ '#27ae60' if rate >= 0 else '#e74c3c' }};font-size:.78rem">{{ '%+.1f'|format(rate) }}% vs start</span>
+        {% endif %}
+      </div>
+    </div>
+    {% endfor %}
+  </div>
+
+  <h3 class="section-title">Trend Sparklines</h3>
+  <div style="display:flex;gap:2rem;flex-wrap:wrap;margin-bottom:2rem">
+    {% set max_cq = [history|map(attribute='codeql')|select('number')|list|max, 1]|max %}
+    <div>
+      <div class="muted" style="font-size:.8rem;margin-bottom:4px">CodeQL findings</div>
+      <div class="spark-wrap">
+        {% for s in history %}
+          {% set h = ((s.codeql or 0) / max_cq * 30)|int %}
+          <div class="spark-bar" style="height:{{ [h,2]|max }}px;background:{{ '#e74c3c' if (s.codeql or 0) > 0 else '#27ae60' }}" title="{{ s.date }} — {{ s.codeql or 0 }} findings"></div>
+        {% endfor %}
+      </div>
+    </div>
+    <div>
+      <div class="muted" style="font-size:.8rem;margin-bottom:4px">Line coverage %</div>
+      <div class="spark-wrap">
+        {% for s in history %}
+          {% set h = ((s.line_cov or 0) / 100 * 30)|int %}
+          <div class="spark-bar" style="height:{{ [h,2]|max }}px;background:{{ cov_colour(s.line_cov or 0) }}" title="{{ s.date }} — {{ '%.1f'|format(s.line_cov or 0) }}%"></div>
+        {% endfor %}
+      </div>
+    </div>
+  </div>
+
+  <h3 class="section-title">Run History</h3>
+  <table>
+    <thead><tr><th>Date</th><th>CodeQL</th><th>Clang-Tidy</th><th>Line Cov</th><th>Func Cov</th><th>Branch Cov</th></tr></thead>
+    <tbody>
+      {% for snap in history|reverse %}
+      {% set idx = (history|length - 1) - loop.index0 %}
+      {% set ps = history[idx - 1] if idx > 0 else none %}
+      {% set is_latest = loop.first %}
+      <tr{% if is_latest %} style="background:var(--surface)"{% endif %}>
+        <td class="mono">{{ snap.date }}{% if is_latest %}&nbsp;<span style="font-size:.72rem;color:var(--accent)">now</span>{% endif %}</td>
+        <td>{{ snap.codeql if snap.codeql is not none else 'N/A' }}{% if ps and snap.codeql is not none and ps.codeql is not none %} {{ delta(snap.codeql, ps.codeql, false) }}{% endif %}</td>
+        <td>{{ snap.clang_tidy if snap.clang_tidy is not none else 'N/A' }}{% if ps and snap.clang_tidy is not none and ps.clang_tidy is not none %} {{ delta(snap.clang_tidy, ps.clang_tidy, false) }}{% endif %}</td>
+        <td>{% if snap.line_cov is not none %}<span style="color:{{ cov_colour(snap.line_cov) }}">{{ '%.1f'|format(snap.line_cov) }}%</span>{% if ps and ps.line_cov is not none %} {{ delta(snap.line_cov, ps.line_cov, true) }}{% endif %}{% else %}N/A{% endif %}</td>
+        <td>{% if snap.func_cov is not none %}<span style="color:{{ cov_colour(snap.func_cov) }}">{{ '%.1f'|format(snap.func_cov) }}%</span>{% if ps and ps.func_cov is not none %} {{ delta(snap.func_cov, ps.func_cov, true) }}{% endif %}{% else %}N/A{% endif %}</td>
+        <td>{% if snap.branch_cov is not none %}<span style="color:{{ cov_colour(snap.branch_cov) }}">{{ '%.1f'|format(snap.branch_cov) }}%</span>{% if ps and ps.branch_cov is not none %} {{ delta(snap.branch_cov, ps.branch_cov, true) }}{% endif %}{% else %}N/A{% endif %}</td>
+      </tr>
+      {% endfor %}
+    </tbody>
+  </table>
+  {% endif %}
+</div>
+
+<script>
+function showTab(name, btn) {
+  document.querySelectorAll('.panel').forEach(p => p.classList.remove('active'));
+  document.querySelectorAll('.tab-btn').forEach(b => b.classList.remove('active'));
+  document.getElementById('tab-' + name).classList.add('active');
+  btn.classList.add('active');
+}
+const cqRows = Array.from(document.querySelectorAll('#cq-tbody tr'));
+function cqFilter() {
+  const q = document.getElementById('cq-search').value.toLowerCase();
+  const s = document.getElementById('cq-sev').value;
+  cqRows.forEach(r => { r.style.display = ((!q || r.textContent.toLowerCase().includes(q)) && (!s || r.dataset.sev === s)) ? '' : 'none'; });
+}
+let cqDir=1; function cqSort(c) { const tb=document.getElementById('cq-tbody');
+  [...tb.querySelectorAll('tr')].sort((a,b)=>(a.cells[c]?.textContent||'').localeCompare(b.cells[c]?.textContent||'')*cqDir).forEach(r=>tb.appendChild(r)); cqDir*=-1; }
+const ctRows = Array.from(document.querySelectorAll('#ct-tbody tr'));
+function ctFilter() {
+  const q = document.getElementById('ct-search').value.toLowerCase();
+  const s = document.getElementById('ct-sev').value;
+  ctRows.forEach(r => { r.style.display = ((!q || r.textContent.toLowerCase().includes(q)) && (!s || r.dataset.sev === s)) ? '' : 'none'; });
+}
+let ctDir=1; function ctSort(c) { const tb=document.getElementById('ct-tbody');
+  [...tb.querySelectorAll('tr')].sort((a,b)=>(a.cells[c]?.textContent||'').localeCompare(b.cells[c]?.textContent||'')*ctDir).forEach(r=>tb.appendChild(r)); ctDir*=-1; }
+let cvDir=1; function cvSort(c) { const tb=document.getElementById('cv-tbody');
+  [...tb.querySelectorAll('tr')].sort((a,b)=>(parseFloat(a.cells[c]?.dataset.val||0)-parseFloat(b.cells[c]?.dataset.val||0))*cvDir).forEach(r=>tb.appendChild(r)); cvDir*=-1; }
+</script>
+</body>
+</html>

--- a/quality/dashboard/generate_dashboard.py
+++ b/quality/dashboard/generate_dashboard.py
@@ -1,0 +1,439 @@
+#!/usr/bin/env python3
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+"""Unified quality dashboard: CodeQL MISRA + Clang-Tidy + Coverage.
+
+Adapted from the CICD reference implementation. Key differences vs the original:
+  - Reads CodeQL findings from SARIF files (communication only produces SARIF,
+    not CSV).
+  - Reads clang-tidy reports from both *.AspectRulesLintClangTidy.out (aspect_
+    rules_lint v2, used by this repo) and *.AspectRulesLintClangTidy.report
+    (newer versions), so it is forward-compatible.
+  - No Bazel workspace resolution or --serve mode (CI-only).
+
+Usage (CI, called from nightly_quality.yml):
+    python3 quality/dashboard/generate_dashboard.py \\
+        --sarif-dir      _quality/codeql \\
+        --clang-tidy-dir _quality/clang_tidy \\
+        --lcov           /tmp/coverage_zip/extracted/artifacts/coverage_report.dat \\
+        --history        _quality/data/quality_history.json \\
+        --html           _quality/index.html \\
+        --github-summary
+"""
+
+import argparse
+import json
+import os
+import pathlib
+import re
+import sys
+from collections import Counter
+from datetime import datetime, timezone
+
+from jinja2 import Environment, FileSystemLoader
+from markupsafe import Markup
+
+_TEMPLATE_DIR = pathlib.Path(__file__).parent
+
+# ── Helpers exposed to the Jinja2 template ────────────────────────────────────
+_SEV_COLOUR = {
+    "critical": "#c0392b", "high": "#e74c3c", "error": "#e74c3c",
+    "warning": "#e67e22", "medium": "#e67e22", "low": "#f1c40f",
+    "recommendation": "#3498db", "note": "#95a5a6",
+}
+_SEV_ORDER = {
+    "critical": 0, "high": 1, "error": 1, "warning": 2, "medium": 2,
+    "low": 3, "recommendation": 4, "note": 4,
+}
+
+
+def _sev_colour(s: str) -> str:
+    return _SEV_COLOUR.get(str(s).lower(), "#95a5a6")
+
+
+def _cov_colour(pct) -> str:
+    pct = float(pct or 0)
+    return "#27ae60" if pct >= 90 else ("#e67e22" if pct >= 70 else "#e74c3c")
+
+
+def _delta_badge(curr, prev, higher_is_better: bool) -> Markup:
+    try:
+        diff = float(curr) - float(prev)
+    except (TypeError, ValueError):
+        return Markup("")
+    if diff == 0:
+        return Markup('<span class="trend-eq">=</span>')
+    improved = (diff < 0) if not higher_is_better else (diff > 0)
+    cls = "trend-dn" if improved else "trend-up"
+    sym = "↓" if diff < 0 else "↑"
+    fmt = f"{abs(diff):.1f}" if abs(diff) != int(abs(diff)) else str(int(abs(diff)))
+    return Markup(f'<span class="{cls}">{sym}{fmt}</span>')
+
+
+# ── Data parsers ──────────────────────────────────────────────────────────────
+
+def load_codeql_sarif(sarif_dir: pathlib.Path) -> list[dict]:
+    """Load CodeQL findings from SARIF files.
+
+    The communication repo's codeql_lint.py outputs SARIF only (CSV was
+    removed). This function parses SARIF v2.1.0 as produced by CodeQL and
+    returns rows in the same schema that dashboard.html.j2 expects:
+      name, description, severity, message, path, start_line.
+    """
+    if not sarif_dir or not sarif_dir.exists():
+        return []
+    rows = []
+    for sarif_path in sarif_dir.rglob("*.sarif"):
+        try:
+            data = json.loads(sarif_path.read_text(encoding="utf-8", errors="replace"))
+            for run in data.get("runs", []):
+                rules = {
+                    r["id"]: r
+                    for r in run.get("tool", {}).get("driver", {}).get("rules", [])
+                }
+                for result in run.get("results", []):
+                    rule_id = result.get("ruleId", "unknown")
+                    rule = rules.get(rule_id, {})
+                    message = result.get("message", {}).get("text", "")
+                    # Prefer the result-level severity; fall back to the rule's
+                    # default configuration level, then to "warning".
+                    severity = (
+                        result.get("level")
+                        or rule.get("defaultConfiguration", {}).get("level")
+                        or "warning"
+                    )
+                    locs = result.get("locations", [{}])
+                    loc = locs[0].get("physicalLocation", {}) if locs else {}
+                    uri = loc.get("artifactLocation", {}).get("uri", "")
+                    line = str(loc.get("region", {}).get("startLine", ""))
+                    rows.append({
+                        "name": rule.get("name", rule_id),
+                        "description": rule.get("shortDescription", {}).get("text", ""),
+                        "severity": severity,
+                        "message": message,
+                        "path": uri,
+                        "start_line": line,
+                    })
+        except Exception:
+            pass
+    return sorted(rows, key=lambda r: _SEV_ORDER.get(r["severity"].lower(), 99))
+
+
+_CT_FULL_RE = re.compile(r'^(.+?):(\d+):\d+: (warning|error): (.+?) \[([^\]]+)\]\s*$')
+_CT_SIMPLE_RE = re.compile(r'^(warning|error): (.+?) \[([^\]]+)\]\s*$')
+
+
+def load_clang_tidy(search_dir: pathlib.Path) -> list[dict]:
+    """Load clang-tidy findings.
+
+    Handles both:
+      *.AspectRulesLintClangTidy.out    – aspect_rules_lint v2 (current repo)
+      *.AspectRulesLintClangTidy.report – newer aspect_rules_lint versions
+    """
+    if not search_dir or not search_dir.exists():
+        return []
+    findings, seen = [], set()
+    patterns = (
+        "*.AspectRulesLintClangTidy.out",
+        "*.AspectRulesLintClangTidy.report",
+    )
+    for pattern in patterns:
+        for report_file in search_dir.rglob(pattern):
+            for line in report_file.read_text(encoding="utf-8", errors="replace").splitlines():
+                m = _CT_FULL_RE.match(line)
+                if m:
+                    fpath, lineno, sev, msg, check = m.groups()
+                    key = (fpath, lineno, check, msg[:80])
+                    if key not in seen:
+                        seen.add(key)
+                        findings.append({
+                            "path": fpath, "line": lineno,
+                            "severity": sev, "message": msg, "check": check,
+                        })
+                    continue
+                m = _CT_SIMPLE_RE.match(line)
+                if m:
+                    sev, msg, check = m.groups()
+                    key = ("", "", check, msg[:80])
+                    if key not in seen:
+                        seen.add(key)
+                        findings.append({
+                            "path": "", "line": "",
+                            "severity": sev, "message": msg, "check": check,
+                        })
+    return sorted(findings, key=lambda r: (0 if r["severity"] == "error" else 1, r["path"]))
+
+
+def load_lcov(path: pathlib.Path) -> tuple[dict, list[dict]]:
+    if not path or not path.is_file():
+        return {}, []
+    files, cur = [], None
+    for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw.strip()
+        if line.startswith("SF:"):
+            cur = {"file": line[3:], "lf": 0, "lh": 0, "fnf": 0, "fnh": 0,
+                   "brf": 0, "brh": 0, "_lf": 0, "_lh": 0}
+        elif cur is None:
+            continue
+        elif line.startswith("DA:"):
+            parts = line[3:].split(",")
+            cur["_lf"] += 1
+            if len(parts) >= 2:
+                try:
+                    if int(parts[1]) > 0:
+                        cur["_lh"] += 1
+                except ValueError:
+                    pass
+        elif line.startswith("LF:"):
+            cur["lf"] = int(line[3:] or 0)
+        elif line.startswith("LH:"):
+            cur["lh"] = int(line[3:] or 0)
+        elif line.startswith("FNF:"):
+            cur["fnf"] = int(line[4:] or 0)
+        elif line.startswith("FNH:"):
+            cur["fnh"] = int(line[4:] or 0)
+        elif line.startswith("BRF:"):
+            cur["brf"] = int(line[4:] or 0)
+        elif line.startswith("BRH:"):
+            cur["brh"] = int(line[4:] or 0)
+        elif line == "end_of_record":
+            if cur["lf"] == 0:
+                cur["lf"] = cur["_lf"]
+            if cur["lh"] == 0:
+                cur["lh"] = cur["_lh"]
+            files.append(cur)
+            cur = None
+
+    def pct(h, f):
+        return round(100.0 * h / f, 1) if f else 0.0
+
+    for f in files:
+        f["line_pct"] = pct(f["lh"], f["lf"])
+        f["func_pct"] = pct(f["fnh"], f["fnf"])
+        f["branch_pct"] = pct(f["brh"], f["brf"])
+
+    lf = sum(f["lf"] for f in files)
+    lh = sum(f["lh"] for f in files)
+    fnf = sum(f["fnf"] for f in files)
+    fnh = sum(f["fnh"] for f in files)
+    brf = sum(f["brf"] for f in files)
+    brh = sum(f["brh"] for f in files)
+    summary = {
+        "line_pct": pct(lh, lf), "func_pct": pct(fnh, fnf), "branch_pct": pct(brh, brf),
+        "lines": f"{lh}/{lf}", "funcs": f"{fnh}/{fnf}", "branches": f"{brh}/{brf}",
+    }
+    return summary, sorted(files, key=lambda f: f["line_pct"])
+
+
+def load_history(path: pathlib.Path) -> list[dict]:
+    if not path or not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, list) else []
+    except (json.JSONDecodeError, OSError):
+        return []
+
+
+def save_history(path: pathlib.Path, history: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(history, indent=2), encoding="utf-8")
+    print(f"History saved: {path}  ({len(history)} runs)")
+
+
+# ── HTML rendering ────────────────────────────────────────────────────────────
+
+def render_dashboard(
+    codeql_rows, clang_rows, cov_summary, cov_files, history, timestamp,
+) -> str:
+    env = Environment(loader=FileSystemLoader(str(_TEMPLATE_DIR)), autoescape=True)
+    env.globals["sev_colour"] = _sev_colour
+    env.globals["cov_colour"] = _cov_colour
+    env.globals["delta"] = _delta_badge
+    env.filters["basename"] = lambda p: pathlib.Path(p).name or p
+    env.tests["number"] = lambda x: isinstance(x, (int, float)) and x is not None
+    tmpl = env.get_template("dashboard.html.j2")
+    return tmpl.render(
+        timestamp=timestamp,
+        codeql_rows=codeql_rows,
+        codeql_counts=Counter(r["severity"].lower() for r in codeql_rows),
+        clang_rows=clang_rows,
+        clang_counts=Counter(r["severity"] for r in clang_rows),
+        clang_errors=sum(1 for r in clang_rows if r["severity"] == "error"),
+        cov=cov_summary or None,
+        cov_files=cov_files,
+        history=history,
+        prev=history[-2] if len(history) >= 2 else None,
+    )
+
+
+# ── GitHub Actions step summary ───────────────────────────────────────────────
+
+def write_github_summary(
+    codeql_rows, clang_rows, cov_summary, history, summary_path,
+) -> None:
+    lines = ["## Quality Dashboard\n", "### CodeQL (MISRA C++)\n"]
+    if not codeql_rows:
+        lines.append("**No findings.** :white_check_mark:\n")
+    else:
+        counts = Counter(r["severity"].lower() for r in codeql_rows)
+        lines += [
+            f"**Total: {len(codeql_rows)} findings**\n",
+            "| Severity | Count |",
+            "|----------|------:|",
+        ]
+        for sev in ["critical", "high", "error", "warning", "medium", "low",
+                    "recommendation", "note"]:
+            if sev in counts:
+                lines.append(f"| {sev.capitalize()} | {counts[sev]} |")
+
+    lines += ["", "### Clang-Tidy\n"]
+    if not clang_rows:
+        lines.append("**No warnings.** :white_check_mark:\n")
+    else:
+        counts = Counter(r["severity"] for r in clang_rows)
+        lines += [
+            f"**Total: {len(clang_rows)} warnings**\n",
+            "| Severity | Count |",
+            "|----------|------:|",
+        ]
+        for sev in ["error", "warning"]:
+            if sev in counts:
+                lines.append(f"| {sev.capitalize()} | {counts[sev]} |")
+
+    lines += ["", "### Coverage\n"]
+    if cov_summary:
+        lines += [
+            "| Metric | Value |",
+            "|--------|-------|",
+            f"| Lines | {cov_summary['line_pct']:.1f}% ({cov_summary['lines']}) |",
+            f"| Functions | {cov_summary['func_pct']:.1f}% ({cov_summary['funcs']}) |",
+            f"| Branches | {cov_summary['branch_pct']:.1f}% ({cov_summary['branches']}) |",
+        ]
+    else:
+        lines.append("Coverage data not available.\n")
+
+    if len(history) >= 2:
+        prev, curr = history[-2], history[-1]
+        lines += [
+            "", "### KPI Trend vs Previous Run\n",
+            "| Metric | Prev | Now | Δ |",
+            "|--------|------|-----|---|",
+        ]
+        for label, key, hib in [
+            ("CodeQL findings", "codeql", False),
+            ("Clang-Tidy warnings", "clang_tidy", False),
+            ("Line coverage %", "line_cov", True),
+            ("Branch coverage %", "branch_cov", True),
+        ]:
+            pv, cv = prev.get(key), curr.get(key)
+            if pv is not None and cv is not None:
+                diff = cv - pv
+                sym = "↓" if diff < 0 else ("↑" if diff > 0 else "=")
+                good = (diff < 0) if not hib else (diff > 0)
+                icon = "✅" if good else ("⚠️" if diff != 0 else "")
+                fmt = (f"{abs(diff):.1f}" if isinstance(diff, float)
+                       else str(abs(int(diff))))
+                lines.append(f"| {label} | {pv} | {cv} | {sym}{fmt} {icon} |")
+        lines.append(
+            f"\n_Tracking since {history[0].get('date', 'start')} ({len(history)} runs)_"
+        )
+
+    with open(summary_path, "a", encoding="utf-8") as fh:
+        fh.write("\n".join(lines) + "\n")
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate unified quality dashboard")
+    parser.add_argument(
+        "--sarif-dir", default="",
+        help="Directory containing CodeQL SARIF files (*.sarif)",
+    )
+    parser.add_argument(
+        "--clang-tidy-dir", default="",
+        help="Directory containing clang-tidy report files "
+             "(*.AspectRulesLintClangTidy.out or .report)",
+    )
+    parser.add_argument(
+        "--lcov", default="",
+        help="Path to LCOV .dat coverage data file",
+    )
+    parser.add_argument(
+        "--html", default="dashboard.html",
+        help="Output HTML dashboard path",
+    )
+    parser.add_argument(
+        "--github-summary", action="store_true",
+        help="Append markdown summary to $GITHUB_STEP_SUMMARY",
+    )
+    parser.add_argument(
+        "--history", default="",
+        help="Path to KPI history JSON file (read before, updated after rendering)",
+    )
+    args = parser.parse_args()
+
+    sarif_dir = pathlib.Path(args.sarif_dir) if args.sarif_dir else pathlib.Path("")
+    clang_tidy_dir = (pathlib.Path(args.clang_tidy_dir)
+                      if args.clang_tidy_dir else pathlib.Path(""))
+    lcov_path = pathlib.Path(args.lcov) if args.lcov else pathlib.Path("")
+    html_path = pathlib.Path(args.html)
+    hist_path = pathlib.Path(args.history) if args.history else None
+
+    html_path.parent.mkdir(parents=True, exist_ok=True)
+
+    codeql_rows = load_codeql_sarif(sarif_dir)
+    clang_rows = load_clang_tidy(clang_tidy_dir)
+    cov_summary, cov_files = load_lcov(lcov_path)
+    timestamp = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    history = load_history(hist_path) if hist_path else []
+    history.append({
+        "date": timestamp,
+        "codeql": len(codeql_rows),
+        "clang_tidy": len(clang_rows),
+        "line_cov": cov_summary.get("line_pct") if cov_summary else None,
+        "func_cov": cov_summary.get("func_pct") if cov_summary else None,
+        "branch_cov": cov_summary.get("branch_pct") if cov_summary else None,
+    })
+    if hist_path:
+        save_history(hist_path, history)
+
+    html_path.write_text(
+        render_dashboard(codeql_rows, clang_rows, cov_summary, cov_files,
+                         history, timestamp),
+        encoding="utf-8",
+    )
+
+    print(f"Dashboard written: {html_path}")
+    print(f"  CodeQL:     {len(codeql_rows)} findings")
+    print(f"  Clang-Tidy: {len(clang_rows)} warnings")
+    if cov_summary:
+        print(f"  Coverage:   {cov_summary['line_pct']:.1f}% lines  "
+              f"{cov_summary['func_pct']:.1f}% funcs  "
+              f"{cov_summary['branch_pct']:.1f}% branches")
+    else:
+        print("  Coverage:   N/A")
+
+    if args.github_summary:
+        write_github_summary(
+            codeql_rows, clang_rows, cov_summary, history,
+            os.environ.get("GITHUB_STEP_SUMMARY", "/dev/null"),
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/quality/static_analysis/codeql_lint.py
+++ b/quality/static_analysis/codeql_lint.py
@@ -60,13 +60,25 @@ def main():
             bazel_command += _get_action_env_extension(necessary_codeql_environment)
             subprocess.run(f"{bazel_command} {target}", shell=True, env=env, cwd=source_root, check=True)
 
-            os.system(f"{code_ql_path} database finalize -j=0 -- {database_location}")
+            # Finalize: compile tracing data into the queryable database.
+            subprocess.run(
+                f"{code_ql_path} database finalize -j=0 -- {database_location}",
+                shell=True, check=False)
 
             output_base = _get_bazel_info(source_root).get('output_path')
-            os.system(
-                f"{code_ql_path} database analyze -j=0 {database_location} --format=sarifv2.1.0 --output={output_base}/codeql.sarif")
-            os.system(
-                f"{code_ql_path} database analyze -j=0 {database_location} --format=csv --output={output_base}/codeql.csv")
+
+            # Analyze: run MISRA/AUTOSAR queries and produce SARIF.
+            # --ram:     cap at 5 GB to prevent swap thrashing on GitHub runners (7 GB total)
+            # --timeout: skip any single query that exceeds 20 minutes instead of hanging
+            # -j 2:      match GitHub runner core count explicitly
+            # CSV output removed — SARIF is sufficient for the CI report.
+            subprocess.run(
+                f"{code_ql_path} database analyze"
+                f" -j 2 --ram 5000 --timeout 20"
+                f" {database_location}"
+                f" --format=sarifv2.1.0 --output={output_base}/codeql.sarif",
+                shell=True, check=False,
+                timeout=5400)  # 90-minute hard ceiling as a last-resort safety net
 
             # @todo it is possible to generate here also a full MISRA compliance report, which we could do in the future.
             # path/to/<output_database_name> <name-of-results-file>.sarif <output_directory>


### PR DESCRIPTION
This PR introduces two separate, reviewable commits built cleanly on top of `eclipse-score/communication:main`:

1. **move docs to GitHub Pages** — sets up the GitHub Actions workflow to build and publish Sphinx docs to GitHub Pages, including a version switcher and `versions.json` management.
2. **Create a KPI dashboard for quality numbers** — adds a nightly quality workflow that generates an HTML dashboard tracking coverage, static analysis, and other quality KPIs.