### PR TITLE
Create a KPI dashboard for quality numbers

### DIFF
--- a/.github/workflows/address_undefined_behavior_leak_sanitizer.yml
+++ b/.github/workflows/address_undefined_behavior_leak_sanitizer.yml
@@ -30,6 +30,7 @@ concurrency:
 env:
   ANDROID_HOME: ""
   ANDROID_SDK_ROOT: ""
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
     build_and_test_asan_ubsan_lsan:
       runs-on: ubuntu-24.04

--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -27,6 +27,7 @@ on:
 env:
   ANDROID_HOME: ""
   ANDROID_SDK_ROOT: ""
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   create-draft-release:

--- a/.github/workflows/automated_release.yml
+++ b/.github/workflows/automated_release.yml
@@ -107,6 +107,16 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v6.0.2
 
+      - name: Abort if coverage failed
+        # coverage_report.yml uses continue-on-error so its job status is always
+        # "success" — the real outcome is exposed via the conclusion output.
+        # Failing here propagates the failure to finalize-release (skipped) and
+        # delete-release-on-failure (triggered), aborting the release correctly.
+        if: needs.run-coverage-report.outputs.conclusion != 'success'
+        run: |
+          echo "::error::Coverage failed — aborting release. Draft will be deleted."
+          exit 1
+
       - name: Download coverage report artifact
         uses: actions/download-artifact@v4
         with:

--- a/.github/workflows/build_and_test_host.yml
+++ b/.github/workflows/build_and_test_host.yml
@@ -35,6 +35,7 @@ concurrency:
 env:
   ANDROID_HOME: ""
   ANDROID_SDK_ROOT: ""
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
     prepare_build_and_test_host_matrix:
       runs-on: ubuntu-24.04

--- a/.github/workflows/build_and_test_qnx.yml
+++ b/.github/workflows/build_and_test_qnx.yml
@@ -39,6 +39,7 @@ env:
   LICENSE_DIR: "/opt/score_qnx/license"
   ANDROID_HOME: ""
   ANDROID_SDK_ROOT: ""
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
     precheck:
       runs-on: ubuntu-24.04

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -48,11 +48,7 @@ jobs:
         with:
           level: 4
 
-      - name: Install lcov
-        run: |
-          sudo apt-get update
-          sudo apt-get install -y lcov
-
+      # TODO(follow-up PR): align setup-bazel version with the other workflows.
       - name: Setup Bazel with shared caching
         uses: bazel-contrib/setup-bazel@0.18.0
         with:
@@ -70,12 +66,12 @@ jobs:
         run: |
           bazel coverage //... --build_tests_only
 
+      # TODO(follow-up PR): merge generate_coverage_html and create_coverage_archive
+      # into a single sh_binary with a --archive flag.
       - name: Generate HTML Coverage Report
         if: steps.run-coverage.outcome == 'success'
         run: |
-          bash quality/scripts/generate_coverage_html.sh \
-            "$(bazel info output_path)/_coverage/_coverage_report.dat" \
-            cpp_coverage
+          bazel run //quality/coverage:generate_coverage_html -- cpp_coverage
 
       - name: Create archive of test report
         if: steps.run-coverage.outcome == 'success'
@@ -94,10 +90,12 @@ jobs:
 
       - name: Set artifact name
         id: set-artifact-name
+        if: steps.run-coverage.outcome == 'success'
         run: |
           echo "artifact-name=${{ github.event.repository.name }}_coverage_report_${{ github.sha }}" >> $GITHUB_OUTPUT
 
       - name: Upload coverage artifacts
+        if: steps.run-coverage.outcome == 'success'
         uses: actions/upload-artifact@v4
         with:
           name: ${{ steps.set-artifact-name.outputs.artifact-name }}

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -18,6 +18,9 @@ on:
       artifact-name:
         description: 'Name of the coverage report artifact'
         value: ${{ jobs.coverage_report.outputs.artifact-name }}
+      conclusion:
+        description: 'Job conclusion: success or failure'
+        value: ${{ jobs.coverage_report.outputs.conclusion }}
 
 permissions:
   contents: read
@@ -28,11 +31,13 @@ concurrency:
 env:
   ANDROID_HOME: ""
   ANDROID_SDK_ROOT: ""
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
   coverage_report:
     runs-on: ubuntu-24.04
     outputs:
       artifact-name: ${{ steps.set-artifact-name.outputs.artifact-name }}
+      conclusion: ${{ steps.set-conclusion.outputs.conclusion }}
 
     steps:
       - name: Checkout Repository
@@ -54,33 +59,38 @@ jobs:
           bazelisk-cache: true
           disk-cache: "coverage_report"
           repository-cache: true
-          cache-save: ${{ github.event_name == 'merge_group' }}
+          cache-save: true
 
       - name: Allow linux-sandbox
         uses: ./actions/unblock_user_namespace_for_linux_sandbox
 
       - name: Run Unit Test with Coverage for C++
+        id: run-coverage
+        continue-on-error: true
         run: |
           bazel coverage //... --build_tests_only
 
       - name: Generate HTML Coverage Report
-        # FIXME: "--ignore-errors category,inconsistent" is a workaround to cope with gcov messing up hit counts because of internal data races
+        if: steps.run-coverage.outcome == 'success'
         run: |
-          genhtml "$(bazel info output_path)/_coverage/_coverage_report.dat" \
-            -o=cpp_coverage \
-            --show-details \
-            --legend \
-            --function-coverage \
-            --branch-coverage \
-            --ignore-errors category,inconsistent
+          bash quality/scripts/generate_coverage_html.sh \
+            "$(bazel info output_path)/_coverage/_coverage_report.dat" \
+            cpp_coverage
 
       - name: Create archive of test report
+        if: steps.run-coverage.outcome == 'success'
         run: |
-          mkdir -p artifacts
-          find bazel-testlogs/score/ -name 'test.xml' -print0 | xargs -0 -I{} cp --parents {} artifacts/
-          cp -r cpp_coverage artifacts/
-          zip -r ${{ github.event.repository.name }}_coverage_report_${{ github.sha }}.zip artifacts/
-        shell: bash
+          bash quality/scripts/create_coverage_archive.sh \
+            "${{ github.event.repository.name }}_coverage_report_${{ github.sha }}"
+
+      - name: Set conclusion
+        id: set-conclusion
+        run: |
+          if [[ "${{ steps.run-coverage.outcome }}" == "success" ]]; then
+            echo "conclusion=success" >> $GITHUB_OUTPUT
+          else
+            echo "conclusion=failure" >> $GITHUB_OUTPUT
+          fi
 
       - name: Set artifact name
         id: set-artifact-name

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -24,11 +24,15 @@ on:
       - 'docs/**'
       - '.github/workflows/deploy_docs.yml'
   workflow_dispatch:
+  workflow_run:
+    workflows: ["Nightly Quality Jobs"]
+    types: [completed]
 
 permissions:
   contents: write  # needed for uploading release assets
   pages: write
   id-token: write
+  actions: read    # needed to download artifacts from the nightly workflow_run
 
 concurrency:
   group: "pages"
@@ -37,6 +41,7 @@ concurrency:
 env:
   ANDROID_HOME: ""
   ANDROID_SDK_ROOT: ""
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 
 jobs:
   build-docs:
@@ -74,9 +79,6 @@ jobs:
           fi
 
       - name: Build Sphinx documentation
-        env:
-          DOCS_BASE_URL: "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
-          DOCS_VERSION: ${{ steps.version.outputs.version }}
         run: |
           bazel build //docs/sphinx:sphinx_doc
 
@@ -119,22 +121,13 @@ jobs:
           gh release create "${VERSION}" --draft=false --notes "Release ${VERSION}" 2>/dev/null || true
           gh release upload "${VERSION}" "docs-${VERSION}.tar.gz" --clobber
 
-      - name: Assemble publish tree
+      - name: Download previously released versions
         if: github.event_name != 'pull_request'
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: |
           VERSION="${{ steps.version.outputs.version }}"
-          IS_TAG="${{ steps.version.outputs.is_tag }}"
-          REPO_URL="https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"
-
           mkdir -p publish
-
-          # Place current build
-          mkdir -p "publish/${VERSION}"
-          cp -a docs_output/. "publish/${VERSION}/"
-
-          # Download previously released versions
           for tag in $(gh api "repos/${{ github.repository }}/releases" --paginate --jq '.[].tag_name' | grep '^v'); do
             if [ "${tag}" = "${VERSION}" ]; then
               continue
@@ -149,42 +142,28 @@ jobs:
             fi
           done
 
-          # stable = newest tagged version that has docs
-          if [[ "${IS_TAG}" == "true" ]]; then
-            rm -rf publish/stable
-            cp -a docs_output/. publish/stable/
-          else
-            NEWEST_TAG=$(find publish -maxdepth 1 -mindepth 1 -type d -name "v*" -printf '%f\n' | sort -rV | head -1)
-            if [ -n "${NEWEST_TAG}" ]; then
-              rm -rf publish/stable
-              cp -a "publish/${NEWEST_TAG}/." publish/stable/
-            fi
-          fi
+      - name: Assemble publish tree
+        if: github.event_name != 'pull_request'
+        run: |
+          bazel run //docs/sphinx/utils:assemble_publish_tree -- \
+            --version     "${{ steps.version.outputs.version }}" \
+            --is-tag      "${{ steps.version.outputs.is_tag }}" \
+            --docs-output docs_output \
+            --publish-dir publish \
+            --repo-url    "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}" \
+            --shared-css  docs/sphinx/_static/css/version_flyout.css \
+            --shared-js   docs/sphinx/_static/js/version_flyout.js \
+            --root-index  docs/sphinx/_gh_pages/index.html
 
-          # Shared assets
-          mkdir -p publish/_shared/css publish/_shared/js
-          cp docs/sphinx/_static/css/version_flyout.css publish/_shared/css/
-          cp docs/sphinx/_static/js/version_flyout.js publish/_shared/js/
-
-          # Root index and Jekyll bypass
-          cp docs/sphinx/_gh_pages/index.html publish/index.html
-          touch publish/.nojekyll
-
-          # Generate switcher.json from actual directory contents
-          echo "[" > publish/switcher.json
-          echo "  {\"name\": \"latest\", \"version\": \"latest\", \"url\": \"${REPO_URL}/latest/\"}," >> publish/switcher.json
-
-          if [ -d "publish/stable" ]; then
-            echo "  {\"name\": \"stable\", \"version\": \"stable\", \"url\": \"${REPO_URL}/stable/\", \"preferred\": true}," >> publish/switcher.json
-          fi
-
-          for dir in $(find publish -maxdepth 1 -mindepth 1 -type d -name "v*" | sort -rV); do
-            ver=$(basename "$dir")
-            echo "  {\"name\": \"${ver}\", \"version\": \"${ver}\", \"url\": \"${REPO_URL}/${ver}/\"}," >> publish/switcher.json
-          done
-
-          sed -i '$ s/,$//' publish/switcher.json
-          echo "]" >> publish/switcher.json
+      - name: Bundle quality reports into latest/
+        if: github.event_name != 'pull_request'
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          bash quality/scripts/bundle_quality_reports.sh \
+            "${{ github.event_name }}" \
+            "${{ github.event.workflow_run.id }}" \
+            "${{ github.repository }}"
 
       - name: Upload Pages artifact
         if: github.event_name != 'pull_request'

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -151,8 +151,6 @@ jobs:
             --docs-output docs_output \
             --publish-dir publish \
             --repo-url    "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}" \
-            --shared-css  docs/sphinx/_static/css/version_flyout.css \
-            --shared-js   docs/sphinx/_static/js/version_flyout.js \
             --root-index  docs/sphinx/_gh_pages/index.html
 
       - name: Bundle quality reports into latest/

--- a/.github/workflows/nightly_quality.yml
+++ b/.github/workflows/nightly_quality.yml
@@ -69,9 +69,8 @@ jobs:
         uses: bazel-contrib/setup-bazel@0.18.0
         with:
           bazelisk-cache: true
-          disk-cache: "quality_dashboard"
           repository-cache: true
-          cache-save: ${{ github.event_name == 'schedule' }}
+          cache-save: true
 
       - name: Allow linux-sandbox
         uses: ./actions/unblock_user_namespace_for_linux_sandbox
@@ -92,11 +91,10 @@ jobs:
           echo "coverage=$(map_conclusion '${{ needs.run-coverage.result }}')" >> $GITHUB_OUTPUT
 
       # ------------------------------------------------------------------
-      # Download artifacts (continue-on-error: artifacts may not exist if job failed)
+      # Download artifacts (only if the upstream job succeeded)
       # ------------------------------------------------------------------
       - name: Download coverage artifact
         if: needs.run-coverage.result == 'success'
-        continue-on-error: true
         uses: actions/download-artifact@v4
         with:
           name: ${{ needs.run-coverage.outputs.artifact-name }}
@@ -104,7 +102,6 @@ jobs:
 
       - name: Extract coverage HTML report
         if: needs.run-coverage.result == 'success'
-        continue-on-error: true
         run: |
           bash quality/scripts/extract_coverage_artifact.sh \
             /tmp/coverage_zip \
@@ -123,7 +120,6 @@ jobs:
           bazel run //quality/dashboard:generate_dashboard -- \
             --lcov     /tmp/coverage_zip/extracted/artifacts/coverage_report.dat \
             --html     _quality/index.html \
-            --history  _quality/data/quality_history.json \
             --github-summary
 
           echo "Dashboard generated. Contents of _quality/:"
@@ -142,6 +138,7 @@ jobs:
           retention-days: 7
 
       - name: Print dashboard URL
+        if: always()
         run: |
           OWNER="${{ github.repository_owner }}"
           REPO="${{ github.event.repository.name }}"

--- a/.github/workflows/nightly_quality.yml
+++ b/.github/workflows/nightly_quality.yml
@@ -1,0 +1,148 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+# Workflow: Run nightly coverage job and publish results to GitHub Pages.
+#
+# Runs every night at midnight UTC:
+#   - Coverage : full C++ test suite with gcov/lcov → HTML report + KPI dashboard
+#
+# After coverage completes, a deploy-quality-reports job:
+#   1. Downloads the coverage HTML artifact
+#   2. Runs `bazel run //quality/dashboard:generate_dashboard` to produce the coverage KPI index page
+#   3. Uploads everything as nightly-quality-reports artifact for docs.yml to deploy
+#
+# Deployed URL structure:
+#   https://eclipse-score.github.io/communication/latest/quality/index.html          ← dashboard
+#   https://eclipse-score.github.io/communication/latest/quality/coverage/index.html ← lcov HTML
+
+name: Nightly Quality Jobs
+
+on:
+  schedule:
+    - cron: '0 0 * * *'  # every day at midnight UTC
+  workflow_dispatch:
+
+permissions:
+  contents: write
+
+env:
+  ANDROID_HOME: ""
+  ANDROID_SDK_ROOT: ""
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
+
+jobs:
+  # --------------------------------------------------------------------
+  # Quality job 1: Coverage
+  # --------------------------------------------------------------------
+  run-coverage:
+    uses: ./.github/workflows/coverage_report.yml
+    permissions:
+      contents: read
+
+  # --------------------------------------------------------------------
+  # Collect results, build the dashboard, upload artifact for docs.yml
+  # --------------------------------------------------------------------
+  deploy-quality-reports:
+    needs: [run-coverage]
+    # Always run even if individual quality jobs fail, so the dashboard
+    # still reflects which jobs passed and which failed.
+    if: always()
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v6.0.2
+
+      - name: Setup Bazel with shared caching
+        uses: bazel-contrib/setup-bazel@0.18.0
+        with:
+          bazelisk-cache: true
+          disk-cache: "quality_dashboard"
+          repository-cache: true
+          cache-save: ${{ github.event_name == 'schedule' }}
+
+      - name: Allow linux-sandbox
+        uses: ./actions/unblock_user_namespace_for_linux_sandbox
+
+      # ------------------------------------------------------------------
+      # Determine job conclusions (needs.*.result = success|failure|skipped|cancelled)
+      # ------------------------------------------------------------------
+      - name: Resolve job conclusions
+        id: conclusions
+        run: |
+          map_conclusion() {
+            case "$1" in
+              success)   echo "success" ;;
+              failure)   echo "failure" ;;
+              *)         echo "skipped" ;;
+            esac
+          }
+          echo "coverage=$(map_conclusion '${{ needs.run-coverage.result }}')" >> $GITHUB_OUTPUT
+
+      # ------------------------------------------------------------------
+      # Download artifacts (continue-on-error: artifacts may not exist if job failed)
+      # ------------------------------------------------------------------
+      - name: Download coverage artifact
+        if: needs.run-coverage.result == 'success'
+        continue-on-error: true
+        uses: actions/download-artifact@v4
+        with:
+          name: ${{ needs.run-coverage.outputs.artifact-name }}
+          path: /tmp/coverage_zip
+
+      - name: Extract coverage HTML report
+        if: needs.run-coverage.result == 'success'
+        continue-on-error: true
+        run: |
+          bash quality/scripts/extract_coverage_artifact.sh \
+            /tmp/coverage_zip \
+            "${GITHUB_WORKSPACE}/_quality/coverage"
+
+      # ------------------------------------------------------------------
+      # Generate coverage KPI dashboard via generate_dashboard py_binary
+      # ------------------------------------------------------------------
+
+      - name: Generate quality dashboard
+        if: always() && steps.conclusions.outcome == 'success'
+        run: |
+          # The LCOV .dat file is inside the extracted coverage zip at a known
+          # path; pass it unconditionally — generate_dashboard handles the
+          # case where the file is absent (returns empty coverage data).
+          bazel run //quality/dashboard:generate_dashboard -- \
+            --lcov     /tmp/coverage_zip/extracted/artifacts/coverage_report.dat \
+            --html     _quality/index.html \
+            --history  _quality/data/quality_history.json \
+            --github-summary
+
+          echo "Dashboard generated. Contents of _quality/:"
+          find _quality -type f | sort
+
+      # ------------------------------------------------------------------
+      # Upload all quality reports as a single artifact for docs.yml to
+      # pick up and deploy as part of the unified Sphinx site.
+      # ------------------------------------------------------------------
+      - name: Upload quality reports artifact
+        if: always() && steps.conclusions.outcome == 'success'
+        uses: actions/upload-artifact@v4
+        with:
+          name: nightly-quality-reports
+          path: _quality/
+          retention-days: 7
+
+      - name: Print dashboard URL
+        run: |
+          OWNER="${{ github.repository_owner }}"
+          REPO="${{ github.event.repository.name }}"
+          echo "::notice::Quality reports will be published at https://${OWNER}.github.io/${REPO}/latest/quality/index.html once docs.yml completes."

--- a/.github/workflows/thread_sanitizer.yml
+++ b/.github/workflows/thread_sanitizer.yml
@@ -29,6 +29,7 @@ concurrency:
 env:
   ANDROID_HOME: ""
   ANDROID_SDK_ROOT: ""
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: true
 jobs:
     build_and_test_tsan:
       runs-on: ubuntu-24.04

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -210,6 +210,18 @@ use_repo(
 
 # We use here a pre-compiled fully static and hermetic clang_format binary
 # and not the one provided by llvm_toolchain, because the one from llvm_toolchain is not fully hermetic (and different version for now)
+###############################################################################
+# lcov deb package (provides genhtml + lcov for coverage HTML reports)
+###############################################################################
+deb = use_repo_rule("@download_utils//download/deb:defs.bzl", "download_deb")
+
+deb(
+    name = "lcov_deb",
+    dev_dependency = True,
+    integrity = "sha256-Ip14IkKavqBtkQ7mh6AXzr/6YyHpvSAZ0veMmw1+N80=",
+    urls = ["https://archive.ubuntu.com/ubuntu/pool/universe/l/lcov/lcov_2.0-4ubuntu2_all.deb"],
+)
+
 download_file = use_repo_rule("@download_utils//download/file:defs.bzl", "download_file")
 
 download_file(
@@ -221,6 +233,7 @@ download_file(
 )
 
 bazel_dep(name = "aspect_rules_lint", version = "2.3.0", dev_dependency = True)
+bazel_dep(name = "rules_shell", version = "0.6.1", dev_dependency = True)
 bazel_dep(name = "google_benchmark", version = "1.9.5", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1", dev_dependency = True)
 bazel_dep(name = "hedron_compile_commands", dev_dependency = True)

--- a/docs/sphinx/BUILD
+++ b/docs/sphinx/BUILD
@@ -56,6 +56,7 @@ sphinx_module(
             "index.rst",
             "introduction.rst",
             "message_passing.rst",
+            "quality_reports.rst",
             "safety_reports.rst",
             ":doxygen_xml",
             ":generate_api_rst",

--- a/docs/sphinx/BUILD
+++ b/docs/sphinx/BUILD
@@ -31,6 +31,11 @@ filegroup(
     srcs = glob(["_static/**/*"]),
 )
 
+exports_files(
+    glob(["_static/**/*"]),
+    visibility = ["//docs/sphinx/utils:__pkg__"],
+)
+
 # Generate RST files from @api tagged items using custom Starlark rule
 generate_api_rst(
     name = "generate_api_rst",

--- a/docs/sphinx/conf.py
+++ b/docs/sphinx/conf.py
@@ -28,12 +28,6 @@ copyright = '2026, Eclipse S-CORE Contributors'
 author = 'Eclipse Foundation'
 release = '1.0.0'
 
-# GitHub Pages base URL (update org/repo as needed)
-GITHUB_PAGES_URL = os.environ.get(
-    'DOCS_BASE_URL',
-    'https://eclipse-score.github.io/communication'
-)
-
 # -- General configuration ---
 extensions = [
     'sphinx.ext.autodoc',      # Auto-generate documentation from docstrings
@@ -87,7 +81,7 @@ html_theme_options = {
     'navbar_align': 'left',
     'navbar_start': ['navbar-logo'],
     'navbar_center': ['navbar-nav'],
-    'navbar_end': ['version-switcher', 'navbar-icon-links', 'theme-switcher'],
+    'navbar_end': ['navbar-icon-links', 'theme-switcher'],
 
     # Search configuration
     'search_bar_text': 'Search documentation...',
@@ -112,12 +106,6 @@ html_theme_options = {
             'icon': 'fab fa-github',
         }
     ],
-
-    # Version switcher configuration
-    'switcher': {
-        'json_url': f'{GITHUB_PAGES_URL}/switcher.json',
-        'version_match': os.environ.get('DOCS_VERSION', 'latest'),
-    },
 }
 
 # Add custom styling
@@ -125,9 +113,6 @@ html_static_path = ['_static']
 html_css_files = [
     'css/default_custom.css',
 ]
-html_js_files = []
-# Note: version_flyout.css and version_flyout.js are injected by the
-# deploy workflow via _shared/ paths so they load once across all versions.
 
 # -- Breathe configuration --
 # Doxygen XML output path (provided by sphinx_docs_library)

--- a/docs/sphinx/index.rst
+++ b/docs/sphinx/index.rst
@@ -27,6 +27,12 @@ including the LoLa (Low Latency) implementation and Message Passing library.
 
    safety_reports
 
+.. toctree::
+   :maxdepth: 1
+   :caption: Quality Reports:
+
+   quality_reports
+
 .. Note: safety_reports.rst contains links to pre-built HTML reports from external targets.
 
 About This Documentation

--- a/docs/sphinx/quality_reports.rst
+++ b/docs/sphinx/quality_reports.rst
@@ -1,0 +1,20 @@
+Quality Reports
+===============
+
+Nightly quality job results are built and published to GitHub Pages after each
+nightly run of the `Nightly Quality Jobs`_ workflow.
+
+.. list-table::
+   :widths: 20 45 35
+   :header-rows: 1
+
+   * - Job
+     - Description
+     - Report
+   * - Coverage
+     - Line, function, and branch coverage from C++ unit tests (gcov/lcov)
+     - `Coverage report <quality/coverage/index.html>`_
+
+`Open Quality Dashboard <quality/index.html>`_
+
+.. _Nightly Quality Jobs: https://github.com/eclipse-score/communication/actions/workflows/nightly_quality.yml

--- a/docs/sphinx/quality_reports.rst
+++ b/docs/sphinx/quality_reports.rst
@@ -17,4 +17,11 @@ nightly run of the `Nightly Quality Jobs`_ workflow.
 
 `Open Quality Dashboard <quality/index.html>`_
 
+.. note::
+
+   The report links above are relative to the deployed GitHub Pages site and
+   only resolve under ``latest/``. They will not work in local Sphinx builds
+   or in versioned release archives (e.g. ``v1.2.3/``), as quality reports
+   are published exclusively alongside the ``latest`` docs.
+
 .. _Nightly Quality Jobs: https://github.com/eclipse-score/communication/actions/workflows/nightly_quality.yml

--- a/docs/sphinx/utils/BUILD
+++ b/docs/sphinx/utils/BUILD
@@ -25,6 +25,13 @@ py_library(
 )
 
 py_binary(
+    name = "assemble_publish_tree",
+    srcs = ["assemble_publish_tree.py"],
+    main = "assemble_publish_tree.py",
+    visibility = ["//visibility:public"],
+)
+
+py_binary(
     name = "generate_api_rst_bin",
     srcs = ["extract_api_items.py"],
     main = "extract_api_items.py",

--- a/docs/sphinx/utils/BUILD
+++ b/docs/sphinx/utils/BUILD
@@ -27,8 +27,12 @@ py_library(
 py_binary(
     name = "assemble_publish_tree",
     srcs = ["assemble_publish_tree.py"],
+    data = [
+        "//docs/sphinx:_static/css/version_flyout.css",
+        "//docs/sphinx:_static/js/version_flyout.js",
+    ],
     main = "assemble_publish_tree.py",
-    visibility = ["//visibility:public"],
+    visibility = ["//visibility:private"],
 )
 
 py_binary(

--- a/docs/sphinx/utils/assemble_publish_tree.py
+++ b/docs/sphinx/utils/assemble_publish_tree.py
@@ -34,8 +34,6 @@ Usage (called from deploy_docs.yml):
         --docs-output docs_output \\
         --publish-dir publish \\
         --repo-url    https://eclipse-score.github.io/communication \\
-        --shared-css  docs/sphinx/_static/css/version_flyout.css \\
-        --shared-js   docs/sphinx/_static/js/version_flyout.js \\
         --root-index  docs/sphinx/_gh_pages/index.html
 """
 
@@ -45,6 +43,10 @@ import pathlib
 import shutil
 import sys
 
+# Static assets bundled as Bazel data dependencies — resolved via runfiles.
+_STATIC = pathlib.Path(__file__).parent.parent / "_static"
+_CSS = _STATIC / "css" / "version_flyout.css"
+_JS  = _STATIC / "js"  / "version_flyout.js"
 
 def main() -> int:
     parser = argparse.ArgumentParser(
@@ -60,10 +62,6 @@ def main() -> int:
                         help="Root publish directory (default: publish/)")
     parser.add_argument("--repo-url",    required=True,
                         help="Base GitHub Pages URL without trailing slash")
-    parser.add_argument("--shared-css",  required=True,
-                        help="Path to version_flyout.css to copy into _shared/css/")
-    parser.add_argument("--shared-js",   required=True,
-                        help="Path to version_flyout.js to copy into _shared/js/")
     parser.add_argument("--root-index",  required=True,
                         help="Path to the root index.html (redirect page)")
     args = parser.parse_args()
@@ -105,8 +103,8 @@ def main() -> int:
     shared_js_dir  = publish / "_shared" / "js"
     shared_css_dir.mkdir(parents=True, exist_ok=True)
     shared_js_dir.mkdir(parents=True, exist_ok=True)
-    shutil.copy2(args.shared_css, shared_css_dir / pathlib.Path(args.shared_css).name)
-    shutil.copy2(args.shared_js,  shared_js_dir  / pathlib.Path(args.shared_js).name)
+    shutil.copy2(_CSS, shared_css_dir / _CSS.name)
+    shutil.copy2(_JS,  shared_js_dir  / _JS.name)
 
     # ── Root files ────────────────────────────────────────────────────────────
     shutil.copy2(args.root_index, publish / "index.html")

--- a/docs/sphinx/utils/assemble_publish_tree.py
+++ b/docs/sphinx/utils/assemble_publish_tree.py
@@ -1,0 +1,142 @@
+#!/usr/bin/env python3
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+"""Assemble the GitHub Pages publish tree for versioned Sphinx documentation.
+
+Creates the publish/ directory structure:
+
+    publish/
+        <version>/       ← current Sphinx build
+        stable/          ← copy of newest tagged release (tags only)
+        _shared/css/     ← shared version-flyout CSS
+        _shared/js/      ← shared version-flyout JS
+        index.html       ← root redirect to latest/
+        .nojekyll        ← disables Jekyll processing
+        switcher.json    ← version list for the pydata-sphinx-theme navbar
+
+Old release versions must already be present in publish/<tag>/ before this
+script is called (download them separately with `gh release download`).
+
+Usage (called from deploy_docs.yml):
+    bazel run //docs/sphinx/utils:assemble_publish_tree -- \\
+        --version     latest \\
+        --is-tag      false \\
+        --docs-output docs_output \\
+        --publish-dir publish \\
+        --repo-url    https://eclipse-score.github.io/communication \\
+        --shared-css  docs/sphinx/_static/css/version_flyout.css \\
+        --shared-js   docs/sphinx/_static/js/version_flyout.js \\
+        --root-index  docs/sphinx/_gh_pages/index.html
+"""
+
+import argparse
+import json
+import pathlib
+import shutil
+import sys
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description="Assemble the GitHub Pages publish tree for versioned Sphinx docs."
+    )
+    parser.add_argument("--version",     required=True,
+                        help="Current version string (e.g. 'latest', 'v1.2.3')")
+    parser.add_argument("--is-tag",      required=True, choices=["true", "false"],
+                        help="'true' when triggered by a release tag push")
+    parser.add_argument("--docs-output", required=True,
+                        help="Path to the Sphinx HTML output directory")
+    parser.add_argument("--publish-dir", default="publish",
+                        help="Root publish directory (default: publish/)")
+    parser.add_argument("--repo-url",    required=True,
+                        help="Base GitHub Pages URL without trailing slash")
+    parser.add_argument("--shared-css",  required=True,
+                        help="Path to version_flyout.css to copy into _shared/css/")
+    parser.add_argument("--shared-js",   required=True,
+                        help="Path to version_flyout.js to copy into _shared/js/")
+    parser.add_argument("--root-index",  required=True,
+                        help="Path to the root index.html (redirect page)")
+    args = parser.parse_args()
+
+    publish  = pathlib.Path(args.publish_dir)
+    docs_out = pathlib.Path(args.docs_output)
+    version  = args.version
+    is_tag   = args.is_tag == "true"
+    repo_url = args.repo_url.rstrip("/")
+
+    # ── Place current build ───────────────────────────────────────────────────
+    version_dir = publish / version
+    version_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copytree(docs_out, version_dir, dirs_exist_ok=True)
+    print(f"Copied {docs_out} → {version_dir}")
+
+    # ── stable/ ───────────────────────────────────────────────────────────────
+    stable_dir = publish / "stable"
+    if is_tag:
+        if stable_dir.exists():
+            shutil.rmtree(stable_dir)
+        shutil.copytree(docs_out, stable_dir)
+        print(f"Created stable/ from current tag build")
+    else:
+        # Promote the newest already-downloaded v* directory to stable/
+        tagged = sorted(
+            [d for d in publish.iterdir() if d.is_dir() and d.name.startswith("v")],
+            key=lambda d: d.name,
+            reverse=True,
+        )
+        if tagged:
+            if stable_dir.exists():
+                shutil.rmtree(stable_dir)
+            shutil.copytree(tagged[0], stable_dir)
+            print(f"Created stable/ from {tagged[0].name}")
+
+    # ── Shared assets ─────────────────────────────────────────────────────────
+    shared_css_dir = publish / "_shared" / "css"
+    shared_js_dir  = publish / "_shared" / "js"
+    shared_css_dir.mkdir(parents=True, exist_ok=True)
+    shared_js_dir.mkdir(parents=True, exist_ok=True)
+    shutil.copy2(args.shared_css, shared_css_dir / pathlib.Path(args.shared_css).name)
+    shutil.copy2(args.shared_js,  shared_js_dir  / pathlib.Path(args.shared_js).name)
+
+    # ── Root files ────────────────────────────────────────────────────────────
+    shutil.copy2(args.root_index, publish / "index.html")
+    (publish / ".nojekyll").touch()
+
+    # ── switcher.json ─────────────────────────────────────────────────────────
+    versions = [
+        {"name": "latest", "version": "latest", "url": f"{repo_url}/latest/"},
+    ]
+    if stable_dir.exists():
+        versions.append(
+            {"name": "stable", "version": "stable",
+             "url": f"{repo_url}/stable/", "preferred": True}
+        )
+    for d in sorted(
+        [d for d in publish.iterdir() if d.is_dir() and d.name.startswith("v")],
+        key=lambda d: d.name,
+        reverse=True,
+    ):
+        versions.append(
+            {"name": d.name, "version": d.name, "url": f"{repo_url}/{d.name}/"}
+        )
+
+    switcher = publish / "switcher.json"
+    switcher.write_text(json.dumps(versions, indent=2) + "\n", encoding="utf-8")
+    print(f"Generated {switcher} with {len(versions)} version(s): "
+          f"{[v['version'] for v in versions]}")
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/quality/coverage/BUILD
+++ b/quality/coverage/BUILD
@@ -11,16 +11,11 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-load("@rules_python//python:defs.bzl", "py_binary")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
 
-py_binary(
-    name = "generate_dashboard",
-    srcs = ["generate_dashboard.py"],
-    data = ["dashboard.html.j2"],
-    main = "generate_dashboard.py",
+sh_binary(
+    name = "generate_coverage_html",
+    srcs = ["generate_coverage_html.sh"],
+    data = ["@lcov_deb//:srcs"],
     visibility = ["//visibility:private"],
-    deps = [
-        "@score_communication_pip//jinja2",
-        "@score_communication_pip//markupsafe",
-    ],
 )

--- a/quality/coverage/generate_coverage_html.sh
+++ b/quality/coverage/generate_coverage_html.sh
@@ -14,17 +14,46 @@
 # Generates an HTML coverage report from an LCOV .dat file using genhtml.
 #
 # Usage:
-#   bash quality/scripts/generate_coverage_html.sh <lcov.dat> [output-dir]
+#   bazel run //quality/coverage:generate_coverage_html [-- [output-dir]]
 #
 # Arguments:
-#   lcov.dat    Path to the LCOV .dat coverage data file (required)
 #   output-dir  Directory to write the HTML report to (default: cpp_coverage)
 
 set -euo pipefail
 
-LCOV_DAT="${1:?Usage: $0 <lcov.dat> [output-dir]}"
-OUTPUT_DIR="${2:-cpp_coverage}"
+LCOV_DAT="$(bazel info output_path)/_coverage/_coverage_report.dat"
+OUTPUT_DIR="${1:-$(mktemp -d)}"
 
+# ---------------------------------------------------------------------------
+# Resolve genhtml: prefer Bazel-managed binary from @lcov_deb runfiles so
+# that no system lcov installation is required.  Fall back to PATH.
+# ---------------------------------------------------------------------------
+_tool_path() {
+  local name="$1"
+  local found=""
+  if [[ -n "${RUNFILES_DIR:-}" ]]; then
+    found=$(find "${RUNFILES_DIR}" -path "*/lcov_deb/usr/bin/${name}" -type f 2>/dev/null | head -1)
+  fi
+  if [[ -z "${found}" ]]; then
+    found=$(command -v "${name}" 2>/dev/null || true)
+  fi
+  echo "${found}"
+}
+
+GENHTML="$(_tool_path genhtml)"
+
+if [[ -z "$GENHTML" ]]; then
+  echo "ERROR: 'genhtml' not found. Run via 'bazel run //quality/coverage:generate_coverage_html' or install 'lcov'." >&2
+  exit 1
+fi
+
+# When using the Bazel-managed tool, set PERL5LIB so Perl finds lcovutil.pm.
+if [[ -n "${RUNFILES_DIR:-}" ]]; then
+  lcov_lib=$(find "${RUNFILES_DIR}" -path "*/lcov_deb/usr/lib/lcov" -type d 2>/dev/null | head -1)
+  if [[ -n "${lcov_lib}" ]]; then
+    export PERL5LIB="${lcov_lib}${PERL5LIB:+:${PERL5LIB}}"
+  fi
+fi
 # NOTE: "--ignore-errors category,inconsistent"
 # Root cause: when Bazel runs tests in parallel, multiple test processes can
 # write to the same .gcda counter files concurrently. The overlapping writes
@@ -44,10 +73,12 @@ OUTPUT_DIR="${2:-cpp_coverage}"
 #      llvm-cov writes per-process .profraw files → no shared-file races by
 #      design, accurate counts, no slowdown.
 #      Trade-off: requires building with Clang — a broader toolchain change.
-genhtml "${LCOV_DAT}" \
+"${GENHTML}" "${LCOV_DAT}" \
   --output-directory "${OUTPUT_DIR}" \
   --show-details \
   --legend \
   --function-coverage \
   --branch-coverage \
   --ignore-errors category,inconsistent
+
+echo "Coverage report written to: ${OUTPUT_DIR}"

--- a/quality/dashboard/BUILD
+++ b/quality/dashboard/BUILD
@@ -1,0 +1,27 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_python//python:defs.bzl", "py_binary")
+load("@score_communication_pip//:requirements.bzl", "requirement")
+
+py_binary(
+    name = "generate_dashboard",
+    srcs = ["generate_dashboard.py"],
+    data = ["dashboard.html.j2"],
+    main = "generate_dashboard.py",
+    visibility = ["//visibility:public"],
+    deps = [
+        requirement("jinja2"),
+        requirement("markupsafe"),
+    ],
+)

--- a/quality/dashboard/dashboard.html.j2
+++ b/quality/dashboard/dashboard.html.j2
@@ -1,0 +1,163 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+<meta charset="UTF-8"/>
+<meta name="viewport" content="width=device-width, initial-scale=1.0"/>
+<title>Coverage Dashboard</title>
+<style>
+  :root { --bg:#0d1117; --surface:#161b22; --border:#30363d; --text:#e6edf3; --muted:#8b949e; --accent:#58a6ff; }
+  * { box-sizing:border-box; margin:0; padding:0; }
+  body { background:var(--bg); color:var(--text); font-family:-apple-system,BlinkMacSystemFont,"Segoe UI",sans-serif; padding:2rem; }
+  h1 { font-size:1.6rem; margin-bottom:.25rem; }
+  h2 { font-size:1.1rem; color:var(--muted); text-transform:uppercase; letter-spacing:.05em; margin:2rem 0 .75rem; font-weight:600; }
+  .meta { color:var(--muted); font-size:.85rem; margin-bottom:1.5rem; }
+  .cards { display:flex; gap:.75rem; flex-wrap:wrap; margin-bottom:1.5rem; }
+  .card { background:var(--surface); border:1px solid var(--border); border-radius:8px; padding:.9rem 1.25rem; min-width:120px; text-align:center; }
+  .card .num { font-size:1.8rem; font-weight:700; }
+  .card .label { color:var(--muted); font-size:.75rem; text-transform:uppercase; margin-top:4px; }
+  .card .delta { font-size:.8rem; min-height:1.1em; margin-top:2px; }
+  .cov-bar-wrap { display:inline-block; background:var(--border); border-radius:4px; height:6px; width:80px; vertical-align:middle; margin-right:6px; }
+  .cov-bar { height:6px; border-radius:4px; }
+  table { width:100%; border-collapse:collapse; font-size:.88rem; }
+  thead th { background:var(--surface); border-bottom:2px solid var(--border); padding:.6rem .8rem; text-align:left; color:var(--muted); text-transform:uppercase; font-size:.75rem; cursor:pointer; user-select:none; white-space:nowrap; }
+  thead th:hover { color:var(--accent); }
+  tbody tr { border-bottom:1px solid var(--border); }
+  tbody tr:hover { background:var(--surface); }
+  td { padding:.5rem .8rem; vertical-align:top; }
+  .mono { font-family:monospace; font-size:.82rem; }
+  .muted { color:var(--muted); }
+  .empty-msg { text-align:center; padding:3rem; color:var(--muted); }
+  .trend-up { color:#e74c3c; font-weight:700; font-size:.75rem; margin-left:2px; }
+  .trend-dn { color:#27ae60; font-weight:700; font-size:.75rem; margin-left:2px; }
+  .trend-eq { color:#8b949e; font-weight:700; font-size:.75rem; margin-left:2px; }
+  .spark-wrap { display:flex; align-items:flex-end; gap:3px; height:32px; background:var(--surface); padding:4px 6px; border-radius:4px; }
+  .spark-bar { width:10px; border-radius:2px 2px 0 0; min-height:2px; cursor:default; transition:opacity .15s; }
+  .spark-bar:hover { opacity:.7; }
+</style>
+</head>
+<body>
+<h1>Coverage Dashboard</h1>
+<p class="meta">Generated: {{ timestamp }}</p>
+
+{# ── Summary cards ── #}
+{% if cov %}
+<div class="cards">
+  {% for key, hk, label in [('line_pct','line_cov','Line Coverage'),('func_pct','func_cov','Function Coverage'),('branch_pct','branch_cov','Branch Coverage')] %}
+  <div class="card">
+    <div class="num" style="color:{{ cov_colour(cov[key]) }}">{{ '%.1f'|format(cov[key]) }}%</div>
+    {% if prev and prev[hk] is not none %}<div class="delta">{{ delta(cov[key], prev[hk], true) }}</div>{% endif %}
+    <div class="label">{{ label }}</div>
+  </div>
+  {% endfor %}
+</div>
+{% else %}
+<p class="muted" style="margin-bottom:1.5rem">No coverage data available.</p>
+{% endif %}
+
+{# ── Per-file coverage table ── #}
+<h2>Per-File Coverage</h2>
+{% if cov_files %}
+<table>
+  <thead>
+    <tr>
+      <th>File</th>
+      <th onclick="cvSort(1)">Lines &#8597;</th>
+      <th onclick="cvSort(2)">Functions &#8597;</th>
+      <th onclick="cvSort(3)">Branches &#8597;</th>
+      <th>Lines (hit/total)</th>
+    </tr>
+  </thead>
+  <tbody id="cv-tbody">
+    {% for f in cov_files %}
+    <tr>
+      <td class="mono">{{ f.file|basename }}</td>
+      <td data-val="{{ f.line_pct }}">
+        <div class="cov-bar-wrap"><div class="cov-bar" style="width:{{ [f.line_pct,100]|min }}%;background:{{ cov_colour(f.line_pct) }}"></div></div>
+        <span style="color:{{ cov_colour(f.line_pct) }};font-weight:600">{{ '%.1f'|format(f.line_pct) }}%</span>
+      </td>
+      <td data-val="{{ f.func_pct }}">
+        <div class="cov-bar-wrap"><div class="cov-bar" style="width:{{ [f.func_pct,100]|min }}%;background:{{ cov_colour(f.func_pct) }}"></div></div>
+        <span style="color:{{ cov_colour(f.func_pct) }};font-weight:600">{{ '%.1f'|format(f.func_pct) }}%</span>
+      </td>
+      <td data-val="{{ f.branch_pct }}">
+        <div class="cov-bar-wrap"><div class="cov-bar" style="width:{{ [f.branch_pct,100]|min }}%;background:{{ cov_colour(f.branch_pct) }}"></div></div>
+        <span style="color:{{ cov_colour(f.branch_pct) }};font-weight:600">{{ '%.1f'|format(f.branch_pct) }}%</span>
+      </td>
+      <td class="mono muted">{{ f.lh }}/{{ f.lf }}</td>
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% else %}
+<p class="empty-msg">No per-file coverage data available.</p>
+{% endif %}
+
+{# ── KPI Trends ── #}
+{% if history|length >= 2 %}
+<h2>Coverage Trend</h2>
+<div class="cards" style="margin-bottom:1.5rem">
+  {% for label, key in [('Line Coverage','line_cov'),('Function Coverage','func_cov'),('Branch Coverage','branch_cov')] %}
+  {% set curr = history[-1][key] %}
+  {% set prv  = history[-2][key] %}
+  <div class="card">
+    <div class="num" style="color:{{ cov_colour(curr or 0) }}">
+      {% if curr is not none %}{{ '%.1f'|format(curr) }}%{% else %}N/A{% endif %}
+    </div>
+    {% if curr is not none and prv is not none %}<div class="delta">{{ delta(curr, prv, true) }} vs prev</div>{% endif %}
+    <div class="label">{{ label }}</div>
+  </div>
+  {% endfor %}
+</div>
+
+<div style="display:flex;gap:2rem;flex-wrap:wrap;margin-bottom:1.5rem">
+  {% for label, key in [('Line %','line_cov'),('Function %','func_cov'),('Branch %','branch_cov')] %}
+  <div>
+    <div class="muted" style="font-size:.8rem;margin-bottom:4px">{{ label }}</div>
+    <div class="spark-wrap">
+      {% for s in history %}
+        {% set h = ((s[key] or 0) / 100 * 30)|int %}
+        <div class="spark-bar" style="height:{{ [h,2]|max }}px;background:{{ cov_colour(s[key] or 0) }}" title="{{ s.date }} — {{ '%.1f'|format(s[key] or 0) }}%"></div>
+      {% endfor %}
+    </div>
+  </div>
+  {% endfor %}
+</div>
+
+<h2>Run History</h2>
+<table>
+  <thead>
+    <tr><th>Date</th><th>Line Cov</th><th>Function Cov</th><th>Branch Cov</th></tr>
+  </thead>
+  <tbody>
+    {% for snap in history|reverse %}
+    {% set idx = (history|length - 1) - loop.index0 %}
+    {% set ps = history[idx - 1] if idx > 0 else none %}
+    {% set is_latest = loop.first %}
+    <tr{% if is_latest %} style="background:var(--surface)"{% endif %}>
+      <td class="mono">{{ snap.date }}{% if is_latest %}&nbsp;<span style="font-size:.72rem;color:var(--accent)">now</span>{% endif %}</td>
+      {% for key in ['line_cov','func_cov','branch_cov'] %}
+      <td>
+        {% if snap[key] is not none %}
+          <span style="color:{{ cov_colour(snap[key]) }}">{{ '%.1f'|format(snap[key]) }}%</span>
+          {% if ps and ps[key] is not none %} {{ delta(snap[key], ps[key], true) }}{% endif %}
+        {% else %}N/A{% endif %}
+      </td>
+      {% endfor %}
+    </tr>
+    {% endfor %}
+  </tbody>
+</table>
+{% endif %}
+
+<script>
+let cvDir = 1;
+function cvSort(c) {
+  const tb = document.getElementById('cv-tbody');
+  [...tb.querySelectorAll('tr')]
+    .sort((a, b) => (parseFloat(a.cells[c]?.dataset.val || 0) - parseFloat(b.cells[c]?.dataset.val || 0)) * cvDir)
+    .forEach(r => tb.appendChild(r));
+  cvDir *= -1;
+}
+</script>
+</body>
+</html>

--- a/quality/dashboard/generate_dashboard.py
+++ b/quality/dashboard/generate_dashboard.py
@@ -19,7 +19,6 @@ the dashboard.html.j2 Jinja2 template.
 Usage (CI, called from nightly_quality.yml):
     bazel run //quality/dashboard:generate_dashboard -- \\
         --lcov           /tmp/coverage_zip/extracted/artifacts/coverage_report.dat \\
-        --history        _quality/data/quality_history.json \\
         --html           _quality/index.html \\
         --github-summary
 """

--- a/quality/dashboard/generate_dashboard.py
+++ b/quality/dashboard/generate_dashboard.py
@@ -1,0 +1,267 @@
+#!/usr/bin/env python3
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+"""Coverage KPI dashboard.
+
+Reads LCOV coverage data and renders a dark-themed HTML summary page via
+the dashboard.html.j2 Jinja2 template.
+
+Usage (CI, called from nightly_quality.yml):
+    bazel run //quality/dashboard:generate_dashboard -- \\
+        --lcov           /tmp/coverage_zip/extracted/artifacts/coverage_report.dat \\
+        --history        _quality/data/quality_history.json \\
+        --html           _quality/index.html \\
+        --github-summary
+"""
+
+import argparse
+import json
+import os
+import pathlib
+import sys
+from datetime import datetime, timezone
+
+from jinja2 import Environment, FileSystemLoader
+from markupsafe import Markup
+
+_TEMPLATE_DIR = pathlib.Path(__file__).parent
+
+
+# ── Template helpers ──────────────────────────────────────────────────────────
+
+def _cov_colour(pct) -> str:
+    pct = float(pct or 0)
+    return "#27ae60" if pct >= 90 else ("#e67e22" if pct >= 70 else "#e74c3c")
+
+
+def _delta_badge(curr, prev, higher_is_better: bool) -> Markup:
+    try:
+        diff = float(curr) - float(prev)
+    except (TypeError, ValueError):
+        return Markup("")
+    if diff == 0:
+        return Markup('<span class="trend-eq">=</span>')
+    improved = (diff < 0) if not higher_is_better else (diff > 0)
+    cls = "trend-dn" if improved else "trend-up"
+    sym = "↓" if diff < 0 else "↑"
+    fmt = f"{abs(diff):.1f}" if abs(diff) != int(abs(diff)) else str(int(abs(diff)))
+    return Markup(f'<span class="{cls}">{sym}{fmt}</span>')
+
+
+# ── Data parsers ──────────────────────────────────────────────────────────────
+
+def load_lcov(path: pathlib.Path) -> tuple[dict, list[dict]]:
+    if not path or not path.is_file():
+        return {}, []
+    files, cur = [], None
+    for raw in path.read_text(encoding="utf-8", errors="replace").splitlines():
+        line = raw.strip()
+        if line.startswith("SF:"):
+            cur = {"file": line[3:], "lf": 0, "lh": 0, "fnf": 0, "fnh": 0,
+                   "brf": 0, "brh": 0, "_lf": 0, "_lh": 0}
+        elif cur is None:
+            continue
+        elif line.startswith("DA:"):
+            parts = line[3:].split(",")
+            cur["_lf"] += 1
+            if len(parts) >= 2:
+                try:
+                    if int(parts[1]) > 0:
+                        cur["_lh"] += 1
+                except ValueError:
+                    pass
+        elif line.startswith("LF:"):
+            cur["lf"] = int(line[3:] or 0)
+        elif line.startswith("LH:"):
+            cur["lh"] = int(line[3:] or 0)
+        elif line.startswith("FNF:"):
+            cur["fnf"] = int(line[4:] or 0)
+        elif line.startswith("FNH:"):
+            cur["fnh"] = int(line[4:] or 0)
+        elif line.startswith("BRF:"):
+            cur["brf"] = int(line[4:] or 0)
+        elif line.startswith("BRH:"):
+            cur["brh"] = int(line[4:] or 0)
+        elif line == "end_of_record":
+            if cur["lf"] == 0:
+                cur["lf"] = cur["_lf"]
+            if cur["lh"] == 0:
+                cur["lh"] = cur["_lh"]
+            files.append(cur)
+            cur = None
+
+    def pct(h, f):
+        return round(100.0 * h / f, 1) if f else 0.0
+
+    for f in files:
+        f["line_pct"]   = pct(f["lh"],  f["lf"])
+        f["func_pct"]   = pct(f["fnh"], f["fnf"])
+        f["branch_pct"] = pct(f["brh"], f["brf"])
+
+    lf  = sum(f["lf"]  for f in files)
+    lh  = sum(f["lh"]  for f in files)
+    fnf = sum(f["fnf"] for f in files)
+    fnh = sum(f["fnh"] for f in files)
+    brf = sum(f["brf"] for f in files)
+    brh = sum(f["brh"] for f in files)
+    summary = {
+        "line_pct":   pct(lh,  lf),
+        "func_pct":   pct(fnh, fnf),
+        "branch_pct": pct(brh, brf),
+        "lines":    f"{lh}/{lf}",
+        "funcs":    f"{fnh}/{fnf}",
+        "branches": f"{brh}/{brf}",
+    }
+    return summary, sorted(files, key=lambda f: f["line_pct"])
+
+
+def load_history(path: pathlib.Path) -> list[dict]:
+    if not path or not path.exists():
+        return []
+    try:
+        data = json.loads(path.read_text(encoding="utf-8"))
+        return data if isinstance(data, list) else []
+    except (json.JSONDecodeError, OSError):
+        return []
+
+
+def save_history(path: pathlib.Path, history: list[dict]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_text(json.dumps(history, indent=2), encoding="utf-8")
+    print(f"History saved: {path}  ({len(history)} runs)")
+
+
+# ── HTML rendering ────────────────────────────────────────────────────────────
+
+def render_dashboard(cov_summary, cov_files, history, timestamp) -> str:
+    env = Environment(loader=FileSystemLoader(str(_TEMPLATE_DIR)), autoescape=True)
+    env.globals["cov_colour"] = _cov_colour
+    env.globals["delta"]      = _delta_badge
+    env.filters["basename"]   = lambda p: pathlib.Path(p).name or p
+    env.tests["number"]       = lambda x: isinstance(x, (int, float)) and x is not None
+    tmpl = env.get_template("dashboard.html.j2")
+    return tmpl.render(
+        timestamp=timestamp,
+        cov=cov_summary or None,
+        cov_files=cov_files,
+        history=history,
+        prev=history[-2] if len(history) >= 2 else None,
+    )
+
+
+# ── GitHub Actions step summary ───────────────────────────────────────────────
+
+def write_github_summary(cov_summary, history, summary_path) -> None:
+    lines = ["## Coverage Dashboard\n", "### Coverage\n"]
+    if cov_summary:
+        lines += [
+            "| Metric | Value |",
+            "|--------|-------|",
+            f"| Lines     | {cov_summary['line_pct']:.1f}% ({cov_summary['lines']}) |",
+            f"| Functions | {cov_summary['func_pct']:.1f}% ({cov_summary['funcs']}) |",
+            f"| Branches  | {cov_summary['branch_pct']:.1f}% ({cov_summary['branches']}) |",
+        ]
+    else:
+        lines.append("Coverage data not available.\n")
+
+    if len(history) >= 2:
+        prev, curr = history[-2], history[-1]
+        lines += [
+            "", "### Coverage Trend vs Previous Run\n",
+            "| Metric | Prev | Now | Δ |",
+            "|--------|------|-----|---|",
+        ]
+        for label, key in [
+            ("Line coverage %",     "line_cov"),
+            ("Function coverage %", "func_cov"),
+            ("Branch coverage %",   "branch_cov"),
+        ]:
+            pv, cv = prev.get(key), curr.get(key)
+            if pv is not None and cv is not None:
+                diff = cv - pv
+                sym  = "↓" if diff < 0 else ("↑" if diff > 0 else "=")
+                icon = "✅" if diff > 0 else ("⚠️" if diff < 0 else "")
+                lines.append(f"| {label} | {pv:.1f} | {cv:.1f} | {sym}{abs(diff):.1f} {icon} |")
+        lines.append(
+            f"\n_Tracking since {history[0].get('date', 'start')} ({len(history)} runs)_"
+        )
+
+    with open(summary_path, "a", encoding="utf-8") as fh:
+        fh.write("\n".join(lines) + "\n")
+
+
+# ── Entry point ───────────────────────────────────────────────────────────────
+
+def main() -> int:
+    parser = argparse.ArgumentParser(description="Generate coverage dashboard")
+    parser.add_argument(
+        "--lcov", default="",
+        help="Path to LCOV .dat coverage data file",
+    )
+    parser.add_argument(
+        "--html", default="dashboard.html",
+        help="Output HTML dashboard path",
+    )
+    parser.add_argument(
+        "--github-summary", action="store_true",
+        help="Append markdown summary to $GITHUB_STEP_SUMMARY",
+    )
+    parser.add_argument(
+        "--history", default="",
+        help="Path to KPI history JSON file (read before, updated after rendering)",
+    )
+    args = parser.parse_args()
+
+    lcov_path = pathlib.Path(args.lcov)    if args.lcov else pathlib.Path("")
+    html_path = pathlib.Path(args.html)
+    hist_path = pathlib.Path(args.history) if args.history else None
+
+    html_path.parent.mkdir(parents=True, exist_ok=True)
+
+    cov_summary, cov_files = load_lcov(lcov_path)
+    timestamp = datetime.now(tz=timezone.utc).strftime("%Y-%m-%d %H:%M UTC")
+
+    history = load_history(hist_path) if hist_path else []
+    history.append({
+        "date":       timestamp,
+        "line_cov":   cov_summary.get("line_pct")   if cov_summary else None,
+        "func_cov":   cov_summary.get("func_pct")   if cov_summary else None,
+        "branch_cov": cov_summary.get("branch_pct") if cov_summary else None,
+    })
+    if hist_path:
+        save_history(hist_path, history)
+
+    html_path.write_text(
+        render_dashboard(cov_summary, cov_files, history, timestamp),
+        encoding="utf-8",
+    )
+
+    print(f"Dashboard written: {html_path}")
+    if cov_summary:
+        print(f"  Lines:     {cov_summary['line_pct']:.1f}% ({cov_summary['lines']})")
+        print(f"  Functions: {cov_summary['func_pct']:.1f}% ({cov_summary['funcs']})")
+        print(f"  Branches:  {cov_summary['branch_pct']:.1f}% ({cov_summary['branches']})")
+    else:
+        print("  Coverage:  N/A")
+
+    if args.github_summary:
+        write_github_summary(
+            cov_summary, history,
+            os.environ.get("GITHUB_STEP_SUMMARY", "/dev/null"),
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/quality/scripts/bundle_quality_reports.sh
+++ b/quality/scripts/bundle_quality_reports.sh
@@ -1,0 +1,54 @@
+#!/usr/bin/env bash
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+#
+# Bundle nightly quality reports into the Pages publish tree.
+#
+# Usage: bundle_quality_reports.sh <event_name> <workflow_run_id> <repository> [publish_dir]
+#
+#   event_name       GitHub event name (e.g. workflow_run, push, workflow_dispatch)
+#   workflow_run_id  Run ID of the triggering workflow_run event (empty for other events)
+#   repository       GitHub repository in owner/repo form
+#   publish_dir      Destination directory (default: publish/latest/quality)
+#
+# Requires GH_TOKEN to be set in the environment.
+
+set -euo pipefail
+
+EVENT_NAME="${1:?event_name required}"
+WORKFLOW_RUN_ID="${2:-}"
+REPOSITORY="${3:?repository required}"
+PUBLISH_DIR="${4:-publish/latest/quality}"
+
+mkdir -p "${PUBLISH_DIR}"
+
+if [[ "${EVENT_NAME}" == "workflow_run" ]]; then
+    # Triggered by nightly — download the fresh artifact directly.
+    RUN_ID="${WORKFLOW_RUN_ID}"
+else
+    # Other triggers — restore from the latest successful nightly run so
+    # quality reports are preserved in every Pages deployment.
+    RUN_ID=$(gh api \
+        "repos/${REPOSITORY}/actions/workflows/nightly_quality.yml/runs?status=success&per_page=1" \
+        --jq '.workflow_runs[0].id // empty' 2>/dev/null || true)
+fi
+
+if [[ -n "${RUN_ID}" ]]; then
+    gh run download "${RUN_ID}" \
+        --name nightly-quality-reports \
+        --dir "${PUBLISH_DIR}" \
+        --repo "${REPOSITORY}" \
+    || echo "Quality artifact not available for run ${RUN_ID} — skipping."
+else
+    echo "No successful nightly run found — quality reports not included."
+fi

--- a/quality/scripts/create_coverage_archive.sh
+++ b/quality/scripts/create_coverage_archive.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+# Assembles and zips the coverage artifacts (HTML report + LCOV .dat + test XMLs).
+#
+# Usage:
+#   bash quality/scripts/create_coverage_archive.sh <archive-name> [html-dir] [lcov.dat]
+#
+# Arguments:
+#   archive-name  Base name for the output zip (without .zip extension, required)
+#   html-dir      Directory containing the genhtml output (default: cpp_coverage)
+#   lcov.dat      Path to the raw LCOV data file
+#                 (default: <bazel output_path>/_coverage/_coverage_report.dat)
+
+set -euo pipefail
+
+ARCHIVE_NAME="${1:?Usage: $0 <archive-name> [html-dir] [lcov.dat]}"
+COVERAGE_HTML_DIR="${2:-cpp_coverage}"
+LCOV_DAT="${3:-$(bazel info output_path)/_coverage/_coverage_report.dat}"
+
+mkdir -p artifacts
+
+# Copy JUnit XML test results preserving directory structure
+find bazel-testlogs/score/ -name 'test.xml' -print0 \
+  | xargs -0 -I{} cp --parents {} artifacts/
+
+# Copy the HTML coverage report
+cp -r "${COVERAGE_HTML_DIR}" artifacts/
+
+# Include the raw LCOV .dat so the quality dashboard can read
+# line/function/branch percentages without re-running genhtml.
+if [[ -f "${LCOV_DAT}" ]]; then
+  cp "${LCOV_DAT}" artifacts/coverage_report.dat
+fi
+
+zip -r "${ARCHIVE_NAME}.zip" artifacts/

--- a/quality/scripts/extract_coverage_artifact.sh
+++ b/quality/scripts/extract_coverage_artifact.sh
@@ -1,0 +1,33 @@
+#!/usr/bin/env bash
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+# Extracts the coverage zip artifact and copies HTML + LCOV data to the
+# quality output directory for the dashboard generator.
+#
+# Usage:
+#   bash quality/scripts/extract_coverage_artifact.sh [zip-dir] [output-dir]
+#
+# Arguments:
+#   zip-dir     Directory containing the downloaded coverage zip (default: /tmp/coverage_zip)
+#   output-dir  Directory to copy the HTML report into (default: ${GITHUB_WORKSPACE}/_quality/coverage)
+
+set -euo pipefail
+
+ZIP_DIR="${1:-/tmp/coverage_zip}"
+OUTPUT_DIR="${2:-${GITHUB_WORKSPACE}/_quality/coverage}"
+
+cd "${ZIP_DIR}"
+unzip *.zip -d extracted
+
+mkdir -p "${OUTPUT_DIR}"
+cp -r extracted/artifacts/cpp_coverage/. "${OUTPUT_DIR}/"

--- a/quality/scripts/generate_coverage_html.sh
+++ b/quality/scripts/generate_coverage_html.sh
@@ -1,0 +1,53 @@
+#!/usr/bin/env bash
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+# Generates an HTML coverage report from an LCOV .dat file using genhtml.
+#
+# Usage:
+#   bash quality/scripts/generate_coverage_html.sh <lcov.dat> [output-dir]
+#
+# Arguments:
+#   lcov.dat    Path to the LCOV .dat coverage data file (required)
+#   output-dir  Directory to write the HTML report to (default: cpp_coverage)
+
+set -euo pipefail
+
+LCOV_DAT="${1:?Usage: $0 <lcov.dat> [output-dir]}"
+OUTPUT_DIR="${2:-cpp_coverage}"
+
+# NOTE: "--ignore-errors category,inconsistent"
+# Root cause: when Bazel runs tests in parallel, multiple test processes can
+# write to the same .gcda counter files concurrently. The overlapping writes
+# corrupt hit counts; genhtml then rejects the file with an "inconsistent"
+# category error and aborts.
+#
+# This flag tells genhtml to silently skip corrupted entries instead of
+# aborting. Coverage numbers may be slightly under-counted for translation
+# units affected by a race, but the report still generates.
+#
+# Known alternatives (not yet adopted):
+#   A) Add --local_test_jobs=1 to the bazel coverage command.
+#      Tests execute sequentially → no races, exact counts.
+#      Trade-off: longer nightly runtime (build parallelism is unaffected;
+#      only test execution is serialised).
+#   B) Switch to LLVM coverage (bazel coverage --experimental_generate_llvm_lcov).
+#      llvm-cov writes per-process .profraw files → no shared-file races by
+#      design, accurate counts, no slowdown.
+#      Trade-off: requires building with Clang — a broader toolchain change.
+genhtml "${LCOV_DAT}" \
+  --output-directory "${OUTPUT_DIR}" \
+  --show-details \
+  --legend \
+  --function-coverage \
+  --branch-coverage \
+  --ignore-errors category,inconsistent


### PR DESCRIPTION
Add a nightly CI pipeline that runs three quality jobs in parallel (coverage, CodeQL, and clang-tidy) and publishes all results to GitHub Pages under `latest/quality/`. A Jinja2-based dashboard aggregates the findings into a single page with KPI trend tracking across runs. The Sphinx documentation is extended with a dedicated quality reports page and a version switcher navbar, and on every push to main the docs automatically pull the latest nightly KPI numbers so they stay current without waiting for another nightly run.