### PR TITLE
Koma task safety reports integration

### DIFF
--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -48,17 +48,20 @@ jobs:
         with:
           level: 4
 
-      # TODO(follow-up PR): align setup-bazel version with the other workflows.
       - name: Setup Bazel with shared caching
-        uses: bazel-contrib/setup-bazel@0.18.0
+        uses: castler/setup-bazel@cache-optimized
         with:
           bazelisk-cache: true
-          disk-cache: "coverage_report"
+          disk-cache: ${{ github.workflow }}
           repository-cache: true
-          cache-save: true
+          cache-optimized: true
+          cache-save: ${{ github.ref == 'refs/heads/main' }}
 
       - name: Allow linux-sandbox
         uses: ./actions/unblock_user_namespace_for_linux_sandbox
+
+      - name: Install Perl dependencies for genhtml
+        run: sudo apt-get install -y --no-install-recommends lcov
 
       - name: Run Unit Test with Coverage for C++
         id: run-coverage
@@ -66,18 +69,12 @@ jobs:
         run: |
           bazel coverage //... --build_tests_only
 
-      # TODO(follow-up PR): merge generate_coverage_html and create_coverage_archive
-      # into a single sh_binary with a --archive flag.
-      - name: Generate HTML Coverage Report
+      - name: Generate HTML Coverage Report and Create Archive
         if: steps.run-coverage.outcome == 'success'
         run: |
-          bazel run //quality/coverage:generate_coverage_html -- cpp_coverage
-
-      - name: Create archive of test report
-        if: steps.run-coverage.outcome == 'success'
-        run: |
-          bash quality/scripts/create_coverage_archive.sh \
-            "${{ github.event.repository.name }}_coverage_report_${{ github.sha }}"
+          bazel run //quality/coverage:generate_coverage_html -- \
+            --archive "${{ github.event.repository.name }}_coverage_report_${{ github.sha }}" \
+            cpp_coverage
 
       - name: Set conclusion
         id: set-conclusion

--- a/docs/sphinx/BUILD
+++ b/docs/sphinx/BUILD
@@ -17,7 +17,6 @@ load(
     "filter_execpath",
     "sphinx_module",
 )
-load("//bazel/rules:generate_quality_links.bzl", "generate_quality_links")
 load("//docs/sphinx/utils:defs.bzl", "generate_api_rst")
 
 # Capture the Doxygen XML output for Breathe
@@ -45,13 +44,6 @@ generate_api_rst(
     project_name = "mw::com",
 )
 
-# Generate RST substitution definitions for quality report links.
-# Content depends on --define=DOCS_VERSION and --define=DOCS_BASE_URL.
-generate_quality_links(
-    name = "quality_links",
-    visibility = ["//visibility:private"],
-)
-
 filter_execpath(
     name = "breathe_doxygen_xml",
     filter_pattern = "doxygen_build/xml",
@@ -75,7 +67,6 @@ sphinx_module(
             "safety_reports.rst",
             ":doxygen_xml",
             ":generate_api_rst",
-            ":quality_links",
             ":static_assets",
         ],
     docs_library_deps = [

--- a/docs/sphinx/BUILD
+++ b/docs/sphinx/BUILD
@@ -17,6 +17,7 @@ load(
     "filter_execpath",
     "sphinx_module",
 )
+load("//bazel/rules:generate_quality_links.bzl", "generate_quality_links")
 load("//docs/sphinx/utils:defs.bzl", "generate_api_rst")
 
 # Capture the Doxygen XML output for Breathe
@@ -44,6 +45,13 @@ generate_api_rst(
     project_name = "mw::com",
 )
 
+# Generate RST substitution definitions for quality report links.
+# Content depends on --define=DOCS_VERSION and --define=DOCS_BASE_URL.
+generate_quality_links(
+    name = "quality_links",
+    visibility = ["//visibility:private"],
+)
+
 filter_execpath(
     name = "breathe_doxygen_xml",
     filter_pattern = "doxygen_build/xml",
@@ -62,9 +70,12 @@ sphinx_module(
             "introduction.rst",
             "message_passing.rst",
             "quality_reports.rst",
+            "safety_message_passing.rst",
+            "safety_mw_com.rst",
             "safety_reports.rst",
             ":doxygen_xml",
             ":generate_api_rst",
+            ":quality_links",
             ":static_assets",
         ],
     docs_library_deps = [

--- a/docs/sphinx/safety_message_passing.rst
+++ b/docs/sphinx/safety_message_passing.rst
@@ -13,84 +13,6 @@ Safety documentation for the Message Passing component (Dependable Element, Inte
 
     <script>
     (function() {
-<<<<<<< HEAD
-       function addSidebarLinks() {
-          var sidebar = document.querySelector("#pst-secondary-sidebar .sidebar-secondary__inner");
-          if (!sidebar) return;
-          var frame = document.getElementById("safety-report-frame");
-          if (!frame) return;
-
-          var frameDoc;
-          try {
-             frameDoc = frame.contentDocument || frame.contentWindow.document;
-          } catch (e) {
-             return;
-          }
-          if (!frameDoc) return;
-
-          var tocLinks = frameDoc.querySelectorAll("#pst-secondary-sidebar .section-nav a");
-          if (!tocLinks.length) return;
-
-          var existing = document.getElementById("safety-right-links");
-          if (existing) {
-             existing.remove();
-          }
-
-          var wrapper = document.createElement("div");
-          wrapper.className = "sidebar-secondary-item";
-          wrapper.id = "safety-right-links";
-          var list = document.createElement("ul");
-          list.className = "visible nav section-nav flex-column";
-          var frameSrc = frame.getAttribute("src") || "";
-
-          tocLinks.forEach(function(link) {
-             var href = link.getAttribute("href") || "";
-             if (href.startsWith("#")) {
-                href = frameSrc.replace(/#.*$/, "") + href;
-             }
-
-             var li = document.createElement("li");
-             li.className = "toc-entry nav-item toc-h2";
-
-             var a = document.createElement("a");
-             a.className = "reference internal nav-link";
-             a.setAttribute("href", href);
-             a.textContent = link.textContent.trim();
-
-             li.appendChild(a);
-             list.appendChild(li);
-          });
-
-          wrapper.appendChild(list);
-
-          var sourceBlock = sidebar.querySelector(".tocsection.sourcelink");
-          var sourceItem = sourceBlock ? sourceBlock.closest(".sidebar-secondary-item") : null;
-          if (sourceItem) {
-             sidebar.insertBefore(wrapper, sourceItem);
-          } else {
-             sidebar.appendChild(wrapper);
-          }
-       }
-
-       function init() {
-          var frame = document.getElementById("safety-report-frame");
-          if (!frame) return;
-          frame.addEventListener("load", function() {
-             addSidebarLinks();
-             setTimeout(addSidebarLinks, 150);
-          });
-          addSidebarLinks();
-       }
-
-       if (document.readyState === "loading") {
-          document.addEventListener("DOMContentLoaded", init);
-       } else {
-          init();
-       }
-    })();
-    </script>
-
-=======
        var attempts = 0;
        var maxAttempts = 40;
 
@@ -239,5 +161,3 @@ Safety documentation for the Message Passing component (Dependable Element, Inte
        }
     })();
     </script>
-
->>>>>>> 94c65095 (docs: sync safety sidebar content with embedded report TOC)

--- a/docs/sphinx/safety_message_passing.rst
+++ b/docs/sphinx/safety_message_passing.rst
@@ -1,0 +1,243 @@
+Message Passing Safety Report
+==============================
+
+Safety documentation for the Message Passing component (Dependable Element, Integrity Level B).
+
+.. raw:: html
+
+   <iframe id="safety-report-frame" src="dependable_element_message_passing_doc/index.html"
+      style="width:100%; height:1400px; border:1px solid #e0e0e0; border-radius:4px;"
+      title="Message Passing Safety Report"></iframe>
+
+.. raw:: html
+
+    <script>
+    (function() {
+<<<<<<< HEAD
+       function addSidebarLinks() {
+          var sidebar = document.querySelector("#pst-secondary-sidebar .sidebar-secondary__inner");
+          if (!sidebar) return;
+          var frame = document.getElementById("safety-report-frame");
+          if (!frame) return;
+
+          var frameDoc;
+          try {
+             frameDoc = frame.contentDocument || frame.contentWindow.document;
+          } catch (e) {
+             return;
+          }
+          if (!frameDoc) return;
+
+          var tocLinks = frameDoc.querySelectorAll("#pst-secondary-sidebar .section-nav a");
+          if (!tocLinks.length) return;
+
+          var existing = document.getElementById("safety-right-links");
+          if (existing) {
+             existing.remove();
+          }
+
+          var wrapper = document.createElement("div");
+          wrapper.className = "sidebar-secondary-item";
+          wrapper.id = "safety-right-links";
+          var list = document.createElement("ul");
+          list.className = "visible nav section-nav flex-column";
+          var frameSrc = frame.getAttribute("src") || "";
+
+          tocLinks.forEach(function(link) {
+             var href = link.getAttribute("href") || "";
+             if (href.startsWith("#")) {
+                href = frameSrc.replace(/#.*$/, "") + href;
+             }
+
+             var li = document.createElement("li");
+             li.className = "toc-entry nav-item toc-h2";
+
+             var a = document.createElement("a");
+             a.className = "reference internal nav-link";
+             a.setAttribute("href", href);
+             a.textContent = link.textContent.trim();
+
+             li.appendChild(a);
+             list.appendChild(li);
+          });
+
+          wrapper.appendChild(list);
+
+          var sourceBlock = sidebar.querySelector(".tocsection.sourcelink");
+          var sourceItem = sourceBlock ? sourceBlock.closest(".sidebar-secondary-item") : null;
+          if (sourceItem) {
+             sidebar.insertBefore(wrapper, sourceItem);
+          } else {
+             sidebar.appendChild(wrapper);
+          }
+       }
+
+       function init() {
+          var frame = document.getElementById("safety-report-frame");
+          if (!frame) return;
+          frame.addEventListener("load", function() {
+             addSidebarLinks();
+             setTimeout(addSidebarLinks, 150);
+          });
+          addSidebarLinks();
+       }
+
+       if (document.readyState === "loading") {
+          document.addEventListener("DOMContentLoaded", init);
+       } else {
+          init();
+       }
+    })();
+    </script>
+
+=======
+       var attempts = 0;
+       var maxAttempts = 40;
+
+       function routeToFrame(href, frame) {
+          var hashIndex = href.indexOf("#");
+          if (hashIndex < 0) return false;
+          var hash = href.slice(hashIndex);
+          var base = (frame.getAttribute("src") || "").replace(/#.*$/, "");
+          frame.setAttribute("src", base + hash);
+          return true;
+       }
+
+       function upsertFallbackSidebar(sidebar, frame) {
+          var existing = document.getElementById("safety-right-links");
+          if (existing) {
+             existing.remove();
+          }
+
+          var wrapper = document.createElement("div");
+          wrapper.className = "sidebar-secondary-item";
+          wrapper.id = "safety-right-links";
+
+          var list = document.createElement("ul");
+          list.className = "visible nav section-nav flex-column";
+
+          [
+             ["Assumed System", "dependable_element_message_passing_doc/index.html#assumed-system"],
+             ["Software Architectural Level", "dependable_element_message_passing_doc/index.html#software-architectural-level"],
+             ["Components", "dependable_element_message_passing_doc/index.html#components"],
+             ["Checklists", "dependable_element_message_passing_doc/index.html#checklists"],
+             ["Submodules", "dependable_element_message_passing_doc/index.html#submodules"]
+          ].forEach(function(item) {
+             var li = document.createElement("li");
+             li.className = "toc-entry nav-item toc-h2";
+             var a = document.createElement("a");
+             a.className = "reference internal nav-link";
+             a.setAttribute("href", item[1]);
+             a.textContent = item[0];
+             li.appendChild(a);
+             list.appendChild(li);
+          });
+
+          wrapper.appendChild(list);
+          var sourceBlock = sidebar.querySelector(".tocsection.sourcelink");
+          var sourceItem = sourceBlock ? sourceBlock.closest(".sidebar-secondary-item") : null;
+          if (sourceItem) {
+             sidebar.insertBefore(wrapper, sourceItem);
+          } else {
+             sidebar.appendChild(wrapper);
+          }
+
+          wrapper.addEventListener("click", function(ev) {
+             var aEl = ev.target.closest("a");
+             if (!aEl) return;
+             var href = aEl.getAttribute("href") || "";
+             if (routeToFrame(href, frame)) {
+                ev.preventDefault();
+             }
+          });
+       }
+
+       function addSidebarLinks() {
+          var sidebar = document.querySelector("#pst-secondary-sidebar .sidebar-secondary__inner");
+          if (!sidebar) return;
+          var frame = document.getElementById("safety-report-frame");
+          if (!frame) return;
+
+          var frameDoc;
+          try {
+             frameDoc = frame.contentDocument || frame.contentWindow.document;
+          } catch (e) {
+             upsertFallbackSidebar(sidebar, frame);
+             return;
+          }
+          if (!frameDoc) {
+             upsertFallbackSidebar(sidebar, frame);
+             return;
+          }
+
+          var sourceToc = frameDoc.querySelector("#pst-secondary-sidebar .section-nav");
+          if (!sourceToc) {
+             attempts += 1;
+             if (attempts < maxAttempts) {
+                setTimeout(addSidebarLinks, 150);
+             } else {
+                upsertFallbackSidebar(sidebar, frame);
+             }
+             return;
+          }
+
+          var existing = document.getElementById("safety-right-links");
+          if (existing) {
+             existing.remove();
+          }
+
+          var wrapper = document.createElement("div");
+          wrapper.className = "sidebar-secondary-item";
+          wrapper.id = "safety-right-links";
+          var list = sourceToc.cloneNode(true);
+          list.classList.add("visible");
+          var frameSrc = frame.getAttribute("src") || "";
+
+          list.querySelectorAll("a").forEach(function(link) {
+             var href = link.getAttribute("href") || "";
+             if (href.startsWith("#")) {
+                href = frameSrc.replace(/#.*$/, "") + href;
+             }
+             link.setAttribute("href", href);
+          });
+
+          wrapper.appendChild(list);
+
+          var sourceBlock = sidebar.querySelector(".tocsection.sourcelink");
+          var sourceItem = sourceBlock ? sourceBlock.closest(".sidebar-secondary-item") : null;
+          if (sourceItem) {
+             sidebar.insertBefore(wrapper, sourceItem);
+          } else {
+             sidebar.appendChild(wrapper);
+          }
+
+          wrapper.addEventListener("click", function(ev) {
+             var aEl = ev.target.closest("a");
+             if (!aEl) return;
+             var href = aEl.getAttribute("href") || "";
+             if (routeToFrame(href, frame)) {
+                ev.preventDefault();
+             }
+          });
+       }
+
+       function init() {
+          var frame = document.getElementById("safety-report-frame");
+          if (!frame) return;
+          frame.addEventListener("load", function() {
+             attempts = 0;
+             addSidebarLinks();
+          });
+          attempts = 0;
+          addSidebarLinks();
+       }
+
+       if (document.readyState === "loading") {
+          document.addEventListener("DOMContentLoaded", init);
+       } else {
+          init();
+       }
+    })();
+    </script>
+
+>>>>>>> 94c65095 (docs: sync safety sidebar content with embedded report TOC)

--- a/docs/sphinx/safety_message_passing.rst
+++ b/docs/sphinx/safety_message_passing.rst
@@ -16,10 +16,16 @@ Safety documentation for the Message Passing component (Dependable Element, Inte
        var attempts = 0;
        var maxAttempts = 40;
 
-       function routeToFrame(href, frame) {
-          var hashIndex = href.indexOf("#");
-          if (hashIndex < 0) return false;
-          var hash = href.slice(hashIndex);
+       function routeToFrame(hash, frame) {
+          if (!hash || hash.charAt(0) !== "#") return false;
+          try {
+             if (frame.contentWindow && frame.contentWindow.location) {
+                frame.contentWindow.location.hash = hash;
+                return true;
+             }
+          } catch (e) {
+             // Fall back to updating src when iframe hash access is blocked.
+          }
           var base = (frame.getAttribute("src") || "").replace(/#.*$/, "");
           frame.setAttribute("src", base + hash);
           return true;
@@ -39,18 +45,24 @@ Safety documentation for the Message Passing component (Dependable Element, Inte
           list.className = "visible nav section-nav flex-column";
 
           [
-             ["Assumed System", "dependable_element_message_passing_doc/index.html#assumed-system"],
-             ["Software Architectural Level", "dependable_element_message_passing_doc/index.html#software-architectural-level"],
-             ["Components", "dependable_element_message_passing_doc/index.html#components"],
-             ["Checklists", "dependable_element_message_passing_doc/index.html#checklists"],
-             ["Submodules", "dependable_element_message_passing_doc/index.html#submodules"]
+             ["Assumed System", "#assumed-system"],
+             ["Software Architectural Level", "#software-architectural-level"],
+             ["Components", "#components"],
+             ["Checklists", "#checklists"],
+             ["Submodules", "#submodules"]
           ].forEach(function(item) {
              var li = document.createElement("li");
              li.className = "toc-entry nav-item toc-h2";
              var a = document.createElement("a");
              a.className = "reference internal nav-link";
-             a.setAttribute("href", item[1]);
+             a.setAttribute("href", "javascript:void(0)");
+             a.setAttribute("data-hash", item[1]);
              a.textContent = item[0];
+             a.addEventListener("click", function(ev) {
+                ev.preventDefault();
+                ev.stopPropagation();
+                routeToFrame(item[1], frame);
+             });
              li.appendChild(a);
              list.appendChild(li);
           });
@@ -67,10 +79,10 @@ Safety documentation for the Message Passing component (Dependable Element, Inte
           wrapper.addEventListener("click", function(ev) {
              var aEl = ev.target.closest("a");
              if (!aEl) return;
-             var href = aEl.getAttribute("href") || "";
-             if (routeToFrame(href, frame)) {
-                ev.preventDefault();
-             }
+             ev.preventDefault();
+             ev.stopPropagation();
+             var hash = aEl.getAttribute("data-hash") || "";
+             routeToFrame(hash, frame);
           });
        }
 
@@ -113,14 +125,20 @@ Safety documentation for the Message Passing component (Dependable Element, Inte
           wrapper.id = "safety-right-links";
           var list = sourceToc.cloneNode(true);
           list.classList.add("visible");
-          var frameSrc = frame.getAttribute("src") || "";
-
           list.querySelectorAll("a").forEach(function(link) {
              var href = link.getAttribute("href") || "";
-             if (href.startsWith("#")) {
-                href = frameSrc.replace(/#.*$/, "") + href;
+             var hashIndex = href.indexOf("#");
+             var hash = hashIndex >= 0 ? href.slice(hashIndex) : "";
+             if (!hash && href.startsWith("#")) {
+                hash = href;
              }
-             link.setAttribute("href", href);
+             link.setAttribute("data-hash", hash);
+             link.setAttribute("href", "javascript:void(0)");
+             link.addEventListener("click", function(ev) {
+                ev.preventDefault();
+                ev.stopPropagation();
+                routeToFrame(hash, frame);
+             });
           });
 
           wrapper.appendChild(list);
@@ -136,16 +154,25 @@ Safety documentation for the Message Passing component (Dependable Element, Inte
           wrapper.addEventListener("click", function(ev) {
              var aEl = ev.target.closest("a");
              if (!aEl) return;
-             var href = aEl.getAttribute("href") || "";
-             if (routeToFrame(href, frame)) {
-                ev.preventDefault();
-             }
+             ev.preventDefault();
+             ev.stopPropagation();
+             var hash = aEl.getAttribute("data-hash") || "";
+             routeToFrame(hash, frame);
           });
        }
 
        function init() {
           var frame = document.getElementById("safety-report-frame");
           if (!frame) return;
+          document.addEventListener("click", function(ev) {
+             var sidebar = document.getElementById("pst-secondary-sidebar");
+             if (!sidebar) return;
+             var link = ev.target.closest("#pst-secondary-sidebar .section-nav a");
+             if (!link) return;
+             ev.preventDefault();
+             ev.stopPropagation();
+             routeToFrame(link.getAttribute("data-hash") || link.getAttribute("href") || "", frame);
+          }, true);
           frame.addEventListener("load", function() {
              attempts = 0;
              addSidebarLinks();

--- a/docs/sphinx/safety_mw_com.rst
+++ b/docs/sphinx/safety_mw_com.rst
@@ -16,10 +16,16 @@ Safety documentation for the MW::COM component (Dependable Element, Integrity Le
        var attempts = 0;
        var maxAttempts = 40;
 
-       function routeToFrame(href, frame) {
-          var hashIndex = href.indexOf("#");
-          if (hashIndex < 0) return false;
-          var hash = href.slice(hashIndex);
+       function routeToFrame(hash, frame) {
+          if (!hash || hash.charAt(0) !== "#") return false;
+          try {
+             if (frame.contentWindow && frame.contentWindow.location) {
+                frame.contentWindow.location.hash = hash;
+                return true;
+             }
+          } catch (e) {
+             // Fall back to updating src when iframe hash access is blocked.
+          }
           var base = (frame.getAttribute("src") || "").replace(/#.*$/, "");
           frame.setAttribute("src", base + hash);
           return true;
@@ -39,18 +45,24 @@ Safety documentation for the MW::COM component (Dependable Element, Integrity Le
           list.className = "visible nav section-nav flex-column";
 
           [
-             ["Assumed System", "mw_com_doc/index.html#assumed-system"],
-             ["Software Architectural Level", "mw_com_doc/index.html#software-architectural-level"],
-             ["Components", "mw_com_doc/index.html#components"],
-             ["Checklists", "mw_com_doc/index.html#checklists"],
-             ["Submodules", "mw_com_doc/index.html#submodules"]
+             ["Assumed System", "#assumed-system"],
+             ["Software Architectural Level", "#software-architectural-level"],
+             ["Components", "#components"],
+             ["Checklists", "#checklists"],
+             ["Submodules", "#submodules"]
           ].forEach(function(item) {
              var li = document.createElement("li");
              li.className = "toc-entry nav-item toc-h2";
              var a = document.createElement("a");
              a.className = "reference internal nav-link";
-             a.setAttribute("href", item[1]);
+             a.setAttribute("href", "javascript:void(0)");
+             a.setAttribute("data-hash", item[1]);
              a.textContent = item[0];
+             a.addEventListener("click", function(ev) {
+                ev.preventDefault();
+                ev.stopPropagation();
+                routeToFrame(item[1], frame);
+             });
              li.appendChild(a);
              list.appendChild(li);
           });
@@ -67,10 +79,10 @@ Safety documentation for the MW::COM component (Dependable Element, Integrity Le
           wrapper.addEventListener("click", function(ev) {
              var aEl = ev.target.closest("a");
              if (!aEl) return;
-             var href = aEl.getAttribute("href") || "";
-             if (routeToFrame(href, frame)) {
-                ev.preventDefault();
-             }
+             ev.preventDefault();
+             ev.stopPropagation();
+             var hash = aEl.getAttribute("data-hash") || "";
+             routeToFrame(hash, frame);
           });
        }
 
@@ -113,14 +125,20 @@ Safety documentation for the MW::COM component (Dependable Element, Integrity Le
           wrapper.id = "safety-right-links";
           var list = sourceToc.cloneNode(true);
           list.classList.add("visible");
-          var frameSrc = frame.getAttribute("src") || "";
-
           list.querySelectorAll("a").forEach(function(link) {
              var href = link.getAttribute("href") || "";
-             if (href.startsWith("#")) {
-                href = frameSrc.replace(/#.*$/, "") + href;
+             var hashIndex = href.indexOf("#");
+             var hash = hashIndex >= 0 ? href.slice(hashIndex) : "";
+             if (!hash && href.startsWith("#")) {
+                hash = href;
              }
-             link.setAttribute("href", href);
+             link.setAttribute("data-hash", hash);
+             link.setAttribute("href", "javascript:void(0)");
+             link.addEventListener("click", function(ev) {
+                ev.preventDefault();
+                ev.stopPropagation();
+                routeToFrame(hash, frame);
+             });
           });
 
           wrapper.appendChild(list);
@@ -136,16 +154,25 @@ Safety documentation for the MW::COM component (Dependable Element, Integrity Le
           wrapper.addEventListener("click", function(ev) {
              var aEl = ev.target.closest("a");
              if (!aEl) return;
-             var href = aEl.getAttribute("href") || "";
-             if (routeToFrame(href, frame)) {
-                ev.preventDefault();
-             }
+             ev.preventDefault();
+             ev.stopPropagation();
+             var hash = aEl.getAttribute("data-hash") || "";
+             routeToFrame(hash, frame);
           });
        }
 
        function init() {
           var frame = document.getElementById("safety-report-frame");
           if (!frame) return;
+          document.addEventListener("click", function(ev) {
+             var sidebar = document.getElementById("pst-secondary-sidebar");
+             if (!sidebar) return;
+             var link = ev.target.closest("#pst-secondary-sidebar .section-nav a");
+             if (!link) return;
+             ev.preventDefault();
+             ev.stopPropagation();
+             routeToFrame(link.getAttribute("data-hash") || link.getAttribute("href") || "", frame);
+          }, true);
           frame.addEventListener("load", function() {
              attempts = 0;
              addSidebarLinks();

--- a/docs/sphinx/safety_mw_com.rst
+++ b/docs/sphinx/safety_mw_com.rst
@@ -1,0 +1,234 @@
+MW::COM Safety Report
+======================
+
+Safety documentation for the MW::COM component (Dependable Element, Integrity Level B).
+
+.. raw:: html
+
+   <iframe id="safety-report-frame" src="mw_com_doc/index.html"
+      style="width:100%; height:1400px; border:1px solid #e0e0e0; border-radius:4px;"
+      title="MW::COM Safety Report"></iframe>
+
+.. raw:: html
+
+    <script>
+    (function() {
+<<<<<<< HEAD
+       function addSidebarLinks() {
+          var sidebar = document.querySelector("#pst-secondary-sidebar .sidebar-secondary__inner");
+          if (!sidebar) return;
+          var frame = document.getElementById("safety-report-frame");
+          if (!frame) return;
+
+          var frameDoc;
+          try {
+             frameDoc = frame.contentDocument || frame.contentWindow.document;
+          } catch (e) {
+             return;
+          }
+          if (!frameDoc) return;
+
+          var tocLinks = frameDoc.querySelectorAll("#pst-secondary-sidebar .section-nav a");
+          if (!tocLinks.length) return;
+
+          var existing = document.getElementById("safety-right-links");
+          if (existing) {
+             existing.remove();
+          }
+
+          var wrapper = document.createElement("div");
+          wrapper.className = "sidebar-secondary-item";
+          wrapper.id = "safety-right-links";
+          var list = document.createElement("ul");
+          list.className = "visible nav section-nav flex-column";
+          var frameSrc = frame.getAttribute("src") || "";
+
+          tocLinks.forEach(function(link) {
+             var href = link.getAttribute("href") || "";
+             if (href.startsWith("#")) {
+                href = frameSrc.replace(/#.*$/, "") + href;
+             }
+
+             var li = document.createElement("li");
+             li.className = "toc-entry nav-item toc-h2";
+
+             var a = document.createElement("a");
+             a.className = "reference internal nav-link";
+             a.setAttribute("href", href);
+             a.textContent = link.textContent.trim();
+
+             li.appendChild(a);
+             list.appendChild(li);
+          });
+
+          wrapper.appendChild(list);
+
+          var sourceBlock = sidebar.querySelector(".tocsection.sourcelink");
+          var sourceItem = sourceBlock ? sourceBlock.closest(".sidebar-secondary-item") : null;
+          if (sourceItem) {
+             sidebar.insertBefore(wrapper, sourceItem);
+          } else {
+             sidebar.appendChild(wrapper);
+          }
+       }
+
+       function init() {
+          var frame = document.getElementById("safety-report-frame");
+          if (!frame) return;
+          frame.addEventListener("load", function() {
+             addSidebarLinks();
+             setTimeout(addSidebarLinks, 150);
+          });
+          addSidebarLinks();
+       }
+
+=======
+       var attempts = 0;
+       var maxAttempts = 40;
+
+       function routeToFrame(href, frame) {
+          var hashIndex = href.indexOf("#");
+          if (hashIndex < 0) return false;
+          var hash = href.slice(hashIndex);
+          var base = (frame.getAttribute("src") || "").replace(/#.*$/, "");
+          frame.setAttribute("src", base + hash);
+          return true;
+       }
+
+       function upsertFallbackSidebar(sidebar, frame) {
+          var existing = document.getElementById("safety-right-links");
+          if (existing) {
+             existing.remove();
+          }
+
+          var wrapper = document.createElement("div");
+          wrapper.className = "sidebar-secondary-item";
+          wrapper.id = "safety-right-links";
+
+          var list = document.createElement("ul");
+          list.className = "visible nav section-nav flex-column";
+
+          [
+             ["Assumed System", "mw_com_doc/index.html#assumed-system"],
+             ["Software Architectural Level", "mw_com_doc/index.html#software-architectural-level"],
+             ["Components", "mw_com_doc/index.html#components"],
+             ["Checklists", "mw_com_doc/index.html#checklists"],
+             ["Submodules", "mw_com_doc/index.html#submodules"]
+          ].forEach(function(item) {
+             var li = document.createElement("li");
+             li.className = "toc-entry nav-item toc-h2";
+             var a = document.createElement("a");
+             a.className = "reference internal nav-link";
+             a.setAttribute("href", item[1]);
+             a.textContent = item[0];
+             li.appendChild(a);
+             list.appendChild(li);
+          });
+
+          wrapper.appendChild(list);
+          var sourceBlock = sidebar.querySelector(".tocsection.sourcelink");
+          var sourceItem = sourceBlock ? sourceBlock.closest(".sidebar-secondary-item") : null;
+          if (sourceItem) {
+             sidebar.insertBefore(wrapper, sourceItem);
+          } else {
+             sidebar.appendChild(wrapper);
+          }
+
+          wrapper.addEventListener("click", function(ev) {
+             var aEl = ev.target.closest("a");
+             if (!aEl) return;
+             var href = aEl.getAttribute("href") || "";
+             if (routeToFrame(href, frame)) {
+                ev.preventDefault();
+             }
+          });
+       }
+
+       function addSidebarLinks() {
+          var sidebar = document.querySelector("#pst-secondary-sidebar .sidebar-secondary__inner");
+          if (!sidebar) return;
+          var frame = document.getElementById("safety-report-frame");
+          if (!frame) return;
+
+          var frameDoc;
+          try {
+             frameDoc = frame.contentDocument || frame.contentWindow.document;
+          } catch (e) {
+             upsertFallbackSidebar(sidebar, frame);
+             return;
+          }
+          if (!frameDoc) {
+             upsertFallbackSidebar(sidebar, frame);
+             return;
+          }
+
+          var sourceToc = frameDoc.querySelector("#pst-secondary-sidebar .section-nav");
+          if (!sourceToc) {
+             attempts += 1;
+             if (attempts < maxAttempts) {
+                setTimeout(addSidebarLinks, 150);
+             } else {
+                upsertFallbackSidebar(sidebar, frame);
+             }
+             return;
+          }
+
+          var existing = document.getElementById("safety-right-links");
+          if (existing) {
+             existing.remove();
+          }
+
+          var wrapper = document.createElement("div");
+          wrapper.className = "sidebar-secondary-item";
+          wrapper.id = "safety-right-links";
+          var list = sourceToc.cloneNode(true);
+          list.classList.add("visible");
+          var frameSrc = frame.getAttribute("src") || "";
+
+          list.querySelectorAll("a").forEach(function(link) {
+             var href = link.getAttribute("href") || "";
+             if (href.startsWith("#")) {
+                href = frameSrc.replace(/#.*$/, "") + href;
+             }
+             link.setAttribute("href", href);
+          });
+
+          wrapper.appendChild(list);
+
+          var sourceBlock = sidebar.querySelector(".tocsection.sourcelink");
+          var sourceItem = sourceBlock ? sourceBlock.closest(".sidebar-secondary-item") : null;
+          if (sourceItem) {
+             sidebar.insertBefore(wrapper, sourceItem);
+          } else {
+             sidebar.appendChild(wrapper);
+          }
+
+          wrapper.addEventListener("click", function(ev) {
+             var aEl = ev.target.closest("a");
+             if (!aEl) return;
+             var href = aEl.getAttribute("href") || "";
+             if (routeToFrame(href, frame)) {
+                ev.preventDefault();
+             }
+          });
+       }
+
+       function init() {
+          var frame = document.getElementById("safety-report-frame");
+          if (!frame) return;
+          frame.addEventListener("load", function() {
+             attempts = 0;
+             addSidebarLinks();
+          });
+          attempts = 0;
+          addSidebarLinks();
+       }
+
+>>>>>>> 94c65095 (docs: sync safety sidebar content with embedded report TOC)
+       if (document.readyState === "loading") {
+          document.addEventListener("DOMContentLoaded", init);
+       } else {
+          init();
+       }
+    })();
+    </script>

--- a/docs/sphinx/safety_mw_com.rst
+++ b/docs/sphinx/safety_mw_com.rst
@@ -13,76 +13,6 @@ Safety documentation for the MW::COM component (Dependable Element, Integrity Le
 
     <script>
     (function() {
-<<<<<<< HEAD
-       function addSidebarLinks() {
-          var sidebar = document.querySelector("#pst-secondary-sidebar .sidebar-secondary__inner");
-          if (!sidebar) return;
-          var frame = document.getElementById("safety-report-frame");
-          if (!frame) return;
-
-          var frameDoc;
-          try {
-             frameDoc = frame.contentDocument || frame.contentWindow.document;
-          } catch (e) {
-             return;
-          }
-          if (!frameDoc) return;
-
-          var tocLinks = frameDoc.querySelectorAll("#pst-secondary-sidebar .section-nav a");
-          if (!tocLinks.length) return;
-
-          var existing = document.getElementById("safety-right-links");
-          if (existing) {
-             existing.remove();
-          }
-
-          var wrapper = document.createElement("div");
-          wrapper.className = "sidebar-secondary-item";
-          wrapper.id = "safety-right-links";
-          var list = document.createElement("ul");
-          list.className = "visible nav section-nav flex-column";
-          var frameSrc = frame.getAttribute("src") || "";
-
-          tocLinks.forEach(function(link) {
-             var href = link.getAttribute("href") || "";
-             if (href.startsWith("#")) {
-                href = frameSrc.replace(/#.*$/, "") + href;
-             }
-
-             var li = document.createElement("li");
-             li.className = "toc-entry nav-item toc-h2";
-
-             var a = document.createElement("a");
-             a.className = "reference internal nav-link";
-             a.setAttribute("href", href);
-             a.textContent = link.textContent.trim();
-
-             li.appendChild(a);
-             list.appendChild(li);
-          });
-
-          wrapper.appendChild(list);
-
-          var sourceBlock = sidebar.querySelector(".tocsection.sourcelink");
-          var sourceItem = sourceBlock ? sourceBlock.closest(".sidebar-secondary-item") : null;
-          if (sourceItem) {
-             sidebar.insertBefore(wrapper, sourceItem);
-          } else {
-             sidebar.appendChild(wrapper);
-          }
-       }
-
-       function init() {
-          var frame = document.getElementById("safety-report-frame");
-          if (!frame) return;
-          frame.addEventListener("load", function() {
-             addSidebarLinks();
-             setTimeout(addSidebarLinks, 150);
-          });
-          addSidebarLinks();
-       }
-
-=======
        var attempts = 0;
        var maxAttempts = 40;
 
@@ -224,7 +154,6 @@ Safety documentation for the MW::COM component (Dependable Element, Integrity Le
           addSidebarLinks();
        }
 
->>>>>>> 94c65095 (docs: sync safety sidebar content with embedded report TOC)
        if (document.readyState === "loading") {
           document.addEventListener("DOMContentLoaded", init);
        } else {

--- a/docs/sphinx/safety_reports.rst
+++ b/docs/sphinx/safety_reports.rst
@@ -3,13 +3,218 @@ Safety Reports
 
 Safety documentation reports
 
-.. list-table::
-   :widths: 30 70
-   :header-rows: 1
+.. raw:: html
 
-   * - Report
-     - Description
-   * - `Message Passing <dependable_element_message_passing_doc/index.html>`_
-     - Dependable Element
-   * - `MW::COM <mw_com_doc/index.html>`_
-     - Dependable Element
+   <div id="safety-report-selector" style="margin-bottom:1rem;">
+   <table class="table" style="width:100%; margin-bottom:0; border-collapse:collapse;">
+     <thead>
+       <tr>
+         <th style="text-align:left; border-bottom:1px solid #d0d7de; padding:0.5rem;">Report</th>
+         <th style="text-align:left; border-bottom:1px solid #d0d7de; padding:0.5rem;">Description</th>
+       </tr>
+     </thead>
+     <tbody>
+       <tr>
+         <td style="padding:0.5rem; border-bottom:1px solid #d0d7de;">
+           <button type="button" class="safety-report-link" data-report="mw_com_doc/index.html" style="background:none; border:none; padding:0; color:#0a6c8e; text-decoration:underline; cursor:pointer; font:inherit;">
+             MW::COM
+           </button>
+         </td>
+         <td style="padding:0.5rem; border-bottom:1px solid #d0d7de;">Dependable Element</td>
+       </tr>
+       <tr>
+         <td style="padding:0.5rem; border-bottom:1px solid #d0d7de;">
+           <button type="button" class="safety-report-link" data-report="dependable_element_message_passing_doc/index.html" style="background:none; border:none; padding:0; color:#0a6c8e; text-decoration:underline; cursor:pointer; font:inherit;">
+             Message Passing
+           </button>
+         </td>
+         <td style="padding:0.5rem; border-bottom:1px solid #d0d7de;">Dependable Element</td>
+       </tr>
+     </tbody>
+   </table>
+   </div>
+
+.. raw:: html
+
+  <iframe id="safety-main-report" src="about:blank"
+      style="width:100%; height:1400px; border:1px solid #e0e0e0; border-radius:4px;"
+      title="Safety Reports"></iframe>
+
+   <script>
+   (function() {
+     var attempts = 0;
+     var maxAttempts = 40;
+     var currentReport = "";
+
+     function buildFallbackItems(report) {
+       if (report.indexOf("dependable_element_message_passing_doc") >= 0) {
+         return [
+           ["#assumed-system", "Assumed System"],
+           ["#software-architectural-level", "Software Architectural Level"],
+           ["#components", "Components"],
+           ["#checklists", "Checklists"],
+           ["#submodules", "Submodules"],
+         ];
+       }
+
+       return [
+         ["#assumed-system", "Assumed System"],
+         ["#software-architectural-level", "Software Architectural Level"],
+         ["#components", "Components"],
+         ["#checklists", "Checklists"],
+         ["#submodules", "Submodules"],
+       ];
+     }
+
+     function upsertFallbackRightSidebar(sidebar, frame, report) {
+       var existing = document.getElementById("safety-right-links");
+       if (existing) {
+         existing.remove();
+       }
+
+       var wrapper = document.createElement("div");
+       wrapper.className = "sidebar-secondary-item";
+       wrapper.id = "safety-right-links";
+       var list = document.createElement("ul");
+       list.className = "visible nav section-nav flex-column";
+
+       buildFallbackItems(report).forEach(function(item) {
+         var li = document.createElement("li");
+         li.className = "toc-entry nav-item toc-h2";
+         var link = document.createElement("a");
+         link.className = "reference internal nav-link";
+         link.setAttribute("href", "javascript:void(0)");
+         link.setAttribute("data-hash", item[0]);
+         link.textContent = item[1];
+         link.addEventListener("click", function(ev) {
+           ev.preventDefault();
+           ev.stopPropagation();
+           var base = (frame.getAttribute("src") || "").replace(/#.*$/, "");
+           frame.setAttribute("src", base + item[0]);
+         });
+         li.appendChild(link);
+         list.appendChild(li);
+       });
+
+       wrapper.appendChild(list);
+       var sourceBlock = sidebar.querySelector(".tocsection.sourcelink");
+       var sourceItem = sourceBlock ? sourceBlock.closest(".sidebar-secondary-item") : null;
+       if (sourceItem) {
+         sidebar.insertBefore(wrapper, sourceItem);
+       } else {
+         sidebar.appendChild(wrapper);
+       }
+     }
+
+     function setReport(src) {
+       var frame = document.getElementById("safety-main-report");
+       var selector = document.getElementById("safety-report-selector");
+       if (!frame) return;
+       currentReport = src;
+       if (selector) {
+         selector.style.display = "none";
+       }
+       frame.style.display = "block";
+       frame.setAttribute("src", src);
+     }
+
+     function syncRightSidebar() {
+       var sidebar = document.querySelector("#pst-secondary-sidebar .sidebar-secondary__inner");
+       var frame = document.getElementById("safety-main-report");
+       if (!sidebar || !frame) return;
+
+       var frameDoc;
+       try {
+         frameDoc = frame.contentDocument || frame.contentWindow.document;
+       } catch (e) {
+         upsertFallbackRightSidebar(sidebar, frame, currentReport || frame.getAttribute("src") || "");
+         return;
+       }
+       if (!frameDoc) {
+         upsertFallbackRightSidebar(sidebar, frame, currentReport || frame.getAttribute("src") || "");
+         return;
+       }
+
+       var sourceToc = frameDoc.querySelector("#pst-secondary-sidebar .section-nav");
+       if (!sourceToc) {
+         attempts += 1;
+         if (attempts < maxAttempts) {
+           setTimeout(syncRightSidebar, 150);
+         } else {
+           upsertFallbackRightSidebar(sidebar, frame, currentReport || frame.getAttribute("src") || "");
+         }
+         return;
+       }
+
+       var existing = document.getElementById("safety-right-links");
+       if (existing) {
+         existing.remove();
+       }
+
+       var wrapper = document.createElement("div");
+       wrapper.className = "sidebar-secondary-item";
+       wrapper.id = "safety-right-links";
+       var list = sourceToc.cloneNode(true);
+       list.classList.add("visible");
+
+       var frameSrc = frame.getAttribute("src") || "";
+       list.querySelectorAll("a").forEach(function(link) {
+         var href = link.getAttribute("href") || "";
+         var hash = href.indexOf("#") >= 0 ? href.slice(href.indexOf("#")) : "";
+         link.setAttribute("href", "javascript:void(0)");
+         link.setAttribute("data-hash", hash);
+         link.addEventListener("click", function(ev) {
+           ev.preventDefault();
+           ev.stopPropagation();
+           var base = frameSrc.replace(/#.*$/, "");
+           if (hash) {
+             frame.setAttribute("src", base + hash);
+           }
+         });
+       });
+
+       wrapper.appendChild(list);
+       var sourceBlock = sidebar.querySelector(".tocsection.sourcelink");
+       var sourceItem = sourceBlock ? sourceBlock.closest(".sidebar-secondary-item") : null;
+       if (sourceItem) {
+         sidebar.insertBefore(wrapper, sourceItem);
+       } else {
+         sidebar.appendChild(wrapper);
+       }
+     }
+
+     function init() {
+       var frame = document.getElementById("safety-main-report");
+       if (!frame) return;
+
+       frame.style.display = "none";
+
+       document.querySelectorAll(".safety-report-link").forEach(function(link) {
+         link.addEventListener("click", function(ev) {
+           ev.preventDefault();
+           var report = link.getAttribute("data-report") || "";
+           if (!report) return;
+           attempts = 0;
+           setReport(report);
+         });
+       });
+
+       frame.addEventListener("load", function() {
+         attempts = 0;
+         syncRightSidebar();
+       });
+     }
+
+     if (document.readyState === "loading") {
+       document.addEventListener("DOMContentLoaded", init);
+     } else {
+       init();
+     }
+   })();
+   </script>
+
+.. toctree::
+   :hidden:
+
+   safety_message_passing
+   safety_mw_com


### PR DESCRIPTION
<p style="margin: 0px 0px 16px; color: rgb(191, 191, 191); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="font-weight: 600;">Problem:</strong><br>Clicking safety report links opened a standalone HTML page, losing all Sphinx navigation.</p><p style="margin: 0px 0px 16px; color: rgb(191, 191, 191); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="font-weight: 600;">Solution:</strong><br>Added a dedicated RST page per report so they appear as proper Sphinx pages with full navigation. This is a Sphinx requirement — every left sidebar entry must have its own RST file.</p><p style="margin: 0px 0px 16px; color: rgb(191, 191, 191); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="font-weight: 600;">Why not auto-generate?</strong><br>Auto-generation only makes sense when there is real logic involved (e.g. parsing 100+ C++ items). Here each file is just a title + one iframe — writing a Bazel rule for that adds more complexity than it saves.</p><p style="margin: 0px 0px 16px; color: rgb(191, 191, 191); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="font-weight: 600;">Files changed:</strong></p><div class="monaco-scrollable-element rendered-markdown-table-scroll-wrapper" role="presentation" style="width: 498.011px; margin-bottom: 16px; color: rgb(191, 191, 191); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial; position: relative; overflow: hidden;"><div style="overflow: hidden;">
File | What changed
-- | --
BUILD | Added 2 new RST files to sphinx sources
safety_reports.rst | Overview table with links + hidden toctree for left sidebar
safety_message_passing.rst | New page showing Message Passing report via iframe
safety_mw_com.rst | New page showing MW::COM report via iframe

</div><div role="presentation" aria-hidden="true" class="invisible scrollbar horizontal" style="opacity: 0; pointer-events: none; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(0, 0, 0, 0); position: absolute; width: 498px; height: 10px; left: 0px; bottom: 0px;"><div class="slider" style="background: none 0% 0% / auto repeat scroll padding-box border-box rgba(131, 132, 133, 0.2); position: absolute; top: 0px; left: 0px; height: 10px; transform: translate3d(0px, 0px, 0px); contain: strict; width: 498px;"></div></div><div role="presentation" aria-hidden="true" class="invisible scrollbar vertical" style="opacity: 0; pointer-events: none; background: none 0% 0% / auto repeat scroll padding-box border-box rgba(0, 0, 0, 0); z-index: 14; position: absolute; width: 0px; height: 182px; right: 0px; top: 0px;"><div class="slider" style="background: none 0% 0% / auto repeat scroll padding-box border-box rgba(131, 132, 133, 0.2); position: absolute; top: 0px; left: 0px; width: 10px; transform: translate3d(0px, 0px, 0px); contain: strict; height: 182px;"></div></div></div><p style="margin: 0px; color: rgb(191, 191, 191); font-family: system-ui, Ubuntu, &quot;Droid Sans&quot;, sans-serif; font-size: 13px; font-style: normal; font-variant-ligatures: normal; font-variant-caps: normal; font-weight: 400; letter-spacing: normal; orphans: 2; text-align: start; text-indent: 0px; text-transform: none; widows: 2; word-spacing: 0px; -webkit-text-stroke-width: 0px; white-space: normal; background-color: rgb(25, 26, 27); text-decoration-thickness: initial; text-decoration-style: initial; text-decoration-color: initial;"><strong style="font-weight: 600;">Result:</strong><span> </span>Left sidebar now shows "Safety Reports → Message Passing / MW::COM", report content only appears after clicking, Sphinx navigation never lost.</p>Problem:
Clicking safety report links opened a standalone HTML page, losing all Sphinx navigation.

Solution:
Added a dedicated RST page per report so they appear as proper Sphinx pages with full navigation. This is a Sphinx requirement — every left sidebar entry must have its own RST file.

Why not auto-generate?
Auto-generation only makes sense when there is real logic involved (e.g. parsing 100+ C++ items). Here each file is just a title + one iframe — writing a Bazel rule for that adds more complexity than it saves.

Files changed:

[BUILD](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — Added 2 new RST files to sphinx sources
[safety_reports.rst](vscode-file://vscode-app/usr/share/code/resources/app/out/vs/code/electron-browser/workbench/workbench.html) — Overview table with links + hidden toctree for left sidebar
safety_message_passing.rst — New page showing Message Passing report via iframe
safety_mw_com.rst — New page showing MW::COM report via iframe

Result: Left sidebar now shows "Safety Reports → Message Passing / MW::COM", report content only appears after clicking, Sphinx navigation never lost.