### PR TITLE
fix: Make GenericSkeleton::GetEvents() non-const

### DIFF
--- a/score/mw/com/impl/generic_skeleton.cpp
+++ b/score/mw/com/impl/generic_skeleton.cpp
@@ -122,7 +122,7 @@ Result<GenericSkeleton> GenericSkeleton::Create(const InstanceIdentifier& identi
     return skeleton;
 }
 
-const GenericSkeleton::EventMap& GenericSkeleton::GetEvents() const noexcept
+GenericSkeleton::EventMap& GenericSkeleton::GetEvents() noexcept
 {
     return events_;
 }

--- a/score/mw/com/impl/generic_skeleton.h
+++ b/score/mw/com/impl/generic_skeleton.h
@@ -70,9 +70,9 @@ class GenericSkeleton : public SkeletonBase
     [[nodiscard]] static Result<GenericSkeleton> Create(const InstanceSpecifier& specifier,
                                                         const GenericSkeletonServiceElementInfo& in) noexcept;
 
-    /// @brief Returns a const reference to the name-keyed map of events.
+    /// @brief Returns a reference to the name-keyed map of events.
     /// @note The returned reference is valid as long as the GenericSkeleton lives.
-    [[nodiscard]] const EventMap& GetEvents() const noexcept;
+    [[nodiscard]] EventMap& GetEvents() noexcept;
 
     /// @brief Offers the service instance.
     /// @return A blank result, or an error if offering fails.

--- a/score/mw/com/impl/generic_skeleton_test.cpp
+++ b/score/mw/com/impl/generic_skeleton_test.cpp
@@ -199,7 +199,7 @@ TEST_F(GenericSkeletonTest, CreateWithEventsInitializesEventBindings)
 
     // Then the skeleton contains the event
     ASSERT_TRUE(result.has_value());
-    const auto& events = result.value().GetEvents();
+    auto& events = result.value().GetEvents();
     ASSERT_EQ(events.size(), 1);
 
     EXPECT_NE(events.find(event_name), events.cend());


### PR DESCRIPTION
In order to Allocate() or Send() an event, the user needs a mutable GenericSkeletonEvent.

Fixes #467