### PR TITLE
mw/com: Use pointer instead of copy for EventDataControlComposite

### DIFF
--- a/score/mw/com/impl/BUILD
+++ b/score/mw/com/impl/BUILD
@@ -200,6 +200,7 @@ cc_library(
         ":data_type_meta_info",
         ":generic_skeleton_event_binding",
         ":reference_to_moveable",
+        ":sample_allocatee_tracker",
         ":skeleton_event_base",
         ":skeleton_event_binding",
         "//score/mw/com/impl/plumbing:sample_allocatee_ptr",
@@ -366,6 +367,7 @@ cc_library(
     deps = [
         ":enable_reference_to_moveable_from_this",
         ":flag_owner",
+        ":sample_allocatee_tracker",
         ":skeleton_event_binding",
         "//score/mw/com/impl/tracing:skeleton_event_tracing",
         "//score/mw/com/impl/tracing:skeleton_event_tracing_data",
@@ -565,6 +567,7 @@ cc_library(
     ],
     deps = [
         ":binding_type",
+        ":sample_allocatee_tracker",
         "//score/mw/com/impl/plumbing:sample_allocatee_ptr",
         "//score/mw/com/impl/plumbing:sample_ptr",
         "//score/mw/com/impl/tracing:skeleton_event_tracing_data",
@@ -1042,6 +1045,26 @@ cc_library(
 )
 
 cc_library(
+    name = "sample_allocatee_tracker",
+    srcs = [
+        "sample_allocatee_guard.cpp",
+        "sample_allocatee_tracker.cpp",
+    ],
+    hdrs = [
+        "sample_allocatee_guard.h",
+        "sample_allocatee_tracker.h",
+    ],
+    features = COMPILER_WARNING_FEATURES,
+    tags = ["FFI"],
+    visibility = [
+        "//score/mw/com/impl:__subpackages__",
+    ],
+    deps = [
+        "@score_baselibs//score/mw/log",
+    ],
+)
+
+cc_library(
     name = "service_element_map_view_factory",
     srcs = ["service_element_map_view_factory.cpp"],
     hdrs = ["service_element_map_view_factory.h"],
@@ -1184,6 +1207,20 @@ cc_unit_test(
     deps = [
         ":sample_reference_tracker",
         "@score_baselibs//score/language/futurecpp",
+    ],
+)
+
+cc_unit_test(
+    name = "sample_allocatee_tracker_test",
+    srcs = ["sample_allocatee_tracker_test.cpp"],
+    deps = [":sample_allocatee_tracker"],
+)
+
+cc_unit_test(
+    name = "sample_allocatee_guard_test",
+    srcs = ["sample_allocatee_guard_test.cpp"],
+    deps = [
+        ":sample_allocatee_tracker",
     ],
 )
 

--- a/score/mw/com/impl/bindings/lola/event_data_control_composite.h
+++ b/score/mw/com/impl/bindings/lola/event_data_control_composite.h
@@ -63,7 +63,12 @@ class EventDataControlComposite
     explicit EventDataControlComposite(
         ProviderEventDataControlLocalView<AtomicIndirectorType>& asil_qm_control_local,
         ProviderEventDataControlLocalView<AtomicIndirectorType>* const asil_b_control_local);
-
+    /// \brief SampleAllocateePtr stores a raw pointer to this object, so any copy or move would silently invalidate
+    /// that pointer, causing undefined behaviour.
+    EventDataControlComposite(const EventDataControlComposite&) = delete;
+    EventDataControlComposite& operator=(const EventDataControlComposite&) = delete;
+    EventDataControlComposite(EventDataControlComposite&&) = delete;
+    EventDataControlComposite& operator=(EventDataControlComposite&&) = delete;
     /// \brief Checks for the oldest unused slot and acquires for writing (thread-safe, wait-free)
     ///
     /// \details This method will perform retries (bounded) on data-races. In order to ensure that _always_

--- a/score/mw/com/impl/bindings/lola/generic_skeleton_event.cpp
+++ b/score/mw/com/impl/bindings/lola/generic_skeleton_event.cpp
@@ -16,6 +16,7 @@
 #include "score/mw/com/impl/bindings/lola/skeleton_event.h"
 #include "score/mw/com/impl/bindings/lola/skeleton_event_properties.h"
 #include "score/mw/com/impl/runtime.h"
+#include "score/mw/com/impl/sample_allocatee_guard.h"
 #include "score/mw/com/impl/skeleton_event_binding.h"
 
 namespace score::mw::com::impl::lola
@@ -53,7 +54,8 @@ Result<void> GenericSkeletonEvent::Send(score::mw::com::impl::SampleAllocateePtr
     return skeleton_event_common_.Send(sample);
 }
 
-Result<score::mw::com::impl::SampleAllocateePtr<void>> GenericSkeletonEvent::Allocate() noexcept
+Result<score::mw::com::impl::SampleAllocateePtr<void>> GenericSkeletonEvent::Allocate(
+    SampleAllocateeGuard guard) noexcept
 {
     auto allocated_slot_result = skeleton_event_common_.AllocateSlot();
     if (!allocated_slot_result.has_value())
@@ -77,7 +79,7 @@ Result<score::mw::com::impl::SampleAllocateePtr<void>> GenericSkeletonEvent::All
         skeleton_event_common_.GetEventDataControlComposite(),
         skeleton_event_common_.GetConsumerEventDataControlLocalView(QualityType::kASIL_QM),
         slot_index);
-    return impl::MakeSampleAllocateePtr(std::move(lola_ptr));
+    return impl::MakeSampleAllocateePtr(std::move(lola_ptr), std::move(guard));
 }
 
 Result<void> GenericSkeletonEvent::Notify() noexcept

--- a/score/mw/com/impl/bindings/lola/generic_skeleton_event.h
+++ b/score/mw/com/impl/bindings/lola/generic_skeleton_event.h
@@ -20,6 +20,7 @@
 #include "score/mw/com/impl/bindings/lola/skeleton_event_properties.h"
 #include "score/mw/com/impl/data_type_meta_info.h"
 #include "score/mw/com/impl/generic_skeleton_event_binding.h"
+#include "score/mw/com/impl/sample_allocatee_guard.h"
 
 #include <optional>
 
@@ -42,7 +43,7 @@ class GenericSkeletonEvent : public GenericSkeletonEventBinding
 
     Result<void> Send(score::mw::com::impl::SampleAllocateePtr<void> sample) noexcept override;
 
-    Result<score::mw::com::impl::SampleAllocateePtr<void>> Allocate() noexcept override;
+    Result<score::mw::com::impl::SampleAllocateePtr<void>> Allocate(SampleAllocateeGuard guard) noexcept override;
 
     Result<void> Notify() noexcept override;
 

--- a/score/mw/com/impl/bindings/lola/generic_skeleton_event_test.cpp
+++ b/score/mw/com/impl/bindings/lola/generic_skeleton_event_test.cpp
@@ -12,8 +12,8 @@
  ********************************************************************************/
 
 #include "score/mw/com/impl/bindings/lola/generic_skeleton_event.h"
-
 #include "score/mw/com/impl/bindings/lola/test/skeleton_event_test_resources.h"
+#include "score/mw/com/impl/sample_allocatee_guard.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -193,7 +193,7 @@ TEST_F(GenericSkeletonEventFixture, CannotAllocateBeforePrepareOffer)
         fake_element_fq_id_, fake_event_name_, max_samples, max_subscribers, enforce_max_samples);
 
     // When trying to allocate without PrepareOffer
-    auto ptr = generic_skeleton_event_->Allocate();
+    auto ptr = generic_skeleton_event_->Allocate(SampleAllocateeGuard{});
 
     // Then allocation fails
     EXPECT_FALSE(ptr.has_value());
@@ -220,7 +220,7 @@ TEST_F(GenericSkeletonEventFixture, CanAllocateAfterPrepareOffer)
     std::ignore = generic_skeleton_event_->PrepareOffer();
 
     // And allocating a sample
-    auto ptr = generic_skeleton_event_->Allocate();
+    auto ptr = generic_skeleton_event_->Allocate(SampleAllocateeGuard{});
 
     // Then allocation succeeds
     EXPECT_TRUE(ptr.has_value());
@@ -250,7 +250,7 @@ TEST_F(GenericSkeletonEventFixture, MultipleAllocationsWork)
     std::vector<impl::SampleAllocateePtr<void>> pointers;
     for (std::size_t i = 0; i < max_samples; ++i)
     {
-        auto ptr = generic_skeleton_event_->Allocate();
+        auto ptr = generic_skeleton_event_->Allocate(SampleAllocateeGuard{});
         EXPECT_TRUE(ptr.has_value());
         pointers.push_back(std::move(ptr).value());
     }
@@ -283,7 +283,7 @@ TEST_F(GenericSkeletonEventFixture, AllocationFailsWhenSlotsFull)
     std::vector<impl::SampleAllocateePtr<void>> pointers;
     for (std::size_t i = 0; i < max_samples; ++i)
     {
-        auto ptr = generic_skeleton_event_->Allocate();
+        auto ptr = generic_skeleton_event_->Allocate(SampleAllocateeGuard{});
         EXPECT_TRUE(ptr.has_value());
         pointers.push_back(std::move(ptr).value());
     }
@@ -292,7 +292,7 @@ TEST_F(GenericSkeletonEventFixture, AllocationFailsWhenSlotsFull)
     EXPECT_CALL(service_discovery_mock_, StopOfferService(testing::_, IServiceDiscovery::QualityTypeSelector::kAsilQm))
         .Times(1);
 
-    auto overflow_ptr = generic_skeleton_event_->Allocate();
+    auto overflow_ptr = generic_skeleton_event_->Allocate(SampleAllocateeGuard{});
 
     // Then allocation fails
     EXPECT_FALSE(overflow_ptr.has_value());
@@ -319,7 +319,7 @@ TEST_F(GenericSkeletonEventFixture, CanSendAfterAllocate)
     std::ignore = generic_skeleton_event_->PrepareOffer();
 
     // And allocating a sample
-    auto ptr = generic_skeleton_event_->Allocate();
+    auto ptr = generic_skeleton_event_->Allocate(SampleAllocateeGuard{});
     ASSERT_TRUE(ptr.has_value());
 
     auto sample = std::move(ptr).value();
@@ -425,7 +425,7 @@ TEST_F(GenericSkeletonEventFixture, PrepareStopOffer)
     std::ignore = generic_skeleton_event_->PrepareOffer();
 
     // And allocating a sample
-    auto ptr = generic_skeleton_event_->Allocate();
+    auto ptr = generic_skeleton_event_->Allocate(SampleAllocateeGuard{});
     ASSERT_TRUE(ptr.has_value());
 
     // When calling PrepareStopOffer
@@ -484,7 +484,7 @@ TEST_F(GenericSkeletonEventFixture, FullEventLifecycle)
     EXPECT_TRUE(offer_result.has_value());
 
     // And allocating a sample
-    auto alloc_result = generic_skeleton_event_->Allocate();
+    auto alloc_result = generic_skeleton_event_->Allocate(SampleAllocateeGuard{});
     EXPECT_TRUE(alloc_result.has_value());
 
     auto sample = std::move(alloc_result).value();

--- a/score/mw/com/impl/bindings/lola/sample_allocatee_ptr.h
+++ b/score/mw/com/impl/bindings/lola/sample_allocatee_ptr.h
@@ -20,7 +20,6 @@
 #include <functional>
 #include <limits>
 #include <memory>
-#include <optional>
 #include <utility>
 
 namespace score::mw::com::impl::lola
@@ -36,7 +35,7 @@ namespace score::mw::com::impl::lola
 template <typename SampleType>
 class SampleAllocateePtr
 {
-    // friends to the View wrapper; is used to acces managed obj and event_data_control_
+    // friends to the View wrapper; is used to access managed obj and event_data_control_ptr_
     template <typename T>
     // coverity[autosar_cpp14_a11_3_1_violation] see above
     friend class SampleAllocateePtrView;
@@ -71,7 +70,7 @@ class SampleAllocateePtr
     explicit SampleAllocateePtr(std::nullptr_t /* ptr */) noexcept
         : managed_object_{nullptr},
           event_slot_index_{kUninitialisedEventSlotIndex},
-          event_data_control_{std::nullopt},
+          event_data_control_ptr_{nullptr},
           consumer_event_data_control_local_view_{nullptr}
     {
     }
@@ -81,12 +80,12 @@ class SampleAllocateePtr
     /// \param event_data_ctrl event data control structure, which manages the underlying event/sample in shmem.
     /// \param slot_index index of event slot
     SampleAllocateePtr(pointer ptr,
-                       const EventDataControlComposite<>& event_data_ctrl,
+                       EventDataControlComposite<>& event_data_ctrl,
                        ConsumerEventDataControlLocalView<>& consumer_event_data_control_local_view,
                        const SlotIndexType slot_index) noexcept
         : managed_object_{ptr},
           event_slot_index_{slot_index},
-          event_data_control_{event_data_ctrl},
+          event_data_control_ptr_{&event_data_ctrl},
           consumer_event_data_control_local_view_{&consumer_event_data_control_local_view}
     {
     }
@@ -128,7 +127,7 @@ class SampleAllocateePtr
 
         swap(this->managed_object_, other.managed_object_);
         swap(this->event_slot_index_, other.event_slot_index_);
-        swap(this->event_data_control_, other.event_data_control_);
+        swap(this->event_data_control_ptr_, other.event_data_control_ptr_);
         swap(this->consumer_event_data_control_local_view_, other.consumer_event_data_control_local_view_);
     }
 
@@ -185,18 +184,24 @@ class SampleAllocateePtr
         if (event_slot_index_ < kUninitialisedEventSlotIndex)
         {
             SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(
-                event_data_control_.has_value(),
-                "The only time that event_data_control_ does not have a value is if the SampleAllocateePtr is default "
+                event_data_control_ptr_ != nullptr,
+                "The only time that event_data_control_ptr_ is nullptr is if the SampleAllocateePtr is default "
                 "initialised or initialised with a nullptr. In both these, cases event_slot_index_ == "
                 "kUninitialisedEventSlotIndex so we will never enter this branch.");
-            event_data_control_->Discard(event_slot_index_);
+            event_data_control_ptr_->Discard(event_slot_index_);
             event_slot_index_ = kUninitialisedEventSlotIndex;
         }
     }
 
     pointer managed_object_;
     SlotIndexType event_slot_index_;
-    std::optional<EventDataControlComposite<>> event_data_control_;
+    /// \brief Pointer to EventDataControlComposite owned by the SkeletonEvent.
+    /// \details This is a non-owning pointer. The SkeletonEvent owns the EventDataControlComposite and must outlive
+    /// any SampleAllocateePtr instances created from it. The SampleAllocateeTracker ensures this by terminating
+    /// if SampleAllocateePtr instances outlive the SkeletonEvent. Can only be a nullptr if SampleAllocateePtr is
+    /// default constructed. This should be a pointer since the SampleAllocateePtr needs to update the ignore_qm_control
+    /// flag in certain situations
+    EventDataControlComposite<>* event_data_control_ptr_;
     ConsumerEventDataControlLocalView<>* consumer_event_data_control_local_view_;
 };
 
@@ -215,9 +220,10 @@ class SampleAllocateePtrView
   public:
     explicit SampleAllocateePtrView(const SampleAllocateePtr<SampleType>& ptr) : ptr_{ptr} {}
 
-    const std::optional<EventDataControlComposite<>>& GetEventDataControlComposite() const noexcept
+    const EventDataControlComposite<>& GetEventDataControlComposite() const noexcept
     {
-        return ptr_.event_data_control_;
+        SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(ptr_.event_data_control_ptr_ != nullptr);
+        return *ptr_.event_data_control_ptr_;
     }
 
     typename SampleAllocateePtr<SampleType>::pointer GetManagedObject() const noexcept
@@ -236,14 +242,10 @@ class SampleAllocateePtrMutableView
   public:
     explicit SampleAllocateePtrMutableView(SampleAllocateePtr<SampleType>& ptr) : ptr_{ptr} {}
 
-    const std::optional<EventDataControlComposite<>>& GetEventDataControlComposite() const noexcept
+    EventDataControlComposite<>& GetEventDataControlComposite() const noexcept
     {
-        return ptr_.event_data_control_;
-    }
-
-    std::optional<EventDataControlComposite<>>& GetEventDataControlComposite() noexcept
-    {
-        return ptr_.event_data_control_;
+        SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(ptr_.event_data_control_ptr_ != nullptr);
+        return *ptr_.event_data_control_ptr_;
     }
 
     [[nodiscard]]
@@ -256,6 +258,23 @@ class SampleAllocateePtrMutableView
   private:
     SampleAllocateePtr<SampleType>& ptr_;
 };
+
+// SampleAllocateePtr stores a raw pointer to EventDataControlComposite. If the composite were
+// moved or copied while a SampleAllocateePtr is alive, that pointer would become invalid (UB).
+// These assertions enforce at compile time that EventDataControlComposite remains non-copyable
+// and non-moveable.
+static_assert(!std::is_copy_constructible_v<EventDataControlComposite<>>,
+              "EventDataControlComposite must not be copy constructible - SampleAllocateePtr holds a "
+              "raw pointer to it and a copy would silently invalidate that pointer");
+static_assert(!std::is_move_constructible_v<EventDataControlComposite<>>,
+              "EventDataControlComposite must not be move constructible - SampleAllocateePtr holds a "
+              "raw pointer to it and a move would silently invalidate that pointer");
+static_assert(!std::is_copy_assignable_v<EventDataControlComposite<>>,
+              "EventDataControlComposite must not be copy assignable - SampleAllocateePtr holds a "
+              "raw pointer to it and a copy would silently invalidate that pointer");
+static_assert(!std::is_move_assignable_v<EventDataControlComposite<>>,
+              "EventDataControlComposite must not be move assignable - SampleAllocateePtr holds a "
+              "raw pointer to it and a move would silently invalidate that pointer");
 
 }  // namespace score::mw::com::impl::lola
 

--- a/score/mw/com/impl/bindings/lola/skeleton_event.h
+++ b/score/mw/com/impl/bindings/lola/skeleton_event.h
@@ -83,14 +83,14 @@ class SkeletonEvent final : public SkeletonEventBinding<SampleType>
     /// \brief Sends a value by _copy_ towards a consumer. It will allocate the necessary space and then copy the value
     /// into Shared Memory.
     Result<void> Send(const SampleType& value,
-                      std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>
-                          send_trace_callback) noexcept override;
+                      std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> send_trace_callback,
+                      SampleAllocateeGuard guard) noexcept override;
 
     Result<void> Send(impl::SampleAllocateePtr<SampleType> sample,
                       std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>
                           send_trace_callback) noexcept override;
 
-    Result<impl::SampleAllocateePtr<SampleType>> Allocate() noexcept override;
+    Result<impl::SampleAllocateePtr<SampleType>> Allocate(SampleAllocateeGuard guard) noexcept override;
 
     Result<impl::SamplePtr<SampleType>> GetLatestSample(QualityType quality_type) override;
 
@@ -140,9 +140,10 @@ template <typename SampleType>
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
 Result<void> SkeletonEvent<SampleType>::Send(
     const SampleType& value,
-    std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> send_trace_callback) noexcept
+    std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> send_trace_callback,
+    SampleAllocateeGuard guard) noexcept
 {
-    auto allocated_slot_result = Allocate();
+    auto allocated_slot_result = Allocate(std::move(guard));
     if (!(allocated_slot_result.has_value()))
     {
         return MakeUnexpected(ComErrc::kSampleAllocationFailure, "Could not allocate slot");
@@ -176,7 +177,7 @@ template <typename SampleType>
 // implicitly". std::terminate() is implicitly called from '.value()' in case it doesn't have value but as we check
 // before with 'has_value()' so no way for throwing std::bad_optional_access, which leads to std::terminate().
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-Result<impl::SampleAllocateePtr<SampleType>> SkeletonEvent<SampleType>::Allocate() noexcept
+Result<impl::SampleAllocateePtr<SampleType>> SkeletonEvent<SampleType>::Allocate(SampleAllocateeGuard guard) noexcept
 {
     const auto allocated_slot_result = skeleton_event_common_.AllocateSlot();
     if (!allocated_slot_result.has_value())
@@ -190,11 +191,13 @@ Result<impl::SampleAllocateePtr<SampleType>> SkeletonEvent<SampleType>::Allocate
     //  Tracing is a diagnostic/monitoring feature with no safety requirement, so QM is sufficient.
     //  GetConsumerEventDataControlLocalView(kASIL_B) is a separate code path introduced specifically for
     //  GetLatestSample().
-    return MakeSampleAllocateePtr(SampleAllocateePtr<SampleType>(
-        &event_data_storage_->at(static_cast<std::uint64_t>(slot_index)),
-        skeleton_event_common_.GetEventDataControlComposite(),
-        skeleton_event_common_.GetConsumerEventDataControlLocalView(QualityType::kASIL_QM),
-        slot_index));
+    return MakeSampleAllocateePtr(
+        SampleAllocateePtr<SampleType>(
+            &event_data_storage_->at(static_cast<std::uint64_t>(slot_index)),
+            skeleton_event_common_.GetEventDataControlComposite(),
+            skeleton_event_common_.GetConsumerEventDataControlLocalView(QualityType::kASIL_QM),
+            slot_index),
+        std::move(guard));
 }
 
 template <typename SampleType>

--- a/score/mw/com/impl/bindings/lola/skeleton_event_test.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_event_test.cpp
@@ -16,6 +16,7 @@
 #include "score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h"
 #include "score/mw/com/impl/com_error.h"
 #include "score/mw/com/impl/configuration/quality_type.h"
+#include "score/mw/com/impl/sample_allocatee_guard.h"
 
 #include "score/filesystem/filesystem.h"
 
@@ -67,7 +68,7 @@ TEST_F(SkeletonEventAllocateFixture, CannotAllocateBeforeCallingOffer)
     InitialiseSkeletonEvent(fake_element_fq_id_, fake_event_name_, max_samples_, max_subscribers_, enforce_max_samples);
 
     // When allocating and sending the allocated event
-    auto ptr = skeleton_event_->Allocate();
+    auto ptr = skeleton_event_->Allocate(SampleAllocateeGuard{});
 
     // Then we should get a nullptr
     EXPECT_FALSE(ptr);
@@ -94,7 +95,7 @@ TEST_F(SkeletonEventAllocateFixture, AllocateErrorLeadsToNullptr)
     std::vector<impl::SampleAllocateePtr<test::TestSampleType>> pointer_collection{max_samples_};
     for (std::size_t counter = 0; counter < max_samples_; ++counter)
     {
-        auto allocate_result = skeleton_event_->Allocate();
+        auto allocate_result = skeleton_event_->Allocate(SampleAllocateeGuard{});
         ASSERT_TRUE(allocate_result.has_value());
         pointer_collection[counter] = std::move(allocate_result).value();
     }
@@ -104,7 +105,7 @@ TEST_F(SkeletonEventAllocateFixture, AllocateErrorLeadsToNullptr)
     EXPECT_CALL(service_discovery_mock_, StopOfferService(_, IServiceDiscovery::QualityTypeSelector::kAsilQm)).Times(1);
 
     // When allocating a sixth (max_samples_ + 1) slot
-    auto allocate_result = skeleton_event_->Allocate();
+    auto allocate_result = skeleton_event_->Allocate(SampleAllocateeGuard{});
 
     // Then the slot cannot be allocated
     ASSERT_FALSE(allocate_result.has_value());
@@ -123,7 +124,7 @@ TEST_F(SkeletonEventAllocateFixture, SkeletonEventWithNotMaxSamplesEnforcementAl
     std::vector<impl::SampleAllocateePtr<test::TestSampleType>> pointer_collection{max_samples_};
     for (std::size_t counter = 0; counter < max_samples_; ++counter)
     {
-        auto allocate_result = skeleton_event_->Allocate();
+        auto allocate_result = skeleton_event_->Allocate(SampleAllocateeGuard{});
         ASSERT_TRUE(allocate_result.has_value());
         pointer_collection[counter] = std::move(allocate_result).value();
     }
@@ -133,7 +134,7 @@ TEST_F(SkeletonEventAllocateFixture, SkeletonEventWithNotMaxSamplesEnforcementAl
     EXPECT_CALL(service_discovery_mock_, StopOfferService(_, IServiceDiscovery::QualityTypeSelector::kAsilQm)).Times(1);
 
     // When allocating a sixth slot
-    auto allocate_result = skeleton_event_->Allocate();
+    auto allocate_result = skeleton_event_->Allocate(SampleAllocateeGuard{});
 
     // Then the slot cannot be allocated
     ASSERT_FALSE(allocate_result.has_value());
@@ -159,7 +160,7 @@ TEST_F(SkeletonEventAllocateFixture, AllocateReturnsUniquePointersForMultipleCal
 
     for (size_t i = 0; i < num_allocations; ++i)
     {
-        auto alloc_result = skeleton_event_->Allocate();
+        auto alloc_result = skeleton_event_->Allocate(SampleAllocateeGuard{});
         ASSERT_TRUE(alloc_result.has_value()) << "Allocation " << i << " failed";
 
         // Store the raw pointer to check for uniqueness
@@ -450,10 +451,10 @@ TEST_P(SkeletonEventAsilBGetLatestSampleFixture, GetLatestSampleReturnsMostRecen
     std::ignore = skeleton_event_->PrepareOffer();
 
     const test::TestSampleType first_sent_value{11U};
-    ASSERT_TRUE(skeleton_event_->Send(first_sent_value, std::nullopt).has_value());
+    ASSERT_TRUE(skeleton_event_->Send(first_sent_value, std::nullopt, SampleAllocateeGuard{}).has_value());
 
     const test::TestSampleType second_sent_value{42U};
-    ASSERT_TRUE(skeleton_event_->Send(second_sent_value, std::nullopt).has_value());
+    ASSERT_TRUE(skeleton_event_->Send(second_sent_value, std::nullopt, SampleAllocateeGuard{}).has_value());
 
     // When getting the latest sample
     const auto latest_sample = skeleton_event_->GetLatestSample(quality_type);
@@ -479,7 +480,7 @@ TEST_P(SkeletonEventAsilBGetLatestSampleFixture, GetLatestSampleReturnsErrorWhen
     std::ignore = skeleton_event_->PrepareOffer();
 
     const test::TestSampleType sent_value{42U};
-    ASSERT_TRUE(skeleton_event_->Send(sent_value, std::nullopt).has_value());
+    ASSERT_TRUE(skeleton_event_->Send(sent_value, std::nullopt, SampleAllocateeGuard{}).has_value());
 
     // And given that GetLatestSample has been called and the returned SamplePtr is still alive
     auto first_sample = skeleton_event_->GetLatestSample(quality_type);
@@ -510,7 +511,7 @@ TEST_P(SkeletonEventAsilBGetLatestSampleFixture, GetLatestSampleSucceedsAfterPre
     std::ignore = skeleton_event_->PrepareOffer();
 
     const test::TestSampleType sent_value{42U};
-    ASSERT_TRUE(skeleton_event_->Send(sent_value, std::nullopt).has_value());
+    ASSERT_TRUE(skeleton_event_->Send(sent_value, std::nullopt, SampleAllocateeGuard{}).has_value());
 
     {
         auto first_sample = skeleton_event_->GetLatestSample(quality_type);
@@ -543,7 +544,7 @@ TEST_P(SkeletonEventAsilBGetLatestSampleFixture,
     std::ignore = skeleton_event_->PrepareOffer();
 
     const test::TestSampleType sent_value{42U};
-    ASSERT_TRUE(skeleton_event_->Send(sent_value, std::nullopt).has_value());
+    ASSERT_TRUE(skeleton_event_->Send(sent_value, std::nullopt, SampleAllocateeGuard{}).has_value());
 
     // And given that GetLatestSample has been called with quality_type and the returned SamplePtr is still alive
     auto first_sample = skeleton_event_->GetLatestSample(quality_type);
@@ -604,10 +605,10 @@ TEST_F(SkeletonEventQmGetLatestSampleFixture, GetLatestSampleReturnsMostRecently
     std::ignore = skeleton_event_->PrepareOffer();
 
     const test::TestSampleType first_sent_value{11U};
-    ASSERT_TRUE(skeleton_event_->Send(first_sent_value, std::nullopt).has_value());
+    ASSERT_TRUE(skeleton_event_->Send(first_sent_value, std::nullopt, SampleAllocateeGuard{}).has_value());
 
     const test::TestSampleType second_sent_value{42U};
-    ASSERT_TRUE(skeleton_event_->Send(second_sent_value, std::nullopt).has_value());
+    ASSERT_TRUE(skeleton_event_->Send(second_sent_value, std::nullopt, SampleAllocateeGuard{}).has_value());
 
     // When getting the latest sample for QM quality type
     const auto latest_sample = skeleton_event_->GetLatestSample(QualityType::kASIL_QM);
@@ -631,7 +632,7 @@ TEST_F(SkeletonEventQmGetLatestSampleFixture, GetLatestSampleReturnsErrorWhenCal
     std::ignore = skeleton_event_->PrepareOffer();
 
     const test::TestSampleType sent_value{42U};
-    ASSERT_TRUE(skeleton_event_->Send(sent_value, std::nullopt).has_value());
+    ASSERT_TRUE(skeleton_event_->Send(sent_value, std::nullopt, SampleAllocateeGuard{}).has_value());
 
     // And given that GetLatestSample has been called and the returned SamplePtr is still alive for QM quality type
     auto first_sample = skeleton_event_->GetLatestSample(QualityType::kASIL_QM);
@@ -660,7 +661,7 @@ TEST_F(SkeletonEventQmGetLatestSampleFixture, GetLatestSampleSucceedsAfterPrevio
     std::ignore = skeleton_event_->PrepareOffer();
 
     const test::TestSampleType sent_value{42U};
-    ASSERT_TRUE(skeleton_event_->Send(sent_value, std::nullopt).has_value());
+    ASSERT_TRUE(skeleton_event_->Send(sent_value, std::nullopt, SampleAllocateeGuard{}).has_value());
 
     {
         auto first_sample = skeleton_event_->GetLatestSample(QualityType::kASIL_QM);
@@ -707,7 +708,7 @@ TEST_F(SkeletonEventTimestampFixture, SendUpdatesTimestampInControlData)
     std::ignore = skeleton_event_->PrepareOffer();
 
     // WHEN we allocate and send a first sample
-    auto first_allocated_slot_result = skeleton_event_->Allocate();
+    auto first_allocated_slot_result = skeleton_event_->Allocate(SampleAllocateeGuard{});
     ASSERT_TRUE(first_allocated_slot_result.has_value());
     auto first_allocated_slot = std::move(first_allocated_slot_result).value();
 
@@ -727,7 +728,7 @@ TEST_F(SkeletonEventTimestampFixture, SendUpdatesTimestampInControlData)
     EXPECT_EQ(first_timestamp, 1U);
 
     // AND WHEN we allocate and send a second sample
-    auto second_allocated_slot_result = skeleton_event_->Allocate();
+    auto second_allocated_slot_result = skeleton_event_->Allocate(SampleAllocateeGuard{});
     ASSERT_TRUE(second_allocated_slot_result.has_value());
     auto second_allocated_slot = std::move(second_allocated_slot_result).value();
 
@@ -778,7 +779,7 @@ TEST_F(SkeletonEventTimestampFixture, PrepareOfferInitializesCurrentTimestampFro
 
     std::ignore = skeleton_event_->PrepareOffer();
 
-    auto allocated_slot_result = skeleton_event_->Allocate();
+    auto allocated_slot_result = skeleton_event_->Allocate(SampleAllocateeGuard{});
     ASSERT_TRUE(allocated_slot_result.has_value());
     auto allocated_slot = std::move(allocated_slot_result).value();
 

--- a/score/mw/com/impl/bindings/lola/skeleton_event_tracing_test.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_event_tracing_test.cpp
@@ -14,6 +14,7 @@
 #include "score/mw/com/impl/bindings/lola/skeleton_event.h"
 #include "score/mw/com/impl/bindings/lola/test/skeleton_event_test_resources.h"
 #include "score/mw/com/impl/bindings/lola/test/transaction_log_test_resources.h"
+#include "score/mw/com/impl/sample_allocatee_guard.h"
 #include "score/mw/com/impl/tracing/configuration/service_element_instance_identifier_view.h"
 #include "score/mw/com/impl/tracing/configuration/tracing_filter_config_mock.h"
 #include "score/mw/com/impl/tracing/i_tracing_runtime.h"
@@ -173,7 +174,7 @@ TEST_F(SkeletonEventTracingSendFixture, SendCallsAreTracedWhenEnabled)
     // and then send is called
     auto tracing_handler =
         impl::tracing::CreateTracingSendCallback<test::TestSampleType>(expected_enabled_trace_points, *skeleton_event_);
-    std::ignore = skeleton_event_->Send(sample_data, {std::move(tracing_handler)});
+    std::ignore = skeleton_event_->Send(sample_data, {std::move(tracing_handler)}, SampleAllocateeGuard{});
 }
 
 TEST_F(SkeletonEventTracingSendFixture, MultipleSendCallsUsesCorrectTracePointDataId)
@@ -242,11 +243,11 @@ TEST_F(SkeletonEventTracingSendFixture, MultipleSendCallsUsesCorrectTracePointDa
     // and then send is called twice
     auto tracing_handler =
         impl::tracing::CreateTracingSendCallback<test::TestSampleType>(expected_enabled_trace_points, *skeleton_event_);
-    std::ignore = skeleton_event_->Send(sample_data[0], {std::move(tracing_handler)});
+    std::ignore = skeleton_event_->Send(sample_data[0], {std::move(tracing_handler)}, SampleAllocateeGuard{});
 
     auto tracing_handler_2 =
         impl::tracing::CreateTracingSendCallback<test::TestSampleType>(expected_enabled_trace_points, *skeleton_event_);
-    std::ignore = skeleton_event_->Send(sample_data[1], {std::move(tracing_handler_2)});
+    std::ignore = skeleton_event_->Send(sample_data[1], {std::move(tracing_handler_2)}, SampleAllocateeGuard{});
 }
 
 TEST_F(SkeletonEventTracingSendFixture, SendCallsAreNotTracedWhenAllocateFails)
@@ -279,7 +280,7 @@ TEST_F(SkeletonEventTracingSendFixture, SendCallsAreNotTracedWhenAllocateFails)
     std::list<impl::SampleAllocateePtr<test::TestSampleType>> data_vector{};
     for (size_t i = 0; i < max_samples_; ++i)
     {
-        auto slot_result = skeleton_event_->Allocate();
+        auto slot_result = skeleton_event_->Allocate(SampleAllocateeGuard{});
         ASSERT_TRUE(slot_result.has_value());
         data_vector.push_back(std::move(slot_result.value()));
     }
@@ -287,7 +288,7 @@ TEST_F(SkeletonEventTracingSendFixture, SendCallsAreNotTracedWhenAllocateFails)
     // and then send is called
     auto tracing_handler =
         impl::tracing::CreateTracingSendCallback<test::TestSampleType>(expected_enabled_trace_points, *skeleton_event_);
-    std::ignore = skeleton_event_->Send(sample_data, {std::move(tracing_handler)});
+    std::ignore = skeleton_event_->Send(sample_data, {std::move(tracing_handler)}, SampleAllocateeGuard{});
 }
 
 using SkeletonEventTracingSendWithAllocateFixture = SkeletonEventTracingFixture;
@@ -353,7 +354,7 @@ TEST_F(SkeletonEventTracingSendWithAllocateFixture, SendWithAllocateCallsAreTrac
     std::ignore = skeleton_event_->PrepareOffer();
 
     // When allocating a slot
-    auto slot_result = skeleton_event_->Allocate();
+    auto slot_result = skeleton_event_->Allocate(SampleAllocateeGuard{});
     ASSERT_TRUE(slot_result.has_value());
     auto& slot = slot_result.value();
 
@@ -430,7 +431,7 @@ TEST_F(SkeletonEventTracingSendWithAllocateFixture, MultipleSendCallsUsesCorrect
     std::ignore = skeleton_event_->PrepareOffer();
 
     // When allocating a slot
-    auto slot_result = skeleton_event_->Allocate();
+    auto slot_result = skeleton_event_->Allocate(SampleAllocateeGuard{});
     ASSERT_TRUE(slot_result.has_value());
     auto& slot = slot_result.value();
 
@@ -443,7 +444,7 @@ TEST_F(SkeletonEventTracingSendWithAllocateFixture, MultipleSendCallsUsesCorrect
     std::ignore = skeleton_event_->Send(std::move(slot), {std::move(tracing_handler)});
 
     // and then allocating another slot
-    auto slot_result_2 = skeleton_event_->Allocate();
+    auto slot_result_2 = skeleton_event_->Allocate(SampleAllocateeGuard{});
     ASSERT_TRUE(slot_result_2.has_value());
     auto& slot_2 = slot_result_2.value();
 

--- a/score/mw/com/impl/bindings/lola/test/skeleton_event_component_test.cpp
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_event_component_test.cpp
@@ -19,6 +19,7 @@
 #include "score/mw/com/impl/bindings/lola/skeleton_event.h"
 #include "score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h"
 #include "score/mw/com/impl/bindings/mock_binding/tracing/tracing_runtime.h"
+#include "score/mw/com/impl/sample_allocatee_guard.h"
 #include "score/mw/com/impl/service_discovery_mock.h"
 #include "score/mw/com/impl/test/runtime_mock_guard.h"
 #include "score/mw/com/impl/tracing/tracing_runtime_mock.h"
@@ -274,7 +275,7 @@ TEST_F(SkeletonEventComponentTestFixture, CanAllocateAndSendEvent)
     attorney.SetHandlerAvailability(true, true);  // Enable both QM and ASIL-B handler availability
 
     // When allocating and sending the allocated event
-    auto slot_result = skeleton_event_.Allocate();
+    auto slot_result = skeleton_event_.Allocate(SampleAllocateeGuard{});
     ASSERT_TRUE(slot_result.has_value());
     auto slot = std::move(slot_result).value();
 
@@ -306,7 +307,7 @@ TEST_F(SkeletonEventComponentTestFixture, CanSendByValue)
     auto free_slots_before = GetFreeSampleSlots();
 
     // When  sending by value
-    std::ignore = skeleton_event_.Send(5, {});
+    std::ignore = skeleton_event_.Send(5, {}, SampleAllocateeGuard{});
 
     // Then the send event in shared memory can be found by a proxy
     EXPECT_EQ(GetLastSendEvent(), 5);
@@ -348,7 +349,7 @@ TEST_F(SkeletonEventComponentDeathTest, CallingSendWillTerminateWhenLolaRuntimeD
         ASSERT_TRUE(prepare_offer_result.has_value());
 
         // When sending by value
-        score::cpp::ignore = skeleton_event_.Send(5, {});
+        score::cpp::ignore = skeleton_event_.Send(5, {}, SampleAllocateeGuard{});
     };
     // Then the program terminates
     EXPECT_DEATH(test_function(), ".*");
@@ -362,11 +363,11 @@ TEST_F(SkeletonEventSingleSlotComponentTestFixture, SendByValueReturnsErrorIfSlo
     ASSERT_TRUE(prepare_offer_result.has_value());
 
     // Allocate a slot so that there are no free slots remaining
-    const auto slot_result = skeleton_event_.Allocate();
+    const auto slot_result = skeleton_event_.Allocate(SampleAllocateeGuard{});
     ASSERT_TRUE(slot_result.has_value());
 
     // When sending by value
-    const auto send_result = skeleton_event_.Send(5, {});
+    const auto send_result = skeleton_event_.Send(5, {}, SampleAllocateeGuard{});
 
     // Then the result should contain an error indicating that the allocation failes
     ASSERT_FALSE(send_result.has_value());
@@ -391,8 +392,8 @@ TEST_F(SkeletonEventSingleSlotComponentTestFixture, SendByValueFreesSampleAlloca
     EXPECT_EQ(GetFreeSampleSlots(), 1);
 
     // and when calling Send twice
-    const auto send_result_1 = skeleton_event_.Send(5, {});
-    const auto send_result_2 = skeleton_event_.Send(5, {});
+    const auto send_result_1 = skeleton_event_.Send(5, {}, SampleAllocateeGuard{});
+    const auto send_result_2 = skeleton_event_.Send(5, {}, SampleAllocateeGuard{});
 
     // Then both sends return no errors indicating that each call allocated a slot and freed it before returning
     ASSERT_TRUE(send_result_1.has_value());
@@ -409,7 +410,7 @@ TEST_F(SkeletonEventComponentTestFixture, CallingAllocateWhenQmSlotsCannotBeAllo
     AllocateQmSlots(kNumberMaxSamples);
 
     // When allocating the allocated event
-    auto slot_result = skeleton_event_.Allocate();
+    auto slot_result = skeleton_event_.Allocate(SampleAllocateeGuard{});
 
     // Then a slot can still be allocated
     ASSERT_TRUE(slot_result.has_value());
@@ -425,7 +426,7 @@ TEST_F(SkeletonEventComponentTestFixture, CallingSendAfterAllocateWhenQmSlotsCan
     AllocateQmSlots(kNumberMaxSamples);
 
     // and given that a slot was allocated
-    auto slot_result = skeleton_event_.Allocate();
+    auto slot_result = skeleton_event_.Allocate(SampleAllocateeGuard{});
     ASSERT_TRUE(slot_result.has_value());
 
     // When calling Send
@@ -450,7 +451,7 @@ TEST_F(SkeletonEventComponentTestFixture,
     AllocateQmSlots(kNumberMaxSamples);
 
     // and given that a slot was allocated
-    auto slot_result = skeleton_event_.Allocate();
+    auto slot_result = skeleton_event_.Allocate(SampleAllocateeGuard{});
     ASSERT_TRUE(slot_result.has_value());
 
     // When calling Send

--- a/score/mw/com/impl/bindings/mock_binding/generic_skeleton_event.h
+++ b/score/mw/com/impl/bindings/mock_binding/generic_skeleton_event.h
@@ -29,7 +29,10 @@ class GenericSkeletonEvent : public GenericSkeletonEventBinding
 
     MOCK_METHOD(Result<void>, Send, (score::mw::com::impl::SampleAllocateePtr<void>), (noexcept, override));
 
-    MOCK_METHOD(Result<score::mw::com::impl::SampleAllocateePtr<void>>, Allocate, (), (noexcept, override));
+    MOCK_METHOD(Result<score::mw::com::impl::SampleAllocateePtr<void>>,
+                Allocate,
+                (SampleAllocateeGuard),
+                (noexcept, override));
 
     MOCK_METHOD(Result<void>, Notify, (), (noexcept, override));
 

--- a/score/mw/com/impl/bindings/mock_binding/skeleton_event.h
+++ b/score/mw/com/impl/bindings/mock_binding/skeleton_event.h
@@ -40,14 +40,19 @@ class SkeletonEvent : public SkeletonEventBinding<SampleType>
   public:
     MOCK_METHOD(Result<void>,
                 Send,
-                (const SampleType& value, std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>),
+                (const SampleType& value,
+                 std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>,
+                 SampleAllocateeGuard),
                 (noexcept, override));
     MOCK_METHOD(Result<void>,
                 Send,
                 (score::mw::com::impl::SampleAllocateePtr<SampleType> sample,
                  std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>),
                 (noexcept, override));
-    MOCK_METHOD(Result<score::mw::com::impl::SampleAllocateePtr<SampleType>>, Allocate, (), (noexcept, override));
+    MOCK_METHOD(Result<score::mw::com::impl::SampleAllocateePtr<SampleType>>,
+                Allocate,
+                (SampleAllocateeGuard),
+                (noexcept, override));
     MOCK_METHOD(Result<score::mw::com::impl::SamplePtr<SampleType>>, GetLatestSample, (QualityType), (override));
     MOCK_METHOD(Result<void>, PrepareOffer, (), (noexcept, override));
     MOCK_METHOD(void, PrepareStopOffer, (), (noexcept, override));
@@ -68,11 +73,11 @@ class SkeletonEventFacade : public SkeletonEventBinding<SampleType>
     }
 
     ~SkeletonEventFacade() override = default;
-    Result<void> Send(
-        const SampleType& value,
-        std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> callback) noexcept override
+    Result<void> Send(const SampleType& value,
+                      std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> callback,
+                      SampleAllocateeGuard guard) noexcept override
     {
-        return skeleton_event_.Send(value, std::move(callback));
+        return skeleton_event_.Send(value, std::move(callback), std::move(guard));
     };
     Result<void> Send(
         score::mw::com::impl::SampleAllocateePtr<SampleType> sample,
@@ -80,9 +85,9 @@ class SkeletonEventFacade : public SkeletonEventBinding<SampleType>
     {
         return skeleton_event_.Send(std::move(sample), std::move(callback));
     }
-    Result<score::mw::com::impl::SampleAllocateePtr<SampleType>> Allocate() noexcept override
+    Result<impl::SampleAllocateePtr<SampleType>> Allocate(SampleAllocateeGuard guard) noexcept override
     {
-        return skeleton_event_.Allocate();
+        return skeleton_event_.Allocate(std::move(guard));
     };
     Result<score::mw::com::impl::SamplePtr<SampleType>> GetLatestSample(QualityType quality_type) override
     {

--- a/score/mw/com/impl/generic_skeleton_event.cpp
+++ b/score/mw/com/impl/generic_skeleton_event.cpp
@@ -76,7 +76,7 @@ Result<SampleAllocateePtr<void>> GenericSkeletonEvent::Allocate() noexcept
     }
     auto* const binding = static_cast<GenericSkeletonEventBinding*>(binding_.get());
 
-    auto result = binding->Allocate();
+    auto result = binding->Allocate(sample_allocatee_tracker_->Allocate());
 
     if (!result.has_value())
     {

--- a/score/mw/com/impl/generic_skeleton_event_binding.h
+++ b/score/mw/com/impl/generic_skeleton_event_binding.h
@@ -17,6 +17,7 @@
 #include "score/mw/com/impl/skeleton_event_binding.h"
 
 #include "score/mw/com/impl/plumbing/sample_allocatee_ptr.h"
+#include "score/mw/com/impl/sample_allocatee_guard.h"
 #include "score/result/result.h"
 
 #include <cstddef>
@@ -30,7 +31,7 @@ class GenericSkeletonEventBinding : public SkeletonEventBindingBase
   public:
     virtual Result<void> Send(SampleAllocateePtr<void> sample) noexcept = 0;
 
-    virtual Result<SampleAllocateePtr<void>> Allocate() noexcept = 0;
+    virtual Result<SampleAllocateePtr<void>> Allocate(SampleAllocateeGuard guard) noexcept = 0;
 
     /// \brief Get Notification when new sample is available.
     virtual Result<void> Notify() noexcept = 0;

--- a/score/mw/com/impl/generic_skeleton_event_test.cpp
+++ b/score/mw/com/impl/generic_skeleton_event_test.cpp
@@ -201,7 +201,7 @@ TEST_F(GenericSkeletonEventTest, AllocateAndSendDispatchesToBindingAfterOffer)
 
     // When calling Allocate()
     mock_binding::SampleAllocateePtr<void> dummy_alloc{nullptr, [](void*) {}};
-    EXPECT_CALL(*mock_event_binding_ptr_, Allocate())
+    EXPECT_CALL(*mock_event_binding_ptr_, Allocate(_))
         .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc)))));
 
     auto alloc_result = event_->Allocate();
@@ -226,7 +226,7 @@ TEST_F(GenericSkeletonEventTest, AllocateReturnsErrorWhenBindingFails)
     this->GivenAGenericSkeletonWithOneEvent().OfferSkeletonService();
 
     // Expect the binding to fail allocation
-    EXPECT_CALL(*mock_event_binding_ptr_, Allocate())
+    EXPECT_CALL(*mock_event_binding_ptr_, Allocate(_))
         .WillOnce(Return(ByMove(MakeUnexpected(ComErrc::kSampleAllocationFailure))));
 
     // When calling Allocate()

--- a/score/mw/com/impl/plumbing/BUILD
+++ b/score/mw/com/impl/plumbing/BUILD
@@ -753,6 +753,7 @@ cc_library(
     tags = ["FFI"],
     visibility = ["//score/mw/com/impl:__subpackages__"],
     deps = [
+        "//score/mw/com/impl:sample_allocatee_tracker",
         "//score/mw/com/impl/bindings/lola:event",
         "//score/mw/com/impl/bindings/mock_binding:sample_allocatee_ptr",
     ],

--- a/score/mw/com/impl/plumbing/rust/sample_allocatee_ptr.rs
+++ b/score/mw/com/impl/plumbing/rust/sample_allocatee_ptr.rs
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -19,13 +19,33 @@ use std::mem::ManuallyDrop;
 
 use common_rs::{
     BlankBinding,
+    ConsumerEventDataControlLocalView,
     CxxOptional,
-    ConsumerEventDataControlLocalView, 
+    CustomDeleter,
     ProviderEventDataControlLocalView,
     SlotIndexType,
-    UniquePtr,
-    CustomDeleter
 };
+
+#[repr(C)]
+struct SampleAllocateeTracker {
+    _data: [u8; 0],
+}
+
+#[repr(C)]
+struct SampleAllocateeGuard {
+    _tracker: *mut SampleAllocateeTracker,
+}
+
+#[repr(C)]
+struct MockBinding<T> {
+    _deleter: CustomDeleter,
+    _ptr: *mut T,
+}
+
+#[repr(C)]
+union MockBindingVariant<T> {
+    _variant: ManuallyDrop<MockBinding<T>>,
+}
 
 #[repr(C)]
 struct EventDataControlComposite {
@@ -38,21 +58,14 @@ struct EventDataControlComposite {
 struct LolaSampleAllocateePtrBinding<T> {
     _managed_object: *mut T,
     _event_slot_index: SlotIndexType,
-    _event_data_control: CxxOptional<EventDataControlComposite<>>,
+    _event_data_control_ptr: *mut EventDataControlComposite,
     _consumer_data_control_local_: *mut ConsumerEventDataControlLocalView,
-}
-
-type UniquePtrBinding<T> = UniquePtr<T, CustomDeleter>;
-
-#[repr(C)]
-union UniquePtrVariant<T> {
-    _variant: ManuallyDrop<UniquePtrBinding<T>>,
 }
 
 #[repr(C)]
 union LolaSampleAllocateePtrVariant<T> {
     _variant: ManuallyDrop<LolaSampleAllocateePtrBinding<T>>,
-    _unique_ptr: ManuallyDrop<UniquePtrVariant<T>>,
+    _mock_binding: ManuallyDrop<MockBindingVariant<T>>,
 }
 
 #[repr(C)]
@@ -70,6 +83,7 @@ struct AllocationVariant<T> {
 #[repr(C, align(16))]
 pub struct SampleAllocateePtr<T> {
     _internal: AllocationVariant<T>,
+    _allocatee_guard: CxxOptional<SampleAllocateeGuard>,
 }
 
 // SAFETY: There is no connection of any data to a particular thread, also not on C++ side.
@@ -133,12 +147,6 @@ mod tests {
             cpp_size,
             "EventDataControlComposite"
         );
-    }
-
-    #[test]
-    fn test_std_unique_ptr_size() {
-        let cpp_size = SampleAllocateePtrLola::get_std_unique_ptr_size();
-        verify_size_and_align!(UniquePtrBinding<i32>, cpp_size, "std::unique_ptr<i32>");
     }
 
     #[test]

--- a/score/mw/com/impl/plumbing/sample_allocatee_ptr.h
+++ b/score/mw/com/impl/plumbing/sample_allocatee_ptr.h
@@ -1,5 +1,5 @@
 /********************************************************************************
- * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
  *
  * See the NOTICE file(s) distributed with this work for additional
  * information regarding copyright ownership.
@@ -15,6 +15,7 @@
 
 #include "score/mw/com/impl/bindings/lola/sample_allocatee_ptr.h"
 #include "score/mw/com/impl/bindings/mock_binding/sample_allocatee_ptr.h"
+#include "score/mw/com/impl/sample_allocatee_tracker.h"
 
 #include <score/blank.hpp>
 #include <score/overload.hpp>
@@ -22,6 +23,7 @@
 #include <cstddef>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <type_traits>
 #include <utility>
 #include <variant>
@@ -123,7 +125,14 @@ class SampleAllocateePtr
     // namespace, or static function with internal linkage, or private member function shall be used.".
     // False-positive, method is used as a delegation constructor.
     // coverity[autosar_cpp14_a0_1_3_violation : FALSE]
-    explicit SampleAllocateePtr(T ptr) : internal_{std::move(ptr)}
+    explicit SampleAllocateePtr(T ptr) : internal_{std::move(ptr)}, allocatee_guard_{}
+    {
+    }
+
+    template <typename T>
+    // coverity[autosar_cpp14_a0_1_3_violation : FALSE]
+    explicit SampleAllocateePtr(T ptr, SampleAllocateeGuard guard)
+        : internal_{std::move(ptr)}, allocatee_guard_{std::move(guard)}
     {
     }
 
@@ -138,6 +147,11 @@ class SampleAllocateePtr
 
     template <typename T>
     // coverity[autosar_cpp14_a11_3_1_violation]
+    friend auto MakeSampleAllocateePtr(T ptr, SampleAllocateeGuard guard) noexcept
+        -> SampleAllocateePtr<typename T::element_type>;
+
+    template <typename T>
+    // coverity[autosar_cpp14_a11_3_1_violation]
     friend class SampleAllocateePtrView;
 
     template <typename T>
@@ -148,6 +162,10 @@ class SampleAllocateePtr
     // Stores either the LoLa pointer or the Mock Binding pointer (which handles void safely)
     std::variant<score::cpp::blank, lola::SampleAllocateePtr<SampleType>, mock_binding::SampleAllocateePtr<SampleType>>
         internal_;
+    /// \brief Guard that tracks this allocation's lifetime in the SampleAllocateeTracker.
+    /// Stored in an optional to handle both cases default-constructed SampleAllocateePtr (which don't track any
+    /// allocation) and allocated SampleAllocateePtr (which are tracked).
+    std::optional<SampleAllocateeGuard> allocatee_guard_;
 };
 
 template <typename SampleType>
@@ -191,6 +209,10 @@ void SampleAllocateePtr<SampleType>::reset() noexcept
         // coverity[autosar_cpp14_a7_1_7_violation]
         [](const score::cpp::blank&) noexcept -> void {});
     std::visit(visitor, internal_);
+    // Release the guard immediately so the tracker count reflects only currently held allocations.
+    // Without this, the counter would remain elevated until the SampleAllocateePtr object is destroyed,
+    // causing SampleAllocateeTracker's destructor to abort even though no slot is actually outstanding.
+    allocatee_guard_.reset();
 }
 
 template <typename SampleType>
@@ -199,6 +221,7 @@ void SampleAllocateePtr<SampleType>::Swap(SampleAllocateePtr<SampleType>& other)
     // Search for custom swap functions via ADL, and use std::swap if none are found.
     using std::swap;
     swap(internal_, other.internal_);
+    swap(allocatee_guard_, other.allocatee_guard_);
 }
 
 template <typename SampleType>
@@ -346,11 +369,21 @@ void swap(SampleAllocateePtr<T>& lhs, SampleAllocateePtr<T>& rhs) noexcept
     lhs.Swap(rhs);
 }
 
-/// \brief Helper function to create a SampleAllocateePtr within the middleware (not to be used by the user)
+/// \brief Helper function to create a SampleAllocateePtr for use in tests (not to be used in production code).
+/// In production, guards must be obtained from SampleAllocateeTracker::Allocate(); use MakeSampleAllocateePtr
+/// with a guard instead.
 template <typename T>
 auto MakeSampleAllocateePtr(T ptr) noexcept -> SampleAllocateePtr<typename T::element_type>
 {
     return SampleAllocateePtr<typename T::element_type>{std::move(ptr)};
+}
+
+/// \brief Helper function to create a SampleAllocateePtr with a lifetime-tracking guard within the middleware (not to
+/// be used by the user)
+template <typename T>
+auto MakeSampleAllocateePtr(T ptr, SampleAllocateeGuard guard) noexcept -> SampleAllocateePtr<typename T::element_type>
+{
+    return SampleAllocateePtr<typename T::element_type>{std::move(ptr), std::move(guard)};
 }
 
 /// \brief SampleAllocateePtr is user facing, in order to interact with its internals we provide a view towards it

--- a/score/mw/com/impl/plumbing/sample_allocatee_ptr_test.cpp
+++ b/score/mw/com/impl/plumbing/sample_allocatee_ptr_test.cpp
@@ -15,8 +15,8 @@
 #include "score/mw/com/impl/bindings/lola/control_slot_types.h"
 #include "score/mw/com/impl/bindings/lola/provider_event_data_control_local_view.h"
 #include "score/mw/com/impl/bindings/lola/test_doubles/fake_memory_resource.h"
-
 #include "score/mw/com/impl/bindings/mock_binding/sample_allocatee_ptr.h"
+#include "score/mw/com/impl/sample_allocatee_tracker.h"
 
 #include <score/assert.hpp>
 
@@ -67,6 +67,10 @@ class SampleAllocateePtrFixture : public ::testing::Test
         mock_binding::SampleAllocateePtr<std::uint8_t>(new std::uint8_t(42), [](std::uint8_t* p) {
             delete p;
         }))};
+
+    SampleAllocateeTracker tracker_{};
+    SampleAllocateePtr<std::uint8_t> unit_with_guard{
+        MakeSampleAllocateePtr(std::move(lola_allocatee_ptr_), tracker_.Allocate())};
 };
 
 TEST_F(SampleAllocateePtrFixture, ConstructFromNullptr)
@@ -550,6 +554,100 @@ TEST_F(SampleAllocateePtrFixture, UnderlyingLolaPtrIsFreedOnDestruction)
     // lola::SampleAllocateePtr will no longer point to the object.
     EXPECT_FALSE(is_destructed);
     EXPECT_EQ(lola_allocatee_ptr.get(), nullptr);
+}
+
+TEST_F(SampleAllocateePtrFixture, ConstructWithGuardDecrementsTrackerOnDestruction)
+{
+    // Given an impl::SampleAllocateePtr constructed with a guard
+    EXPECT_EQ(tracker_.GetNumAllocated(), 1U);
+
+    // When the SampleAllocateePtr goes out of scope
+    unit_with_guard = SampleAllocateePtr<std::uint8_t>{};
+
+    // Then the tracker count is decremented back to 0
+    EXPECT_EQ(tracker_.GetNumAllocated(), 0U);
+}
+
+TEST_F(SampleAllocateePtrFixture, ConstructWithGuardDecrementsTrackerOnReset)
+{
+    // Given an impl::SampleAllocateePtr constructed with a guard
+    ASSERT_EQ(tracker_.GetNumAllocated(), 1U);
+
+    // When reset() is called
+    unit_with_guard.reset();
+
+    // Then the tracker count is decremented immediately
+    EXPECT_EQ(tracker_.GetNumAllocated(), 0U);
+}
+
+TEST_F(SampleAllocateePtrFixture, ConstructWithGuardDecrementsTrackerOnNullptrAssignment)
+{
+    // Given an impl::SampleAllocateePtr constructed with a guard
+    ASSERT_EQ(tracker_.GetNumAllocated(), 1U);
+
+    // When assigning nullptr
+    unit_with_guard = nullptr;
+
+    // Then the tracker count is decremented immediately
+    EXPECT_EQ(tracker_.GetNumAllocated(), 0U);
+}
+
+TEST_F(SampleAllocateePtrFixture, MoveConstructorTransfersGuard)
+{
+    // Given a SampleAllocateePtr that owns a tracked allocation
+    ASSERT_EQ(tracker_.GetNumAllocated(), 1U);
+
+    // When move constructing from it
+    SampleAllocateePtr<std::uint8_t> moved_to{std::move(unit_with_guard)};
+
+    // Then the tracker count remains at 1 (the guard was transferred, not released)
+    EXPECT_EQ(tracker_.GetNumAllocated(), 1U);
+    // And the source no longer holds any allocation
+    EXPECT_EQ(unit_with_guard.Get(), nullptr);
+}
+
+TEST_F(SampleAllocateePtrFixture, MoveAssignmentTransfersGuard)
+{
+    // Given a SampleAllocateePtr that owns a tracked allocation
+    ASSERT_EQ(tracker_.GetNumAllocated(), 1U);
+
+    // When move assigning from it into an empty SampleAllocateePtr
+    SampleAllocateePtr<std::uint8_t> moved_to{};
+    moved_to = std::move(unit_with_guard);
+
+    // Then the tracker count remains at 1 (the guard was transferred, not released)
+    EXPECT_EQ(tracker_.GetNumAllocated(), 1U);
+    // And the source no longer holds any allocation
+    EXPECT_EQ(unit_with_guard.Get(), nullptr);
+}
+
+TEST_F(SampleAllocateePtrFixture, MoveConstructorDecrementsTrackerOnDestruction)
+{
+    // Given a SampleAllocateePtr with a guard that has been move-constructed into a new object
+    ASSERT_EQ(tracker_.GetNumAllocated(), 1U);
+    std::optional<SampleAllocateePtr<std::uint8_t>> moved_to{std::move(unit_with_guard)};
+    EXPECT_EQ(tracker_.GetNumAllocated(), 1U);
+
+    // When the moved-to object is explicitly destroyed
+    moved_to.reset();
+
+    // Then the tracker count is decremented to 0
+    EXPECT_EQ(tracker_.GetNumAllocated(), 0U);
+}
+
+TEST_F(SampleAllocateePtrFixture, MoveAssignmentDecrementsTrackerOnDestruction)
+{
+    // Given a SampleAllocateePtr with a guard that has been move-assigned into a new object
+    ASSERT_EQ(tracker_.GetNumAllocated(), 1U);
+    std::optional<SampleAllocateePtr<std::uint8_t>> moved_to{SampleAllocateePtr<std::uint8_t>{}};
+    moved_to.value() = std::move(unit_with_guard);
+    EXPECT_EQ(tracker_.GetNumAllocated(), 1U);
+
+    // When the moved-to object is explicitly destroyed
+    moved_to.reset();
+
+    // Then the tracker count is decremented to 0
+    EXPECT_EQ(tracker_.GetNumAllocated(), 0U);
 }
 
 }  // namespace

--- a/score/mw/com/impl/sample_allocatee_guard.cpp
+++ b/score/mw/com/impl/sample_allocatee_guard.cpp
@@ -1,0 +1,61 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/impl/sample_allocatee_guard.h"
+#include "score/mw/com/impl/sample_allocatee_tracker.h"
+
+#include <type_traits>
+
+namespace score::mw::com::impl
+{
+
+// Static assert to ensure SampleAllocateeTracker is not moveable (guards hold pointers to it).
+// Must be in the .cpp where SampleAllocateeTracker is a complete type.
+static_assert(!std::is_move_assignable_v<SampleAllocateeTracker> &&
+                  !std::is_move_constructible_v<SampleAllocateeTracker>,
+              "SampleAllocateeTracker must not be movable, otherwise the guard's stored pointer would dangle");
+SampleAllocateeGuard::SampleAllocateeGuard(SampleAllocateeTracker& tracker) : tracker_{&tracker} {}
+
+SampleAllocateeGuard::SampleAllocateeGuard(SampleAllocateeGuard&& other) noexcept : tracker_{other.tracker_}
+{
+    other.tracker_ = nullptr;
+}
+
+SampleAllocateeGuard& SampleAllocateeGuard::operator=(SampleAllocateeGuard&& other) noexcept
+{
+    if (this != &other)
+    {
+        if (tracker_ != nullptr)
+        {
+            Deallocate();
+        }
+        tracker_ = other.tracker_;
+        other.tracker_ = nullptr;
+    }
+    return *this;
+}
+
+SampleAllocateeGuard::~SampleAllocateeGuard() noexcept
+{
+    Deallocate();
+}
+
+void SampleAllocateeGuard::Deallocate()
+{
+    if (tracker_ != nullptr)
+    {
+        tracker_->Deallocate();
+        tracker_ = nullptr;
+    }
+}
+
+}  // namespace score::mw::com::impl

--- a/score/mw/com/impl/sample_allocatee_guard.h
+++ b/score/mw/com/impl/sample_allocatee_guard.h
@@ -1,0 +1,68 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_IMPL_SAMPLE_ALLOCATEE_GUARD_H
+#define SCORE_MW_COM_IMPL_SAMPLE_ALLOCATEE_GUARD_H
+
+namespace score::mw::com::impl
+{
+
+class SampleAllocateeTracker;
+
+/// \brief RAII guard for a sample allocation.
+///
+/// \details When this guard is destroyed, it decrements the allocation count in the associated SampleAllocateeTracker.
+/// This class is move-only to ensure each allocation is tracked exactly once.
+class SampleAllocateeGuard final
+{
+  public:
+    /// \brief Default constructs a null guard that does not track any allocation.
+    ///
+    /// \details In production code, guards must be obtained via SampleAllocateeTracker::Allocate() so that
+    /// every allocation is tracked. Direct default construction produces a no-op guard and is therefore
+    /// only intended for use in tests, where a real SampleAllocateeTracker is not available.
+    SampleAllocateeGuard() = default;
+
+    SampleAllocateeGuard(SampleAllocateeGuard&&) noexcept;
+    SampleAllocateeGuard& operator=(SampleAllocateeGuard&&) noexcept;
+    SampleAllocateeGuard(const SampleAllocateeGuard&) = delete;
+    SampleAllocateeGuard& operator=(const SampleAllocateeGuard&) = delete;
+
+    /// \brief Decrements the outstanding-allocation count in the associated tracker, if this guard owns a tracked
+    /// allocation.
+    ~SampleAllocateeGuard() noexcept;
+
+  private:
+    // Only SampleAllocateeTracker can construct non-null guards
+    // Suppress "AUTOSAR C++14 A11-3-1", The rule states: "Friend declarations shall not be used".
+    // Design decision: this is the only class that shall be able to construct non-null SampleAllocateeGuard
+    // instances via the private explicit constructor. This enforces the invariant that every guard is created
+    // through a tracked Allocate() call, preventing untracked allocations.
+    // coverity[autosar_cpp14_a11_3_1_violation]
+    friend class SampleAllocateeTracker;
+
+    explicit SampleAllocateeGuard(SampleAllocateeTracker& tracker);
+
+    /// \brief Decrements the tracker count and clears tracker_, shared by the destructor and move-assignment to
+    /// avoid duplicating the null-check logic.
+    void Deallocate();
+
+    /// \brief Pointer to the associated tracker, serving two purposes:
+    /// - Provides access to SampleAllocateeTracker so that Deallocate() can be called on destruction.
+    /// - Acts as an "active" flag, a nullptr value indicates that this guard has been moved-from or
+    ///   default-constructed and does not own an allocation, while a non-null value indicates ownership.
+    SampleAllocateeTracker* tracker_{nullptr};
+};
+
+}  // namespace score::mw::com::impl
+
+#endif  // SCORE_MW_COM_IMPL_SAMPLE_ALLOCATEE_GUARD_H

--- a/score/mw/com/impl/sample_allocatee_guard_test.cpp
+++ b/score/mw/com/impl/sample_allocatee_guard_test.cpp
@@ -1,0 +1,152 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/impl/sample_allocatee_tracker.h"
+
+#include <gtest/gtest.h>
+
+#include <utility>
+
+namespace score::mw::com::impl
+{
+
+namespace
+{
+
+class SampleAllocateeGuardTest : public ::testing::Test
+{
+  protected:
+    SampleAllocateeTracker tracker_{};
+    SampleAllocateeGuard guard_{tracker_.Allocate()};
+};
+
+TEST_F(SampleAllocateeGuardTest, DestructorDecrementsCounter)
+{
+    EXPECT_EQ(tracker_.GetNumAllocated(), 1U);
+    std::optional<SampleAllocateeGuard> guard{std::move(guard_)};
+
+    // When the guard is destroyed
+    guard.reset();
+
+    // Then the counter is decremented to 0
+    EXPECT_EQ(tracker_.GetNumAllocated(), 0U);
+}
+
+TEST_F(SampleAllocateeGuardTest, MoveConstructorDoesNotIncrementCounter)
+{
+    // Given a SampleAllocateeTracker with one allocation
+    EXPECT_EQ(tracker_.GetNumAllocated(), 1U);
+
+    // When move constructing a new guard
+    SampleAllocateeGuard guard2{std::move(guard_)};
+
+    // Then the counter should not be decremented
+    EXPECT_EQ(tracker_.GetNumAllocated(), 1U);
+}
+
+TEST_F(SampleAllocateeGuardTest, DestroyingMovedToGuardDecrementsCounter)
+{
+    // Given a SampleAllocateeTracker with one allocation
+    EXPECT_EQ(tracker_.GetNumAllocated(), 1U);
+    std::optional<SampleAllocateeGuard> guard2{std::move(guard_)};
+    EXPECT_EQ(tracker_.GetNumAllocated(), 1U);
+
+    // When destroying the moved-to guard
+    guard2.reset();
+
+    // Then the counter should decrement to 0
+    EXPECT_EQ(tracker_.GetNumAllocated(), 0U);
+}
+
+TEST_F(SampleAllocateeGuardTest, DestroyingMovedFromGuardDoesNotDecrementCounter)
+{
+    // Given a SampleAllocateeTracker with one allocation
+    EXPECT_EQ(tracker_.GetNumAllocated(), 1U);
+    std::optional<SampleAllocateeGuard> moved_from{std::move(guard_)};
+
+    // When move constructing a second guard from the first
+    SampleAllocateeGuard guard2{std::move(moved_from.value())};
+    EXPECT_EQ(tracker_.GetNumAllocated(), 1U);
+
+    // When destroying the moved-from guard
+    moved_from.reset();
+
+    // Then the counter should not have been decremented
+    EXPECT_EQ(tracker_.GetNumAllocated(), 1U);
+}
+
+TEST_F(SampleAllocateeGuardTest, MoveAssignmentTransfersOwnership)
+{
+    // Given a SampleAllocateeTracker with two allocations
+    SampleAllocateeGuard guard2 = tracker_.Allocate();
+    EXPECT_EQ(tracker_.GetNumAllocated(), 2U);
+
+    // When move assigning one guard to another
+    guard_ = std::move(guard2);
+
+    // Then one allocation should be deallocated
+    EXPECT_EQ(tracker_.GetNumAllocated(), 1U);
+}
+
+TEST_F(SampleAllocateeGuardTest, DestroyingMovedToGuardAfterAssignmentDecrementsCounter)
+{
+    // Given a SampleAllocateeTracker with two allocations
+    std::optional<SampleAllocateeGuard> guard1{std::move(guard_)};
+    SampleAllocateeGuard guard2 = tracker_.Allocate();
+    EXPECT_EQ(tracker_.GetNumAllocated(), 2U);
+
+    // When move assigning guard2 to guard1
+    guard1 = std::move(guard2);
+    // guard1's original allocation was released
+    EXPECT_EQ(tracker_.GetNumAllocated(), 1U);
+
+    // When destroying the moved-to guard
+    guard1.reset();
+
+    // Then the counter should be 0
+    EXPECT_EQ(tracker_.GetNumAllocated(), 0U);
+}
+
+TEST_F(SampleAllocateeGuardTest, DestroyingMovedFromGuardAfterAssignmentDoesNotDecrementCounter)
+{
+    // Given a SampleAllocateeTracker with two allocations
+    std::optional<SampleAllocateeGuard> guard2{tracker_.Allocate()};
+    EXPECT_EQ(tracker_.GetNumAllocated(), 2U);
+
+    // When move assigning guard2 to guard_
+    guard_ = std::move(guard2.value());
+    // guard_'s original allocation was released
+    EXPECT_EQ(tracker_.GetNumAllocated(), 1U);
+
+    // When destroying the moved-from guard2
+    guard2.reset();
+
+    // Then the counter should still be 1 (guard2 did not decrement)
+    EXPECT_EQ(tracker_.GetNumAllocated(), 1U);
+}
+
+TEST_F(SampleAllocateeGuardTest, SelfMoveAssignmentDoesNotDoubleDecrement)
+{
+    // Given a SampleAllocateeTracker with one allocation
+    EXPECT_EQ(tracker_.GetNumAllocated(), 1U);
+
+    // When self move assigning the guard (using reference to avoid clang self-move warning)
+    SampleAllocateeGuard& guard_ref = guard_;
+    guard_ = std::move(guard_ref);
+
+    // Then the counter should still be 1
+    EXPECT_EQ(tracker_.GetNumAllocated(), 1U);
+}
+
+}  // namespace
+
+}  // namespace score::mw::com::impl

--- a/score/mw/com/impl/sample_allocatee_tracker.cpp
+++ b/score/mw/com/impl/sample_allocatee_tracker.cpp
@@ -1,0 +1,52 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/impl/sample_allocatee_tracker.h"
+
+#include "score/mw/log/logging.h"
+
+#include <score/assert.hpp>
+#include <score/utility.hpp>
+
+#include <cstdlib>
+
+namespace score::mw::com::impl
+{
+SampleAllocateeTracker::~SampleAllocateeTracker() noexcept
+{
+    const std::size_t num_allocated = GetNumAllocated();
+    if (num_allocated != 0U)
+    {
+        score::mw::log::LogFatal("lola") << "SampleAllocateeTracker destroyed while still holding" << num_allocated
+                                         << "outstanding SampleAllocateePtr instance(s), terminating.";
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(false);
+    }
+}
+
+[[nodiscard]] SampleAllocateeGuard SampleAllocateeTracker::Allocate()
+{
+    score::cpp::ignore = allocated_count_.fetch_add(1U);
+    return SampleAllocateeGuard{*this};
+}
+
+std::size_t SampleAllocateeTracker::GetNumAllocated() const
+{
+    return allocated_count_.load();
+}
+
+void SampleAllocateeTracker::Deallocate()
+{
+    const std::size_t previous = allocated_count_.fetch_sub(1U);
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(previous > 0U, "Deallocating more samples than were allocated.");
+}
+
+}  // namespace score::mw::com::impl

--- a/score/mw/com/impl/sample_allocatee_tracker.h
+++ b/score/mw/com/impl/sample_allocatee_tracker.h
@@ -1,0 +1,68 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_IMPL_SAMPLE_ALLOCATEE_TRACKER_H
+#define SCORE_MW_COM_IMPL_SAMPLE_ALLOCATEE_TRACKER_H
+
+#include "score/mw/com/impl/sample_allocatee_guard.h"
+
+#include <atomic>
+
+namespace score::mw::com::impl
+{
+
+/// \brief Tracks the number of outstanding SampleAllocateePtr instances for a SkeletonEvent.
+///
+/// \details This class is used to ensure that all SampleAllocateePtr instances are released before the SkeletonEvent
+/// is destroyed. Similar to SampleReferenceTracker on the proxy side, but simpler since skeleton side doesn't need
+/// the same pre-allocation pattern, it just needs to track allocations.
+class SampleAllocateeTracker final
+{
+  public:
+    SampleAllocateeTracker() = default;
+
+    SampleAllocateeTracker(SampleAllocateeTracker&&) = delete;
+    SampleAllocateeTracker(const SampleAllocateeTracker&) = delete;
+    SampleAllocateeTracker& operator=(SampleAllocateeTracker&&) = delete;
+    SampleAllocateeTracker& operator=(const SampleAllocateeTracker&) = delete;
+
+    /// \brief Aborts if any SampleAllocateePtr instances are still outstanding at destruction time.
+    ~SampleAllocateeTracker() noexcept;
+
+    /// \brief Creates a guard that tracks one allocated sample.
+    /// \return A guard that will decrement the counter when destroyed.
+    SampleAllocateeGuard Allocate();
+
+    /// \brief Returns the number of currently allocated SampleAllocateeGuards.
+    std::size_t GetNumAllocated() const;
+
+  private:
+    // SampleAllocateeGuard needs access to Deallocate().
+    // Suppress "AUTOSAR C++14 A11-3-1", The rule states: "Friend declarations shall not be used".
+    // Design decision: SampleAllocateeGuard needs to call the private Deallocate() method when the guard is destroyed
+    // or moved-from. Keeping Deallocate() private ensures that only the RAII guard can decrement the allocation count,
+    // preventing misuse by external callers.
+    // coverity[autosar_cpp14_a11_3_1_violation]
+    friend class SampleAllocateeGuard;
+
+    /// \brief Decrements allocated_count_ by one, called exclusively by SampleAllocateeGuard on destruction or
+    /// move-assignment. Keeping this private ensures the count can never be decremented by any path other than the RAII
+    /// guard, so a non-zero count at tracker destruction is always a real lifecycle violation, not a misuse of the API.
+    void Deallocate();
+
+    /// \brief Number of SampleAllocateeGuard instances that are currently alive and point back to this tracker.
+    std::atomic_size_t allocated_count_{0U};
+};
+
+}  // namespace score::mw::com::impl
+
+#endif  // SCORE_MW_COM_IMPL_SAMPLE_ALLOCATEE_TRACKER_H

--- a/score/mw/com/impl/sample_allocatee_tracker_test.cpp
+++ b/score/mw/com/impl/sample_allocatee_tracker_test.cpp
@@ -1,0 +1,103 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/impl/sample_allocatee_tracker.h"
+
+#include <gtest/gtest.h>
+
+#include <utility>
+
+namespace score::mw::com::impl
+{
+
+namespace
+{
+
+class SampleAllocateeTrackerTest : public ::testing::Test
+{
+  protected:
+    SampleAllocateeTracker tracker_{};
+};
+
+TEST_F(SampleAllocateeTrackerTest, InitialStateHasNoAllocations)
+{
+    // When constructing a SampleAllocateeTracker
+    // Then the number of allocations should be 0
+    EXPECT_EQ(tracker_.GetNumAllocated(), 0U);
+}
+
+TEST_F(SampleAllocateeTrackerTest, AllocateIncrementsCounter)
+{
+    // When allocating a sample
+    SampleAllocateeGuard guard = tracker_.Allocate();
+
+    // Then the tracker should have one allocation
+    EXPECT_EQ(tracker_.GetNumAllocated(), 1U);
+}
+
+TEST_F(SampleAllocateeTrackerTest, MultipleAllocationsIncrementCounter)
+{
+    // When allocating multiple samples
+    SampleAllocateeGuard guard1 = tracker_.Allocate();
+    SampleAllocateeGuard guard2 = tracker_.Allocate();
+    SampleAllocateeGuard guard3 = tracker_.Allocate();
+
+    // Then the counter should reflect all allocations
+    EXPECT_EQ(tracker_.GetNumAllocated(), 3U);
+}
+
+TEST_F(SampleAllocateeTrackerTest, GuardDestructionDecrementsCounter)
+{
+    {
+        // Given a SampleAllocateeTracker with multiple allocations and then let them go out of scope.
+        SampleAllocateeGuard guard1 = tracker_.Allocate();
+        SampleAllocateeGuard guard2 = tracker_.Allocate();
+        EXPECT_EQ(tracker_.GetNumAllocated(), 2U);
+    }
+
+    // When the guards go out of scope
+    // Then the counter should return to zero
+    EXPECT_EQ(tracker_.GetNumAllocated(), 0U);
+}
+
+TEST_F(SampleAllocateeTrackerTest, PartialGuardDeallocation)
+{
+    // Given a SampleAllocateeTracker with one allocation
+    SampleAllocateeGuard guard1 = tracker_.Allocate();
+
+    {
+        // Create additional two guards and then let them go out of scope, leaving guard1 still alive
+        SampleAllocateeGuard guard2 = tracker_.Allocate();
+        SampleAllocateeGuard guard3 = tracker_.Allocate();
+        EXPECT_EQ(tracker_.GetNumAllocated(), 3U);
+    }
+
+    // When some guards are destroyed but not all
+    // Then the counter should reflect remaining allocations
+    EXPECT_EQ(tracker_.GetNumAllocated(), 1U);
+}
+
+TEST(SampleAllocateeTrackerDeathTest, TerminatesWhenDestroyedWithOutstandingAllocations)
+{
+    // Given a SampleAllocateeTracker with an outstanding guard
+    auto tracker = std::make_unique<SampleAllocateeTracker>();
+    SampleAllocateeGuard guard = tracker->Allocate();
+    EXPECT_EQ(tracker->GetNumAllocated(), 1U);
+
+    // When destroying the tracker while the guard is still alive
+    // Then the application should terminate
+    EXPECT_DEATH(tracker.reset(), "");
+}
+
+}  // namespace
+
+}  // namespace score::mw::com::impl

--- a/score/mw/com/impl/sample_reference_tracker.h
+++ b/score/mw/com/impl/sample_reference_tracker.h
@@ -151,7 +151,7 @@ class SampleReferenceGuard final
     explicit SampleReferenceGuard(SampleReferenceTracker& tracker) noexcept;
     void Deallocate() noexcept;
 
-    /// Reference to the tracker. It must not move, otherwise the pointer will be dangling.
+    /// Pointer to the tracker. It must not move, otherwise the pointer will be dangling.
     SampleReferenceTracker* tracker_{nullptr};
     static_assert((std::is_move_assignable<SampleReferenceTracker>::value == false) &&
                       (std::is_move_constructible<SampleReferenceTracker>::value == false),

--- a/score/mw/com/impl/skeleton_base_test.cpp
+++ b/score/mw/com/impl/skeleton_base_test.cpp
@@ -219,7 +219,7 @@ TEST_F(SkeletonBaseOfferFixture, OfferService)
     ExpectOfferService();
 
     // and expecting that Send is called on the event binding with the initial value
-    EXPECT_CALL(*field_binding_mock_, Send(kInitialFieldValue, _));
+    EXPECT_CALL(*field_binding_mock_, Send(kInitialFieldValue, _, _));
 
     // and the initial field value is set
     std::ignore = skeleton_->dummy_field.Update(kInitialFieldValue);
@@ -396,7 +396,7 @@ TEST_F(SkeletonBaseStopOfferFixture, PrepareStopOffer)
     ExpectStopOfferService();
 
     // and expecting that Send is called on the event binding with the initial value
-    EXPECT_CALL(*field_binding_mock_, Send(kInitialFieldValue, _));
+    EXPECT_CALL(*field_binding_mock_, Send(kInitialFieldValue, _, _));
 
     // and the initial field value is set
     std::ignore = skeleton_->dummy_field.Update(kInitialFieldValue);
@@ -503,7 +503,7 @@ TEST_F(SkeletonBaseOfferFixture, ServiceCanBeReOfferedAfterMoveConstructingServi
     EXPECT_CALL(service_discovery_mock_, OfferService(_)).Times(2);
 
     // and expecting that Send is called on the event binding once with the initial value
-    EXPECT_CALL(*field_binding_mock_, Send(kInitialFieldValue, _));
+    EXPECT_CALL(*field_binding_mock_, Send(kInitialFieldValue, _, _));
 
     // and the initial field value is set
     std::ignore = skeleton.dummy_field.Update(kInitialFieldValue);
@@ -576,7 +576,7 @@ TEST_F(SkeletonBaseOfferFixture, ServiceCanBeReOfferedAfterCallingStopOfferServi
         EXPECT_CALL(service_discovery_mock_, OfferService(_)).Times(2);
 
         // and expecting that Send is called on the event binding with the initial value
-        EXPECT_CALL(*field_binding_mock_, Send(kInitialFieldValue, _));
+        EXPECT_CALL(*field_binding_mock_, Send(kInitialFieldValue, _, _));
 
         // and the initial field value is set
         std::ignore = skeleton.dummy_field.Update(kInitialFieldValue);

--- a/score/mw/com/impl/skeleton_event.h
+++ b/score/mw/com/impl/skeleton_event.h
@@ -196,7 +196,8 @@ Result<void> SkeletonEvent<SampleDataType>::Send(const EventType& sample_value) 
     }
     auto tracing_handler = impl::tracing::CreateTracingSendCallback<SampleDataType>(tracing_data_, *binding_);
 
-    const auto send_result = GetTypedEventBinding()->Send(sample_value, std::move(tracing_handler));
+    const auto send_result =
+        GetTypedEventBinding()->Send(sample_value, std::move(tracing_handler), sample_allocatee_tracker_->Allocate());
     if (!send_result.has_value())
     {
         score::mw::log::LogError("lola") << "SkeletonEvent::Send with copy failed: " << send_result.error().Message()
@@ -249,7 +250,7 @@ Result<SampleAllocateePtr<SampleDataType>> SkeletonEvent<SampleDataType>::Alloca
         return MakeUnexpected(ComErrc::kNotOffered);
     }
 
-    auto allocate_result = GetTypedEventBinding()->Allocate();
+    auto allocate_result = GetTypedEventBinding()->Allocate(sample_allocatee_tracker_->Allocate());
     if (!allocate_result.has_value())
     {
         score::mw::log::LogError("lola") << "SkeletonEvent::Allocate failed: " << allocate_result.error().Message()

--- a/score/mw/com/impl/skeleton_event_base.h
+++ b/score/mw/com/impl/skeleton_event_base.h
@@ -15,6 +15,7 @@
 
 #include "score/mw/com/impl/enable_reference_to_moveable_from_this.h"
 #include "score/mw/com/impl/flag_owner.h"
+#include "score/mw/com/impl/sample_allocatee_tracker.h"
 #include "score/mw/com/impl/skeleton_event_binding.h"
 #include "score/mw/com/impl/tracing/skeleton_event_tracing_data.h"
 
@@ -42,7 +43,8 @@ class SkeletonEventBase : public EnableReferenceToMoveableFromThis<SkeletonEvent
           binding_{std::move(binding)},
           event_name_{event_name},
           tracing_data_{},
-          service_offered_flag_{}
+          service_offered_flag_{},
+          sample_allocatee_tracker_{std::make_unique<SampleAllocateeTracker>()}
     {
     }
 
@@ -89,6 +91,13 @@ class SkeletonEventBase : public EnableReferenceToMoveableFromThis<SkeletonEvent
     tracing::SkeletonEventTracingData tracing_data_;
     // coverity[autosar_cpp14_m11_0_1_violation]
     FlagOwner service_offered_flag_;
+    /// \brief Tracker for outstanding SampleAllocateePtr instances.
+    /// \details This tracker ensures that all SampleAllocateePtr instances created via Allocate() are destroyed
+    /// before the SkeletonEvent is destroyed. If any SampleAllocateePtr outlives the SkeletonEvent, the destructor
+    /// will terminate the application (symmetric with ProxyEventBase behavior for SamplePtr).
+    /// A unique_ptr is used since SampleAllocateeTracker is not moveable.
+    // coverity[autosar_cpp14_m11_0_1_violation]
+    std::unique_ptr<SampleAllocateeTracker> sample_allocatee_tracker_;
 };
 
 class SkeletonEventBaseView

--- a/score/mw/com/impl/skeleton_event_binding.h
+++ b/score/mw/com/impl/skeleton_event_binding.h
@@ -17,6 +17,7 @@
 #include "score/mw/com/impl/configuration/quality_type.h"
 #include "score/mw/com/impl/plumbing/sample_allocatee_ptr.h"
 #include "score/mw/com/impl/plumbing/sample_ptr.h"
+#include "score/mw/com/impl/sample_allocatee_guard.h"
 #include "score/mw/com/impl/tracing/skeleton_event_tracing_data.h"
 
 #include "score/result/result.h"
@@ -80,7 +81,7 @@ class SkeletonEventBinding : public SkeletonEventBindingBase
 
     /// \brief SampleType is allocated by the user and provided to the middleware to send
     /// \return On failure, returns an error code.
-    virtual Result<void> Send(const SampleType&, std::optional<SendTraceCallback>) noexcept = 0;
+    virtual Result<void> Send(const SampleType&, std::optional<SendTraceCallback>, SampleAllocateeGuard) noexcept = 0;
 
     /// \brief SampleType is previously allocated by middleware and provided by the user to indicate that he is finished
     /// filling the provided pointer with live.
@@ -89,7 +90,7 @@ class SkeletonEventBinding : public SkeletonEventBindingBase
 
     /// \brief Allocates memory for SampleType for the user to fill it. This is especially necessary for Zero-Copy
     /// implementations.
-    virtual Result<SampleAllocateePtr<SampleType>> Allocate() noexcept = 0;
+    virtual Result<SampleAllocateePtr<SampleType>> Allocate(SampleAllocateeGuard guard) noexcept = 0;
 
     /// \brief Retrieves the latest sample, intended to support the getter of a SkeletonField.
     virtual Result<SamplePtr<SampleType>> GetLatestSample(QualityType quality_type) = 0;

--- a/score/mw/com/impl/skeleton_event_binding_test.cpp
+++ b/score/mw/com/impl/skeleton_event_binding_test.cpp
@@ -14,6 +14,7 @@
 
 #include "score/mw/com/impl/plumbing/sample_allocatee_ptr.h"
 #include "score/mw/com/impl/plumbing/sample_ptr.h"
+#include "score/mw/com/impl/sample_allocatee_guard.h"
 
 #include <gtest/gtest.h>
 #include <memory>
@@ -34,7 +35,8 @@ class MyEvent final : public SkeletonEventBinding<SampleType>
     }
     void PrepareStopOffer() noexcept override {}
     Result<void> Send(const SampleType&,
-                      std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>) noexcept override
+                      std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>,
+                      SampleAllocateeGuard) noexcept override
     {
         return {};
     }
@@ -43,9 +45,9 @@ class MyEvent final : public SkeletonEventBinding<SampleType>
     {
         return {};
     }
-    Result<SampleAllocateePtr<SampleType>> Allocate() noexcept override
+    Result<SampleAllocateePtr<SampleType>> Allocate(SampleAllocateeGuard guard) noexcept override
     {
-        return MakeSampleAllocateePtr(std::make_unique<SampleType>());
+        return MakeSampleAllocateePtr(std::make_unique<SampleType>(), std::move(guard));
     }
     Result<SamplePtr<SampleType>> GetLatestSample(QualityType) override
     {

--- a/score/mw/com/impl/skeleton_event_test.cpp
+++ b/score/mw/com/impl/skeleton_event_test.cpp
@@ -14,6 +14,7 @@
 
 #include "score/mw/com/impl/runtime.h"
 #include "score/mw/com/impl/runtime_mock.h"
+#include "score/mw/com/impl/sample_allocatee_guard.h"
 #include "score/mw/com/impl/test/binding_factory_resources.h"
 #include "score/mw/com/impl/test/runtime_mock_guard.h"
 
@@ -128,8 +129,8 @@ TEST(SkeletonEventAllocateTest, CallingAllocateAfterPrepareOfferDispatchesToBind
     EXPECT_CALL(skeleton_event_binding_mock, PrepareOffer());
 
     // and that Allocate() is called once on the event binding
-    EXPECT_CALL(skeleton_event_binding_mock, Allocate())
-        .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>()))));
+    EXPECT_CALL(skeleton_event_binding_mock, Allocate(_))
+        .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>(), SampleAllocateeGuard{}))));
 
     // Given a skeleton which has a mock skeleton-binding
     MyDummySkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
@@ -163,7 +164,7 @@ TEST(SkeletonEventAllocateTest, CallingAllocateBeforePrepareOfferReturnsError)
         .WillOnce(Return(ByMove(std::move(skeleton_event_binding_mock_ptr))));
 
     // and that Allocate() is never called on the event binding
-    EXPECT_CALL(skeleton_event_binding_mock, Allocate()).Times(0);
+    EXPECT_CALL(skeleton_event_binding_mock, Allocate(_)).Times(0);
 
     // Given a skeleton which has a mock skeleton-binding
     MyDummySkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
@@ -190,7 +191,7 @@ TEST(SkeletonEventAllocateTest, CallingAllocateAfterStopOfferReturnsError)
         .WillOnce(Return(ByMove(std::move(skeleton_event_binding_mock_ptr))));
 
     // Expecting that Allocate() is never called on the event binding
-    EXPECT_CALL(skeleton_event_binding_mock, Allocate()).Times(0);
+    EXPECT_CALL(skeleton_event_binding_mock, Allocate(_)).Times(0);
 
     // Given a skeleton which has a mock skeleton-binding which has been offered and stop offered
     MyDummySkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
@@ -203,6 +204,43 @@ TEST(SkeletonEventAllocateTest, CallingAllocateAfterStopOfferReturnsError)
     // Then the result contains an error the service has not been offered
     ASSERT_FALSE(allocated_slot_result.has_value());
     EXPECT_EQ(allocated_slot_result.error(), ComErrc::kNotOffered);
+}
+
+TEST(SkeletonEventAllocateDeathTest, DestroyingSkeletonEventWhileHoldingSampleAllocateePtrTerminates)
+{
+    RuntimeMockGuard runtime_mock_guard{};
+    ON_CALL(runtime_mock_guard.runtime_mock_, GetTracingFilterConfig()).WillByDefault(Return(nullptr));
+    SkeletonEventBindingFactoryMockGuard<TestSampleType> skeleton_event_binding_factory_mock_guard{};
+
+    // Expecting that a SkeletonEvent binding is created
+    auto skeleton_event_binding_mock_ptr = std::make_unique<mock_binding::SkeletonEvent<TestSampleType>>();
+    auto& skeleton_event_binding_mock = *skeleton_event_binding_mock_ptr;
+    EXPECT_CALL(skeleton_event_binding_factory_mock_guard.factory_mock_,
+                Create(kInstanceIdWithLolaBinding, _, kEventName))
+        .WillOnce(Return(ByMove(std::move(skeleton_event_binding_mock_ptr))));
+
+    // and that PrepareOffer() is called once on the event binding
+    EXPECT_CALL(skeleton_event_binding_mock, PrepareOffer());
+
+    // and that Allocate() is called once on the event binding, returning a ptr backed by a real tracker guard
+    EXPECT_CALL(skeleton_event_binding_mock, Allocate(_)).WillOnce([](SampleAllocateeGuard guard) {
+        return MakeSampleAllocateePtr(std::make_unique<TestSampleType>(), std::move(guard));
+    });
+
+    // Given a skeleton which has a mock skeleton-binding
+    auto unit =
+        std::make_unique<MyDummySkeleton>(std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding);
+
+    // and PrepareOffer() has been called on the event
+    std::ignore = unit->my_dummy_event_.PrepareOffer();
+
+    // and a slot has been allocated and is still held
+    auto allocated_slot_result = unit->my_dummy_event_.Allocate();
+    ASSERT_TRUE(allocated_slot_result.has_value());
+
+    // When the SkeletonEvent is destroyed while the SampleAllocateePtr is still held
+    // Then the application terminates
+    EXPECT_DEATH(unit.reset(), "");
 }
 
 TEST(SkeletonEventAllocateTest, CallingAllocateAfterPrepareOfferWhenBindingFailsReturnsError)
@@ -228,7 +266,7 @@ TEST(SkeletonEventAllocateTest, CallingAllocateAfterPrepareOfferWhenBindingFails
     EXPECT_CALL(skeleton_event_binding_mock, PrepareOffer());
 
     // and that Allocate() is called once on the event binding which returns an error
-    EXPECT_CALL(skeleton_event_binding_mock, Allocate())
+    EXPECT_CALL(skeleton_event_binding_mock, Allocate(_))
         .WillOnce(Return(ByMove(MakeUnexpected(ComErrc::kInvalidConfiguration))));
 
     // Given a skeleton which has a mock skeleton-binding
@@ -268,8 +306,8 @@ TEST(SkeletonEventSendZeroCopyTest, CallingSendDispatchesToBinding)
     EXPECT_CALL(skeleton_event_binding_mock, PrepareOffer());
 
     // and that Allocate() is called once on the event binding
-    EXPECT_CALL(skeleton_event_binding_mock, Allocate())
-        .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>()))));
+    EXPECT_CALL(skeleton_event_binding_mock, Allocate(_))
+        .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>(), SampleAllocateeGuard{}))));
 
     // and that Send(SampleAllocateePtr) is called on the event binding with the expected value
     EXPECT_CALL(skeleton_event_binding_mock, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
@@ -315,8 +353,9 @@ TEST(SkeletonEventSendZeroCopyTest, CallingSendAfterStopOfferReturnsError)
         .WillOnce(Return(ByMove(std::move(skeleton_event_binding_mock_ptr))));
 
     // and that Allocate() is called once on the event binding
-    ON_CALL(skeleton_event_binding_mock, Allocate())
-        .WillByDefault(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>()))));
+    ON_CALL(skeleton_event_binding_mock, Allocate(_))
+        .WillByDefault(
+            Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>(), SampleAllocateeGuard{}))));
 
     // Expecting that Send(SampleAllocateePtr) is not called on the event binding
     EXPECT_CALL(skeleton_event_binding_mock, Send(An<SampleAllocateePtr<TestSampleType>>(), _)).Times(0);
@@ -363,8 +402,8 @@ TEST(SkeletonEventSendZeroCopyTest, CallingSendWhenBindingFailsReturnsError)
     EXPECT_CALL(skeleton_event_binding_mock, PrepareOffer());
 
     // and that Allocate() is called once on the event binding
-    EXPECT_CALL(skeleton_event_binding_mock, Allocate())
-        .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>()))));
+    EXPECT_CALL(skeleton_event_binding_mock, Allocate(_))
+        .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>(), SampleAllocateeGuard{}))));
 
     // and that Send(SampleAllocateePtr) is called on the event binding with the expected value
     EXPECT_CALL(skeleton_event_binding_mock, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
@@ -423,7 +462,7 @@ TEST(SkeletonEventTest, CallingSendAfterPrepareOfferDispatchesToBinding)
     EXPECT_CALL(skeleton_event_binding_mock, PrepareOffer());
 
     // and that Send() is called once on the event binding
-    EXPECT_CALL(skeleton_event_binding_mock, Send(test_value, _)).WillOnce(Return(Result<void>{}));
+    EXPECT_CALL(skeleton_event_binding_mock, Send(test_value, _, _)).WillOnce(Return(Result<void>{}));
 
     // Given a skeleton which has a mock skeleton-binding
     MyDummySkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
@@ -462,7 +501,7 @@ TEST(SkeletonEventSendWithCopyTest, CallingSendBeforePrepareOfferReturnsError)
     EXPECT_CALL(skeleton_event_binding_mock, PrepareOffer()).Times(0);
 
     // and that Send() is never called on the event binding
-    EXPECT_CALL(skeleton_event_binding_mock, Send(test_value, _)).Times(0);
+    EXPECT_CALL(skeleton_event_binding_mock, Send(test_value, _, _)).Times(0);
 
     // Given a skeleton which has a mock skeleton-binding
     MyDummySkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
@@ -491,7 +530,7 @@ TEST(SkeletonEventSendWithCopyTest, CallingSendAfterStopOfferReturnsError)
         .WillOnce(Return(ByMove(std::move(skeleton_event_binding_mock_ptr))));
 
     // Expecting that Send() is never called on the event binding
-    EXPECT_CALL(skeleton_event_binding_mock, Send(test_value, _)).Times(0);
+    EXPECT_CALL(skeleton_event_binding_mock, Send(test_value, _, _)).Times(0);
 
     // Given a skeleton which has a mock skeleton-binding which has been offered and stop offered
     MyDummySkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
@@ -530,7 +569,7 @@ TEST(SkeletonEventSendWithCopyTest, CallingSendAfterPrepareOfferWhenBindingFails
     EXPECT_CALL(skeleton_event_binding_mock, PrepareOffer());
 
     // and that Send() is called once on the event binding which returns an error
-    EXPECT_CALL(skeleton_event_binding_mock, Send(test_value, _))
+    EXPECT_CALL(skeleton_event_binding_mock, Send(test_value, _, _))
         .WillOnce(Return(MakeUnexpected(ComErrc::kInvalidConfiguration)));
 
     // Given a skeleton which has a mock skeleton-binding

--- a/score/mw/com/impl/skeleton_field_test.cpp
+++ b/score/mw/com/impl/skeleton_field_test.cpp
@@ -16,6 +16,7 @@
 #include "score/mw/com/impl/method_type.h"
 #include "score/mw/com/impl/methods/skeleton_method.h"
 #include "score/mw/com/impl/methods/skeleton_method_binding.h"
+#include "score/mw/com/impl/sample_allocatee_guard.h"
 #include "score/mw/com/impl/test/binding_factory_resources.h"
 #include "score/mw/com/impl/test/runtime_mock_guard.h"
 
@@ -188,7 +189,7 @@ TEST_F(SkeletonFieldCopyUpdateTest, CallingUpdateBeforeOfferServiceDefersCallToO
     EXPECT_CALL(skeleton_field_binding_mock_, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called on the event binding with the initial value and returns an empty result
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _))
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _, _))
         .WillOnce(InvokeWithoutArgs([&is_send_called_on_binding]() noexcept -> Result<void> {
             is_send_called_on_binding = true;
             return {};
@@ -233,7 +234,7 @@ TEST_F(SkeletonFieldCopyUpdateTest, CallingUpdateBeforeOfferServicePropagatesBin
     EXPECT_CALL(skeleton_field_binding_mock_, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called on the event binding with the initial value and returns an error
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _))
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _, _))
         .WillOnce(InvokeWithoutArgs([&is_send_called_on_binding] {
             is_send_called_on_binding = true;
             return MakeUnexpected(ComErrc::kInvalidBindingInformation);
@@ -276,10 +277,10 @@ TEST_F(SkeletonFieldCopyUpdateTest, CallingUpdateAfterOfferServiceDispatchesToBi
     EXPECT_CALL(skeleton_field_binding_mock_, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called on the event binding with the initial value and returns an empty result
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _)).WillOnce(Return(score::Result<void>{}));
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _, _)).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called a second time on the event binding with the updated value and returns an empty result
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(updated_value, _)).WillOnce(Return(score::Result<void>{}));
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(updated_value, _, _)).WillOnce(Return(score::Result<void>{}));
 
     // Given a skeleton created based on a Lola binding
     MyDummySkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
@@ -319,10 +320,10 @@ TEST_F(SkeletonFieldCopyUpdateTest, CallingUpdateAfterOfferServicePropagatesBind
     EXPECT_CALL(skeleton_field_binding_mock_, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called on the event binding with the initial value and returns an empty result
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _)).WillOnce(Return(score::Result<void>{}));
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _, _)).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called a second time on the event binding with the updated value and returns an error
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(updated_value, _))
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(updated_value, _, _))
         .WillOnce(Return(MakeUnexpected(ComErrc::kInvalidBindingInformation)));
 
     // Given a skeleton created based on a Lola binding
@@ -357,7 +358,7 @@ TEST_F(SkeletonFieldAllocateTest, CallingAllocateBeforePrepareOfferDoesNotReturn
     EXPECT_CALL(skeleton_field_binding_mock_, PrepareOffer()).Times(0);
 
     // and Allocate will not be called on the event binding
-    EXPECT_CALL(skeleton_field_binding_mock_, Allocate()).Times(0);
+    EXPECT_CALL(skeleton_field_binding_mock_, Allocate(_)).Times(0);
 
     // Given a skeleton created based on a Lola binding
     MyDummySkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
@@ -382,11 +383,11 @@ TEST_F(SkeletonFieldAllocateTest, CallingAllocateAfterPrepareOfferDispatchesToBi
     EXPECT_CALL(skeleton_field_binding_mock_, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called on the event binding with the initial value
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _));
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _, _));
 
     // and Allocate will be called again which returns a valid SampleAllocateePtr
-    EXPECT_CALL(skeleton_field_binding_mock_, Allocate())
-        .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>()))));
+    EXPECT_CALL(skeleton_field_binding_mock_, Allocate(_))
+        .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>(), SampleAllocateeGuard{}))));
 
     // Given a skeleton created based on a Lola binding
     MyDummySkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
@@ -423,11 +424,13 @@ TEST_F(SkeletonFieldAllocateTest, CallingAllocateAfterPrepareOfferFailsWhenBindi
     EXPECT_CALL(skeleton_field_binding_mock_, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called on the event binding with the initial value
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _));
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _, _));
 
     // and Allocate will be called again which returns a nullptr
-    EXPECT_CALL(skeleton_field_binding_mock_, Allocate())
-        .WillOnce(Return(ByMove(MakeUnexpected(ComErrc::kInvalidConfiguration))));
+    EXPECT_CALL(skeleton_field_binding_mock_, Allocate(_))
+        .WillOnce([](SampleAllocateeGuard) -> Result<SampleAllocateePtr<TestSampleType>> {
+            return MakeUnexpected(ComErrc::kInvalidConfiguration);
+        });
 
     // Given a skeleton created based on a Lola binding
     MyDummySkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
@@ -469,11 +472,11 @@ TEST_F(SkeletonFieldZeroCopyUpdateTest, CallingZeroCopyUpdateAfterOfferServiceDi
     EXPECT_CALL(skeleton_field_binding_mock_, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called on the event binding with the initial value
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _));
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _, _));
 
     // and Allocate will be called again which returns a valid SampleAllocateePtr
-    EXPECT_CALL(skeleton_field_binding_mock_, Allocate())
-        .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>()))));
+    EXPECT_CALL(skeleton_field_binding_mock_, Allocate(_))
+        .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>(), SampleAllocateeGuard{}))));
 
     // and Send will be called a second time on the event binding with a new value which returns an empty result
     EXPECT_CALL(skeleton_field_binding_mock_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
@@ -531,11 +534,11 @@ TEST_F(SkeletonFieldZeroCopyUpdateTest, CallingZeroCopyUpdateAfterOfferServicePr
     EXPECT_CALL(skeleton_field_binding_mock_, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called on the event binding with the initial value
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _));
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _, _));
 
     // and Allocate will be called again which returns a valid SampleAllocateePtr
-    EXPECT_CALL(skeleton_field_binding_mock_, Allocate())
-        .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>()))));
+    EXPECT_CALL(skeleton_field_binding_mock_, Allocate(_))
+        .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::make_unique<TestSampleType>(), SampleAllocateeGuard{}))));
 
     // and Send will be called a second time on the event binding with a new value which returns an error
     EXPECT_CALL(skeleton_field_binding_mock_, Send(An<SampleAllocateePtr<TestSampleType>>(), _))
@@ -593,7 +596,7 @@ TEST_F(SkeletonFieldInitialValueFixture, LatestFieldValueWillBeSetOnPrepareOffer
     EXPECT_CALL(skeleton_field_binding_mock_, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called only once on the event binding with the latest value
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(latest_value, _));
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(latest_value, _, _));
 
     // Given a skeleton created based on a Lola binding
     MyDummySkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
@@ -647,7 +650,7 @@ TEST_F(SkeletonFieldInitialValueFixture, MoveConstructingFieldBeforePrepareOffer
     EXPECT_CALL(skeleton_field_binding_mock_, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called on the event binding with the initial value
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _));
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _, _));
 
     // Given a skeleton created based on a Lola binding
     MyDummySkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
@@ -697,7 +700,7 @@ TEST(SkeletonFieldInitialValueTest, MoveAssigningFieldBeforePrepareOfferWillKeep
     EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
 
     // and Send will be called on the event binding with the initial value from the moved-from field
-    EXPECT_CALL(skeleton_field_binding_mock, Send(kDummyInitialValue, _));
+    EXPECT_CALL(skeleton_field_binding_mock, Send(kDummyInitialValue, _, _));
 
     // Given a skeleton created based on a Lola binding
     MyDummySkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
@@ -820,7 +823,52 @@ TEST_F(SkeletonFieldTestFixture, MovingAssigningSkeletonUpdatesFieldMapReference
     EXPECT_EQ(&field, &unit2.my_dummy_field_);
 }
 
-// Helper skeleton that holds a SkeletonField with all three tags.
+using SkeletonFieldDeathTest = SkeletonFieldTestFixture;
+TEST_F(SkeletonFieldDeathTest, DestroyingSkeletonFieldWhileHoldingSampleAllocateePtrTerminates)
+{
+    const TestSampleType initial_value{42};
+
+    RuntimeMockGuard runtime_mock_guard{};
+    ON_CALL(runtime_mock_guard.runtime_mock_, GetTracingFilterConfig()).WillByDefault(Return(nullptr));
+
+    SkeletonFieldBindingFactoryMockGuard<TestSampleType> skeleton_field_binding_factory_mock_guard{};
+
+    // Expecting that a SkeletonField binding is created
+    auto skeleton_field_binding_mock_ptr = std::make_unique<mock_binding::SkeletonEvent<TestSampleType>>();
+    auto& skeleton_field_binding_mock = *skeleton_field_binding_mock_ptr;
+    EXPECT_CALL(skeleton_field_binding_factory_mock_guard.factory_mock_,
+                CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName))
+        .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
+
+    // and that PrepareOffer() is called once on the field binding
+    EXPECT_CALL(skeleton_field_binding_mock, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
+
+    // and that Send() is called once on the field binding with the initial value
+    EXPECT_CALL(skeleton_field_binding_mock, Send(initial_value, _, _));
+
+    // and that Allocate() is called once on the field binding, returning a ptr backed by a real tracker guard
+    EXPECT_CALL(skeleton_field_binding_mock, Allocate(_)).WillOnce([](SampleAllocateeGuard guard) {
+        return MakeSampleAllocateePtr(std::make_unique<TestSampleType>(), std::move(guard));
+    });
+
+    // Given a skeleton which has a mock skeleton-binding
+    auto unit =
+        std::make_unique<MyDummySkeleton>(std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding);
+
+    // and the initial field value has been set and PrepareOffer() has been called
+    std::ignore = unit->my_dummy_field_.Update(initial_value);
+    std::ignore = unit->my_dummy_field_.PrepareOffer();
+
+    // and a slot has been allocated and is still held
+    auto allocated_slot_result = unit->my_dummy_field_.Allocate();
+    ASSERT_TRUE(allocated_slot_result.has_value());
+
+    // When the SkeletonField is destroyed while the SampleAllocateePtr is still held
+    // Then the application terminates
+    EXPECT_DEATH(unit.reset(), "");
+}
+
+// Helper skeleton that holds an EnableSet=true field (setter-capable field)
 class MySetterSkeleton : public SkeletonBase
 {
   public:
@@ -1067,8 +1115,8 @@ TEST_F(SkeletonFieldSetHandlerTest, CallingMethodHandlerCallsSend)
 {
     // Expect that Send will be called on the event binding twice: (1) when the initial value of the field is set. (2)
     // with the value provided to the set handler when the handler is called
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _)).WillOnce(Return(Result<void>{}));
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummySetValue, _)).WillOnce(Return(Result<void>{}));
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _, _)).WillOnce(Return(Result<void>{}));
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummySetValue, _, _)).WillOnce(Return(Result<void>{}));
 
     GivenASkeletonWithSetterEnabled().WhichCapturesASetHandler();
 
@@ -1086,8 +1134,8 @@ TEST_F(SkeletonFieldSetHandlerTest, MethodHandlerDoesNotTerminateWhenSendFails)
 {
     // Expect that Send will be called on the event binding twice: (1) when the initial value of the field is set. (2)
     // with the value provided to the set handler when the handler is called which returns an error.
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _)).WillOnce(Return(Result<void>{}));
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummySetValue, _))
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _, _)).WillOnce(Return(Result<void>{}));
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummySetValue, _, _))
         .WillOnce(Return(MakeUnexpected(ComErrc::kCommunicationLinkError)));
 
     GivenASkeletonWithSetterEnabled().WhichCapturesASetHandler();
@@ -1117,8 +1165,8 @@ TEST_F(SkeletonFieldSetHandlerTest, CallingMethodHandlerCallsSendWithValueModifi
 
     // Expect that Send will be called on the event binding twice: (1) when the initial value of the field is set. (2)
     // with the value modified by the set handler when the handler is called
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _)).WillOnce(Return(Result<void>{}));
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(modified_value, _)).WillOnce(Return(Result<void>{}));
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _, _)).WillOnce(Return(Result<void>{}));
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(modified_value, _, _)).WillOnce(Return(Result<void>{}));
 
     GivenASkeletonWithSetterEnabled().WhichCapturesASetHandler();
 
@@ -1194,8 +1242,8 @@ TEST_F(SkeletonFieldMoveConstructionFixture,
 
     // Expect that Send will be called on the event binding twice: (1) when the initial value of the field is set. (2)
     // with the value modified by the set handler when the handler is called
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _)).WillOnce(Return(Result<void>{}));
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(modified_value, _)).WillOnce(Return(Result<void>{}));
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _, _)).WillOnce(Return(Result<void>{}));
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(modified_value, _, _)).WillOnce(Return(Result<void>{}));
 
     GivenASkeletonWithSetterEnabled().WhichCapturesASetHandler();
 

--- a/score/mw/com/impl/tracing/BUILD
+++ b/score/mw/com/impl/tracing/BUILD
@@ -146,6 +146,7 @@ cc_library(
         "//score/mw/com/impl:instance_identifier",
         "//score/mw/com/impl:runtime",
         "//score/mw/com/impl:skeleton_event_binding",
+        "//score/mw/com/impl/bindings/lola:event_data_control_composite",
         "//score/mw/com/impl/plumbing:sample_allocatee_ptr",
         "//score/mw/com/impl/plumbing:sample_ptr",
         "//score/mw/com/impl/tracing/configuration:service_element_instance_identifier_view",

--- a/score/mw/com/impl/tracing/skeleton_event_tracing.h
+++ b/score/mw/com/impl/tracing/skeleton_event_tracing.h
@@ -15,6 +15,7 @@
 
 #include "score/mw/com/impl/binding_type.h"
 #include "score/mw/com/impl/bindings/lola/event_data_control.h"
+#include "score/mw/com/impl/bindings/lola/event_data_control_composite.h"
 #include "score/mw/com/impl/bindings/lola/sample_allocatee_ptr.h"
 #include "score/mw/com/impl/bindings/lola/sample_ptr.h"
 #include "score/mw/com/impl/bindings/lola/transaction_log_set.h"
@@ -63,11 +64,10 @@ TracingData ExtractBindingTracingData(const impl::SampleAllocateePtr<SampleType>
     const auto& binding_ptr_variant = SampleAllocateePtrView{sample_data_ptr}.GetUnderlyingVariant();
     auto visitor = score::cpp::overload(
         [](const lola::SampleAllocateePtr<SampleType>& lola_ptr) -> TracingData {
-            const auto& event_data_control_composite =
+            const lola::EventDataControlComposite<>& event_data_control_composite =
                 lola::SampleAllocateePtrView{lola_ptr}.GetEventDataControlComposite();
-            SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(event_data_control_composite.has_value());
             const auto referenced_slot = lola_ptr.GetReferencedSlot();
-            const auto sample_timestamp = event_data_control_composite->GetEventSlotTimestamp(referenced_slot);
+            const auto sample_timestamp = event_data_control_composite.GetEventSlotTimestamp(referenced_slot);
             static_assert(
                 sizeof(lola::EventSlotStatus::EventTimeStamp) ==
                     sizeof(impl::tracing::ITracingRuntime::TracePointDataId),
@@ -107,7 +107,7 @@ TypeErasedSamplePtr CreateTypeErasedSamplePtr(impl::SampleAllocateePtr<SampleTyp
     auto& binding_ptr_variant = SampleAllocateePtrMutableView{sample_data_ptr}.GetUnderlyingVariant();
     auto visitor = score::cpp::overload(
         [](lola::SampleAllocateePtr<SampleType>& lola_ptr) -> TypeErasedSamplePtr {
-            auto& consumer_event_data_control_local =
+            lola::ConsumerEventDataControlLocalView<>& consumer_event_data_control_local =
                 lola::SampleAllocateePtrMutableView{lola_ptr}.GetConsumerEventDataControlLocalView();
 
             const auto event_slot_index = lola_ptr.GetReferencedSlot();

--- a/score/mw/com/impl/traits_test.cpp
+++ b/score/mw/com/impl/traits_test.cpp
@@ -1018,8 +1018,8 @@ TEST_F(GeneratedSkeletonCreationInstanceIdentifierTestFixture, CanInterpretAsSke
     EXPECT_CALL(skeleton_field_binding_mock_, GetBindingType()).WillOnce(Return(BindingType::kLoLa));
 
     // and that Send is called on the event binding once for the event and once for the field
-    EXPECT_CALL(skeleton_event_binding_mock_, Send(event_value, _));
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(field_value, _));
+    EXPECT_CALL(skeleton_event_binding_mock_, Send(event_value, _, _));
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(field_value, _, _));
 
     // and that VerifyAllMethodHandlersRegistered returns true because there are no methods to register
     EXPECT_CALL(skeleton_binding_mock_, VerifyAllMethodHandlersRegistered()).WillOnce(Return(true));


### PR DESCRIPTION
Changed SampleAllocateePtr to hold pointer to SkeletonEvent's EventDataControlComposite
Added SampleAllocateeTracker/Guard to track outstanding allocations
SkeletonEvent terminates if destroyed while SampleAllocateePtr instances exist
Update unit tests

Fixes state synchronization issues and prevents dangling pointer access.