### PR TITLE
feat(mw::com): Implement Field Notifier support for Generic Skeleton

### DIFF
--- a/score/mw/com/design/skeleton_proxy/generic_skeleton/generic_skeleton_model.puml
+++ b/score/mw/com/design/skeleton_proxy/generic_skeleton/generic_skeleton_model.puml
@@ -32,15 +32,18 @@ abstract class "SkeletonBinding" {
 
 class "mw::com::impl::GenericSkeleton" #yellow {
   using EventMapView = ServiceElementMapView<GenericSkeletonEvent>
+  using FieldMap = ServiceElementMap<GenericSkeletonField>
   ..
   +Create(const InstanceIdentifier&, const GenericSkeletonServiceElementInfo&): Result<GenericSkeleton>
   +Create(const InstanceSpecifier&, const GenericSkeletonServiceElementInfo&): Result<GenericSkeleton>
   +GetEvents() : EventMapView
+  +GetFields(): const FieldMap&
   +OfferService(): Result<void>
   +StopOfferService(): void
   ..
   -GenericSkeleton(const InstanceIdentifier&, std::unique_ptr<SkeletonBinding>)
   -events_ : std::unique_ptr<ServiceElementMapViewFactory<GenericSkeletonEvent>::map_type> events_
+  -fields_ : FieldMap
 }
 
 class "lola::Skeleton" {
@@ -110,6 +113,28 @@ class "ServiceElementMapView<ElementType>" {
   +empty() : bool
 }
 
+abstract class "score::mw::com::impl::SkeletonFieldBase" {
+  #skeleton_event_dispatch_ : std::unique_ptr<impl::SkeletonEventBase>
+  +PrepareOffer(): Result<void>
+  -{abstract} IsInitialValueSaved(): bool
+  -{abstract} DoDeferredUpdate(): Result<void>
+}
+
+class "mw::com::impl::GenericSkeletonField" #LightGreen {
+  -initial_field_value_ : std::vector<uint8_t>
+  -has_initial_value_ : bool
+  -has_getter_ : bool
+  -has_setter_ : bool
+  -has_notifier_ : bool
+  .. Notifier API ..
+  +Update(raw_value: span<const uint8_t>): Result<void>
+  +Update(SampleAllocateePtr<void> sample): Result<void>
+  +Allocate(): Result<SampleAllocateePtr<void>>
+  .. Method Handlers (Stubs) ..
+  +RegisterGetHandler(std::function<std::vector<uint8_t>()> handler): Result<void>
+  +RegisterSetHandler(std::function<std::vector<uint8_t>(span<const uint8_t>)> handler): Result<void>
+}
+
 abstract class "mw::com::impl::SkeletonEventBase" #yellow {
   +SkeletonEventBase(SkeletonBase&, const std::string_view, std::unique_ptr<SkeletonEventBindingBase>)
   +OfferService(): Result<void>
@@ -175,6 +200,9 @@ class "DummySkeleton" <<generated>>  {
 "score::mw::com::impl::SkeletonBase" *--> "SkeletonBinding"
 "score::mw::com::impl::SkeletonBase" <|-- "DummySkeleton"
 "score::mw::com::impl::SkeletonBase" <|-- "mw::com::impl::GenericSkeleton"
+"mw::com::impl::GenericSkeleton" *-- "ServiceElementMap"
+"score::mw::com::impl::SkeletonFieldBase" <|-- "mw::com::impl::GenericSkeletonField"
+"SkeletonFieldBase" "1" *-- "1" "mw::com::impl::SkeletonEventBase" : skeleton_event_dispatch_
 "SkeletonBindingFactory" ..> "SkeletonBinding" : creates
 "SkeletonBinding" <|-- "lola::Skeleton"
 
@@ -200,5 +228,6 @@ class "DummySkeleton" <<generated>>  {
 "mw::com::impl::GenericSkeleton" ..> "ServiceElementMapViewFactory<ElementType>" : uses
 "ServiceElementMapViewFactory<ElementType>" ..> "ServiceElementMapView<ElementType>" : creates
 "ServiceElementMapView<ElementType>" o-- "mw::com::impl::GenericSkeletonEvent" : "0..n"
+"mw::com::impl::GenericSkeleton" *--> "mw::com::impl::GenericSkeletonField" : "0..n"
 
 @enduml

--- a/score/mw/com/design/skeleton_proxy/generic_skeleton/generic_skeleton_model.puml
+++ b/score/mw/com/design/skeleton_proxy/generic_skeleton/generic_skeleton_model.puml
@@ -32,18 +32,18 @@ abstract class "SkeletonBinding" {
 
 class "mw::com::impl::GenericSkeleton" #yellow {
   using EventMapView = ServiceElementMapView<GenericSkeletonEvent>
-  using FieldMap = ServiceElementMap<GenericSkeletonField>
+  using FieldMapView = ServiceElementMapView<GenericSkeletonField>
   ..
   +Create(const InstanceIdentifier&, const GenericSkeletonServiceElementInfo&): Result<GenericSkeleton>
   +Create(const InstanceSpecifier&, const GenericSkeletonServiceElementInfo&): Result<GenericSkeleton>
   +GetEvents() : EventMapView
-  +GetFields(): const FieldMap&
+  +GetFields(): FieldMapView
   +OfferService(): Result<void>
   +StopOfferService(): void
   ..
   -GenericSkeleton(const InstanceIdentifier&, std::unique_ptr<SkeletonBinding>)
   -events_ : std::unique_ptr<ServiceElementMapViewFactory<GenericSkeletonEvent>::map_type> events_
-  -fields_ : FieldMap
+  -fields_ : std::unique_ptr<ServiceElementMapViewFactory<GenericSkeletonField>::map_type>
 }
 
 class "lola::Skeleton" {
@@ -116,8 +116,10 @@ class "ServiceElementMapView<ElementType>" {
 abstract class "score::mw::com::impl::SkeletonFieldBase" {
   #skeleton_event_dispatch_ : std::unique_ptr<impl::SkeletonEventBase>
   +PrepareOffer(): Result<void>
+  +UpdateSkeletonReference(skeleton_base: SkeletonBase&): void
   -{abstract} IsInitialValueSaved(): bool
   -{abstract} DoDeferredUpdate(): Result<void>
+  -{abstract} IsSetHandlerMissing(): bool
 }
 
 class "mw::com::impl::GenericSkeletonField" #LightGreen {
@@ -126,10 +128,12 @@ class "mw::com::impl::GenericSkeletonField" #LightGreen {
   -has_getter_ : bool
   -has_setter_ : bool
   -has_notifier_ : bool
+  -is_set_handler_registered_ : bool
   .. Notifier API ..
   +Update(raw_value: span<const uint8_t>): Result<void>
   +Update(SampleAllocateePtr<void> sample): Result<void>
   +Allocate(): Result<SampleAllocateePtr<void>>
+  +UpdateSkeletonReference(skeleton_base: SkeletonBase&): void
   .. Method Handlers (Stubs) ..
   +RegisterGetHandler(std::function<std::vector<uint8_t>()> handler): Result<void>
   +RegisterSetHandler(std::function<std::vector<uint8_t>(span<const uint8_t>)> handler): Result<void>
@@ -139,10 +143,12 @@ abstract class "mw::com::impl::SkeletonEventBase" #yellow {
   +SkeletonEventBase(SkeletonBase&, const std::string_view, std::unique_ptr<SkeletonEventBindingBase>)
   +OfferService(): Result<void>
   +StopOfferService(): void
+  +UpdateSkeletonReference(skeleton_base: SkeletonBase&): void
 }
 
 class "mw::com::impl::GenericSkeletonEvent" #yellow {
   +GenericSkeletonEvent(SkeletonBase&, const std::string_view, std::unique_ptr<GenericSkeletonEventBinding>)
+  +GenericSkeletonEvent(SkeletonBase&, const std::string_view, std::unique_ptr<GenericSkeletonEventBinding>, FieldOnlyConstructorEnabler)
   +Send(SampleAllocateePtr<void> sample): Result<void>
   +Allocate(): Result<SampleAllocateePtr<void>>
   +GetSizeInfo() const : DataTypeMetaInfo
@@ -200,7 +206,7 @@ class "DummySkeleton" <<generated>>  {
 "score::mw::com::impl::SkeletonBase" *--> "SkeletonBinding"
 "score::mw::com::impl::SkeletonBase" <|-- "DummySkeleton"
 "score::mw::com::impl::SkeletonBase" <|-- "mw::com::impl::GenericSkeleton"
-"mw::com::impl::GenericSkeleton" *-- "ServiceElementMap"
+"mw::com::impl::GenericSkeleton" *-- "ServiceElementMapView"
 "score::mw::com::impl::SkeletonFieldBase" <|-- "mw::com::impl::GenericSkeletonField"
 "SkeletonFieldBase" "1" *-- "1" "mw::com::impl::SkeletonEventBase" : skeleton_event_dispatch_
 "SkeletonBindingFactory" ..> "SkeletonBinding" : creates

--- a/score/mw/com/design/skeleton_proxy/generic_skeleton/generic_skeleton_model.puml
+++ b/score/mw/com/design/skeleton_proxy/generic_skeleton/generic_skeleton_model.puml
@@ -116,7 +116,6 @@ class "ServiceElementMapView<ElementType>" {
 abstract class "score::mw::com::impl::SkeletonFieldBase" {
   #skeleton_event_dispatch_ : std::unique_ptr<impl::SkeletonEventBase>
   +PrepareOffer(): Result<void>
-  +UpdateSkeletonReference(skeleton_base: SkeletonBase&): void
   -{abstract} IsInitialValueSaved(): bool
   -{abstract} DoDeferredUpdate(): Result<void>
   -{abstract} IsSetHandlerMissing(): bool
@@ -133,17 +132,14 @@ class "mw::com::impl::GenericSkeletonField" #LightGreen {
   +Update(raw_value: span<const uint8_t>): Result<void>
   +Update(SampleAllocateePtr<void> sample): Result<void>
   +Allocate(): Result<SampleAllocateePtr<void>>
-  +UpdateSkeletonReference(skeleton_base: SkeletonBase&): void
   .. Method Handlers (Stubs) ..
-  +RegisterGetHandler(std::function<std::vector<uint8_t>()> handler): Result<void>
-  +RegisterSetHandler(std::function<std::vector<uint8_t>(span<const uint8_t>)> handler): Result<void>
+  +RegisterSetHandler(std::function<void(span<uint8_t>)> handler): Result<void>
 }
 
 abstract class "mw::com::impl::SkeletonEventBase" #yellow {
-  +SkeletonEventBase(SkeletonBase&, const std::string_view, std::unique_ptr<SkeletonEventBindingBase>)
+  +SkeletonEventBase(const std::string_view, std::unique_ptr<SkeletonEventBindingBase>)
   +OfferService(): Result<void>
   +StopOfferService(): void
-  +UpdateSkeletonReference(skeleton_base: SkeletonBase&): void
 }
 
 class "mw::com::impl::GenericSkeletonEvent" #yellow {

--- a/score/mw/com/impl/BUILD
+++ b/score/mw/com/impl/BUILD
@@ -68,6 +68,7 @@ cc_library(
         ":generic_proxy",
         ":generic_proxy_event",
         ":generic_skeleton",
+        ":generic_skeleton_field",
         ":proxy_event",
         ":proxy_field",
         ":skeleton_event",
@@ -173,6 +174,7 @@ cc_library(
     deps = [
         ":data_type_meta_info",
         ":generic_skeleton_event",
+        ":generic_skeleton_field",
         ":instance_identifier",
         ":instance_specifier",
         ":service_element_map_view",
@@ -205,6 +207,27 @@ cc_library(
         ":skeleton_event_base",
         ":skeleton_event_binding",
         "//score/mw/com/impl/plumbing:sample_allocatee_ptr",
+        "@score_baselibs//score/result",
+    ],
+)
+
+cc_library(
+    name = "generic_skeleton_field",
+    srcs = ["generic_skeleton_field.cpp"],
+    hdrs = ["generic_skeleton_field.h"],
+    features = COMPILER_WARNING_FEATURES,
+    tags = ["FFI"],
+    visibility = [
+        "//score/mw/com:__subpackages__",
+    ],
+    deps = [
+        ":error",
+        ":generic_skeleton_event",
+        ":skeleton_base",
+        ":skeleton_field_base",
+        "//score/mw/com/impl/plumbing:sample_allocatee_ptr",
+        "@score_baselibs//score/language/futurecpp",
+        "@score_baselibs//score/mw/log",
         "@score_baselibs//score/result",
     ],
 )

--- a/score/mw/com/impl/BUILD
+++ b/score/mw/com/impl/BUILD
@@ -1429,6 +1429,24 @@ cc_unit_test(
 )
 
 cc_unit_test(
+    name = "generic_skeleton_field_test",
+    srcs = ["generic_skeleton_field_test.cpp"],
+    deps = [
+        ":generic_skeleton",
+        ":generic_skeleton_field",
+        ":runtime_mock",
+        ":service_discovery_client_mock",
+        ":service_discovery_mock",
+        "//score/mw/com/impl/bindings/mock_binding:generic_skeleton_event",
+        "//score/mw/com/impl/plumbing:generic_skeleton_event_binding_factory",
+        "//score/mw/com/impl/plumbing:generic_skeleton_event_binding_factory_mock",
+        "//score/mw/com/impl/test:binding_factory_resources",
+        "//score/mw/com/impl/test:dummy_instance_identifier_builder",
+        "//score/mw/com/impl/test:runtime_mock_guard",
+    ],
+)
+
+cc_unit_test(
     name = "traits_test",
     srcs = [
         "traits_test.cpp",

--- a/score/mw/com/impl/BUILD
+++ b/score/mw/com/impl/BUILD
@@ -1425,6 +1425,24 @@ cc_unit_test(
 )
 
 cc_unit_test(
+    name = "generic_skeleton_field_test",
+    srcs = ["generic_skeleton_field_test.cpp"],
+    deps = [
+        ":generic_skeleton",
+        ":generic_skeleton_field",
+        ":runtime_mock",
+        ":service_discovery_client_mock",
+        ":service_discovery_mock",
+        "//score/mw/com/impl/bindings/mock_binding:generic_skeleton_event",
+        "//score/mw/com/impl/plumbing:generic_skeleton_event_binding_factory",
+        "//score/mw/com/impl/plumbing:generic_skeleton_event_binding_factory_mock",
+        "//score/mw/com/impl/test:binding_factory_resources",
+        "//score/mw/com/impl/test:dummy_instance_identifier_builder",
+        "//score/mw/com/impl/test:runtime_mock_guard",
+    ],
+)
+
+cc_unit_test(
     name = "traits_test",
     srcs = [
         "traits_test.cpp",

--- a/score/mw/com/impl/generic_skeleton.cpp
+++ b/score/mw/com/impl/generic_skeleton.cpp
@@ -159,7 +159,7 @@ Result<GenericSkeleton> GenericSkeleton::Create(const InstanceIdentifier& identi
     for (const auto& info : in.fields)
     {
         // Check for duplicates
-        if (skeleton.fields_.find(info.name) != skeleton.fields_.cend())
+        if (skeleton.fields_->find(info.name) != skeleton.fields_->cend())
         {
             score::mw::log::LogError("GenericSkeleton") << "Duplicate field name provided: " << info.name;
             return MakeUnexpected(ComErrc::kServiceElementAlreadyExists);
@@ -181,12 +181,18 @@ Result<GenericSkeleton> GenericSkeleton::Create(const InstanceIdentifier& identi
             return MakeUnexpected(ComErrc::kBindingFailure);
         }
 
-        auto generic_event = std::make_unique<GenericSkeletonEvent>(skeleton, stable_name, std::move(field_binding_result).value());
+        // Use the hidden constructor tag so the event doesn't register itself in the events_ map
+        auto generic_event =
+            std::make_unique<GenericSkeletonEvent>(skeleton,
+                                                   stable_name,
+                                                   std::move(field_binding_result).value(),
+                                                   GenericSkeletonEvent::FieldOnlyConstructorEnabler{});
 
-        const auto emplace_result = skeleton.fields_.emplace(
+        const auto emplace_result = skeleton.fields_->emplace(
             std::piecewise_construct,
             std::forward_as_tuple(stable_name),
-            std::forward_as_tuple(skeleton, stable_name, std::move(generic_event), info.has_getter, info.has_setter, info.has_notifier));
+            std::forward_as_tuple(
+                skeleton, stable_name, std::move(generic_event), info.has_getter, info.has_setter, info.has_notifier));
 
         if (!emplace_result.second)
         {
@@ -198,7 +204,7 @@ Result<GenericSkeleton> GenericSkeleton::Create(const InstanceIdentifier& identi
         if (!update_result.has_value())
         {
             score::mw::log::LogError("GenericSkeleton") << "Failed to set initial value for field: " << info.name;
-            return score::Unexpected{update_result.error()};
+            return score::Unexpected(update_result.error());
         }
     }
 
@@ -210,9 +216,9 @@ ServiceElementMapView<GenericSkeletonEvent> GenericSkeleton::GetEvents() const n
     return ServiceElementMapViewFactory<GenericSkeletonEvent>::Create(*events_);
 }
 
-const GenericSkeleton::FieldMap& GenericSkeleton::GetFields() const noexcept
+GenericSkeleton::FieldMapView GenericSkeleton::GetFields() const noexcept
 {
-    return fields_;
+    return ServiceElementMapViewFactory<GenericSkeletonField>::Create(*fields_);
 }
 
 Result<void> GenericSkeleton::OfferService() noexcept
@@ -227,7 +233,8 @@ void GenericSkeleton::StopOfferService() noexcept
 
 GenericSkeleton::GenericSkeleton(const InstanceIdentifier& identifier, std::unique_ptr<SkeletonBinding> binding)
     : SkeletonBase(std::move(binding), identifier),
-      events_(std::make_unique<std::map<std::string_view, GenericSkeletonEvent>>())
+      events_(std::make_unique<std::map<std::string_view, GenericSkeletonEvent>>()),
+      fields_(std::make_unique<std::map<std::string_view, GenericSkeletonField>>())
 {
 }
 

--- a/score/mw/com/impl/generic_skeleton.cpp
+++ b/score/mw/com/impl/generic_skeleton.cpp
@@ -199,13 +199,6 @@ Result<GenericSkeleton> GenericSkeleton::Create(const InstanceIdentifier& identi
             score::mw::log::LogError("GenericSkeleton") << "Failed to emplace field in map: " << info.name;
             return MakeUnexpected(ComErrc::kBindingFailure);
         }
-
-        auto update_result = emplace_result.first->second.Update(info.initial_value);
-        if (!update_result.has_value())
-        {
-            score::mw::log::LogError("GenericSkeleton") << "Failed to set initial value for field: " << info.name;
-            return score::Unexpected(update_result.error());
-        }
     }
 
     return skeleton;

--- a/score/mw/com/impl/generic_skeleton.cpp
+++ b/score/mw/com/impl/generic_skeleton.cpp
@@ -125,7 +125,7 @@ Result<GenericSkeleton> GenericSkeleton::Create(const InstanceIdentifier& identi
         // Validate & convert the public DataTypeMetaInfo into the internal DataTypeSizeInfo. Invalid meta-info (e.g.
         // alignment not a power of two, or size not a multiple of alignment) results in an error instead of a later
         // contract violation. Unfortunately our public interface DataTypeMetaInfo does not enforce these invariants,
-        // so we have to check them here. @ToDo: At some point we should already enforce this on DataTypeMetaInfo,
+        // so we have to check them here. \todo: At some point we should already enforce this on DataTypeMetaInfo,
         // but this would require a break in the public API!
         auto data_type_size_info_result = MakeDataTypeSizeInfo(info.data_type_meta_info);
         if (!data_type_size_info_result.has_value())

--- a/score/mw/com/impl/generic_skeleton.cpp
+++ b/score/mw/com/impl/generic_skeleton.cpp
@@ -52,6 +52,27 @@ std::string_view GetEventName(const InstanceIdentifier& identifier, std::string_
 
     return std::visit(visitor, service_type_deployment.binding_info_);
 }
+
+// Helper to fetch the stable field name from the Configuration
+std::string_view GetFieldName(const InstanceIdentifier& identifier, std::string_view search_name)
+{
+    const auto& service_type_deployment = InstanceIdentifierView{identifier}.GetServiceTypeDeployment();
+
+    auto visitor = score::cpp::overload(
+        [&](const LolaServiceTypeDeployment& deployment) -> std::string_view {
+            const auto it = deployment.fields_.find(std::string{search_name});
+            if (it != deployment.fields_.end())
+            {
+                return it->first;  // Return the stable address of the Key from the Config Map
+            }
+            return {};
+        },
+        [](const score::cpp::blank&) noexcept -> std::string_view {
+            return {};
+        });
+
+    return std::visit(visitor, service_type_deployment.binding_info_);
+}
 }  // namespace
 
 Result<GenericSkeleton> GenericSkeleton::Create(const InstanceSpecifier& specifier,
@@ -134,12 +155,64 @@ Result<GenericSkeleton> GenericSkeleton::Create(const InstanceIdentifier& identi
         }
     }
 
+    // 3. Create fields directly in the map
+    for (const auto& info : in.fields)
+    {
+        // Check for duplicates
+        if (skeleton.fields_.find(info.name) != skeleton.fields_.cend())
+        {
+            score::mw::log::LogError("GenericSkeleton") << "Duplicate field name provided: " << info.name;
+            return MakeUnexpected(ComErrc::kServiceElementAlreadyExists);
+        }
+
+        std::string_view stable_name = GetFieldName(identifier, info.name);
+
+        if (stable_name.empty())
+        {
+            score::mw::log::LogError("GenericSkeleton") << "Field name not found in configuration: " << info.name;
+            return MakeUnexpected(ComErrc::kBindingFailure);
+        }
+
+        auto field_binding_result =
+            GenericSkeletonEventBindingFactory::Create(skeleton, info.name, info.data_type_meta_info);
+
+        if (!field_binding_result.has_value())
+        {
+            return MakeUnexpected(ComErrc::kBindingFailure);
+        }
+
+        auto generic_event = std::make_unique<GenericSkeletonEvent>(skeleton, stable_name, std::move(field_binding_result).value());
+
+        const auto emplace_result = skeleton.fields_.emplace(
+            std::piecewise_construct,
+            std::forward_as_tuple(stable_name),
+            std::forward_as_tuple(skeleton, stable_name, std::move(generic_event), info.has_getter, info.has_setter, info.has_notifier));
+
+        if (!emplace_result.second)
+        {
+            score::mw::log::LogError("GenericSkeleton") << "Failed to emplace field in map: " << info.name;
+            return MakeUnexpected(ComErrc::kBindingFailure);
+        }
+
+        auto update_result = emplace_result.first->second.Update(info.initial_value);
+        if (!update_result.has_value())
+        {
+            score::mw::log::LogError("GenericSkeleton") << "Failed to set initial value for field: " << info.name;
+            return MakeUnexpected(update_result.error());
+        }
+    }
+
     return skeleton;
 }
 
 ServiceElementMapView<GenericSkeletonEvent> GenericSkeleton::GetEvents() const noexcept
 {
     return ServiceElementMapViewFactory<GenericSkeletonEvent>::Create(*events_);
+}
+
+const GenericSkeleton::FieldMap& GenericSkeleton::GetFields() const noexcept
+{
+    return fields_;
 }
 
 Result<void> GenericSkeleton::OfferService()

--- a/score/mw/com/impl/generic_skeleton.cpp
+++ b/score/mw/com/impl/generic_skeleton.cpp
@@ -198,7 +198,7 @@ Result<GenericSkeleton> GenericSkeleton::Create(const InstanceIdentifier& identi
         if (!update_result.has_value())
         {
             score::mw::log::LogError("GenericSkeleton") << "Failed to set initial value for field: " << info.name;
-            return MakeUnexpected(update_result.error());
+            return score::Unexpected{update_result.error()};
         }
     }
 

--- a/score/mw/com/impl/generic_skeleton.cpp
+++ b/score/mw/com/impl/generic_skeleton.cpp
@@ -173,10 +173,19 @@ Result<GenericSkeleton> GenericSkeleton::Create(const InstanceIdentifier& identi
             return MakeUnexpected(ComErrc::kBindingFailure);
         }
 
-        auto field_binding_result =
-            GenericSkeletonEventBindingFactory::Create(skeleton, info.name, info.data_type_meta_info);
+        // Validate & convert the public DataTypeMetaInfo into the internal DataTypeSizeInfo.
+        auto data_type_size_info_result = MakeDataTypeSizeInfo(info.data_type_meta_info);
+        if (!data_type_size_info_result.has_value())
+        {
+            score::mw::log::LogError("GenericSkeleton")
+                << "Invalid data type meta-info provided for field: " << info.name;
+            return MakeUnexpected(ComErrc::kInvalidConfiguration);
+        }
 
-        if (!field_binding_result.has_value())
+        auto event_binding_result =
+            GenericSkeletonEventBindingFactory::Create(skeleton, info.name, data_type_size_info_result.value());
+
+        if (!event_binding_result.has_value())
         {
             return MakeUnexpected(ComErrc::kBindingFailure);
         }
@@ -185,7 +194,7 @@ Result<GenericSkeleton> GenericSkeleton::Create(const InstanceIdentifier& identi
         auto generic_event =
             std::make_unique<GenericSkeletonEvent>(skeleton,
                                                    stable_name,
-                                                   std::move(field_binding_result).value(),
+                                                   std::move(event_binding_result).value(),
                                                    GenericSkeletonEvent::FieldOnlyConstructorEnabler{});
 
         const auto emplace_result = skeleton.fields_->emplace(

--- a/score/mw/com/impl/generic_skeleton.cpp
+++ b/score/mw/com/impl/generic_skeleton.cpp
@@ -159,7 +159,7 @@ Result<GenericSkeleton> GenericSkeleton::Create(const InstanceIdentifier& identi
     for (const auto& info : in.fields)
     {
         // Check for duplicates
-        if (skeleton.fields_.find(info.name) != skeleton.fields_.cend())
+        if (skeleton.fields_->find(info.name) != skeleton.fields_->cend())
         {
             score::mw::log::LogError("GenericSkeleton") << "Duplicate field name provided: " << info.name;
             return MakeUnexpected(ComErrc::kServiceElementAlreadyExists);
@@ -181,12 +181,18 @@ Result<GenericSkeleton> GenericSkeleton::Create(const InstanceIdentifier& identi
             return MakeUnexpected(ComErrc::kBindingFailure);
         }
 
-        auto generic_event = std::make_unique<GenericSkeletonEvent>(skeleton, stable_name, std::move(field_binding_result).value());
+        // Use the hidden constructor tag so the event doesn't register itself in the events_ map
+        auto generic_event =
+            std::make_unique<GenericSkeletonEvent>(skeleton,
+                                                   stable_name,
+                                                   std::move(field_binding_result).value(),
+                                                   GenericSkeletonEvent::FieldOnlyConstructorEnabler{});
 
-        const auto emplace_result = skeleton.fields_.emplace(
+        const auto emplace_result = skeleton.fields_->emplace(
             std::piecewise_construct,
             std::forward_as_tuple(stable_name),
-            std::forward_as_tuple(skeleton, stable_name, std::move(generic_event), info.has_getter, info.has_setter, info.has_notifier));
+            std::forward_as_tuple(
+                skeleton, stable_name, std::move(generic_event), info.has_getter, info.has_setter, info.has_notifier));
 
         if (!emplace_result.second)
         {
@@ -198,7 +204,7 @@ Result<GenericSkeleton> GenericSkeleton::Create(const InstanceIdentifier& identi
         if (!update_result.has_value())
         {
             score::mw::log::LogError("GenericSkeleton") << "Failed to set initial value for field: " << info.name;
-            return score::Unexpected{update_result.error()};
+            return score::Unexpected(update_result.error());
         }
     }
 
@@ -210,9 +216,9 @@ ServiceElementMapView<GenericSkeletonEvent> GenericSkeleton::GetEvents() const n
     return ServiceElementMapViewFactory<GenericSkeletonEvent>::Create(*events_);
 }
 
-const GenericSkeleton::FieldMap& GenericSkeleton::GetFields() const noexcept
+GenericSkeleton::FieldMapView GenericSkeleton::GetFields() const noexcept
 {
-    return fields_;
+    return ServiceElementMapViewFactory<GenericSkeletonField>::Create(*fields_);
 }
 
 Result<void> GenericSkeleton::OfferService()
@@ -227,7 +233,8 @@ void GenericSkeleton::StopOfferService()
 
 GenericSkeleton::GenericSkeleton(const InstanceIdentifier& identifier, std::unique_ptr<SkeletonBinding> binding)
     : SkeletonBase(std::move(binding), identifier),
-      events_(std::make_unique<std::map<std::string_view, GenericSkeletonEvent>>())
+      events_(std::make_unique<std::map<std::string_view, GenericSkeletonEvent>>()),
+      fields_(std::make_unique<std::map<std::string_view, GenericSkeletonField>>())
 {
 }
 

--- a/score/mw/com/impl/generic_skeleton.cpp
+++ b/score/mw/com/impl/generic_skeleton.cpp
@@ -52,6 +52,27 @@ std::string_view GetEventName(const InstanceIdentifier& identifier, std::string_
 
     return std::visit(visitor, service_type_deployment.binding_info_);
 }
+
+// Helper to fetch the stable field name from the Configuration
+std::string_view GetFieldName(const InstanceIdentifier& identifier, std::string_view search_name)
+{
+    const auto& service_type_deployment = InstanceIdentifierView{identifier}.GetServiceTypeDeployment();
+
+    auto visitor = score::cpp::overload(
+        [&](const LolaServiceTypeDeployment& deployment) -> std::string_view {
+            const auto it = deployment.fields_.find(std::string{search_name});
+            if (it != deployment.fields_.end())
+            {
+                return it->first;  // Return the stable address of the Key from the Config Map
+            }
+            return {};
+        },
+        [](const score::cpp::blank&) noexcept -> std::string_view {
+            return {};
+        });
+
+    return std::visit(visitor, service_type_deployment.binding_info_);
+}
 }  // namespace
 
 Result<GenericSkeleton> GenericSkeleton::Create(const InstanceSpecifier& specifier,
@@ -134,12 +155,64 @@ Result<GenericSkeleton> GenericSkeleton::Create(const InstanceIdentifier& identi
         }
     }
 
+    // 3. Create fields directly in the map
+    for (const auto& info : in.fields)
+    {
+        // Check for duplicates
+        if (skeleton.fields_.find(info.name) != skeleton.fields_.cend())
+        {
+            score::mw::log::LogError("GenericSkeleton") << "Duplicate field name provided: " << info.name;
+            return MakeUnexpected(ComErrc::kServiceElementAlreadyExists);
+        }
+
+        std::string_view stable_name = GetFieldName(identifier, info.name);
+
+        if (stable_name.empty())
+        {
+            score::mw::log::LogError("GenericSkeleton") << "Field name not found in configuration: " << info.name;
+            return MakeUnexpected(ComErrc::kBindingFailure);
+        }
+
+        auto field_binding_result =
+            GenericSkeletonEventBindingFactory::Create(skeleton, info.name, info.data_type_meta_info);
+
+        if (!field_binding_result.has_value())
+        {
+            return MakeUnexpected(ComErrc::kBindingFailure);
+        }
+
+        auto generic_event = std::make_unique<GenericSkeletonEvent>(skeleton, stable_name, std::move(field_binding_result).value());
+
+        const auto emplace_result = skeleton.fields_.emplace(
+            std::piecewise_construct,
+            std::forward_as_tuple(stable_name),
+            std::forward_as_tuple(skeleton, stable_name, std::move(generic_event), info.has_getter, info.has_setter, info.has_notifier));
+
+        if (!emplace_result.second)
+        {
+            score::mw::log::LogError("GenericSkeleton") << "Failed to emplace field in map: " << info.name;
+            return MakeUnexpected(ComErrc::kBindingFailure);
+        }
+
+        auto update_result = emplace_result.first->second.Update(info.initial_value);
+        if (!update_result.has_value())
+        {
+            score::mw::log::LogError("GenericSkeleton") << "Failed to set initial value for field: " << info.name;
+            return MakeUnexpected(update_result.error());
+        }
+    }
+
     return skeleton;
 }
 
 ServiceElementMapView<GenericSkeletonEvent> GenericSkeleton::GetEvents() const noexcept
 {
     return ServiceElementMapViewFactory<GenericSkeletonEvent>::Create(*events_);
+}
+
+const GenericSkeleton::FieldMap& GenericSkeleton::GetFields() const noexcept
+{
+    return fields_;
 }
 
 Result<void> GenericSkeleton::OfferService() noexcept

--- a/score/mw/com/impl/generic_skeleton.h
+++ b/score/mw/com/impl/generic_skeleton.h
@@ -15,6 +15,7 @@
 
 #include "score/mw/com/impl/data_type_meta_info.h"
 #include "score/mw/com/impl/generic_skeleton_event.h"
+#include "score/mw/com/impl/generic_skeleton_field.h"
 #include "score/mw/com/impl/instance_identifier.h"
 #include "score/mw/com/impl/instance_specifier.h"
 #include "score/mw/com/impl/service_element_map_view.h"
@@ -35,9 +36,20 @@ struct EventInfo
     DataTypeMetaInfo data_type_meta_info;
 };
 
+struct FieldInfo
+{
+    std::string_view name;
+    DataTypeMetaInfo data_type_meta_info;
+    bool has_getter{false};
+    bool has_setter{false};
+    bool has_notifier{false};
+    score::cpp::span<const uint8_t> initial_value{};
+};
+
 struct GenericSkeletonServiceElementInfo
 {
     score::cpp::span<const EventInfo> events{};
+    score::cpp::span<const FieldInfo> fields{};
 };
 
 /// @brief Represents a type-erased, runtime-configurable skeleton for a service instance.
@@ -49,7 +61,8 @@ class GenericSkeleton : public SkeletonBase
 {
   public:
     using EventMapView = ServiceElementMapView<GenericSkeletonEvent>;
-    /// \brief Creates a GenericSkeleton and all its service elements (events + fields) atomically.
+    using FieldMap = ServiceElementMap<GenericSkeletonField>;
+    /// @brief Creates a GenericSkeleton and all its service elements (events + fields) atomically.
     ///
     /// \contract
     /// - Empty spans are allowed for `in.events` and/or `in.fields`
@@ -72,8 +85,12 @@ class GenericSkeleton : public SkeletonBase
     /// \note The returned view is valid as long as the GenericSkeleton lives.
     [[nodiscard]] EventMapView GetEvents() const noexcept;
 
-    /// \brief Offers the service instance.
-    /// \return A blank result, or an error if offering fails.
+    /// @brief Returns a const reference to the name-keyed map of fields.
+    /// @note The returned reference is valid as long as the GenericSkeleton lives.
+    [[nodiscard]] const FieldMap& GetFields() const noexcept;
+
+    /// @brief Offers the service instance.
+    /// @return A blank result, or an error if offering fails.
     [[nodiscard]] Result<void> OfferService() noexcept;
 
     /// \brief Stops offering the service instance.
@@ -88,6 +105,8 @@ class GenericSkeleton : public SkeletonBase
     /// GenericSkeleton. This is required as we hand out views to this map (see GetEvents()), which need to be valid
     /// even after the GenericSkeleton instance has been moved.
     std::unique_ptr<ServiceElementMapViewFactory<GenericSkeletonEvent>::map_type> events_;
+    /// @brief This map owns all GenericSkeletonField instances.
+    FieldMap fields_;
 };
 }  // namespace score::mw::com::impl
 

--- a/score/mw/com/impl/generic_skeleton.h
+++ b/score/mw/com/impl/generic_skeleton.h
@@ -61,7 +61,7 @@ class GenericSkeleton : public SkeletonBase
 {
   public:
     using EventMapView = ServiceElementMapView<GenericSkeletonEvent>;
-    using FieldMap = ServiceElementMap<GenericSkeletonField>;
+    using FieldMapView = ServiceElementMapView<GenericSkeletonField>;
     /// @brief Creates a GenericSkeleton and all its service elements (events + fields) atomically.
     ///
     /// \contract
@@ -85,9 +85,9 @@ class GenericSkeleton : public SkeletonBase
     /// \note The returned view is valid as long as the GenericSkeleton lives.
     [[nodiscard]] EventMapView GetEvents() const noexcept;
 
-    /// @brief Returns a const reference to the name-keyed map of fields.
-    /// @note The returned reference is valid as long as the GenericSkeleton lives.
-    [[nodiscard]] const FieldMap& GetFields() const noexcept;
+    /// @brief Returns a read-only view to the name-keyed map of fields.
+    /// @note The returned view is valid as long as the GenericSkeleton lives.
+    [[nodiscard]] FieldMapView GetFields() const noexcept;
 
     /// @brief Offers the service instance.
     /// @return A blank result, or an error if offering fails.
@@ -106,7 +106,7 @@ class GenericSkeleton : public SkeletonBase
     /// even after the GenericSkeleton instance has been moved.
     std::unique_ptr<ServiceElementMapViewFactory<GenericSkeletonEvent>::map_type> events_;
     /// @brief This map owns all GenericSkeletonField instances.
-    FieldMap fields_;
+    std::unique_ptr<ServiceElementMapViewFactory<GenericSkeletonField>::map_type> fields_;
 };
 }  // namespace score::mw::com::impl
 

--- a/score/mw/com/impl/generic_skeleton.h
+++ b/score/mw/com/impl/generic_skeleton.h
@@ -51,7 +51,7 @@ struct GenericSkeletonServiceElementInfo
     score::cpp::span<const FieldInfo> fields{};
 };
 
-/// @brief Represents a type-erased, runtime-configurable skeleton for a service instance.
+/// \brief Represents a type-erased, runtime-configurable skeleton for a service instance.
 ///
 /// A `GenericSkeleton` is created at runtime based on configuration data. It manages
 /// a collection of `GenericSkeletonEvent` and `GenericSkeletonField` instances.
@@ -61,7 +61,7 @@ class GenericSkeleton : public SkeletonBase
   public:
     using EventMapView = ServiceElementMapView<GenericSkeletonEvent>;
     using FieldMapView = ServiceElementMapView<GenericSkeletonField>;
-    /// @brief Creates a GenericSkeleton and all its service elements (events + fields) atomically.
+    /// \brief Creates a GenericSkeleton and all its service elements (events + fields) atomically.
     ///
     /// \contract
     /// - Empty spans are allowed for `in.events` and/or `in.fields`
@@ -82,12 +82,12 @@ class GenericSkeleton : public SkeletonBase
     /// \note The returned view is valid as long as the GenericSkeleton lives.
     [[nodiscard]] EventMapView GetEvents() const noexcept;
 
-    /// @brief Returns a read-only view to the name-keyed map of fields.
-    /// @note The returned view is valid as long as the GenericSkeleton lives.
+    /// \brief Returns a read-only view to the name-keyed map of fields.
+    /// \note The returned view is valid as long as the GenericSkeleton lives.
     [[nodiscard]] FieldMapView GetFields() const noexcept;
 
-    /// @brief Offers the service instance.
-    /// @return A blank result, or an error if offering fails.
+    /// \brief Offers the service instance.
+    /// \return A blank result, or an error if offering fails.
     [[nodiscard]] Result<void> OfferService() noexcept;
 
     /// \brief Stops offering the service instance.
@@ -102,7 +102,7 @@ class GenericSkeleton : public SkeletonBase
     /// GenericSkeleton. This is required as we hand out views to this map (see GetEvents()), which need to be valid
     /// even after the GenericSkeleton instance has been moved.
     std::unique_ptr<ServiceElementMapViewFactory<GenericSkeletonEvent>::map_type> events_;
-    /// @brief This map owns all GenericSkeletonField instances.
+    /// \brief This map owns all GenericSkeletonField instances.
     std::unique_ptr<ServiceElementMapViewFactory<GenericSkeletonField>::map_type> fields_;
 };
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/generic_skeleton.h
+++ b/score/mw/com/impl/generic_skeleton.h
@@ -51,7 +51,7 @@ struct GenericSkeletonServiceElementInfo
     score::cpp::span<const FieldInfo> fields{};
 };
 
-/// @brief Represents a type-erased, runtime-configurable skeleton for a service instance.
+/// \brief Represents a type-erased, runtime-configurable skeleton for a service instance.
 ///
 /// A `GenericSkeleton` is created at runtime based on configuration data. It manages
 /// a collection of `GenericSkeletonEvent` and `GenericSkeletonField` instances.
@@ -61,7 +61,7 @@ class GenericSkeleton : public SkeletonBase
   public:
     using EventMapView = ServiceElementMapView<GenericSkeletonEvent>;
     using FieldMapView = ServiceElementMapView<GenericSkeletonField>;
-    /// @brief Creates a GenericSkeleton and all its service elements (events + fields) atomically.
+    /// \brief Creates a GenericSkeleton and all its service elements (events + fields) atomically.
     ///
     /// \contract
     /// - Empty spans are allowed for `in.events` and/or `in.fields`
@@ -82,13 +82,17 @@ class GenericSkeleton : public SkeletonBase
     /// \note The returned view is valid as long as the GenericSkeleton lives.
     [[nodiscard]] EventMapView GetEvents() const noexcept;
 
-    /// @brief Returns a read-only view to the name-keyed map of fields.
-    /// @note The returned view is valid as long as the GenericSkeleton lives.
+    /// \brief Returns a read-only view to the name-keyed map of fields.
+    /// \note The returned view is valid as long as the GenericSkeleton lives.
     [[nodiscard]] FieldMapView GetFields() const noexcept;
 
     /// \brief Offers the service instance.
     /// \return A blank result, or an error if offering fails.
+<<<<<<< HEAD
     [[nodiscard]] Result<void> OfferService();
+=======
+    [[nodiscard]] Result<void> OfferService() noexcept;
+>>>>>>> 217eb836 (Docs: refactor doxygen tag prefix)
 
     /// \brief Stops offering the service instance.
     void StopOfferService();
@@ -102,7 +106,7 @@ class GenericSkeleton : public SkeletonBase
     /// GenericSkeleton. This is required as we hand out views to this map (see GetEvents()), which need to be valid
     /// even after the GenericSkeleton instance has been moved.
     std::unique_ptr<ServiceElementMapViewFactory<GenericSkeletonEvent>::map_type> events_;
-    /// @brief This map owns all GenericSkeletonField instances.
+    /// \brief This map owns all GenericSkeletonField instances.
     std::unique_ptr<ServiceElementMapViewFactory<GenericSkeletonField>::map_type> fields_;
 };
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/generic_skeleton.h
+++ b/score/mw/com/impl/generic_skeleton.h
@@ -61,7 +61,7 @@ class GenericSkeleton : public SkeletonBase
 {
   public:
     using EventMapView = ServiceElementMapView<GenericSkeletonEvent>;
-    using FieldMap = ServiceElementMap<GenericSkeletonField>;
+    using FieldMapView = ServiceElementMapView<GenericSkeletonField>;
     /// @brief Creates a GenericSkeleton and all its service elements (events + fields) atomically.
     ///
     /// \contract
@@ -85,9 +85,9 @@ class GenericSkeleton : public SkeletonBase
     /// \note The returned view is valid as long as the GenericSkeleton lives.
     [[nodiscard]] EventMapView GetEvents() const noexcept;
 
-    /// @brief Returns a const reference to the name-keyed map of fields.
-    /// @note The returned reference is valid as long as the GenericSkeleton lives.
-    [[nodiscard]] const FieldMap& GetFields() const noexcept;
+    /// @brief Returns a read-only view to the name-keyed map of fields.
+    /// @note The returned view is valid as long as the GenericSkeleton lives.
+    [[nodiscard]] FieldMapView GetFields() const noexcept;
 
     /// \brief Offers the service instance.
     /// \return A blank result, or an error if offering fails.
@@ -106,7 +106,7 @@ class GenericSkeleton : public SkeletonBase
     /// even after the GenericSkeleton instance has been moved.
     std::unique_ptr<ServiceElementMapViewFactory<GenericSkeletonEvent>::map_type> events_;
     /// @brief This map owns all GenericSkeletonField instances.
-    FieldMap fields_;
+    std::unique_ptr<ServiceElementMapViewFactory<GenericSkeletonField>::map_type> fields_;
 };
 }  // namespace score::mw::com::impl
 

--- a/score/mw/com/impl/generic_skeleton.h
+++ b/score/mw/com/impl/generic_skeleton.h
@@ -15,6 +15,7 @@
 
 #include "score/mw/com/impl/data_type_meta_info.h"
 #include "score/mw/com/impl/generic_skeleton_event.h"
+#include "score/mw/com/impl/generic_skeleton_field.h"
 #include "score/mw/com/impl/instance_identifier.h"
 #include "score/mw/com/impl/instance_specifier.h"
 #include "score/mw/com/impl/service_element_map_view.h"
@@ -35,9 +36,20 @@ struct EventInfo
     DataTypeMetaInfo data_type_meta_info;
 };
 
+struct FieldInfo
+{
+    std::string_view name;
+    DataTypeMetaInfo data_type_meta_info;
+    bool has_getter{false};
+    bool has_setter{false};
+    bool has_notifier{false};
+    score::cpp::span<const uint8_t> initial_value{};
+};
+
 struct GenericSkeletonServiceElementInfo
 {
     score::cpp::span<const EventInfo> events{};
+    score::cpp::span<const FieldInfo> fields{};
 };
 
 /// @brief Represents a type-erased, runtime-configurable skeleton for a service instance.
@@ -49,7 +61,8 @@ class GenericSkeleton : public SkeletonBase
 {
   public:
     using EventMapView = ServiceElementMapView<GenericSkeletonEvent>;
-    /// \brief Creates a GenericSkeleton and all its service elements (events + fields) atomically.
+    using FieldMap = ServiceElementMap<GenericSkeletonField>;
+    /// @brief Creates a GenericSkeleton and all its service elements (events + fields) atomically.
     ///
     /// \contract
     /// - Empty spans are allowed for `in.events` and/or `in.fields`
@@ -72,6 +85,10 @@ class GenericSkeleton : public SkeletonBase
     /// \note The returned view is valid as long as the GenericSkeleton lives.
     [[nodiscard]] EventMapView GetEvents() const noexcept;
 
+    /// @brief Returns a const reference to the name-keyed map of fields.
+    /// @note The returned reference is valid as long as the GenericSkeleton lives.
+    [[nodiscard]] const FieldMap& GetFields() const noexcept;
+
     /// \brief Offers the service instance.
     /// \return A blank result, or an error if offering fails.
     [[nodiscard]] Result<void> OfferService();
@@ -88,6 +105,8 @@ class GenericSkeleton : public SkeletonBase
     /// GenericSkeleton. This is required as we hand out views to this map (see GetEvents()), which need to be valid
     /// even after the GenericSkeleton instance has been moved.
     std::unique_ptr<ServiceElementMapViewFactory<GenericSkeletonEvent>::map_type> events_;
+    /// @brief This map owns all GenericSkeletonField instances.
+    FieldMap fields_;
 };
 }  // namespace score::mw::com::impl
 

--- a/score/mw/com/impl/generic_skeleton.h
+++ b/score/mw/com/impl/generic_skeleton.h
@@ -43,7 +43,6 @@ struct FieldInfo
     bool has_getter{false};
     bool has_setter{false};
     bool has_notifier{false};
-    score::cpp::span<const uint8_t> initial_value{};
 };
 
 struct GenericSkeletonServiceElementInfo
@@ -68,8 +67,6 @@ class GenericSkeleton : public SkeletonBase
     /// - Empty spans are allowed for `in.events` and/or `in.fields`
     /// - Each provided name must exist in the binding deployment for this instance (events/fields respectively).
     /// - All element names must be unique across all element kinds within this skeleton.
-    /// - For each field, `initial_value_bytes` must be non-empty and
-    ///   `initial_value_bytes.size()` must be <= `size_info.size`.
     /// - On error, no partially-created elements are left behind.
     [[nodiscard]] static Result<GenericSkeleton> Create(const InstanceIdentifier& identifier,
                                                         const GenericSkeletonServiceElementInfo& in);

--- a/score/mw/com/impl/generic_skeleton.h
+++ b/score/mw/com/impl/generic_skeleton.h
@@ -88,11 +88,7 @@ class GenericSkeleton : public SkeletonBase
 
     /// \brief Offers the service instance.
     /// \return A blank result, or an error if offering fails.
-<<<<<<< HEAD
     [[nodiscard]] Result<void> OfferService();
-=======
-    [[nodiscard]] Result<void> OfferService() noexcept;
->>>>>>> 217eb836 (Docs: refactor doxygen tag prefix)
 
     /// \brief Stops offering the service instance.
     void StopOfferService();

--- a/score/mw/com/impl/generic_skeleton_event.cpp
+++ b/score/mw/com/impl/generic_skeleton_event.cpp
@@ -43,6 +43,29 @@ GenericSkeletonEvent::GenericSkeletonEvent(SkeletonBase& skeleton_base,
     }
 }
 
+GenericSkeletonEvent::GenericSkeletonEvent(SkeletonBase& skeleton_base,
+                                           const std::string_view event_name,
+                                           std::unique_ptr<GenericSkeletonEventBinding> binding,
+                                           FieldOnlyConstructorEnabler /*tag*/)
+    : SkeletonEventBase(skeleton_base, event_name, std::move(binding))
+{
+    // Intentionally omitting SkeletonBaseView{skeleton_base}.RegisterEvent(event_name, *this);
+
+    if (binding_ != nullptr)
+    {
+        const SkeletonBaseView skeleton_base_view{skeleton_base};
+        const auto& instance_identifier = skeleton_base_view.GetAssociatedInstanceIdentifier();
+        auto* const binding_ptr = static_cast<GenericSkeletonEventBinding*>(binding_.get());
+        if (binding_ptr)
+        {
+            const auto binding_type = binding_ptr->GetBindingType();
+            auto tracing_data =
+                tracing::GenerateSkeletonTracingStructFromEventConfig(instance_identifier, binding_type, event_name);
+            binding_ptr->SetSkeletonEventTracingData(tracing_data);
+        }
+    }
+}
+
 Result<void> GenericSkeletonEvent::Send(SampleAllocateePtr<void> sample) noexcept
 {
     if (!service_offered_flag_.IsSet())

--- a/score/mw/com/impl/generic_skeleton_event.cpp
+++ b/score/mw/com/impl/generic_skeleton_event.cpp
@@ -32,7 +32,9 @@ GenericSkeletonEvent::GenericSkeletonEvent(SkeletonBase& skeleton_base,
     {
         const SkeletonBaseView skeleton_base_view{skeleton_base};
         const auto& instance_identifier = skeleton_base_view.GetAssociatedInstanceIdentifier();
-        auto* const binding_ptr = static_cast<GenericSkeletonEventBinding*>(binding_.get());
+        auto* const binding_ptr = dynamic_cast<GenericSkeletonEventBinding*>(binding_.get());
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(binding_ptr != nullptr,
+                                                    "Cast to GenericSkeletonEventBinding failed");
         if (binding_ptr)
         {
             const auto binding_type = binding_ptr->GetBindingType();
@@ -55,7 +57,9 @@ GenericSkeletonEvent::GenericSkeletonEvent(SkeletonBase& skeleton_base,
     {
         const SkeletonBaseView skeleton_base_view{skeleton_base};
         const auto& instance_identifier = skeleton_base_view.GetAssociatedInstanceIdentifier();
-        auto* const binding_ptr = static_cast<GenericSkeletonEventBinding*>(binding_.get());
+        auto* const binding_ptr = dynamic_cast<GenericSkeletonEventBinding*>(binding_.get());
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(binding_ptr != nullptr,
+                                                    "Cast to GenericSkeletonEventBinding failed");
         if (binding_ptr)
         {
             const auto binding_type = binding_ptr->GetBindingType();
@@ -76,7 +80,8 @@ Result<void> GenericSkeletonEvent::Send(SampleAllocateePtr<void> sample) noexcep
     }
 
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(binding_ != nullptr, "Binding is not initialized!");
-    auto* const binding = static_cast<GenericSkeletonEventBinding*>(binding_.get());
+    auto* const binding = dynamic_cast<GenericSkeletonEventBinding*>(binding_.get());
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(binding != nullptr, "Cast to GenericSkeletonEventBinding failed");
 
     const auto send_result = binding->Send(std::move(sample));
 
@@ -97,7 +102,8 @@ Result<SampleAllocateePtr<void>> GenericSkeletonEvent::Allocate() noexcept
             << "GenericSkeletonEvent::Allocate failed as Event has not yet been offered or has been stop offered";
         return MakeUnexpected(ComErrc::kNotOffered);
     }
-    auto* const binding = static_cast<GenericSkeletonEventBinding*>(binding_.get());
+    auto* const binding = dynamic_cast<GenericSkeletonEventBinding*>(binding_.get());
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(binding != nullptr, "Cast to GenericSkeletonEventBinding failed");
 
     auto result = binding->Allocate(sample_allocatee_tracker_->Allocate());
 
@@ -119,16 +125,18 @@ Result<void> GenericSkeletonEvent::Notify() noexcept
             << "GenericSkeletonEvent::Notify failed as Event has not yet been offered or has been stop offered";
         return MakeUnexpected(ComErrc::kNotOffered);
     }
-    auto* const binding = static_cast<GenericSkeletonEventBinding*>(binding_.get());
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(binding != nullptr, "Binding is not initialized!");
+    auto* const binding = dynamic_cast<GenericSkeletonEventBinding*>(binding_.get());
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(binding != nullptr, "Cast to GenericSkeletonEventBinding failed");
     return binding->Notify();
 }
 
 DataTypeMetaInfo GenericSkeletonEvent::GetSizeInfo() const noexcept
 {
-    const auto* const binding = static_cast<const GenericSkeletonEventBinding*>(binding_.get());
+    const auto* const binding = dynamic_cast<const GenericSkeletonEventBinding*>(binding_.get());
     if (!binding)
+    {
         return {};
+    }
     const auto size_info_pair = binding->GetSizeInfo();
     return {size_info_pair.first, size_info_pair.second};
 }

--- a/score/mw/com/impl/generic_skeleton_event.cpp
+++ b/score/mw/com/impl/generic_skeleton_event.cpp
@@ -35,7 +35,7 @@ GenericSkeletonEvent::GenericSkeletonEvent(SkeletonBase& skeleton_base,
         auto* const binding_ptr = dynamic_cast<GenericSkeletonEventBinding*>(binding_.get());
         SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(binding_ptr != nullptr,
                                                     "Cast to GenericSkeletonEventBinding failed");
-        if (binding_ptr)
+        if (binding_ptr != nullptr)
         {
             const auto binding_type = binding_ptr->GetBindingType();
             auto tracing_data =
@@ -60,7 +60,7 @@ GenericSkeletonEvent::GenericSkeletonEvent(SkeletonBase& skeleton_base,
         auto* const binding_ptr = dynamic_cast<GenericSkeletonEventBinding*>(binding_.get());
         SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(binding_ptr != nullptr,
                                                     "Cast to GenericSkeletonEventBinding failed");
-        if (binding_ptr)
+        if (binding_ptr != nullptr)
         {
             const auto binding_type = binding_ptr->GetBindingType();
             auto tracing_data =
@@ -133,7 +133,7 @@ Result<void> GenericSkeletonEvent::Notify() noexcept
 DataTypeMetaInfo GenericSkeletonEvent::GetSizeInfo() const noexcept
 {
     const auto* const binding = dynamic_cast<const GenericSkeletonEventBinding*>(binding_.get());
-    if (!binding)
+    if (binding == nullptr)
     {
         return {};
     }

--- a/score/mw/com/impl/generic_skeleton_event.cpp
+++ b/score/mw/com/impl/generic_skeleton_event.cpp
@@ -47,7 +47,7 @@ GenericSkeletonEvent::GenericSkeletonEvent(SkeletonBase& skeleton_base,
                                            const std::string_view event_name,
                                            std::unique_ptr<GenericSkeletonEventBinding> binding,
                                            FieldOnlyConstructorEnabler /*tag*/)
-    : SkeletonEventBase(skeleton_base, event_name, std::move(binding))
+    : SkeletonEventBase(event_name, std::move(binding))
 {
     // Intentionally omitting SkeletonBaseView{skeleton_base}.RegisterEvent(event_name, *this);
 

--- a/score/mw/com/impl/generic_skeleton_event.h
+++ b/score/mw/com/impl/generic_skeleton_event.h
@@ -31,9 +31,19 @@ class SkeletonBase;
 class GenericSkeletonEvent : public SkeletonEventBase
 {
   public:
+    struct FieldOnlyConstructorEnabler
+    {
+        explicit FieldOnlyConstructorEnabler() = default;
+    };
+
     GenericSkeletonEvent(SkeletonBase& skeleton_base,
                          const std::string_view event_name,
                          std::unique_ptr<GenericSkeletonEventBinding> binding);
+
+    GenericSkeletonEvent(SkeletonBase& skeleton_base,
+                         const std::string_view event_name,
+                         std::unique_ptr<GenericSkeletonEventBinding> binding,
+                         FieldOnlyConstructorEnabler tag);
 
     Result<void> Send(SampleAllocateePtr<void> sample) noexcept;
 

--- a/score/mw/com/impl/generic_skeleton_field.cpp
+++ b/score/mw/com/impl/generic_skeleton_field.cpp
@@ -68,6 +68,15 @@ GenericSkeletonField& GenericSkeletonField::operator=(GenericSkeletonField&& oth
     return *this;
 }
 
+void GenericSkeletonField::UpdateSkeletonReference(SkeletonBase& skeleton_base) noexcept
+{
+    skeleton_base_ = skeleton_base;
+    if (skeleton_event_dispatch_ != nullptr)
+    {
+        skeleton_event_dispatch_->UpdateSkeletonReference(skeleton_base);
+    }
+}
+
 Result<void> GenericSkeletonField::Update(SampleAllocateePtr<void> sample) noexcept
 {
     // If the field is not configured with a notifier, pushing updates is a no-op.
@@ -107,7 +116,7 @@ Result<void> GenericSkeletonField::Update(score::cpp::span<const uint8_t> raw_va
                                                 "Raw value payload exceeds configured generic field size.");
 
     // Copy the raw bytes into the shared memory slot and immediately push to subscribers
-    std::memcpy(sample.Get(), raw_value.data(), raw_value.size()); 
+    std::memcpy(sample.Get(), raw_value.data(), raw_value.size());
     return Update(std::move(sample));
 }
 
@@ -164,7 +173,7 @@ Result<void> GenericSkeletonField::DoDeferredUpdate() noexcept
         return Result<void>{};
     }
 
-    auto alloc_res = Allocate();
+    auto alloc_res = GetGenericEvent()->Allocate();
     if (!alloc_res.has_value())
     {
         return score::Unexpected{alloc_res.error()};
@@ -173,7 +182,7 @@ Result<void> GenericSkeletonField::DoDeferredUpdate() noexcept
     auto sample = std::move(alloc_res.value());
     // Transfer the cached initial bytes into the shared memory slot
     std::memcpy(sample.Get(), initial_field_value_.data(), initial_field_value_.size());
-    
+
     auto res = Update(std::move(sample));
 
     if (res.has_value())
@@ -182,17 +191,17 @@ Result<void> GenericSkeletonField::DoDeferredUpdate() noexcept
         // Clean up cached buffer to free process memory since initial state is now distributed
         initial_field_value_.clear();
     }
-    
+
     return res;
 }
 
-bool GenericSkeletonField::IsSetHandlerRegistered() const noexcept
+bool GenericSkeletonField::IsSetHandlerMissing() const noexcept
 {
     if (has_setter_)
     {
-        return is_set_handler_registered_;
+        return !is_set_handler_registered_;
     }
-    return true; // If no setter is required by config, it's virtually "registered" (OfferService passes)
+    return false;  // If no setter is required by config, it's not "missing" (OfferService passes)
 }
 
 GenericSkeletonEvent* GenericSkeletonField::GetGenericEvent() const noexcept

--- a/score/mw/com/impl/generic_skeleton_field.cpp
+++ b/score/mw/com/impl/generic_skeleton_field.cpp
@@ -1,0 +1,190 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/impl/generic_skeleton_field.h"
+#include "score/mw/com/impl/com_error.h"
+#include "score/mw/com/impl/skeleton_base.h"
+#include "score/mw/log/logging.h"
+#include <cstring>
+#include <utility>
+
+namespace score::mw::com::impl
+{
+
+GenericSkeletonField::GenericSkeletonField(SkeletonBase& skeleton_base,
+                                           const std::string_view field_name,
+                                           std::unique_ptr<GenericSkeletonEvent> generic_event,
+                                           bool has_getter,
+                                           bool has_setter,
+                                           bool has_notifier)
+    : SkeletonFieldBase{skeleton_base, field_name, std::move(generic_event)},
+      has_getter_{has_getter},
+      has_setter_{has_setter},
+      has_notifier_{has_notifier}
+{
+    SkeletonBaseView skeleton_base_view{skeleton_base};
+    skeleton_base_view.RegisterField(field_name, *this);
+}
+
+GenericSkeletonField::GenericSkeletonField(GenericSkeletonField&& other) noexcept
+    : SkeletonFieldBase(static_cast<SkeletonFieldBase&&>(other)),
+      initial_field_value_{std::move(other.initial_field_value_)},
+      has_initial_value_{std::exchange(other.has_initial_value_, false)},
+      has_getter_{other.has_getter_},
+      has_setter_{other.has_setter_},
+      has_notifier_{other.has_notifier_}
+{
+    SkeletonBaseView skeleton_base_view{skeleton_base_.get()};
+    skeleton_base_view.UpdateField(field_name_, *this);
+}
+
+GenericSkeletonField& GenericSkeletonField::operator=(GenericSkeletonField&& other) & noexcept
+{
+    if (this != &other)
+    {
+        SkeletonFieldBase::operator=(std::move(other));
+        initial_field_value_ = std::move(other.initial_field_value_);
+        has_initial_value_ = std::exchange(other.has_initial_value_, false);
+        has_getter_ = other.has_getter_;
+        has_setter_ = other.has_setter_;
+        has_notifier_ = other.has_notifier_;
+
+        SkeletonBaseView skeleton_base_view{skeleton_base_.get()};
+        skeleton_base_view.UpdateField(field_name_, *this);
+    }
+    return *this;
+}
+
+Result<void> GenericSkeletonField::Update(SampleAllocateePtr<void> sample) noexcept
+{
+    if (!has_notifier_)
+    {
+        return Result<void>{};
+    }
+    return GetGenericEvent()->Send(std::move(sample));
+}
+
+Result<void> GenericSkeletonField::Update(score::cpp::span<const uint8_t> raw_value) noexcept
+{
+    // Cache the initial value
+    if (raw_value.data() != initial_field_value_.data())
+    {
+        initial_field_value_.assign(raw_value.begin(), raw_value.end());
+        has_initial_value_ = true;
+    }
+
+    if (!was_prepare_offer_called_ || !has_notifier_)
+    {
+        return Result<void>{};
+    }
+
+    auto alloc_res = Allocate();
+    if (!alloc_res.has_value())
+    {
+        return MakeUnexpected(alloc_res.error());
+    }
+
+    auto sample = std::move(alloc_res.value());
+    const auto size_info = GetGenericEvent()->GetSizeInfo();
+
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(raw_value.size() <= size_info.size,
+                                                "Raw value payload exceeds configured generic field size.");
+
+    std::memcpy(sample.Get(), raw_value.data(), raw_value.size()); // Fixed sample.get() -> sample.Get()
+    return Update(std::move(sample));
+}
+
+Result<SampleAllocateePtr<void>> GenericSkeletonField::Allocate() noexcept
+{
+    if (!has_notifier_)
+    {
+        score::mw::log::LogWarn("GenericSkeletonField") << "Cannot allocate memory for a field without a notifier.";
+        return MakeUnexpected(ComErrc::kBindingFailure);
+    }
+
+    if (!was_prepare_offer_called_)
+    {
+        score::mw::log::LogWarn("GenericSkeletonField")
+            << "Cannot allocate memory for Generic Field before OfferService() is called.";
+        return MakeUnexpected(ComErrc::kBindingFailure);
+    }
+    return GetGenericEvent()->Allocate();
+}
+
+Result<void> GenericSkeletonField::RegisterGetHandler(std::function<std::vector<uint8_t>()> /*get_handler*/)
+{
+    if (!has_getter_)
+    {
+        return MakeUnexpected(ComErrc::kCouldNotExecute);
+    }
+    score::mw::log::LogWarn("GenericSkeletonField") << "Getters are currently WIP and cannot be registered.";
+    return MakeUnexpected(ComErrc::kCouldNotExecute);
+}
+
+Result<void> GenericSkeletonField::RegisterSetHandler(
+    std::function<std::vector<uint8_t>(score::cpp::span<const uint8_t>)> /*set_handler*/)
+{
+    if (!has_setter_)
+    {
+        return MakeUnexpected(ComErrc::kCouldNotExecute);
+    }
+    score::mw::log::LogWarn("GenericSkeletonField") << "Setters are currently WIP and cannot be registered.";
+    return MakeUnexpected(ComErrc::kCouldNotExecute);
+}
+
+bool GenericSkeletonField::IsInitialValueSaved() const noexcept
+{
+    return has_initial_value_;
+}
+
+Result<void> GenericSkeletonField::DoDeferredUpdate() noexcept
+{
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(has_initial_value_, "Deferred update requires initial value.");
+
+    if (!has_notifier_)
+    {
+        return Result<void>{};
+    }
+
+    // Directly process internal memory into event to avoid span self-assignment cycle via Update(span)
+    auto alloc_res = Allocate();
+    if (!alloc_res.has_value())
+    {
+        return MakeUnexpected(alloc_res.error());
+    }
+
+    auto sample = std::move(alloc_res.value());
+    std::memcpy(sample.Get(), initial_field_value_.data(), initial_field_value_.size());
+    
+    auto res = Update(std::move(sample));
+
+    if (res.has_value())
+    {
+        has_initial_value_ = false;
+        initial_field_value_.clear();
+    }
+    
+    return res;
+}
+
+bool GenericSkeletonField::IsSetHandlerRegistered() const noexcept
+{
+    return true;
+}
+
+GenericSkeletonEvent* GenericSkeletonField::GetGenericEvent() const noexcept
+{
+    auto* const typed_event = dynamic_cast<GenericSkeletonEvent*>(skeleton_event_dispatch_.get());
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(typed_event != nullptr, "Downcast to GenericSkeletonEvent failed!");
+    return typed_event;
+}
+
+}  // namespace score::mw::com::impl

--- a/score/mw/com/impl/generic_skeleton_field.cpp
+++ b/score/mw/com/impl/generic_skeleton_field.cpp
@@ -89,7 +89,7 @@ Result<void> GenericSkeletonField::Update(score::cpp::span<const uint8_t> raw_va
     auto alloc_res = Allocate();
     if (!alloc_res.has_value())
     {
-        return MakeUnexpected(alloc_res.error());
+        return score::Unexpected{alloc_res.error()};
     }
 
     auto sample = std::move(alloc_res.value());
@@ -98,7 +98,7 @@ Result<void> GenericSkeletonField::Update(score::cpp::span<const uint8_t> raw_va
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(raw_value.size() <= size_info.size,
                                                 "Raw value payload exceeds configured generic field size.");
 
-    std::memcpy(sample.Get(), raw_value.data(), raw_value.size()); // Fixed sample.get() -> sample.Get()
+    std::memcpy(sample.Get(), raw_value.data(), raw_value.size()); 
     return Update(std::move(sample));
 }
 
@@ -154,11 +154,10 @@ Result<void> GenericSkeletonField::DoDeferredUpdate() noexcept
         return Result<void>{};
     }
 
-    // Directly process internal memory into event to avoid span self-assignment cycle via Update(span)
     auto alloc_res = Allocate();
     if (!alloc_res.has_value())
     {
-        return MakeUnexpected(alloc_res.error());
+        return score::Unexpected{alloc_res.error()};
     }
 
     auto sample = std::move(alloc_res.value());

--- a/score/mw/com/impl/generic_skeleton_field.cpp
+++ b/score/mw/com/impl/generic_skeleton_field.cpp
@@ -30,6 +30,7 @@ GenericSkeletonField::GenericSkeletonField(SkeletonBase& skeleton_base,
       has_setter_{has_setter},
       has_notifier_{has_notifier}
 {
+    // Register this field instance with the parent skeleton's element map
     SkeletonBaseView skeleton_base_view{skeleton_base};
     skeleton_base_view.RegisterField(field_name, *this);
 }
@@ -40,8 +41,10 @@ GenericSkeletonField::GenericSkeletonField(GenericSkeletonField&& other) noexcep
       has_initial_value_{std::exchange(other.has_initial_value_, false)},
       has_getter_{other.has_getter_},
       has_setter_{other.has_setter_},
-      has_notifier_{other.has_notifier_}
+      has_notifier_{other.has_notifier_},
+      is_set_handler_registered_{std::exchange(other.is_set_handler_registered_, false)}
 {
+    // Update the parent skeleton's reference to point to this newly moved instance
     SkeletonBaseView skeleton_base_view{skeleton_base_.get()};
     skeleton_base_view.UpdateField(field_name_, *this);
 }
@@ -56,7 +59,9 @@ GenericSkeletonField& GenericSkeletonField::operator=(GenericSkeletonField&& oth
         has_getter_ = other.has_getter_;
         has_setter_ = other.has_setter_;
         has_notifier_ = other.has_notifier_;
+        is_set_handler_registered_ = std::exchange(other.is_set_handler_registered_, false);
 
+        // Update the parent skeleton's reference to point to this newly moved instance
         SkeletonBaseView skeleton_base_view{skeleton_base_.get()};
         skeleton_base_view.UpdateField(field_name_, *this);
     }
@@ -65,6 +70,7 @@ GenericSkeletonField& GenericSkeletonField::operator=(GenericSkeletonField&& oth
 
 Result<void> GenericSkeletonField::Update(SampleAllocateePtr<void> sample) noexcept
 {
+    // If the field is not configured with a notifier, pushing updates is a no-op.
     if (!has_notifier_)
     {
         return Result<void>{};
@@ -74,13 +80,14 @@ Result<void> GenericSkeletonField::Update(SampleAllocateePtr<void> sample) noexc
 
 Result<void> GenericSkeletonField::Update(score::cpp::span<const uint8_t> raw_value) noexcept
 {
-    // Cache the initial value
+    // Cache the initial value if we are updating from a new raw_value payload
     if (raw_value.data() != initial_field_value_.data())
     {
         initial_field_value_.assign(raw_value.begin(), raw_value.end());
         has_initial_value_ = true;
     }
 
+    // If we haven't offered the service yet, just cache it for DoDeferredUpdate()
     if (!was_prepare_offer_called_ || !has_notifier_)
     {
         return Result<void>{};
@@ -95,9 +102,11 @@ Result<void> GenericSkeletonField::Update(score::cpp::span<const uint8_t> raw_va
     auto sample = std::move(alloc_res.value());
     const auto size_info = GetGenericEvent()->GetSizeInfo();
 
+    // Ensure the payload fits in the allocated sample memory
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(raw_value.size() <= size_info.size,
                                                 "Raw value payload exceeds configured generic field size.");
 
+    // Copy the raw bytes into the shared memory slot and immediately push to subscribers
     std::memcpy(sample.Get(), raw_value.data(), raw_value.size()); 
     return Update(std::move(sample));
 }
@@ -112,6 +121,7 @@ Result<SampleAllocateePtr<void>> GenericSkeletonField::Allocate() noexcept
 
     if (!was_prepare_offer_called_)
     {
+        // Shared memory backing the sample allocator isn't active until OfferService is called.
         score::mw::log::LogWarn("GenericSkeletonField")
             << "Cannot allocate memory for Generic Field before OfferService() is called.";
         return MakeUnexpected(ComErrc::kBindingFailure);
@@ -161,6 +171,7 @@ Result<void> GenericSkeletonField::DoDeferredUpdate() noexcept
     }
 
     auto sample = std::move(alloc_res.value());
+    // Transfer the cached initial bytes into the shared memory slot
     std::memcpy(sample.Get(), initial_field_value_.data(), initial_field_value_.size());
     
     auto res = Update(std::move(sample));
@@ -168,6 +179,7 @@ Result<void> GenericSkeletonField::DoDeferredUpdate() noexcept
     if (res.has_value())
     {
         has_initial_value_ = false;
+        // Clean up cached buffer to free process memory since initial state is now distributed
         initial_field_value_.clear();
     }
     
@@ -176,7 +188,11 @@ Result<void> GenericSkeletonField::DoDeferredUpdate() noexcept
 
 bool GenericSkeletonField::IsSetHandlerRegistered() const noexcept
 {
-    return true;
+    if (has_setter_)
+    {
+        return is_set_handler_registered_;
+    }
+    return true; // If no setter is required by config, it's virtually "registered" (OfferService passes)
 }
 
 GenericSkeletonEvent* GenericSkeletonField::GetGenericEvent() const noexcept

--- a/score/mw/com/impl/generic_skeleton_field.cpp
+++ b/score/mw/com/impl/generic_skeleton_field.cpp
@@ -37,26 +37,16 @@ GenericSkeletonField::GenericSkeletonField(SkeletonBase& skeleton_base,
 
 Result<void> GenericSkeletonField::Update(SampleAllocateePtr<void> sample) noexcept
 {
-    // If the field is not configured with a notifier, pushing updates is a no-op.
-    if (!has_notifier_)
-    {
-        return Result<void>{};
-    }
     return GetGenericEvent()->Send(std::move(sample));
 }
 
 Result<void> GenericSkeletonField::Update(score::cpp::span<const uint8_t> raw_value) noexcept
 {
-    // Cache the initial value if we are updating from a new raw_value payload
-    if (raw_value.data() != initial_field_value_.data())
+    // If OfferService() has not been called yet, we cache the value as the initial value.
+    if (!was_prepare_offer_called_)
     {
         initial_field_value_.assign(raw_value.begin(), raw_value.end());
         has_initial_value_ = true;
-    }
-
-    // If we haven't offered the service yet, just cache it for DoDeferredUpdate()
-    if (!was_prepare_offer_called_ || !has_notifier_)
-    {
         return Result<void>{};
     }
 
@@ -80,12 +70,6 @@ Result<void> GenericSkeletonField::Update(score::cpp::span<const uint8_t> raw_va
 
 Result<SampleAllocateePtr<void>> GenericSkeletonField::Allocate() noexcept
 {
-    if (!has_notifier_)
-    {
-        score::mw::log::LogWarn("GenericSkeletonField") << "Cannot allocate memory for a field without a notifier.";
-        return MakeUnexpected(ComErrc::kBindingFailure);
-    }
-
     if (!was_prepare_offer_called_)
     {
         // Shared memory backing the sample allocator isn't active until OfferService is called.
@@ -94,16 +78,6 @@ Result<SampleAllocateePtr<void>> GenericSkeletonField::Allocate() noexcept
         return MakeUnexpected(ComErrc::kBindingFailure);
     }
     return GetGenericEvent()->Allocate();
-}
-
-Result<void> GenericSkeletonField::RegisterGetHandler(std::function<std::vector<uint8_t>()> /*get_handler*/)
-{
-    if (!has_getter_)
-    {
-        return MakeUnexpected(ComErrc::kCouldNotExecute);
-    }
-    score::mw::log::LogWarn("GenericSkeletonField") << "Getters are currently WIP and cannot be registered.";
-    return MakeUnexpected(ComErrc::kCouldNotExecute);
 }
 
 Result<void> GenericSkeletonField::RegisterSetHandler(
@@ -125,11 +99,6 @@ bool GenericSkeletonField::IsInitialValueSaved() const noexcept
 Result<void> GenericSkeletonField::DoDeferredUpdate() noexcept
 {
     SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(has_initial_value_, "Deferred update requires initial value.");
-
-    if (!has_notifier_)
-    {
-        return Result<void>{};
-    }
 
     auto alloc_res = GetGenericEvent()->Allocate();
     if (!alloc_res.has_value())

--- a/score/mw/com/impl/generic_skeleton_field.cpp
+++ b/score/mw/com/impl/generic_skeleton_field.cpp
@@ -80,7 +80,9 @@ Result<SampleAllocateePtr<void>> GenericSkeletonField::Allocate() noexcept
     return GetGenericEvent()->Allocate();
 }
 
-Result<void> GenericSkeletonField::RegisterSetHandler(std::function<void(score::cpp::span<uint8_t>)> /*set_handler*/)
+// NOLINTNEXTLINE(readability-make-member-function-const)
+Result<void> GenericSkeletonField::RegisterSetHandler(
+    const std::function<void(score::cpp::span<uint8_t>)>& /*set_handler*/)
 {
     if (!has_setter_)
     {

--- a/score/mw/com/impl/generic_skeleton_field.cpp
+++ b/score/mw/com/impl/generic_skeleton_field.cpp
@@ -132,9 +132,9 @@ bool GenericSkeletonField::IsSetHandlerMissing() const noexcept
 
 GenericSkeletonEvent* GenericSkeletonField::GetGenericEvent() const noexcept
 {
-    auto* const typed_event = dynamic_cast<GenericSkeletonEvent*>(skeleton_event_dispatch_.get());
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(typed_event != nullptr, "Downcast to GenericSkeletonEvent failed!");
-    return typed_event;
+    auto* const generic_event = dynamic_cast<GenericSkeletonEvent*>(skeleton_event_dispatch_.get());
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(generic_event != nullptr, "Downcast to GenericSkeletonEvent failed!");
+    return generic_event;
 }
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/generic_skeleton_field.cpp
+++ b/score/mw/com/impl/generic_skeleton_field.cpp
@@ -130,6 +130,19 @@ bool GenericSkeletonField::IsSetHandlerMissing() const noexcept
     return false;  // If no setter is required by config, it's not "missing" (OfferService passes)
 }
 
+Result<void> GenericSkeletonField::RegisterGetHandler()
+{
+    // If this field is not configured with a Getter, we don't need to do any wiring.
+    if (!has_getter_)
+    {
+        return {};
+    }
+
+    // TODO: Implement generic Getter wiring once GenericSkeletonMethod is available.
+    // For now, return an error because generic getters are WIP.
+    return MakeUnexpected(ComErrc::kCouldNotExecute);
+}
+
 GenericSkeletonEvent* GenericSkeletonField::GetGenericEvent() const noexcept
 {
     auto* const generic_event = dynamic_cast<GenericSkeletonEvent*>(skeleton_event_dispatch_.get());

--- a/score/mw/com/impl/generic_skeleton_field.cpp
+++ b/score/mw/com/impl/generic_skeleton_field.cpp
@@ -80,8 +80,7 @@ Result<SampleAllocateePtr<void>> GenericSkeletonField::Allocate() noexcept
     return GetGenericEvent()->Allocate();
 }
 
-Result<void> GenericSkeletonField::RegisterSetHandler(
-    std::function<void(score::cpp::span<uint8_t>)> /*set_handler*/)
+Result<void> GenericSkeletonField::RegisterSetHandler(std::function<void(score::cpp::span<uint8_t>)> /*set_handler*/)
 {
     if (!has_setter_)
     {

--- a/score/mw/com/impl/generic_skeleton_field.cpp
+++ b/score/mw/com/impl/generic_skeleton_field.cpp
@@ -25,56 +25,14 @@ GenericSkeletonField::GenericSkeletonField(SkeletonBase& skeleton_base,
                                            bool has_getter,
                                            bool has_setter,
                                            bool has_notifier)
-    : SkeletonFieldBase{skeleton_base, field_name, std::move(generic_event)},
+    : SkeletonFieldBase{field_name, std::move(generic_event)},
       has_getter_{has_getter},
       has_setter_{has_setter},
       has_notifier_{has_notifier}
 {
     // Register this field instance with the parent skeleton's element map
     SkeletonBaseView skeleton_base_view{skeleton_base};
-    skeleton_base_view.RegisterField(field_name, *this);
-}
-
-GenericSkeletonField::GenericSkeletonField(GenericSkeletonField&& other) noexcept
-    : SkeletonFieldBase(static_cast<SkeletonFieldBase&&>(other)),
-      initial_field_value_{std::move(other.initial_field_value_)},
-      has_initial_value_{std::exchange(other.has_initial_value_, false)},
-      has_getter_{other.has_getter_},
-      has_setter_{other.has_setter_},
-      has_notifier_{other.has_notifier_},
-      is_set_handler_registered_{std::exchange(other.is_set_handler_registered_, false)}
-{
-    // Update the parent skeleton's reference to point to this newly moved instance
-    SkeletonBaseView skeleton_base_view{skeleton_base_.get()};
-    skeleton_base_view.UpdateField(field_name_, *this);
-}
-
-GenericSkeletonField& GenericSkeletonField::operator=(GenericSkeletonField&& other) & noexcept
-{
-    if (this != &other)
-    {
-        SkeletonFieldBase::operator=(std::move(other));
-        initial_field_value_ = std::move(other.initial_field_value_);
-        has_initial_value_ = std::exchange(other.has_initial_value_, false);
-        has_getter_ = other.has_getter_;
-        has_setter_ = other.has_setter_;
-        has_notifier_ = other.has_notifier_;
-        is_set_handler_registered_ = std::exchange(other.is_set_handler_registered_, false);
-
-        // Update the parent skeleton's reference to point to this newly moved instance
-        SkeletonBaseView skeleton_base_view{skeleton_base_.get()};
-        skeleton_base_view.UpdateField(field_name_, *this);
-    }
-    return *this;
-}
-
-void GenericSkeletonField::UpdateSkeletonReference(SkeletonBase& skeleton_base) noexcept
-{
-    skeleton_base_ = skeleton_base;
-    if (skeleton_event_dispatch_ != nullptr)
-    {
-        skeleton_event_dispatch_->UpdateSkeletonReference(skeleton_base);
-    }
+    skeleton_base_view.RegisterField(field_name, GetReferenceToMoveable());
 }
 
 Result<void> GenericSkeletonField::Update(SampleAllocateePtr<void> sample) noexcept

--- a/score/mw/com/impl/generic_skeleton_field.cpp
+++ b/score/mw/com/impl/generic_skeleton_field.cpp
@@ -81,7 +81,7 @@ Result<SampleAllocateePtr<void>> GenericSkeletonField::Allocate() noexcept
 }
 
 Result<void> GenericSkeletonField::RegisterSetHandler(
-    std::function<std::vector<uint8_t>(score::cpp::span<const uint8_t>)> /*set_handler*/)
+    std::function<void(score::cpp::span<uint8_t>)> /*set_handler*/)
 {
     if (!has_setter_)
     {

--- a/score/mw/com/impl/generic_skeleton_field.h
+++ b/score/mw/com/impl/generic_skeleton_field.h
@@ -29,8 +29,8 @@ namespace score::mw::com::impl
 
 /// @brief Represents a generic, type-erased skeleton field.
 ///
-/// This class provides runtime-configurable field support for `GenericSkeleton`. 
-/// It manages notifications via an underlying `GenericSkeletonEvent` and serves 
+/// This class provides runtime-configurable field support for `GenericSkeleton`.
+/// It manages notifications via an underlying `GenericSkeletonEvent` and serves
 /// as a facade for field Get and Set operations based on the provided configuration.
 class GenericSkeletonField : public SkeletonFieldBase
 {
@@ -56,8 +56,11 @@ class GenericSkeletonField : public SkeletonFieldBase
     GenericSkeletonField(GenericSkeletonField&& other) noexcept;
     GenericSkeletonField& operator=(GenericSkeletonField&& other) & noexcept;
 
+    /// @brief Updates the reference to the parent skeleton when the skeleton is moved.
+    void UpdateSkeletonReference(SkeletonBase& skeleton_base) noexcept override;
+
     /// @brief Updates the field value using a raw byte payload and notifies subscribers.
-    /// @details If `OfferService()` has not been called yet, the payload is cached as 
+    /// @details If `OfferService()` has not been called yet, the payload is cached as
     ///          the initial value and deferred until the service is offered.
     /// @param raw_value The type-erased payload representing the new field value.
     /// @return A result indicating success or an error code on failure.
@@ -69,7 +72,7 @@ class GenericSkeletonField : public SkeletonFieldBase
     Result<void> Update(SampleAllocateePtr<void> sample) noexcept;
 
     /// @brief Allocates a zero-copy sample buffer for this field.
-    /// @return The allocated sample pointer, or an error if allocation fails or 
+    /// @return The allocated sample pointer, or an error if allocation fails or
     ///         if the field does not support notifications.
     Result<SampleAllocateePtr<void>> Allocate() noexcept;
 
@@ -79,7 +82,7 @@ class GenericSkeletonField : public SkeletonFieldBase
     Result<void> RegisterGetHandler(std::function<std::vector<uint8_t>()> get_handler);
 
     /// @brief Registers a handler for answering Set requests from proxies.
-    /// @param set_handler The user-provided handler callback accepting raw bytes and returning 
+    /// @param set_handler The user-provided handler callback accepting raw bytes and returning
     ///        the accepted/modified field value as raw bytes.
     /// @return A result indicating success or an error code.
     Result<void> RegisterSetHandler(std::function<std::vector<uint8_t>(score::cpp::span<const uint8_t>)> set_handler);
@@ -89,7 +92,7 @@ class GenericSkeletonField : public SkeletonFieldBase
     bool IsInitialValueSaved() const noexcept override;
     /// @brief Allocates and sends the cached initial value after the service is successfully offered.
     Result<void> DoDeferredUpdate() noexcept override;
-    bool IsSetHandlerRegistered() const noexcept override;
+    [[nodiscard]] bool IsSetHandlerMissing() const noexcept override;
 
     GenericSkeletonEvent* GetGenericEvent() const noexcept;
 

--- a/score/mw/com/impl/generic_skeleton_field.h
+++ b/score/mw/com/impl/generic_skeleton_field.h
@@ -1,0 +1,71 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_IMPL_GENERIC_SKELETON_FIELD_H_
+#define SCORE_MW_COM_IMPL_GENERIC_SKELETON_FIELD_H_
+
+#include "score/mw/com/impl/generic_skeleton_event.h"
+#include "score/mw/com/impl/plumbing/sample_allocatee_ptr.h"
+#include "score/mw/com/impl/skeleton_field_base.h"
+#include "score/result/result.h"
+#include <score/span.hpp>
+
+#include <cstdint>
+#include <functional>
+#include <memory>
+#include <string_view>
+#include <vector>
+
+namespace score::mw::com::impl
+{
+
+class GenericSkeletonField : public SkeletonFieldBase
+{
+  public:
+    GenericSkeletonField(SkeletonBase& skeleton_base,
+                         const std::string_view field_name,
+                         std::unique_ptr<GenericSkeletonEvent> generic_event,
+                         bool has_getter,
+                         bool has_setter,
+                         bool has_notifier);
+
+    ~GenericSkeletonField() override = default;
+    GenericSkeletonField(const GenericSkeletonField&) = delete;
+    GenericSkeletonField& operator=(const GenericSkeletonField&) & = delete;
+
+    GenericSkeletonField(GenericSkeletonField&& other) noexcept;
+    GenericSkeletonField& operator=(GenericSkeletonField&& other) & noexcept;
+
+    Result<void> Update(score::cpp::span<const uint8_t> raw_value) noexcept;
+    Result<void> Update(SampleAllocateePtr<void> sample) noexcept;
+    Result<SampleAllocateePtr<void>> Allocate() noexcept;
+
+    Result<void> RegisterGetHandler(std::function<std::vector<uint8_t>()> get_handler);
+    Result<void> RegisterSetHandler(std::function<std::vector<uint8_t>(score::cpp::span<const uint8_t>)> set_handler);
+
+  private:
+    bool IsInitialValueSaved() const noexcept override;
+    Result<void> DoDeferredUpdate() noexcept override;
+    bool IsSetHandlerRegistered() const noexcept override;
+
+    GenericSkeletonEvent* GetGenericEvent() const noexcept;
+
+    std::vector<uint8_t> initial_field_value_;
+    bool has_initial_value_{false};
+
+    bool has_getter_{false};
+    bool has_setter_{false};
+    bool has_notifier_{false};
+};
+
+}  // namespace score::mw::com::impl
+
+#endif  // SCORE_MW_COM_IMPL_GENERIC_SKELETON_FIELD_H_

--- a/score/mw/com/impl/generic_skeleton_field.h
+++ b/score/mw/com/impl/generic_skeleton_field.h
@@ -27,9 +27,21 @@
 namespace score::mw::com::impl
 {
 
+/// @brief Represents a generic, type-erased skeleton field.
+///
+/// This class provides runtime-configurable field support for `GenericSkeleton`. 
+/// It manages notifications via an underlying `GenericSkeletonEvent` and serves 
+/// as a facade for field Get and Set operations based on the provided configuration.
 class GenericSkeletonField : public SkeletonFieldBase
 {
   public:
+    /// @brief Constructs a new GenericSkeletonField.
+    /// @param skeleton_base The parent skeleton instance.
+    /// @param field_name The logical name of the field.
+    /// @param generic_event The underlying type-erased event used for field notifications.
+    /// @param has_getter Indicates whether this field is configured to have a Get handler.
+    /// @param has_setter Indicates whether this field is configured to have a Set handler.
+    /// @param has_notifier Indicates whether this field is configured to support notifications.
     GenericSkeletonField(SkeletonBase& skeleton_base,
                          const std::string_view field_name,
                          std::unique_ptr<GenericSkeletonEvent> generic_event,
@@ -44,15 +56,38 @@ class GenericSkeletonField : public SkeletonFieldBase
     GenericSkeletonField(GenericSkeletonField&& other) noexcept;
     GenericSkeletonField& operator=(GenericSkeletonField&& other) & noexcept;
 
+    /// @brief Updates the field value using a raw byte payload and notifies subscribers.
+    /// @details If `OfferService()` has not been called yet, the payload is cached as 
+    ///          the initial value and deferred until the service is offered.
+    /// @param raw_value The type-erased payload representing the new field value.
+    /// @return A result indicating success or an error code on failure.
     Result<void> Update(score::cpp::span<const uint8_t> raw_value) noexcept;
+
+    /// @brief Updates the field value using a pre-allocated sample and notifies subscribers.
+    /// @param sample A sample previously allocated via `Allocate()`.
+    /// @return A result indicating success or an error code on failure.
     Result<void> Update(SampleAllocateePtr<void> sample) noexcept;
+
+    /// @brief Allocates a zero-copy sample buffer for this field.
+    /// @return The allocated sample pointer, or an error if allocation fails or 
+    ///         if the field does not support notifications.
     Result<SampleAllocateePtr<void>> Allocate() noexcept;
 
+    /// @brief Registers a handler for answering Get requests from proxies.
+    /// @param get_handler The user-provided handler callback returning the field value as raw bytes.
+    /// @return A result indicating success or an error code.
     Result<void> RegisterGetHandler(std::function<std::vector<uint8_t>()> get_handler);
+
+    /// @brief Registers a handler for answering Set requests from proxies.
+    /// @param set_handler The user-provided handler callback accepting raw bytes and returning 
+    ///        the accepted/modified field value as raw bytes.
+    /// @return A result indicating success or an error code.
     Result<void> RegisterSetHandler(std::function<std::vector<uint8_t>(score::cpp::span<const uint8_t>)> set_handler);
 
   private:
+    /// @brief Checks if a valid initial value was cached prior to offering the service.
     bool IsInitialValueSaved() const noexcept override;
+    /// @brief Allocates and sends the cached initial value after the service is successfully offered.
     Result<void> DoDeferredUpdate() noexcept override;
     bool IsSetHandlerRegistered() const noexcept override;
 
@@ -64,6 +99,7 @@ class GenericSkeletonField : public SkeletonFieldBase
     bool has_getter_{false};
     bool has_setter_{false};
     bool has_notifier_{false};
+    bool is_set_handler_registered_{false};
 };
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/generic_skeleton_field.h
+++ b/score/mw/com/impl/generic_skeleton_field.h
@@ -27,7 +27,7 @@
 namespace score::mw::com::impl
 {
 
-/// @brief Represents a generic, type-erased skeleton field.
+/// \brief Represents a generic, type-erased skeleton field.
 ///
 /// This class provides runtime-configurable field support for `GenericSkeleton`.
 /// It manages notifications via an underlying `GenericSkeletonEvent` and serves
@@ -35,13 +35,13 @@ namespace score::mw::com::impl
 class GenericSkeletonField : public SkeletonFieldBase
 {
   public:
-    /// @brief Constructs a new GenericSkeletonField.
-    /// @param skeleton_base The parent skeleton instance.
-    /// @param field_name The logical name of the field.
-    /// @param generic_event The underlying type-erased event used for field notifications.
-    /// @param has_getter Indicates whether this field is configured to have a Get handler.
-    /// @param has_setter Indicates whether this field is configured to have a Set handler.
-    /// @param has_notifier Indicates whether this field is configured to support notifications.
+    /// \brief Constructs a new GenericSkeletonField.
+    /// \param skeleton_base The parent skeleton instance.
+    /// \param field_name The logical name of the field.
+    /// \param generic_event The underlying type-erased event used for field notifications.
+    /// \param has_getter Indicates whether this field is configured to have a Get handler.
+    /// \param has_setter Indicates whether this field is configured to have a Set handler.
+    /// \param has_notifier Indicates whether this field is configured to support notifications.
     GenericSkeletonField(SkeletonBase& skeleton_base,
                          const std::string_view field_name,
                          std::unique_ptr<GenericSkeletonEvent> generic_event,
@@ -56,46 +56,46 @@ class GenericSkeletonField : public SkeletonFieldBase
     GenericSkeletonField(GenericSkeletonField&& other) noexcept = default;
     GenericSkeletonField& operator=(GenericSkeletonField&& other) & noexcept = default;
 
-    /// @brief Updates the field value using a raw byte payload.
-    /// @details If the field is configured with a getter, this updates the binding's
+    /// \brief Updates the field value using a raw byte payload.
+    /// \details If the field is configured with a getter, this updates the binding's
     ///          shared memory so the value is visible to subsequent Get requests.
     ///          If configured with a notifier, it also notifies subscribers.
     ///          If `OfferService()` has not been called yet, the payload is cached as
     ///          the initial value and deferred until the service is offered.
-    /// @param raw_value The type-erased payload representing the new field value.
-    /// @return A result indicating success or an error code on failure.
+    /// \param raw_value The type-erased payload representing the new field value.
+    /// \return A result indicating success or an error code on failure.
     Result<void> Update(score::cpp::span<const uint8_t> raw_value) noexcept;
 
-    /// @brief Updates the field value using a pre-allocated sample.
-    /// @details If the field is configured with a getter, this updates the binding's
+    /// \brief Updates the field value using a pre-allocated sample.
+    /// \details If the field is configured with a getter, this updates the binding's
     ///          shared memory so the value is visible to subsequent Get requests.
     ///          If configured with a notifier, it also notifies subscribers.
-    /// @param sample A sample previously allocated via `Allocate()`.
-    /// @return A result indicating success or an error code on failure.
+    /// \param sample A sample previously allocated via `Allocate()`.
+    /// \return A result indicating success or an error code on failure.
     Result<void> Update(SampleAllocateePtr<void> sample) noexcept;
 
-    /// @brief Allocates a zero-copy sample buffer for this field.
-    /// @return The allocated sample pointer, or an error if allocation fails or
+    /// \brief Allocates a zero-copy sample buffer for this field.
+    /// \return The allocated sample pointer, or an error if allocation fails or
     ///         if OfferService() has not been called yet.
     Result<SampleAllocateePtr<void>> Allocate() noexcept;
 
-    /// @brief Registers a handler for answering Set requests from proxies.
-    /// @param set_handler The user-provided handler callback accepting a mutable span of raw bytes,
+    /// \brief Registers a handler for answering Set requests from proxies.
+    /// \param set_handler The user-provided handler callback accepting a mutable span of raw bytes,
     ///        allowing the provider to read the proposed value and optionally write directly to it
     ///        to correct/clamp the value in-place.
-    /// @return A result indicating success, or ComErrc::kCouldNotExecute if the field was not configured
+    /// \return A result indicating success, or ComErrc::kCouldNotExecute if the field was not configured
     ///         with a setter (i.e. has_setter in the constructor was false).
     Result<void> RegisterSetHandler(std::function<void(score::cpp::span<uint8_t>)> set_handler);
 
-    /// @brief Internal hook to register the get handler with the binding.
-    /// @details This is called by SkeletonFieldBase::PrepareOffer().
-    /// @return A result indicating success or an error code.
+    /// \brief Internal hook to register the get handler with the binding.
+    /// \details This is called by SkeletonFieldBase::PrepareOffer().
+    /// \return A result indicating success or an error code.
     [[nodiscard]] Result<void> RegisterGetHandler() override;
 
     private:
-    /// @brief Checks if a valid initial value was cached prior to offering the service.
+    /// \brief Checks if a valid initial value was cached prior to offering the service.
     bool IsInitialValueSaved() const noexcept override;
-    /// @brief Allocates and sends the cached initial value after the service is successfully offered.
+    /// \brief Allocates and sends the cached initial value after the service is successfully offered.
     Result<void> DoDeferredUpdate() noexcept override;
     [[nodiscard]] bool IsSetHandlerMissing() const noexcept override;
 

--- a/score/mw/com/impl/generic_skeleton_field.h
+++ b/score/mw/com/impl/generic_skeleton_field.h
@@ -80,10 +80,12 @@ class GenericSkeletonField : public SkeletonFieldBase
     Result<SampleAllocateePtr<void>> Allocate() noexcept;
 
     /// @brief Registers a handler for answering Set requests from proxies.
-    /// @param set_handler The user-provided handler callback accepting raw bytes and returning
-    ///        the accepted/modified field value as raw bytes.
-    /// @return A result indicating success or an error code.
-    Result<void> RegisterSetHandler(std::function<std::vector<uint8_t>(score::cpp::span<const uint8_t>)> set_handler);
+    /// @param set_handler The user-provided handler callback accepting a mutable span of raw bytes,
+    ///        allowing the provider to read the proposed value and optionally write directly to it
+    ///        to correct/clamp the value in-place.
+    /// @return A result indicating success, or ComErrc::kCouldNotExecute if the field was not configured
+    ///         with a setter (i.e. has_setter in the constructor was false).
+    Result<void> RegisterSetHandler(std::function<void(score::cpp::span<uint8_t>)> set_handler);
 
   private:
     /// @brief Checks if a valid initial value was cached prior to offering the service.

--- a/score/mw/com/impl/generic_skeleton_field.h
+++ b/score/mw/com/impl/generic_skeleton_field.h
@@ -53,11 +53,8 @@ class GenericSkeletonField : public SkeletonFieldBase
     GenericSkeletonField(const GenericSkeletonField&) = delete;
     GenericSkeletonField& operator=(const GenericSkeletonField&) & = delete;
 
-    GenericSkeletonField(GenericSkeletonField&& other) noexcept;
-    GenericSkeletonField& operator=(GenericSkeletonField&& other) & noexcept;
-
-    /// @brief Updates the reference to the parent skeleton when the skeleton is moved.
-    void UpdateSkeletonReference(SkeletonBase& skeleton_base) noexcept override;
+    GenericSkeletonField(GenericSkeletonField&& other) noexcept = default;
+    GenericSkeletonField& operator=(GenericSkeletonField&& other) & noexcept = default;
 
     /// @brief Updates the field value using a raw byte payload and notifies subscribers.
     /// @details If `OfferService()` has not been called yet, the payload is cached as

--- a/score/mw/com/impl/generic_skeleton_field.h
+++ b/score/mw/com/impl/generic_skeleton_field.h
@@ -87,7 +87,12 @@ class GenericSkeletonField : public SkeletonFieldBase
     ///         with a setter (i.e. has_setter in the constructor was false).
     Result<void> RegisterSetHandler(std::function<void(score::cpp::span<uint8_t>)> set_handler);
 
-  private:
+    /// @brief Internal hook to register the get handler with the binding.
+    /// @details This is called by SkeletonFieldBase::PrepareOffer().
+    /// @return A result indicating success or an error code.
+    [[nodiscard]] Result<void> RegisterGetHandler() override;
+
+    private:
     /// @brief Checks if a valid initial value was cached prior to offering the service.
     bool IsInitialValueSaved() const noexcept override;
     /// @brief Allocates and sends the cached initial value after the service is successfully offered.

--- a/score/mw/com/impl/generic_skeleton_field.h
+++ b/score/mw/com/impl/generic_skeleton_field.h
@@ -85,7 +85,7 @@ class GenericSkeletonField : public SkeletonFieldBase
     ///        to correct/clamp the value in-place.
     /// \return A result indicating success, or ComErrc::kCouldNotExecute if the field was not configured
     ///         with a setter (i.e. has_setter in the constructor was false).
-    Result<void> RegisterSetHandler(std::function<void(score::cpp::span<uint8_t>)> set_handler);
+    Result<void> RegisterSetHandler(const std::function<void(score::cpp::span<uint8_t>)>& set_handler);
 
     /// \brief Internal hook to register the get handler with the binding.
     /// \details This is called by SkeletonFieldBase::PrepareOffer().

--- a/score/mw/com/impl/generic_skeleton_field.h
+++ b/score/mw/com/impl/generic_skeleton_field.h
@@ -56,27 +56,28 @@ class GenericSkeletonField : public SkeletonFieldBase
     GenericSkeletonField(GenericSkeletonField&& other) noexcept = default;
     GenericSkeletonField& operator=(GenericSkeletonField&& other) & noexcept = default;
 
-    /// @brief Updates the field value using a raw byte payload and notifies subscribers.
-    /// @details If `OfferService()` has not been called yet, the payload is cached as
+    /// @brief Updates the field value using a raw byte payload.
+    /// @details If the field is configured with a getter, this updates the binding's
+    ///          shared memory so the value is visible to subsequent Get requests.
+    ///          If configured with a notifier, it also notifies subscribers.
+    ///          If `OfferService()` has not been called yet, the payload is cached as
     ///          the initial value and deferred until the service is offered.
     /// @param raw_value The type-erased payload representing the new field value.
     /// @return A result indicating success or an error code on failure.
     Result<void> Update(score::cpp::span<const uint8_t> raw_value) noexcept;
 
-    /// @brief Updates the field value using a pre-allocated sample and notifies subscribers.
+    /// @brief Updates the field value using a pre-allocated sample.
+    /// @details If the field is configured with a getter, this updates the binding's
+    ///          shared memory so the value is visible to subsequent Get requests.
+    ///          If configured with a notifier, it also notifies subscribers.
     /// @param sample A sample previously allocated via `Allocate()`.
     /// @return A result indicating success or an error code on failure.
     Result<void> Update(SampleAllocateePtr<void> sample) noexcept;
 
     /// @brief Allocates a zero-copy sample buffer for this field.
     /// @return The allocated sample pointer, or an error if allocation fails or
-    ///         if the field does not support notifications.
+    ///         if OfferService() has not been called yet.
     Result<SampleAllocateePtr<void>> Allocate() noexcept;
-
-    /// @brief Registers a handler for answering Get requests from proxies.
-    /// @param get_handler The user-provided handler callback returning the field value as raw bytes.
-    /// @return A result indicating success or an error code.
-    Result<void> RegisterGetHandler(std::function<std::vector<uint8_t>()> get_handler);
 
     /// @brief Registers a handler for answering Set requests from proxies.
     /// @param set_handler The user-provided handler callback accepting raw bytes and returning

--- a/score/mw/com/impl/generic_skeleton_field.h
+++ b/score/mw/com/impl/generic_skeleton_field.h
@@ -99,9 +99,9 @@ class GenericSkeletonField : public SkeletonFieldBase
     std::vector<uint8_t> initial_field_value_;
     bool has_initial_value_{false};
 
-    bool has_getter_{false};
+    [[maybe_unused]] bool has_getter_{false};
     bool has_setter_{false};
-    bool has_notifier_{false};
+    [[maybe_unused]] bool has_notifier_{false};
     bool is_set_handler_registered_{false};
 };
 

--- a/score/mw/com/impl/generic_skeleton_field.h
+++ b/score/mw/com/impl/generic_skeleton_field.h
@@ -97,12 +97,12 @@ class GenericSkeletonField : public SkeletonFieldBase
     GenericSkeletonEvent* GetGenericEvent() const noexcept;
 
     std::vector<uint8_t> initial_field_value_;
-    bool has_initial_value_{false};
+    bool has_initial_value_;
 
-    [[maybe_unused]] bool has_getter_{false};
-    bool has_setter_{false};
-    [[maybe_unused]] bool has_notifier_{false};
-    bool is_set_handler_registered_{false};
+    [[maybe_unused]] bool has_getter_;
+    bool has_setter_;
+    [[maybe_unused]] bool has_notifier_;
+    bool is_set_handler_registered_;
 };
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/generic_skeleton_field.h
+++ b/score/mw/com/impl/generic_skeleton_field.h
@@ -102,12 +102,12 @@ class GenericSkeletonField : public SkeletonFieldBase
     GenericSkeletonEvent* GetGenericEvent() const noexcept;
 
     std::vector<uint8_t> initial_field_value_;
-    bool has_initial_value_;
+    bool has_initial_value_{false};
 
     [[maybe_unused]] bool has_getter_;
     bool has_setter_;
     [[maybe_unused]] bool has_notifier_;
-    bool is_set_handler_registered_;
+    bool is_set_handler_registered_{false};
 };
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/generic_skeleton_field.h
+++ b/score/mw/com/impl/generic_skeleton_field.h
@@ -92,7 +92,7 @@ class GenericSkeletonField : public SkeletonFieldBase
     /// \return A result indicating success or an error code.
     [[nodiscard]] Result<void> RegisterGetHandler() override;
 
-    private:
+  private:
     /// \brief Checks if a valid initial value was cached prior to offering the service.
     bool IsInitialValueSaved() const noexcept override;
     /// \brief Allocates and sends the cached initial value after the service is successfully offered.

--- a/score/mw/com/impl/generic_skeleton_field_test.cpp
+++ b/score/mw/com/impl/generic_skeleton_field_test.cpp
@@ -1,0 +1,377 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/impl/generic_skeleton_field.h"
+#include "score/mw/com/impl/generic_skeleton.h"
+
+#include "score/mw/com/impl/bindings/mock_binding/generic_skeleton_event.h"
+#include "score/mw/com/impl/bindings/mock_binding/skeleton.h"
+#include "score/mw/com/impl/plumbing/generic_skeleton_event_binding_factory.h"
+#include "score/mw/com/impl/plumbing/generic_skeleton_event_binding_factory_mock.h"
+#include "score/mw/com/impl/plumbing/sample_allocatee_ptr.h"
+
+#include "score/mw/com/impl/com_error.h"
+#include "score/mw/com/impl/configuration/lola_service_type_deployment.h"
+#include "score/mw/com/impl/i_binding_runtime.h"
+#include "score/mw/com/impl/instance_identifier.h"
+#include "score/mw/com/impl/runtime_mock.h"
+#include "score/mw/com/impl/service_discovery_client_mock.h"
+#include "score/mw/com/impl/service_discovery_mock.h"
+#include "score/mw/com/impl/test/binding_factory_resources.h"
+#include "score/mw/com/impl/test/dummy_instance_identifier_builder.h"
+#include "score/mw/com/impl/test/runtime_mock_guard.h"
+#include <variant>
+
+#include <gmock/gmock.h>
+#include <gtest/gtest.h>
+
+#include <string>
+#include <vector>
+
+namespace score::mw::com::impl
+{
+namespace
+{
+
+using ::testing::_;
+using ::testing::ByMove;
+using ::testing::Invoke;
+using ::testing::NiceMock;
+
+using ::testing::Return;
+using ::testing::ReturnRef;
+
+class IBindingRuntimeMock : public IBindingRuntime
+{
+  public:
+    MOCK_METHOD(IServiceDiscoveryClient&, GetServiceDiscoveryClient, (), (noexcept, override));
+    MOCK_METHOD(BindingType, GetBindingType, (), (const, noexcept, override));
+    MOCK_METHOD(tracing::IBindingTracingRuntime*, GetTracingRuntime, (), (noexcept, override));
+};
+
+class GenericSkeletonFieldTest : public ::testing::Test
+{
+  public:
+    GenericSkeletonFieldTest()
+    {
+        GenericSkeletonEventBindingFactory::mock_ = &generic_event_binding_factory_mock_;
+
+        ON_CALL(runtime_mock_guard_.runtime_mock_, GetBindingRuntime(BindingType::kLoLa))
+            .WillByDefault(Return(&binding_runtime_mock_));
+        ON_CALL(runtime_mock_guard_.runtime_mock_, GetServiceDiscovery())
+            .WillByDefault(ReturnRef(service_discovery_mock_));
+        ON_CALL(binding_runtime_mock_, GetBindingType()).WillByDefault(Return(BindingType::kLoLa));
+        ON_CALL(binding_runtime_mock_, GetServiceDiscoveryClient())
+            .WillByDefault(ReturnRef(service_discovery_client_mock_));
+        ON_CALL(service_discovery_mock_, OfferService(_)).WillByDefault(Return(score::Result<void>{}));
+
+        ON_CALL(skeleton_binding_factory_mock_guard_.factory_mock_, Create(_))
+            .WillByDefault(Invoke([this](const auto&) {
+                auto mock = std::make_unique<NiceMock<mock_binding::Skeleton>>();
+                this->skeleton_binding_mock_ = mock.get();
+                ON_CALL(*mock, PrepareOffer(_, _, _)).WillByDefault(Return(score::Result<void>{}));
+                return mock;
+            }));
+    }
+
+    ~GenericSkeletonFieldTest() override
+    {
+        GenericSkeletonEventBindingFactory::mock_ = nullptr;
+    }
+
+    std::string GetConfiguredFieldName()
+    {
+        auto identifier = dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField();
+        const auto& type_depl = InstanceIdentifierView{identifier}.GetServiceTypeDeployment();
+        auto* lola_type = std::get_if<LolaServiceTypeDeployment>(&type_depl.binding_info_);
+        if (lola_type && !lola_type->fields_.empty())
+        {
+            return lola_type->fields_.begin()->first;
+        }
+        return "test_field";
+    }
+
+    // Mocks
+    NiceMock<GenericSkeletonEventBindingFactoryMock> generic_event_binding_factory_mock_;
+    RuntimeMockGuard runtime_mock_guard_{};
+    NiceMock<IBindingRuntimeMock> binding_runtime_mock_{};
+    NiceMock<ServiceDiscoveryMock> service_discovery_mock_{};
+    NiceMock<ServiceDiscoveryClientMock> service_discovery_client_mock_{};
+    SkeletonBindingFactoryMockGuard skeleton_binding_factory_mock_guard_{};
+
+    // Pointers and Helpers
+    mock_binding::Skeleton* skeleton_binding_mock_{nullptr};
+    DummyInstanceIdentifierBuilder dummy_instance_identifier_builder_;
+};
+
+TEST_F(GenericSkeletonFieldTest, AllocateBeforeOfferReturnsError)
+{
+    RecordProperty("Description", "Checks that calling Allocate() before OfferService() returns an error.");
+    RecordProperty("TestType", "Requirements-based test");
+
+    const std::string field_name = GetConfiguredFieldName();
+    std::vector<uint8_t> init_val{0};
+    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, true, init_val}};
+    GenericSkeletonServiceElementInfo create_params;
+    create_params.fields = field_storage;
+
+    EXPECT_CALL(generic_event_binding_factory_mock_, Create(_, field_name, _))
+        .WillOnce(Return(ByMove(std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>())));
+
+    auto skeleton_result = GenericSkeleton::Create(
+        dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
+    ASSERT_TRUE(skeleton_result.has_value());
+
+    auto& skeleton = skeleton_result.value();
+    auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
+
+    auto alloc_result = field->Allocate();
+
+    ASSERT_FALSE(alloc_result.has_value());
+    EXPECT_EQ(alloc_result.error(), ComErrc::kBindingFailure);
+}
+
+TEST_F(GenericSkeletonFieldTest, AllocateFailsWithoutNotifier)
+{
+    RecordProperty("Description", "Checks that calling Allocate() without a notifier configured returns an error.");
+    RecordProperty("TestType", "Requirements-based test");
+
+    const std::string field_name = GetConfiguredFieldName();
+    std::vector<uint8_t> init_val{0};
+    // has_notifier set to false
+    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, false, init_val}};
+    GenericSkeletonServiceElementInfo create_params;
+    create_params.fields = field_storage;
+
+    EXPECT_CALL(generic_event_binding_factory_mock_, Create(_, field_name, _))
+        .WillOnce(Return(ByMove(std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>())));
+
+    auto skeleton_result = GenericSkeleton::Create(
+        dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
+    ASSERT_TRUE(skeleton_result.has_value());
+
+    auto& skeleton = skeleton_result.value();
+    auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
+
+    auto alloc_result = field->Allocate();
+
+    ASSERT_FALSE(alloc_result.has_value());
+    EXPECT_EQ(alloc_result.error(), ComErrc::kBindingFailure);
+}
+
+TEST_F(GenericSkeletonFieldTest, GettersAndSettersReturnError)
+{
+    RecordProperty("Description", "Checks that Get/Set handlers are currently WIP and correctly return an error.");
+    RecordProperty("TestType", "Requirements-based test");
+
+    const std::string field_name = GetConfiguredFieldName();
+    std::vector<uint8_t> init_val{0};
+    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, true, true, false, init_val}};
+    GenericSkeletonServiceElementInfo create_params;
+    create_params.fields = field_storage;
+
+    EXPECT_CALL(generic_event_binding_factory_mock_, Create(_, field_name, _))
+        .WillOnce(Return(ByMove(std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>())));
+
+    auto skeleton_result = GenericSkeleton::Create(
+        dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
+    ASSERT_TRUE(skeleton_result.has_value());
+
+    auto& skeleton = skeleton_result.value();
+    auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
+
+    auto get_result = field->RegisterGetHandler([]() {
+        return std::vector<uint8_t>{};
+    });
+    EXPECT_FALSE(get_result.has_value());
+    EXPECT_EQ(get_result.error(), ComErrc::kCouldNotExecute);
+
+    auto set_result = field->RegisterSetHandler([](auto) {
+        return std::vector<uint8_t>{};
+    });
+    EXPECT_FALSE(set_result.has_value());
+    EXPECT_EQ(set_result.error(), ComErrc::kCouldNotExecute);
+}
+
+TEST_F(GenericSkeletonFieldTest, UpdateBeforeOfferCachesValue)
+{
+    RecordProperty("Description",
+                   "Checks that updating a field before offering the service caches the value without sending it.");
+    RecordProperty("TestType", "Requirements-based test");
+
+    const std::string field_name = GetConfiguredFieldName();
+    std::vector<uint8_t> init_val{0xAA, 0xBB};
+    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, true, init_val}};
+    GenericSkeletonServiceElementInfo create_params;
+    create_params.fields = field_storage;
+
+    auto mock_event = std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>();
+
+    // Expect NO Send or Allocate to be called since the service is not offered yet.
+    EXPECT_CALL(*mock_event, Allocate()).Times(0);
+    EXPECT_CALL(*mock_event, Send(_)).Times(0);
+
+    EXPECT_CALL(generic_event_binding_factory_mock_, Create(_, field_name, _))
+        .WillOnce(Return(ByMove(std::move(mock_event))));
+
+    auto skeleton_result = GenericSkeleton::Create(
+        dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
+
+    ASSERT_TRUE(skeleton_result.has_value());
+
+    auto& skeleton = skeleton_result.value();
+    auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
+
+    // Explicitly update the field before calling OfferService
+    std::vector<uint8_t> explicit_update_val{0x11, 0x22, 0x33};
+    auto update_res = field->Update(explicit_update_val);
+
+    // The update should succeed and cache the value without making any binding calls (Allocate/Send).
+    EXPECT_TRUE(update_res.has_value());
+}
+
+TEST_F(GenericSkeletonFieldTest, DoDeferredUpdatePushesCachedValueOnOffer)
+{
+    RecordProperty("Description",
+                   "Checks that offering the service triggers DoDeferredUpdate, which allocates and sends the cached "
+                   "initial value.");
+    RecordProperty("TestType", "Requirements-based test");
+
+    const std::string field_name = GetConfiguredFieldName();
+    std::vector<uint8_t> init_val{0xAA, 0xBB};
+    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, true, init_val}};
+    GenericSkeletonServiceElementInfo create_params;
+    create_params.fields = field_storage;
+
+    auto mock_event = std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>();
+    auto* mock_event_ptr = mock_event.get();
+
+    EXPECT_CALL(generic_event_binding_factory_mock_, Create(_, field_name, _))
+        .WillOnce(Return(ByMove(std::move(mock_event))));
+
+    // Setup mock event expectations BEFORE the skeleton is even created
+    EXPECT_CALL(*mock_event_ptr, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
+    EXPECT_CALL(*mock_event_ptr, GetSizeInfo()).WillRepeatedly(Return(std::make_pair<size_t, size_t>(16, 8)));
+
+    std::vector<uint8_t> dummy_memory(16, 0);
+    mock_binding::SampleAllocateePtr<void> dummy_alloc{dummy_memory.data(), [](void*) {}};
+    EXPECT_CALL(*mock_event_ptr, Allocate()).WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc)))));
+    EXPECT_CALL(*mock_event_ptr, Send(_)).WillOnce(Return(score::Result<void>{}));
+
+    auto skeleton_result = GenericSkeleton::Create(
+        dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
+    ASSERT_TRUE(skeleton_result.has_value());
+
+    // skeleton_binding_mock_ is initialized inside Create(), so its expectations must come after
+    EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodsRegistered()).WillRepeatedly(Return(true));
+
+    // When offering service, DoDeferredUpdate is executed
+    auto offer_res = skeleton_result.value().OfferService();
+    EXPECT_TRUE(offer_res.has_value());
+}
+
+TEST_F(GenericSkeletonFieldTest, UpdateAfterOfferAllocatesAndSends)
+{
+    RecordProperty("Description",
+                   "Checks that updating a field after offering the service successfully allocates and sends.");
+    RecordProperty("TestType", "Requirements-based test");
+
+    const std::string field_name = GetConfiguredFieldName();
+    std::vector<uint8_t> init_val{0xAA, 0xBB};
+    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, true, init_val}};
+    GenericSkeletonServiceElementInfo create_params;
+    create_params.fields = field_storage;
+
+    auto mock_event = std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>();
+    auto* mock_event_ptr = mock_event.get();
+
+    EXPECT_CALL(generic_event_binding_factory_mock_, Create(_, field_name, _))
+        .WillOnce(Return(ByMove(std::move(mock_event))));
+
+    // Setup expectations for initial OfferService caching BEFORE creation
+    EXPECT_CALL(*mock_event_ptr, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
+    EXPECT_CALL(*mock_event_ptr, GetSizeInfo()).WillRepeatedly(Return(std::make_pair<size_t, size_t>(16, 8)));
+
+    std::vector<uint8_t> dummy_memory1(16, 0);
+    mock_binding::SampleAllocateePtr<void> dummy_alloc1{dummy_memory1.data(), [](void*) {}};
+    EXPECT_CALL(*mock_event_ptr, Allocate()).WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc1)))));
+    EXPECT_CALL(*mock_event_ptr, Send(_)).WillOnce(Return(score::Result<void>{}));
+
+    auto skeleton_result = GenericSkeleton::Create(
+        dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
+    ASSERT_TRUE(skeleton_result.has_value());
+
+    EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodsRegistered()).WillRepeatedly(Return(true));
+
+    // Offer the service (Handle initial value allocation/send)
+    ASSERT_TRUE(skeleton_result.value().OfferService().has_value());
+
+    // When calling Update after OfferService
+    std::vector<uint8_t> new_val{0xCC, 0xDD};
+    std::vector<uint8_t> dummy_memory2(16, 0);
+    mock_binding::SampleAllocateePtr<void> dummy_alloc2{dummy_memory2.data(), [](void*) {}};
+
+    // Expect a NEW allocation and send
+    EXPECT_CALL(*mock_event_ptr, Allocate()).WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc2)))));
+    EXPECT_CALL(*mock_event_ptr, Send(_)).WillOnce(Return(score::Result<void>{}));
+
+    auto& skeleton = skeleton_result.value();
+    auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
+    auto update_res = field->Update(new_val);
+
+    EXPECT_TRUE(update_res.has_value());
+}
+
+TEST_F(GenericSkeletonFieldTest, UpdateWithoutNotifierReturnsSuccessAndDoesNotSend)
+{
+    RecordProperty(
+        "Description",
+        "Checks that updating a field without a notifier returns success immediately without allocating or sending.");
+    RecordProperty("TestType", "Requirements-based test");
+
+    const std::string field_name = GetConfiguredFieldName();
+    std::vector<uint8_t> init_val{0xAA, 0xBB};
+    // has_notifier = false
+    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, false, init_val}};
+    GenericSkeletonServiceElementInfo create_params;
+    create_params.fields = field_storage;
+
+    auto mock_event = std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>();
+    auto* mock_event_ptr = mock_event.get();
+
+    EXPECT_CALL(generic_event_binding_factory_mock_, Create(_, field_name, _))
+        .WillOnce(Return(ByMove(std::move(mock_event))));
+
+    auto skeleton_result = GenericSkeleton::Create(
+        dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
+    ASSERT_TRUE(skeleton_result.has_value());
+
+    // Offer the service
+    EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodsRegistered()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*mock_event_ptr, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
+    ASSERT_TRUE(skeleton_result.value().OfferService().has_value());
+
+    // When calling Update, expect NO Allocate and NO Send since has_notifier_ is false
+    EXPECT_CALL(*mock_event_ptr, Allocate()).Times(0);
+    EXPECT_CALL(*mock_event_ptr, Send(_)).Times(0);
+
+    auto& skeleton = skeleton_result.value();
+    auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
+
+    std::vector<uint8_t> new_val{0xCC, 0xDD};
+    auto update_res = field->Update(new_val);
+
+    EXPECT_TRUE(update_res.has_value());
+}
+
+}  // namespace
+}  // namespace score::mw::com::impl

--- a/score/mw/com/impl/generic_skeleton_field_test.cpp
+++ b/score/mw/com/impl/generic_skeleton_field_test.cpp
@@ -108,8 +108,7 @@ class GenericSkeletonFieldTest : public ::testing::Test
         create_params.fields = field_storage;
 
         auto skeleton_result = GenericSkeleton::Create(
-            dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(),
-            create_params);
+            dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
         EXPECT_TRUE(skeleton_result.has_value());
 
         skeleton_ = std::make_unique<GenericSkeleton>(std::move(skeleton_result.value()));
@@ -235,18 +234,18 @@ TEST_F(GenericSkeletonFieldTest, UpdateAfterOfferAllocatesAndSends)
 
     // GIVEN: An offered skeleton service
     GivenAGenericSkeletonWithOneField();
-    
+
     // Set initial value manually before offering
     std::vector<uint8_t> init_val{0xAA, 0xBB};
     static_cast<void>(field_->Update(init_val));
-    
+
     // EXPECT: Initial value allocation and send to the binding during OfferService
     std::vector<uint8_t> dummy_memory1(16, 0);
     mock_binding::SampleAllocateePtr<void> dummy_alloc1{dummy_memory1.data(), [](void*) {}};
     EXPECT_CALL(*mock_event_binding_ptr_, Allocate(_))
         .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc1)))));
     EXPECT_CALL(*mock_event_binding_ptr_, Send(_)).WillOnce(Return(score::Result<void>{}));
-    
+
     OfferSkeletonService();
 
     // WHEN: Calling Update after OfferService
@@ -273,18 +272,18 @@ TEST_F(GenericSkeletonFieldTest, UpdateWithoutNotifierSendsToBinding)
 
     // GIVEN: An offered skeleton service for a field with no notifier
     GivenAGenericSkeletonWithOneField("test_field", {16, 8}, false, false, false);
-    
+
     // Set initial value manually before offering
     std::vector<uint8_t> init_val{0xAA, 0xBB};
     static_cast<void>(field_->Update(init_val));
-    
+
     // EXPECT: Initial value allocation and send to the binding during OfferService
     std::vector<uint8_t> dummy_memory1(16, 0);
     mock_binding::SampleAllocateePtr<void> dummy_alloc1{dummy_memory1.data(), [](void*) {}};
     EXPECT_CALL(*mock_event_binding_ptr_, Allocate(_))
         .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc1)))));
     EXPECT_CALL(*mock_event_binding_ptr_, Send(_)).WillOnce(Return(score::Result<void>{}));
-    
+
     OfferSkeletonService();
 
     // WHEN: Calling Update

--- a/score/mw/com/impl/generic_skeleton_field_test.cpp
+++ b/score/mw/com/impl/generic_skeleton_field_test.cpp
@@ -316,11 +316,13 @@ TEST_F(GenericSkeletonFieldTest, UpdateWithoutNotifierSendsToBinding)
     EXPECT_CALL(generic_event_binding_factory_mock_, Create(_, field_name, _))
         .WillOnce(Return(ByMove(std::move(mock_event))));
 
-    // Expect allocation and send even though has_notifier_ is false
-    std::vector<uint8_t> dummy_memory(16, 0);
-    mock_binding::SampleAllocateePtr<void> dummy_alloc{dummy_memory.data(), [](void*) {}};
+    EXPECT_CALL(*mock_event_ptr, GetSizeInfo()).WillRepeatedly(Return(std::make_pair<size_t, size_t>(16, 8)));
 
-    EXPECT_CALL(*mock_event_ptr, Allocate(_)).WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc)))));
+    // 1. Expect allocation and send of the INITIAL VALUE during OfferService()
+    std::vector<uint8_t> dummy_memory1(16, 0);
+    mock_binding::SampleAllocateePtr<void> dummy_alloc1{dummy_memory1.data(), [](void*) {}};
+
+    EXPECT_CALL(*mock_event_ptr, Allocate(_)).WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc1)))));
     EXPECT_CALL(*mock_event_ptr, Send(_)).WillOnce(Return(score::Result<void>{}));
 
     auto skeleton_result = GenericSkeleton::Create(
@@ -331,6 +333,13 @@ TEST_F(GenericSkeletonFieldTest, UpdateWithoutNotifierSendsToBinding)
     EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodHandlersRegistered()).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_event_ptr, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
     ASSERT_TRUE(skeleton_result.value().OfferService().has_value());
+
+    // 2. Expect a NEW allocation and send during explicit Update()
+    std::vector<uint8_t> dummy_memory2(16, 0);
+    mock_binding::SampleAllocateePtr<void> dummy_alloc2{dummy_memory2.data(), [](void*) {}};
+
+    EXPECT_CALL(*mock_event_ptr, Allocate(_)).WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc2)))));
+    EXPECT_CALL(*mock_event_ptr, Send(_)).WillOnce(Return(score::Result<void>{}));
 
     auto& skeleton = skeleton_result.value();
     auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);

--- a/score/mw/com/impl/generic_skeleton_field_test.cpp
+++ b/score/mw/com/impl/generic_skeleton_field_test.cpp
@@ -161,8 +161,8 @@ TEST_F(GenericSkeletonFieldTest, GettersAndSettersReturnError)
     auto& skeleton = skeleton_result.value();
     auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
 
-    auto set_result = field->RegisterSetHandler([](auto) {
-        return std::vector<uint8_t>{};
+    auto set_result = field->RegisterSetHandler([](score::cpp::span<uint8_t>) {
+        // Return void
     });
     EXPECT_FALSE(set_result.has_value());
     EXPECT_EQ(set_result.error(), ComErrc::kCouldNotExecute);

--- a/score/mw/com/impl/generic_skeleton_field_test.cpp
+++ b/score/mw/com/impl/generic_skeleton_field_test.cpp
@@ -104,7 +104,8 @@ class GenericSkeletonFieldTest : public ::testing::Test
             .WillOnce(Return(ByMove(std::move(mock_event_binding))));
 
         GenericSkeletonServiceElementInfo create_params;
-        create_params.fields = {{field_name, size_info, has_getter, has_setter, has_notifier}};
+        std::vector<FieldInfo> field_storage{{field_name, size_info, has_getter, has_setter, has_notifier}};
+        create_params.fields = field_storage;
 
         auto skeleton_result = GenericSkeleton::Create(
             dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(),
@@ -233,7 +234,20 @@ TEST_F(GenericSkeletonFieldTest, UpdateAfterOfferAllocatesAndSends)
     RecordProperty("TestType", "Requirements-based test");
 
     // GIVEN: An offered skeleton service
-    this->GivenAGenericSkeletonWithOneField().OfferSkeletonService();
+    GivenAGenericSkeletonWithOneField();
+    
+    // Set initial value manually before offering
+    std::vector<uint8_t> init_val{0xAA, 0xBB};
+    static_cast<void>(field_->Update(init_val));
+    
+    // EXPECT: Initial value allocation and send to the binding during OfferService
+    std::vector<uint8_t> dummy_memory1(16, 0);
+    mock_binding::SampleAllocateePtr<void> dummy_alloc1{dummy_memory1.data(), [](void*) {}};
+    EXPECT_CALL(*mock_event_binding_ptr_, Allocate(_))
+        .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc1)))));
+    EXPECT_CALL(*mock_event_binding_ptr_, Send(_)).WillOnce(Return(score::Result<void>{}));
+    
+    OfferSkeletonService();
 
     // WHEN: Calling Update after OfferService
     std::vector<uint8_t> new_val{0xCC, 0xDD};
@@ -258,7 +272,20 @@ TEST_F(GenericSkeletonFieldTest, UpdateWithoutNotifierSendsToBinding)
     RecordProperty("TestType", "Requirements-based test");
 
     // GIVEN: An offered skeleton service for a field with no notifier
-    this->GivenAGenericSkeletonWithOneField("test_field", {16, 8}, false, false, false).OfferSkeletonService();
+    GivenAGenericSkeletonWithOneField("test_field", {16, 8}, false, false, false);
+    
+    // Set initial value manually before offering
+    std::vector<uint8_t> init_val{0xAA, 0xBB};
+    static_cast<void>(field_->Update(init_val));
+    
+    // EXPECT: Initial value allocation and send to the binding during OfferService
+    std::vector<uint8_t> dummy_memory1(16, 0);
+    mock_binding::SampleAllocateePtr<void> dummy_alloc1{dummy_memory1.data(), [](void*) {}};
+    EXPECT_CALL(*mock_event_binding_ptr_, Allocate(_))
+        .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc1)))));
+    EXPECT_CALL(*mock_event_binding_ptr_, Send(_)).WillOnce(Return(score::Result<void>{}));
+    
+    OfferSkeletonService();
 
     // WHEN: Calling Update
     std::vector<uint8_t> new_val{0xCC, 0xDD};

--- a/score/mw/com/impl/generic_skeleton_field_test.cpp
+++ b/score/mw/com/impl/generic_skeleton_field_test.cpp
@@ -120,7 +120,7 @@ TEST_F(GenericSkeletonFieldTest, AllocateBeforeOfferReturnsError)
 
     const std::string field_name = GetConfiguredFieldName();
     std::vector<uint8_t> init_val{0};
-    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, true, init_val}};
+    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, true}};
     GenericSkeletonServiceElementInfo create_params;
     create_params.fields = field_storage;
 
@@ -133,6 +133,9 @@ TEST_F(GenericSkeletonFieldTest, AllocateBeforeOfferReturnsError)
 
     auto& skeleton = skeleton_result.value();
     auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
+
+    // Set initial value manually after creation
+    static_cast<void>(field->Update(init_val));
 
     auto alloc_result = field->Allocate();
 
@@ -147,7 +150,7 @@ TEST_F(GenericSkeletonFieldTest, GettersAndSettersReturnError)
 
     const std::string field_name = GetConfiguredFieldName();
     std::vector<uint8_t> init_val{0};
-    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, true, true, false, init_val}};
+    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, true, true, false}};
     GenericSkeletonServiceElementInfo create_params;
     create_params.fields = field_storage;
 
@@ -160,6 +163,9 @@ TEST_F(GenericSkeletonFieldTest, GettersAndSettersReturnError)
 
     auto& skeleton = skeleton_result.value();
     auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
+
+    // Set initial value manually after creation
+    static_cast<void>(field->Update(init_val));
 
     auto set_result = field->RegisterSetHandler([](score::cpp::span<uint8_t>) {
         // Return void
@@ -176,7 +182,7 @@ TEST_F(GenericSkeletonFieldTest, UpdateBeforeOfferCachesValue)
 
     const std::string field_name = GetConfiguredFieldName();
     std::vector<uint8_t> init_val{0xAA, 0xBB};
-    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, true, init_val}};
+    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, true}};
     GenericSkeletonServiceElementInfo create_params;
     create_params.fields = field_storage;
 
@@ -214,7 +220,7 @@ TEST_F(GenericSkeletonFieldTest, DoDeferredUpdatePushesCachedValueOnOffer)
 
     const std::string field_name = GetConfiguredFieldName();
     std::vector<uint8_t> init_val{0xAA, 0xBB};
-    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, true, init_val}};
+    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, true}};
     GenericSkeletonServiceElementInfo create_params;
     create_params.fields = field_storage;
 
@@ -237,6 +243,12 @@ TEST_F(GenericSkeletonFieldTest, DoDeferredUpdatePushesCachedValueOnOffer)
         dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
     ASSERT_TRUE(skeleton_result.has_value());
 
+    auto& skeleton = skeleton_result.value();
+    auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
+
+    // Set initial value manually after creation
+    static_cast<void>(field->Update(init_val));
+
     // skeleton_binding_mock_ is initialized inside Create(), so its expectations must come after
     EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodHandlersRegistered()).WillRepeatedly(Return(true));
 
@@ -253,7 +265,7 @@ TEST_F(GenericSkeletonFieldTest, UpdateAfterOfferAllocatesAndSends)
 
     const std::string field_name = GetConfiguredFieldName();
     std::vector<uint8_t> init_val{0xAA, 0xBB};
-    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, true, init_val}};
+    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, true}};
     GenericSkeletonServiceElementInfo create_params;
     create_params.fields = field_storage;
 
@@ -275,6 +287,12 @@ TEST_F(GenericSkeletonFieldTest, UpdateAfterOfferAllocatesAndSends)
     auto skeleton_result = GenericSkeleton::Create(
         dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
     ASSERT_TRUE(skeleton_result.has_value());
+
+    auto& skeleton = skeleton_result.value();
+    auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
+
+    // Set initial value manually after creation
+    static_cast<void>(field->Update(init_val));
 
     EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodHandlersRegistered()).WillRepeatedly(Return(true));
 
@@ -306,7 +324,7 @@ TEST_F(GenericSkeletonFieldTest, UpdateWithoutNotifierSendsToBinding)
     const std::string field_name = GetConfiguredFieldName();
     std::vector<uint8_t> init_val{0xAA, 0xBB};
     // has_notifier = false
-    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, false, init_val}};
+    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, false}};
     GenericSkeletonServiceElementInfo create_params;
     create_params.fields = field_storage;
 
@@ -328,6 +346,12 @@ TEST_F(GenericSkeletonFieldTest, UpdateWithoutNotifierSendsToBinding)
     auto skeleton_result = GenericSkeleton::Create(
         dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
     ASSERT_TRUE(skeleton_result.has_value());
+
+    auto& skeleton = skeleton_result.value();
+    auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
+
+    // Set initial value manually after creation
+    static_cast<void>(field->Update(init_val));
 
     // Offer the service
     EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodHandlersRegistered()).WillRepeatedly(Return(true));

--- a/score/mw/com/impl/generic_skeleton_field_test.cpp
+++ b/score/mw/com/impl/generic_skeleton_field_test.cpp
@@ -5,8 +5,7 @@
  * information regarding copyright ownership.
  *
  * This program and the accompanying materials are made available under the
- * terms of the Apache License Version 2.0 which is available at
- * https://www.apache.org/licenses/LICENSE-2.0
+ * terms of the Apache License Version 2.0
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
@@ -20,20 +19,18 @@
 #include "score/mw/com/impl/plumbing/sample_allocatee_ptr.h"
 
 #include "score/mw/com/impl/com_error.h"
-#include "score/mw/com/impl/configuration/lola_service_type_deployment.h"
 #include "score/mw/com/impl/i_binding_runtime.h"
-#include "score/mw/com/impl/instance_identifier.h"
 #include "score/mw/com/impl/runtime_mock.h"
 #include "score/mw/com/impl/service_discovery_client_mock.h"
 #include "score/mw/com/impl/service_discovery_mock.h"
 #include "score/mw/com/impl/test/binding_factory_resources.h"
 #include "score/mw/com/impl/test/dummy_instance_identifier_builder.h"
 #include "score/mw/com/impl/test/runtime_mock_guard.h"
-#include <variant>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
+#include <memory>
 #include <string>
 #include <vector>
 
@@ -46,14 +43,14 @@ using ::testing::_;
 using ::testing::ByMove;
 using ::testing::Invoke;
 using ::testing::NiceMock;
-
 using ::testing::Return;
 using ::testing::ReturnRef;
 
+// --- Helper Mocks ---
 class IBindingRuntimeMock : public IBindingRuntime
 {
   public:
-    MOCK_METHOD(IServiceDiscoveryClient&, GetServiceDiscoveryClient, (), (noexcept, override, ref(&)));
+    MOCK_METHOD(IServiceDiscoveryClient&, GetServiceDiscoveryClient, (), (ref(&), noexcept, override));
     MOCK_METHOD(BindingType, GetBindingType, (), (const, noexcept, override));
     MOCK_METHOD(tracing::IBindingTracingRuntime*, GetTracingRuntime, (), (noexcept, override));
 };
@@ -67,17 +64,22 @@ class GenericSkeletonFieldTest : public ::testing::Test
 
         ON_CALL(runtime_mock_guard_.runtime_mock_, GetBindingRuntime(BindingType::kLoLa))
             .WillByDefault(Return(&binding_runtime_mock_));
+
         ON_CALL(runtime_mock_guard_.runtime_mock_, GetServiceDiscovery())
             .WillByDefault(ReturnRef(service_discovery_mock_));
+
         ON_CALL(binding_runtime_mock_, GetBindingType()).WillByDefault(Return(BindingType::kLoLa));
+
         ON_CALL(binding_runtime_mock_, GetServiceDiscoveryClient())
             .WillByDefault(ReturnRef(service_discovery_client_mock_));
+
         ON_CALL(service_discovery_mock_, OfferService(_)).WillByDefault(Return(score::Result<void>{}));
 
         ON_CALL(skeleton_binding_factory_mock_guard_.factory_mock_, Create(_))
             .WillByDefault(Invoke([this](const auto&) {
                 auto mock = std::make_unique<NiceMock<mock_binding::Skeleton>>();
                 this->skeleton_binding_mock_ = mock.get();
+                ON_CALL(*mock, VerifyAllMethodHandlersRegistered()).WillByDefault(Return(true));
                 ON_CALL(*mock, PrepareOffer(_, _, _)).WillByDefault(Return(score::Result<void>{}));
                 return mock;
             }));
@@ -88,17 +90,50 @@ class GenericSkeletonFieldTest : public ::testing::Test
         GenericSkeletonEventBindingFactory::mock_ = nullptr;
     }
 
-    std::string GetConfiguredFieldName()
+    /// \brief Creates a GenericSkeleton with one field
+    GenericSkeletonFieldTest& GivenAGenericSkeletonWithOneField(const std::string& field_name = "test_field",
+                                                                DataTypeMetaInfo size_info = {16, 8},
+                                                                bool has_getter = false,
+                                                                bool has_setter = false,
+                                                                bool has_notifier = true)
     {
-        auto identifier = dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField();
-        const auto& type_depl = InstanceIdentifierView{identifier}.GetServiceTypeDeployment();
-        auto* lola_type = std::get_if<LolaServiceTypeDeployment>(&type_depl.binding_info_);
-        if (lola_type && !lola_type->fields_.empty())
-        {
-            return lola_type->fields_.begin()->first;
-        }
-        return "test_field";
+        auto mock_event_binding = std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>();
+        mock_event_binding_ptr_ = mock_event_binding.get();
+
+        EXPECT_CALL(generic_event_binding_factory_mock_, Create(_, field_name, _))
+            .WillOnce(Return(ByMove(std::move(mock_event_binding))));
+
+        GenericSkeletonServiceElementInfo create_params;
+        create_params.fields = {{field_name, size_info, has_getter, has_setter, has_notifier}};
+
+        auto skeleton_result = GenericSkeleton::Create(
+            dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
+        EXPECT_TRUE(skeleton_result.has_value());
+
+        skeleton_ = std::make_unique<GenericSkeleton>(std::move(skeleton_result.value()));
+        auto it = skeleton_->GetFields().find(field_name);
+        EXPECT_NE(it, skeleton_->GetFields().cend());
+        field_ = &it->second;
+
+        return *this;
     }
+
+    /// \brief Offers the skeleton service
+    GenericSkeletonFieldTest& OfferSkeletonService()
+    {
+        EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodHandlersRegistered()).WillRepeatedly(Return(true));
+        EXPECT_CALL(*mock_event_binding_ptr_, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
+        EXPECT_CALL(*mock_event_binding_ptr_, GetSizeInfo()).WillRepeatedly(Return(std::make_pair<size_t, size_t>(16, 8)));
+
+        const auto offer_result = skeleton_->OfferService();
+        EXPECT_TRUE(offer_result.has_value());
+        return *this;
+    }
+
+  protected:
+    std::unique_ptr<GenericSkeleton> skeleton_;
+    GenericSkeletonField* field_{nullptr};
+    mock_binding::GenericSkeletonEvent* mock_event_binding_ptr_{nullptr};
 
     // Mocks
     NiceMock<GenericSkeletonEventBindingFactoryMock> generic_event_binding_factory_mock_;
@@ -118,27 +153,13 @@ TEST_F(GenericSkeletonFieldTest, AllocateBeforeOfferReturnsError)
     RecordProperty("Description", "Checks that calling Allocate() before OfferService() returns an error.");
     RecordProperty("TestType", "Requirements-based test");
 
-    const std::string field_name = GetConfiguredFieldName();
-    std::vector<uint8_t> init_val{0};
-    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, true}};
-    GenericSkeletonServiceElementInfo create_params;
-    create_params.fields = field_storage;
+    // GIVEN: A skeleton created with one field "test_field"
+    this->GivenAGenericSkeletonWithOneField();
 
-    EXPECT_CALL(generic_event_binding_factory_mock_, Create(_, field_name, _))
-        .WillOnce(Return(ByMove(std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>())));
+    // WHEN: Calling Allocate() before OfferService()
+    auto alloc_result = field_->Allocate();
 
-    auto skeleton_result = GenericSkeleton::Create(
-        dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
-    ASSERT_TRUE(skeleton_result.has_value());
-
-    auto& skeleton = skeleton_result.value();
-    auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
-
-    // Set initial value manually after creation
-    static_cast<void>(field->Update(init_val));
-
-    auto alloc_result = field->Allocate();
-
+    // THEN: It fails with kBindingFailure
     ASSERT_FALSE(alloc_result.has_value());
     EXPECT_EQ(alloc_result.error(), ComErrc::kBindingFailure);
 }
@@ -148,29 +169,14 @@ TEST_F(GenericSkeletonFieldTest, GettersAndSettersReturnError)
     RecordProperty("Description", "Checks that Get/Set handlers are currently WIP and correctly return an error.");
     RecordProperty("TestType", "Requirements-based test");
 
-    const std::string field_name = GetConfiguredFieldName();
-    std::vector<uint8_t> init_val{0};
-    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, true, true, false}};
-    GenericSkeletonServiceElementInfo create_params;
-    create_params.fields = field_storage;
+    // GIVEN: A skeleton created with one field that has getter and setter enabled
+    this->GivenAGenericSkeletonWithOneField("test_field", {16, 8}, true, true, false);
 
-    EXPECT_CALL(generic_event_binding_factory_mock_, Create(_, field_name, _))
-        .WillOnce(Return(ByMove(std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>())));
+    // WHEN: Attempting to register a set handler
+    auto set_result = field_->RegisterSetHandler([](score::cpp::span<uint8_t>) {});
 
-    auto skeleton_result = GenericSkeleton::Create(
-        dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
-    ASSERT_TRUE(skeleton_result.has_value());
-
-    auto& skeleton = skeleton_result.value();
-    auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
-
-    // Set initial value manually after creation
-    static_cast<void>(field->Update(init_val));
-
-    auto set_result = field->RegisterSetHandler([](score::cpp::span<uint8_t>) {
-        // Return void
-    });
-    EXPECT_FALSE(set_result.has_value());
+    // THEN: It fails with kCouldNotExecute (WIP)
+    ASSERT_FALSE(set_result.has_value());
     EXPECT_EQ(set_result.error(), ComErrc::kCouldNotExecute);
 }
 
@@ -180,34 +186,14 @@ TEST_F(GenericSkeletonFieldTest, UpdateBeforeOfferCachesValue)
                    "Checks that updating a field before offering the service caches the value without sending it.");
     RecordProperty("TestType", "Requirements-based test");
 
-    const std::string field_name = GetConfiguredFieldName();
-    std::vector<uint8_t> init_val{0xAA, 0xBB};
-    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, true}};
-    GenericSkeletonServiceElementInfo create_params;
-    create_params.fields = field_storage;
+    // GIVEN: A skeleton created with one field
+    this->GivenAGenericSkeletonWithOneField();
 
-    auto mock_event = std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>();
+    // WHEN: Updating the field before calling OfferService
+    std::vector<uint8_t> update_val{0x11, 0x22, 0x33};
+    auto update_res = field_->Update(update_val);
 
-    // Expect NO Send or Allocate to be called since the service is not offered yet.
-    EXPECT_CALL(*mock_event, Allocate(_)).Times(0);
-    EXPECT_CALL(*mock_event, Send(_)).Times(0);
-
-    EXPECT_CALL(generic_event_binding_factory_mock_, Create(_, field_name, _))
-        .WillOnce(Return(ByMove(std::move(mock_event))));
-
-    auto skeleton_result = GenericSkeleton::Create(
-        dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
-
-    ASSERT_TRUE(skeleton_result.has_value());
-
-    auto& skeleton = skeleton_result.value();
-    auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
-
-    // Explicitly update the field before calling OfferService
-    std::vector<uint8_t> explicit_update_val{0x11, 0x22, 0x33};
-    auto update_res = field->Update(explicit_update_val);
-
-    // The update should succeed and cache the value without making any binding calls (Allocate/Send).
+    // THEN: The update succeeds (value is cached internally)
     EXPECT_TRUE(update_res.has_value());
 }
 
@@ -218,43 +204,24 @@ TEST_F(GenericSkeletonFieldTest, DoDeferredUpdatePushesCachedValueOnOffer)
                    "initial value.");
     RecordProperty("TestType", "Requirements-based test");
 
-    const std::string field_name = GetConfiguredFieldName();
+    // GIVEN: A skeleton created with one field
+    this->GivenAGenericSkeletonWithOneField();
+
+    // AND: An initial value is set before offering
     std::vector<uint8_t> init_val{0xAA, 0xBB};
-    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, true}};
-    GenericSkeletonServiceElementInfo create_params;
-    create_params.fields = field_storage;
+    static_cast<void>(field_->Update(init_val));
 
-    auto mock_event = std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>();
-    auto* mock_event_ptr = mock_event.get();
-
-    EXPECT_CALL(generic_event_binding_factory_mock_, Create(_, field_name, _))
-        .WillOnce(Return(ByMove(std::move(mock_event))));
-
-    // Setup mock event expectations BEFORE the skeleton is even created
-    EXPECT_CALL(*mock_event_ptr, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
-    EXPECT_CALL(*mock_event_ptr, GetSizeInfo()).WillRepeatedly(Return(std::make_pair<size_t, size_t>(16, 8)));
-
+    // EXPECT: Allocation and Send to be triggered during OfferService()
     std::vector<uint8_t> dummy_memory(16, 0);
     mock_binding::SampleAllocateePtr<void> dummy_alloc{dummy_memory.data(), [](void*) {}};
-    EXPECT_CALL(*mock_event_ptr, Allocate(_)).WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc)))));
-    EXPECT_CALL(*mock_event_ptr, Send(_)).WillOnce(Return(score::Result<void>{}));
+    EXPECT_CALL(*mock_event_binding_ptr_, Allocate(_))
+        .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc)))));
+    EXPECT_CALL(*mock_event_binding_ptr_, Send(_)).WillOnce(Return(score::Result<void>{}));
 
-    auto skeleton_result = GenericSkeleton::Create(
-        dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
-    ASSERT_TRUE(skeleton_result.has_value());
+    // WHEN: Offering the service
+    this->OfferSkeletonService();
 
-    auto& skeleton = skeleton_result.value();
-    auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
-
-    // Set initial value manually after creation
-    static_cast<void>(field->Update(init_val));
-
-    // skeleton_binding_mock_ is initialized inside Create(), so its expectations must come after
-    EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodHandlersRegistered()).WillRepeatedly(Return(true));
-
-    // When offering service, DoDeferredUpdate is executed
-    auto offer_res = skeleton_result.value().OfferService();
-    EXPECT_TRUE(offer_res.has_value());
+    // THEN: The deferred update is executed (verified by mock expectations)
 }
 
 TEST_F(GenericSkeletonFieldTest, UpdateAfterOfferAllocatesAndSends)
@@ -263,55 +230,22 @@ TEST_F(GenericSkeletonFieldTest, UpdateAfterOfferAllocatesAndSends)
                    "Checks that updating a field after offering the service successfully allocates and sends.");
     RecordProperty("TestType", "Requirements-based test");
 
-    const std::string field_name = GetConfiguredFieldName();
-    std::vector<uint8_t> init_val{0xAA, 0xBB};
-    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, true}};
-    GenericSkeletonServiceElementInfo create_params;
-    create_params.fields = field_storage;
+    // GIVEN: An offered skeleton service
+    this->GivenAGenericSkeletonWithOneField().OfferSkeletonService();
 
-    auto mock_event = std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>();
-    auto* mock_event_ptr = mock_event.get();
-
-    EXPECT_CALL(generic_event_binding_factory_mock_, Create(_, field_name, _))
-        .WillOnce(Return(ByMove(std::move(mock_event))));
-
-    // Setup expectations for initial OfferService caching BEFORE creation
-    EXPECT_CALL(*mock_event_ptr, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
-    EXPECT_CALL(*mock_event_ptr, GetSizeInfo()).WillRepeatedly(Return(std::make_pair<size_t, size_t>(16, 8)));
-
-    std::vector<uint8_t> dummy_memory1(16, 0);
-    mock_binding::SampleAllocateePtr<void> dummy_alloc1{dummy_memory1.data(), [](void*) {}};
-    EXPECT_CALL(*mock_event_ptr, Allocate(_)).WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc1)))));
-    EXPECT_CALL(*mock_event_ptr, Send(_)).WillOnce(Return(score::Result<void>{}));
-
-    auto skeleton_result = GenericSkeleton::Create(
-        dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
-    ASSERT_TRUE(skeleton_result.has_value());
-
-    auto& skeleton = skeleton_result.value();
-    auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
-
-    // Set initial value manually after creation
-    static_cast<void>(field->Update(init_val));
-
-    EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodHandlersRegistered()).WillRepeatedly(Return(true));
-
-    // Offer the service (Handle initial value allocation/send)
-    ASSERT_TRUE(skeleton_result.value().OfferService().has_value());
-
-    // When calling Update after OfferService
+    // WHEN: Calling Update after OfferService
     std::vector<uint8_t> new_val{0xCC, 0xDD};
-    std::vector<uint8_t> dummy_memory2(16, 0);
-    mock_binding::SampleAllocateePtr<void> dummy_alloc2{dummy_memory2.data(), [](void*) {}};
+    std::vector<uint8_t> dummy_memory(16, 0);
+    mock_binding::SampleAllocateePtr<void> dummy_alloc{dummy_memory.data(), [](void*) {}};
 
-    // Expect a NEW allocation and send
-    EXPECT_CALL(*mock_event_ptr, Allocate(_)).WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc2)))));
-    EXPECT_CALL(*mock_event_ptr, Send(_)).WillOnce(Return(score::Result<void>{}));
+    // EXPECT: A new allocation and send to the binding
+    EXPECT_CALL(*mock_event_binding_ptr_, Allocate(_))
+        .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc)))));
+    EXPECT_CALL(*mock_event_binding_ptr_, Send(_)).WillOnce(Return(score::Result<void>{}));
 
-    auto& skeleton = skeleton_result.value();
-    auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
-    auto update_res = field->Update(new_val);
+    auto update_res = field_->Update(new_val);
 
+    // THEN: The update succeeds
     EXPECT_TRUE(update_res.has_value());
 }
 
@@ -321,56 +255,22 @@ TEST_F(GenericSkeletonFieldTest, UpdateWithoutNotifierSendsToBinding)
                    "Checks that updating a field without a notifier successfully forwards the value to the binding.");
     RecordProperty("TestType", "Requirements-based test");
 
-    const std::string field_name = GetConfiguredFieldName();
-    std::vector<uint8_t> init_val{0xAA, 0xBB};
-    // has_notifier = false
-    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, false}};
-    GenericSkeletonServiceElementInfo create_params;
-    create_params.fields = field_storage;
+    // GIVEN: An offered skeleton service for a field with no notifier
+    this->GivenAGenericSkeletonWithOneField("test_field", {16, 8}, false, false, false).OfferSkeletonService();
 
-    auto mock_event = std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>();
-    auto* mock_event_ptr = mock_event.get();
-
-    EXPECT_CALL(generic_event_binding_factory_mock_, Create(_, field_name, _))
-        .WillOnce(Return(ByMove(std::move(mock_event))));
-
-    EXPECT_CALL(*mock_event_ptr, GetSizeInfo()).WillRepeatedly(Return(std::make_pair<size_t, size_t>(16, 8)));
-
-    // 1. Expect allocation and send of the INITIAL VALUE during OfferService()
-    std::vector<uint8_t> dummy_memory1(16, 0);
-    mock_binding::SampleAllocateePtr<void> dummy_alloc1{dummy_memory1.data(), [](void*) {}};
-
-    EXPECT_CALL(*mock_event_ptr, Allocate(_)).WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc1)))));
-    EXPECT_CALL(*mock_event_ptr, Send(_)).WillOnce(Return(score::Result<void>{}));
-
-    auto skeleton_result = GenericSkeleton::Create(
-        dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
-    ASSERT_TRUE(skeleton_result.has_value());
-
-    auto& skeleton = skeleton_result.value();
-    auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
-
-    // Set initial value manually after creation
-    static_cast<void>(field->Update(init_val));
-
-    // Offer the service
-    EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodHandlersRegistered()).WillRepeatedly(Return(true));
-    EXPECT_CALL(*mock_event_ptr, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
-    ASSERT_TRUE(skeleton_result.value().OfferService().has_value());
-
-    // 2. Expect a NEW allocation and send during explicit Update()
-    std::vector<uint8_t> dummy_memory2(16, 0);
-    mock_binding::SampleAllocateePtr<void> dummy_alloc2{dummy_memory2.data(), [](void*) {}};
-
-    EXPECT_CALL(*mock_event_ptr, Allocate(_)).WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc2)))));
-    EXPECT_CALL(*mock_event_ptr, Send(_)).WillOnce(Return(score::Result<void>{}));
-
-    auto& skeleton = skeleton_result.value();
-    auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
-
+    // WHEN: Calling Update
     std::vector<uint8_t> new_val{0xCC, 0xDD};
-    auto update_res = field->Update(new_val);
+    std::vector<uint8_t> dummy_memory(16, 0);
+    mock_binding::SampleAllocateePtr<void> dummy_alloc{dummy_memory.data(), [](void*) {}};
 
+    // EXPECT: An allocation and send to the binding (to update shared memory for Getters)
+    EXPECT_CALL(*mock_event_binding_ptr_, Allocate(_))
+        .WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc)))));
+    EXPECT_CALL(*mock_event_binding_ptr_, Send(_)).WillOnce(Return(score::Result<void>{}));
+
+    auto update_res = field_->Update(new_val);
+
+    // THEN: The update succeeds
     EXPECT_TRUE(update_res.has_value());
 }
 

--- a/score/mw/com/impl/generic_skeleton_field_test.cpp
+++ b/score/mw/com/impl/generic_skeleton_field_test.cpp
@@ -53,7 +53,7 @@ using ::testing::ReturnRef;
 class IBindingRuntimeMock : public IBindingRuntime
 {
   public:
-    MOCK_METHOD(IServiceDiscoveryClient&, GetServiceDiscoveryClient, (), (noexcept, override));
+    MOCK_METHOD(IServiceDiscoveryClient&, GetServiceDiscoveryClient, (), (noexcept, override, ref(&)));
     MOCK_METHOD(BindingType, GetBindingType, (), (const, noexcept, override));
     MOCK_METHOD(tracing::IBindingTracingRuntime*, GetTracingRuntime, (), (noexcept, override));
 };
@@ -183,7 +183,7 @@ TEST_F(GenericSkeletonFieldTest, UpdateBeforeOfferCachesValue)
     auto mock_event = std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>();
 
     // Expect NO Send or Allocate to be called since the service is not offered yet.
-    EXPECT_CALL(*mock_event, Allocate()).Times(0);
+    EXPECT_CALL(*mock_event, Allocate(_)).Times(0);
     EXPECT_CALL(*mock_event, Send(_)).Times(0);
 
     EXPECT_CALL(generic_event_binding_factory_mock_, Create(_, field_name, _))
@@ -230,7 +230,7 @@ TEST_F(GenericSkeletonFieldTest, DoDeferredUpdatePushesCachedValueOnOffer)
 
     std::vector<uint8_t> dummy_memory(16, 0);
     mock_binding::SampleAllocateePtr<void> dummy_alloc{dummy_memory.data(), [](void*) {}};
-    EXPECT_CALL(*mock_event_ptr, Allocate()).WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc)))));
+    EXPECT_CALL(*mock_event_ptr, Allocate(_)).WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc)))));
     EXPECT_CALL(*mock_event_ptr, Send(_)).WillOnce(Return(score::Result<void>{}));
 
     auto skeleton_result = GenericSkeleton::Create(
@@ -238,7 +238,7 @@ TEST_F(GenericSkeletonFieldTest, DoDeferredUpdatePushesCachedValueOnOffer)
     ASSERT_TRUE(skeleton_result.has_value());
 
     // skeleton_binding_mock_ is initialized inside Create(), so its expectations must come after
-    EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodsRegistered()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodHandlersRegistered()).WillRepeatedly(Return(true));
 
     // When offering service, DoDeferredUpdate is executed
     auto offer_res = skeleton_result.value().OfferService();
@@ -269,14 +269,14 @@ TEST_F(GenericSkeletonFieldTest, UpdateAfterOfferAllocatesAndSends)
 
     std::vector<uint8_t> dummy_memory1(16, 0);
     mock_binding::SampleAllocateePtr<void> dummy_alloc1{dummy_memory1.data(), [](void*) {}};
-    EXPECT_CALL(*mock_event_ptr, Allocate()).WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc1)))));
+    EXPECT_CALL(*mock_event_ptr, Allocate(_)).WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc1)))));
     EXPECT_CALL(*mock_event_ptr, Send(_)).WillOnce(Return(score::Result<void>{}));
 
     auto skeleton_result = GenericSkeleton::Create(
         dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
     ASSERT_TRUE(skeleton_result.has_value());
 
-    EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodsRegistered()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodHandlersRegistered()).WillRepeatedly(Return(true));
 
     // Offer the service (Handle initial value allocation/send)
     ASSERT_TRUE(skeleton_result.value().OfferService().has_value());
@@ -287,7 +287,7 @@ TEST_F(GenericSkeletonFieldTest, UpdateAfterOfferAllocatesAndSends)
     mock_binding::SampleAllocateePtr<void> dummy_alloc2{dummy_memory2.data(), [](void*) {}};
 
     // Expect a NEW allocation and send
-    EXPECT_CALL(*mock_event_ptr, Allocate()).WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc2)))));
+    EXPECT_CALL(*mock_event_ptr, Allocate(_)).WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc2)))));
     EXPECT_CALL(*mock_event_ptr, Send(_)).WillOnce(Return(score::Result<void>{}));
 
     auto& skeleton = skeleton_result.value();
@@ -299,9 +299,8 @@ TEST_F(GenericSkeletonFieldTest, UpdateAfterOfferAllocatesAndSends)
 
 TEST_F(GenericSkeletonFieldTest, UpdateWithoutNotifierSendsToBinding)
 {
-    RecordProperty(
-        "Description",
-        "Checks that updating a field without a notifier successfully forwards the value to the binding.");
+    RecordProperty("Description",
+                   "Checks that updating a field without a notifier successfully forwards the value to the binding.");
     RecordProperty("TestType", "Requirements-based test");
 
     const std::string field_name = GetConfiguredFieldName();
@@ -321,7 +320,7 @@ TEST_F(GenericSkeletonFieldTest, UpdateWithoutNotifierSendsToBinding)
     std::vector<uint8_t> dummy_memory(16, 0);
     mock_binding::SampleAllocateePtr<void> dummy_alloc{dummy_memory.data(), [](void*) {}};
 
-    EXPECT_CALL(*mock_event_ptr, Allocate()).WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc)))));
+    EXPECT_CALL(*mock_event_ptr, Allocate(_)).WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc)))));
     EXPECT_CALL(*mock_event_ptr, Send(_)).WillOnce(Return(score::Result<void>{}));
 
     auto skeleton_result = GenericSkeleton::Create(
@@ -329,7 +328,7 @@ TEST_F(GenericSkeletonFieldTest, UpdateWithoutNotifierSendsToBinding)
     ASSERT_TRUE(skeleton_result.has_value());
 
     // Offer the service
-    EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodsRegistered()).WillRepeatedly(Return(true));
+    EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodHandlersRegistered()).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_event_ptr, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
     ASSERT_TRUE(skeleton_result.value().OfferService().has_value());
 

--- a/score/mw/com/impl/generic_skeleton_field_test.cpp
+++ b/score/mw/com/impl/generic_skeleton_field_test.cpp
@@ -107,7 +107,8 @@ class GenericSkeletonFieldTest : public ::testing::Test
         create_params.fields = {{field_name, size_info, has_getter, has_setter, has_notifier}};
 
         auto skeleton_result = GenericSkeleton::Create(
-            dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
+            dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(),
+            create_params);
         EXPECT_TRUE(skeleton_result.has_value());
 
         skeleton_ = std::make_unique<GenericSkeleton>(std::move(skeleton_result.value()));
@@ -123,7 +124,8 @@ class GenericSkeletonFieldTest : public ::testing::Test
     {
         EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodHandlersRegistered()).WillRepeatedly(Return(true));
         EXPECT_CALL(*mock_event_binding_ptr_, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
-        EXPECT_CALL(*mock_event_binding_ptr_, GetSizeInfo()).WillRepeatedly(Return(std::make_pair<size_t, size_t>(16, 8)));
+        EXPECT_CALL(*mock_event_binding_ptr_, GetSizeInfo())
+            .WillRepeatedly(Return(std::make_pair<size_t, size_t>(16, 8)));
 
         const auto offer_result = skeleton_->OfferService();
         EXPECT_TRUE(offer_result.has_value());

--- a/score/mw/com/impl/generic_skeleton_field_test.cpp
+++ b/score/mw/com/impl/generic_skeleton_field_test.cpp
@@ -140,34 +140,6 @@ TEST_F(GenericSkeletonFieldTest, AllocateBeforeOfferReturnsError)
     EXPECT_EQ(alloc_result.error(), ComErrc::kBindingFailure);
 }
 
-TEST_F(GenericSkeletonFieldTest, AllocateFailsWithoutNotifier)
-{
-    RecordProperty("Description", "Checks that calling Allocate() without a notifier configured returns an error.");
-    RecordProperty("TestType", "Requirements-based test");
-
-    const std::string field_name = GetConfiguredFieldName();
-    std::vector<uint8_t> init_val{0};
-    // has_notifier set to false
-    std::vector<FieldInfo> field_storage{{field_name, {16, 8}, false, false, false, init_val}};
-    GenericSkeletonServiceElementInfo create_params;
-    create_params.fields = field_storage;
-
-    EXPECT_CALL(generic_event_binding_factory_mock_, Create(_, field_name, _))
-        .WillOnce(Return(ByMove(std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>())));
-
-    auto skeleton_result = GenericSkeleton::Create(
-        dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
-    ASSERT_TRUE(skeleton_result.has_value());
-
-    auto& skeleton = skeleton_result.value();
-    auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
-
-    auto alloc_result = field->Allocate();
-
-    ASSERT_FALSE(alloc_result.has_value());
-    EXPECT_EQ(alloc_result.error(), ComErrc::kBindingFailure);
-}
-
 TEST_F(GenericSkeletonFieldTest, GettersAndSettersReturnError)
 {
     RecordProperty("Description", "Checks that Get/Set handlers are currently WIP and correctly return an error.");
@@ -188,12 +160,6 @@ TEST_F(GenericSkeletonFieldTest, GettersAndSettersReturnError)
 
     auto& skeleton = skeleton_result.value();
     auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);
-
-    auto get_result = field->RegisterGetHandler([]() {
-        return std::vector<uint8_t>{};
-    });
-    EXPECT_FALSE(get_result.has_value());
-    EXPECT_EQ(get_result.error(), ComErrc::kCouldNotExecute);
 
     auto set_result = field->RegisterSetHandler([](auto) {
         return std::vector<uint8_t>{};
@@ -331,11 +297,11 @@ TEST_F(GenericSkeletonFieldTest, UpdateAfterOfferAllocatesAndSends)
     EXPECT_TRUE(update_res.has_value());
 }
 
-TEST_F(GenericSkeletonFieldTest, UpdateWithoutNotifierReturnsSuccessAndDoesNotSend)
+TEST_F(GenericSkeletonFieldTest, UpdateWithoutNotifierSendsToBinding)
 {
     RecordProperty(
         "Description",
-        "Checks that updating a field without a notifier returns success immediately without allocating or sending.");
+        "Checks that updating a field without a notifier successfully forwards the value to the binding.");
     RecordProperty("TestType", "Requirements-based test");
 
     const std::string field_name = GetConfiguredFieldName();
@@ -351,6 +317,13 @@ TEST_F(GenericSkeletonFieldTest, UpdateWithoutNotifierReturnsSuccessAndDoesNotSe
     EXPECT_CALL(generic_event_binding_factory_mock_, Create(_, field_name, _))
         .WillOnce(Return(ByMove(std::move(mock_event))));
 
+    // Expect allocation and send even though has_notifier_ is false
+    std::vector<uint8_t> dummy_memory(16, 0);
+    mock_binding::SampleAllocateePtr<void> dummy_alloc{dummy_memory.data(), [](void*) {}};
+
+    EXPECT_CALL(*mock_event_ptr, Allocate()).WillOnce(Return(ByMove(MakeSampleAllocateePtr(std::move(dummy_alloc)))));
+    EXPECT_CALL(*mock_event_ptr, Send(_)).WillOnce(Return(score::Result<void>{}));
+
     auto skeleton_result = GenericSkeleton::Create(
         dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(), create_params);
     ASSERT_TRUE(skeleton_result.has_value());
@@ -359,10 +332,6 @@ TEST_F(GenericSkeletonFieldTest, UpdateWithoutNotifierReturnsSuccessAndDoesNotSe
     EXPECT_CALL(*skeleton_binding_mock_, VerifyAllMethodsRegistered()).WillRepeatedly(Return(true));
     EXPECT_CALL(*mock_event_ptr, PrepareOffer()).WillOnce(Return(score::Result<void>{}));
     ASSERT_TRUE(skeleton_result.value().OfferService().has_value());
-
-    // When calling Update, expect NO Allocate and NO Send since has_notifier_ is false
-    EXPECT_CALL(*mock_event_ptr, Allocate()).Times(0);
-    EXPECT_CALL(*mock_event_ptr, Send(_)).Times(0);
 
     auto& skeleton = skeleton_result.value();
     auto* field = const_cast<GenericSkeletonField*>(&skeleton.GetFields().find(field_name)->second);

--- a/score/mw/com/impl/generic_skeleton_test.cpp
+++ b/score/mw/com/impl/generic_skeleton_test.cpp
@@ -492,11 +492,13 @@ TEST_F(GenericSkeletonTest, GetFieldsReturnsCorrectMapOfServiceElements)
     GenericSkeletonServiceElementInfo params;
     params.fields = field_storage;
 
-    // 3. Expect the binding factory to be called for each field
+    // Expect the binding factory to be called for each field
     EXPECT_CALL(generic_skeleton_event_binding_factory_mock_, Create(_, _, _))
         .Times(3)
         .WillRepeatedly(Invoke([](auto&, auto&, auto&) {
-            return std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>();
+            std::unique_ptr<GenericSkeletonEventBinding> binding =
+                std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>();
+            return Result<std::unique_ptr<GenericSkeletonEventBinding>>{std::move(binding)};
         }));
 
     // 4. When creating the skeleton

--- a/score/mw/com/impl/generic_skeleton_test.cpp
+++ b/score/mw/com/impl/generic_skeleton_test.cpp
@@ -373,5 +373,166 @@ TEST_F(GenericSkeletonTest, OfferServiceReturnsErrorIfBindingFails)
     EXPECT_EQ(result.error(), ComErrc::kBindingFailure);
 }
 
+TEST_F(GenericSkeletonTest, CreateWithFieldsInitializesFieldBindings)
+{
+    RecordProperty("Description", "Checks that GenericSkeleton creates bindings for configured fields.");
+    RecordProperty("TestType", "Requirements-based test");
+
+    // Given configuration for one field
+    auto identifier = dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField();
+    const std::string field_name = "test_field";
+    const DataTypeMetaInfo meta_info{16, 8};
+
+    std::vector<FieldInfo> field_storage;
+    field_storage.push_back({field_name, meta_info, false, false, true});
+
+    GenericSkeletonServiceElementInfo params;
+    params.fields = field_storage;
+
+    // Expect the Event Factory to be called (since Fields use Event bindings for notifiers)
+    auto MetaMatcher = AllOf(Property(&score::memory::DataTypeSizeInfo::Size, meta_info.size),
+                             Property(&score::memory::DataTypeSizeInfo::Alignment, meta_info.alignment));
+
+    EXPECT_CALL(generic_skeleton_event_binding_factory_mock_, Create(_, field_name, MetaMatcher))
+        .WillOnce(Return(ByMove(std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>())));
+
+    // When creating the skeleton
+    auto result = GenericSkeleton::Create(identifier, params);
+
+    // Then the skeleton contains the field
+    ASSERT_TRUE(result.has_value());
+    const auto& fields = result.value().GetFields();
+    ASSERT_EQ(fields.size(), 1);
+
+    EXPECT_NE(fields.find(field_name), fields.cend());
+}
+
+TEST_F(GenericSkeletonTest, CreateWithDuplicateFieldNamesFails)
+{
+    RecordProperty("Description", "Checks that creating a skeleton with duplicate field names returns an error.");
+    RecordProperty("TestType", "Requirements-based test");
+
+    // Given an identifier and configuration with duplicate field names
+    auto identifier = dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField();
+    const std::string field_name = "test_field";
+
+    std::vector<FieldInfo> field_storage;
+    field_storage.push_back({field_name, {1, 1}, false, false, true});
+    field_storage.push_back({field_name, {2, 2}, false, false, true});  // Duplicate
+
+    GenericSkeletonServiceElementInfo params;
+    params.fields = field_storage;
+
+    // Expecting at least one attempt to create an event binding
+    EXPECT_CALL(generic_skeleton_event_binding_factory_mock_, Create(_, field_name, _))
+        .WillRepeatedly(Return(ByMove(std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>())));
+
+    // When creating the skeleton
+    auto result = GenericSkeleton::Create(identifier, params);
+
+    // Then creation fails with kServiceElementAlreadyExists
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ComErrc::kServiceElementAlreadyExists);
+}
+
+TEST_F(GenericSkeletonTest, CreateFailsIfFieldBindingCannotBeCreated)
+{
+    RecordProperty(
+        "Description",
+        "Checks that creation fails if the GenericSkeletonEventBindingFactory returns an error for any field.");
+    RecordProperty("TestType", "Requirements-based test");
+
+    // Given an identifier and configuration with one valid field
+    auto identifier = dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField();
+    const std::string field_name = "test_field";
+
+    std::vector<FieldInfo> field_storage;
+    field_storage.push_back({field_name, {16, 8}, false, false, true});
+
+    GenericSkeletonServiceElementInfo params;
+    params.fields = field_storage;
+
+    // Expect the Event Binding Factory to be called, but force it to FAIL
+    EXPECT_CALL(generic_skeleton_event_binding_factory_mock_, Create(_, field_name, _))
+        .WillOnce(Return(ByMove(MakeUnexpected(ComErrc::kBindingFailure))));
+
+    // When creating the skeleton
+    auto result = GenericSkeleton::Create(identifier, params);
+
+    // Then creation fails and correctly propagates the kBindingFailure error
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ComErrc::kBindingFailure);
+}
+
+TEST_F(GenericSkeletonTest, GetFieldsReturnsCorrectMapOfServiceElements)
+{
+    RecordProperty("Description", "Checks that GetFields provides access to all configured fields by name.");
+    RecordProperty("TestType", "Requirements-based test");
+
+    // 1. Prepare a deployment configuration containing three specific field names
+    LolaServiceInstanceDeployment::FieldInstanceMapping field_mapping;
+    field_mapping["temperature"] = {LolaEventInstanceDeployment{1, 1, 1, true, 0}, false, false};
+    field_mapping["pressure"] = {LolaEventInstanceDeployment{2, 1, 1, true, 0}, false, false};
+    field_mapping["status"] = {LolaEventInstanceDeployment{3, 1, 1, true, 0}, false, false};
+
+    auto identifier = dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(field_mapping);
+
+    // 2. Setup configuration for the three requested fields
+    std::vector<FieldInfo> field_storage;
+    field_storage.push_back({"temperature", {4, 4}, true, false, true});
+    field_storage.push_back({"pressure", {4, 4}, false, true, false});
+    field_storage.push_back({"status", {1, 1}, true, true, true});
+
+    GenericSkeletonServiceElementInfo params;
+    params.fields = field_storage;
+
+    // 3. Expect the binding factory to be called for each field
+    EXPECT_CALL(generic_skeleton_event_binding_factory_mock_, Create(_, _, _))
+        .Times(3)
+        .WillRepeatedly(Invoke([](auto&, auto&, auto&) {
+            return std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>();
+        }));
+
+    // 4. When creating the skeleton
+    auto result = GenericSkeleton::Create(identifier, params);
+    ASSERT_TRUE(result.has_value());
+    auto& skeleton = result.value();
+
+    // 5. Then GetFields returns all of them correctly
+    const auto& fields = skeleton.GetFields();
+    EXPECT_EQ(fields.size(), 3);
+    EXPECT_NE(fields.find("temperature"), fields.cend());
+    EXPECT_NE(fields.find("pressure"), fields.cend());
+    EXPECT_NE(fields.find("status"), fields.cend());
+}
+
+TEST_F(GenericSkeletonTest, CreateFailsIfFieldNameNotFoundInConfiguration)
+{
+    RecordProperty("Description",
+                   "Checks that creation fails if a field name is not found in the deployment configuration.");
+    RecordProperty("TestType", "Requirements-based test");
+
+    // Given an identifier with a default deployment (usually contains "test_field")
+    auto identifier = dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField();
+    const std::string unknown_field_name = "unknown_field";
+
+    // When requesting a field that is NOT in that deployment
+    std::vector<FieldInfo> field_storage;
+    field_storage.push_back({unknown_field_name, {1, 1}, false, false, true});
+
+    GenericSkeletonServiceElementInfo params;
+    params.fields = field_storage;
+
+    // The factory should not be called because name resolution fails first
+    EXPECT_CALL(generic_skeleton_event_binding_factory_mock_, Create(_, _, _)).Times(0);
+
+    // When creating the skeleton
+    auto result = GenericSkeleton::Create(identifier, params);
+
+    // Then creation fails with kBindingFailure
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ComErrc::kBindingFailure);
+}
+
 }  // namespace
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/generic_skeleton_test.cpp
+++ b/score/mw/com/impl/generic_skeleton_test.cpp
@@ -471,9 +471,15 @@ TEST_F(GenericSkeletonTest, GetFieldsReturnsCorrectMapOfServiceElements)
 
     // 1. Prepare a deployment configuration containing three specific field names
     LolaServiceInstanceDeployment::FieldInstanceMapping field_mapping;
-    field_mapping["temperature"] = {LolaEventInstanceDeployment{1, 1, 1, true, 0}, false, false};
-    field_mapping["pressure"] = {LolaEventInstanceDeployment{2, 1, 1, true, 0}, false, false};
-    field_mapping["status"] = {LolaEventInstanceDeployment{3, 1, 1, true, 0}, false, false};
+    field_mapping.emplace(
+        "temperature",
+        LolaFieldInstanceDeployment{LolaEventInstanceDeployment{1, 1, 1, true, 0}, false, false});
+    field_mapping.emplace(
+        "pressure",
+        LolaFieldInstanceDeployment{LolaEventInstanceDeployment{2, 1, 1, true, 0}, false, false});
+    field_mapping.emplace(
+        "status",
+        LolaFieldInstanceDeployment{LolaEventInstanceDeployment{3, 1, 1, true, 0}, false, false});
 
     auto identifier = dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(field_mapping);
 

--- a/score/mw/com/impl/generic_skeleton_test.cpp
+++ b/score/mw/com/impl/generic_skeleton_test.cpp
@@ -471,15 +471,12 @@ TEST_F(GenericSkeletonTest, GetFieldsReturnsCorrectMapOfServiceElements)
 
     // 1. Prepare a deployment configuration containing three specific field names
     LolaServiceInstanceDeployment::FieldInstanceMapping field_mapping;
-    field_mapping.emplace(
-        "temperature",
-        LolaFieldInstanceDeployment{LolaEventInstanceDeployment{1, 1, 1, true, 0}, false, false});
-    field_mapping.emplace(
-        "pressure",
-        LolaFieldInstanceDeployment{LolaEventInstanceDeployment{2, 1, 1, true, 0}, false, false});
-    field_mapping.emplace(
-        "status",
-        LolaFieldInstanceDeployment{LolaEventInstanceDeployment{3, 1, 1, true, 0}, false, false});
+    field_mapping.emplace("temperature",
+                          LolaFieldInstanceDeployment{LolaEventInstanceDeployment{1, 1, 1, true, 0}, false, false});
+    field_mapping.emplace("pressure",
+                          LolaFieldInstanceDeployment{LolaEventInstanceDeployment{2, 1, 1, true, 0}, false, false});
+    field_mapping.emplace("status",
+                          LolaFieldInstanceDeployment{LolaEventInstanceDeployment{3, 1, 1, true, 0}, false, false});
 
     auto identifier = dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithField(field_mapping);
 

--- a/score/mw/com/impl/generic_skeleton_test.cpp
+++ b/score/mw/com/impl/generic_skeleton_test.cpp
@@ -495,7 +495,7 @@ TEST_F(GenericSkeletonTest, GetFieldsReturnsCorrectMapOfServiceElements)
     // Expect the binding factory to be called for each field
     EXPECT_CALL(generic_skeleton_event_binding_factory_mock_, Create(_, _, _))
         .Times(3)
-        .WillRepeatedly(Invoke([](auto&, auto&, auto&) {
+        .WillRepeatedly(Invoke([](SkeletonBase&, std::string_view, const score::memory::DataTypeSizeInfo&) {
             std::unique_ptr<GenericSkeletonEventBinding> binding =
                 std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>();
             return Result<std::unique_ptr<GenericSkeletonEventBinding>>{std::move(binding)};

--- a/score/mw/com/impl/test/dummy_instance_identifier_builder.cpp
+++ b/score/mw/com/impl/test/dummy_instance_identifier_builder.cpp
@@ -81,6 +81,15 @@ InstanceIdentifier DummyInstanceIdentifierBuilder::CreateValidLolaInstanceIdenti
     service_instance_deployment_.instance_id_ = LolaServiceInstanceId{0x42};
     service_instance_deployment_.allowed_consumer_ = {{QualityType::kASIL_QM, {42}}};
     service_instance_deployment_.fields_ = fields;
+
+    // The GenericSkeleton needs the field names to be present in the Type Deployment
+    // to perform the stable string lookup. We sync it here.
+    service_type_deployment_.fields_.clear();
+    for (const auto& field_pair : fields)
+    {
+        service_type_deployment_.fields_[field_pair.first] = {};
+    }
+
     type_deployment_.binding_info_ = service_type_deployment_;
     instance_deployment_ = std::make_unique<ServiceInstanceDeployment>(
         type_, service_instance_deployment_, QualityType::kASIL_QM, instance_specifier_);


### PR DESCRIPTION
**Summary:** 
This PR extends the GenericSkeleton to support type-erased Fields and solves this issue https://github.com/eclipse-score/communication/issues/181

**Key Changes:**

**GenericSkeletonField**: Introduced as a type-erased facade for fields. It takes ownership of a GenericSkeletonEvent under the hood to handle shared memory interactions and broadcasts.
**Initial Value Caching:** Calling Update() before OfferService() caches the field payload locally. Once the service is offered, DoDeferredUpdate() automatically allocates memory and dispatches this initial value to subscribers.
**Zero-copy Notifications:** Added support for Allocate() and Update(SampleAllocateePtr) to push new field values to subscribers after the service is actively running.
**Skeleton Orchestration:** Updated GenericSkeleton::Create to parse field configurations, spawn the fields, and properly populate the internal fields_ map.

**Next Steps / Future Work:**

Generic Getters & Setters: Currently, RegisterGetHandler and RegisterSetHandler are stubbed out as WIP and return ComErrc::kCouldNotExecute. In the next step, this generic field will be extended with full set and get method support over shared memory once those features are fully implemented.