### PR TITLE
Use Graphviz dot for PlantUML rendering

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -73,6 +73,10 @@ jobs:
             echo "should_deploy=true" >> "$GITHUB_OUTPUT"
           fi
 
+      - name: Install Graphviz
+        run: |
+          sudo apt-get update && sudo apt-get install -y graphviz
+
       - name: Build Sphinx documentation
         env:
           DOCS_BASE_URL: "https://${{ github.repository_owner }}.github.io/${{ github.event.repository.name }}"

--- a/bazel/toolchains/template/conf.template.py
+++ b/bazel/toolchains/template/conf.template.py
@@ -144,7 +144,25 @@ if _plantuml_path is None:
         "Ensure @score_tooling//tools/sphinx:plantuml is in sphinx_build data."
     )
 else:
-    plantuml = str(_plantuml_path)
+    # Locate the Graphviz dot binary so PlantUML can render diagrams that
+    # require a layout engine (class, state, component diagrams, etc.).
+    import shutil
+
+    _dot_path = (
+        os.environ.get("GRAPHVIZ_DOT")
+        or shutil.which("dot")
+        or "/usr/bin/dot"
+    )
+    if Path(_dot_path).exists():
+        plantuml = f"{_plantuml_path} -graphvizdot {_dot_path}"
+        logger.info(f"PlantUML will use Graphviz dot at: {_dot_path}")
+    else:
+        plantuml = str(_plantuml_path)
+        logger.warning(
+            "Graphviz dot binary not found — diagrams requiring layout "
+            "engines (class, state, etc.) may fail to render. "
+            "Install it with: sudo apt-get install graphviz"
+        )
     plantuml_output_format = "svg_obj"
 
 


### PR DESCRIPTION
Install graphviz in the docs deployment workflow and configure the Sphinx PlantUML setup to use dot when available. Keep a fallback when dot is missing and log how to install graphviz locally.