### PR TITLE
Rust::com async cancellable receive API and SampleContainer return handling

### DIFF
--- a/score/mw/com/example/com-api-example/basic-consumer-producer.rs
+++ b/score/mw/com/example/com-api-example/basic-consumer-producer.rs
@@ -328,33 +328,25 @@ mod test {
                 for attempt in 0..MAX_ATTEMPTS {
                     println!("[RECEIVER] Attempt {}", attempt);
 
-                    // Match and immediately reassign in all branches
-                    sample_buf = match subscribed.receive(sample_buf, 1, 3).await {
-                        Ok(returned_buf) => {
-                            let count = returned_buf.sample_count();
-
-                            if count > 0 {
-                                total_received += count;
-                                println!(
-                                    "[RECEIVER] Received {} samples (total: {})",
-                                    count, total_received
-                                );
-
-                                // Create a mutable version to pop from
-                                let mut buf = returned_buf;
-                                while let Some(sample) = buf.pop_front() {
-                                    println!("[RECEIVER]   Sample: {:.2} psi", sample.pressure);
-                                }
-                                buf
-                            } else {
-                                returned_buf
-                            }
-                        }
-                        Err(e) => {
+                    // Destructure tuple - container is always returned even on error
+                    let (returned_buf, result) = subscribed.receive(sample_buf, 1, 3).await;
+                    sample_buf = {
+                        let count = returned_buf.sample_count();
+                        if let Err(e) = result {
                             println!("[RECEIVER] Error on attempt {}: {:?}", attempt, e);
-                            // Create a fresh buffer if there's an error
-                            SampleContainer::new(5)
+                        } else if count > 0 {
+                            total_received += count;
+                            println!(
+                                "[RECEIVER] Received {} samples (total: {})",
+                                count, total_received
+                            );
                         }
+                        // Drain printed samples
+                        let mut buf = returned_buf;
+                        while let Some(sample) = buf.pop_front() {
+                            println!("[RECEIVER]   Sample: {:.2} psi", sample.pressure);
+                        }
+                        buf
                     };
                 }
 
@@ -399,24 +391,21 @@ mod test {
         println!("[RECEIVER] Async data processor started");
         let mut buffer = SampleContainer::new(5);
         for _ in 0..5 {
-            buffer = match subscribed.receive(buffer, 2, 3).await {
-                Ok(returned_buf) => {
+            let (returned_buf, result) = subscribed.receive(buffer, 2, 3).await;
+            buffer = {
+                if let Err(e) = result {
+                    println!("[RECEIVER] Error receiving data: {:?}", e);
+                } else {
                     let count = returned_buf.sample_count();
                     if count > 0 {
                         println!("[RECEIVER] Received {} samples", count);
-                        let mut buf = returned_buf;
-                        while let Some(sample) = buf.pop_front() {
-                            println!("[RECEIVER]   Sample: {:.2} psi", sample.pressure);
-                        }
-                        buf
-                    } else {
-                        returned_buf
                     }
                 }
-                Err(e) => {
-                    println!("[RECEIVER] Error receiving data: {:?}", e);
-                    SampleContainer::new(5)
+                let mut buf = returned_buf;
+                while let Some(sample) = buf.pop_front() {
+                    println!("[RECEIVER]   Sample: {:.2} psi", sample.pressure);
                 }
+                buf
             }
         }
     }

--- a/score/mw/com/example/com-api-example/basic-consumer-producer.rs
+++ b/score/mw/com/example/com-api-example/basic-consumer-producer.rs
@@ -368,7 +368,7 @@ mod test {
             let uninit_sample = match offered_producer.left_tire.allocate() {
                 Ok(sample) => sample,
                 Err(e) => {
-                    eprintln!("Failed to allocate sample: {:?}", e);
+                    eprintln!("[SENDER] Failed to allocate sample: {:?}", e);
                     continue;
                 }
             };
@@ -377,9 +377,9 @@ mod test {
             });
             match sample.send() {
                 Ok(_) => (),
-                Err(e) => eprintln!("Failed to send sample: {:?}", e),
+                Err(e) => eprintln!("[SENDER] Failed to send sample: {:?}", e),
             }
-            println!("Sent sample with pressure: {}", 1.0 + i as f32);
+            println!("[SENDER] Sent sample with pressure: {}", 1.0 + i as f32);
             tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
         }
         offered_producer
@@ -387,26 +387,32 @@ mod test {
 
     //receiver function which use async receive to get data, it waits for new data and process it once it arrives,
     //it will receive data 10 times and print the received samples
-    async fn async_data_processor_fn<R: Runtime>(subscribed: impl Subscription<Tire, R>) {
+    async fn async_data_processor_fn<R: Runtime>(
+        subscribed: impl Subscription<Tire, R> + Send + 'static,
+        is_timeout: bool,
+    ) {
         println!("[RECEIVER] Async data processor started");
         let mut buffer = SampleContainer::new(5);
         for _ in 0..5 {
-            let (returned_buf, result) = subscribed.receive(buffer, 2, 3).await;
-            buffer = {
-                if let Err(e) = result {
-                    println!("[RECEIVER] Error receiving data: {:?}", e);
-                } else {
-                    let count = returned_buf.sample_count();
-                    if count > 0 {
-                        println!("[RECEIVER] Received {} samples", count);
-                    }
+            let (returned_buf, result) = if is_timeout {
+                let timeout = tokio::time::sleep(Duration::from_millis(1000));
+                subscribed.receive_with_timeout(buffer, 2, 3, timeout).await
+            } else {
+                subscribed.receive(buffer, 2, 3).await
+            };
+            if let Err(e) = result {
+                println!("[RECEIVER] Error receiving data: {:?}", e);
+            } else {
+                let count = returned_buf.sample_count();
+                if count > 0 {
+                    println!("[RECEIVER] Received {} samples", count);
                 }
-                let mut buf = returned_buf;
-                while let Some(sample) = buf.pop_front() {
-                    println!("[RECEIVER]   Sample: {:.2} psi", sample.pressure);
-                }
-                buf
             }
+            let mut buf = returned_buf;
+            while let Some(sample) = buf.pop_front() {
+                println!("[RECEIVER]   Sample: {:.2} psi", sample.pressure);
+            }
+            buffer = buf;
         }
     }
 
@@ -433,8 +439,45 @@ mod test {
         let consumer = consumer.await.expect("Failed to create consumer");
         // Subscribe to one event
         let subscribed = consumer.left_tire.subscribe(5).unwrap();
-        // Spawn async data processor
-        let processor_join_handle = tokio::spawn(async_data_processor_fn(subscribed));
+
+        let processor_join_handle = tokio::spawn(async_data_processor_fn(subscribed, false));
+        processor_join_handle
+            .await
+            .expect("Error returned from task");
+        let producer = sender_join_handle.await.expect("Error returned from task");
+
+        match producer.unoffer() {
+            Ok(_) => println!("Successfully unoffered the service"),
+            Err(e) => eprintln!("Failed to unoffer: {:?}", e),
+        }
+
+        println!("=== Async subscription test with Lola runtime completed ===\n");
+    }
+
+    #[tokio::test(flavor = "multi_thread")]
+    async fn receive_with_timeout_and_send_using_multi_thread() {
+        println!("Starting async subscription test with Lola runtime");
+        //Intentionally using service instance of test1, if you face issue add new service instance in config file and use it here.
+        let service_id = InstanceSpecifier::new("/Vehicle/Service1/Instance")
+            .expect("Failed to create InstanceSpecifier");
+        let service_id_clone = service_id.clone();
+        //consumer create
+        let consumer_runtime = get_test_runtime();
+        //starting service discovery in async way, so that it can be discovered when producer offer service after some delay, and consumer is waiting for discovery result
+        let consumer = tokio::spawn(create_consumer_async(consumer_runtime, service_id));
+        //simulate some delay before producer offer service, so that consumer is waiting for discovery
+        tokio::time::sleep(tokio::time::Duration::from_millis(1000)).await;
+        //Producer create
+        let producer_runtime = get_test_runtime();
+        let producer = create_producer(producer_runtime, service_id_clone);
+        // Spawn async data sender
+        let sender_join_handle = tokio::spawn(async_data_sender_fn(producer));
+        // Await consumer creation and subscribe to events
+        let consumer = consumer.await.expect("Failed to create consumer");
+        // Subscribe to one event
+        let subscribed = consumer.left_tire.subscribe(5).unwrap();
+
+        let processor_join_handle = tokio::spawn(async_data_processor_fn(subscribed, true));
         processor_join_handle
             .await
             .expect("Error returned from task");

--- a/score/mw/com/example/com-api-example/basic-consumer-producer.rs
+++ b/score/mw/com/example/com-api-example/basic-consumer-producer.rs
@@ -396,7 +396,7 @@ mod test {
         for _ in 0..5 {
             let (returned_buf, result) = if is_timeout {
                 let timeout = tokio::time::sleep(Duration::from_millis(1000));
-                subscribed.receive_timeout(buffer, 2, 3, timeout).await
+                subscribed.cancellable_receive(buffer, 2, 3, timeout).await
             } else {
                 subscribed.receive(buffer, 2, 3).await
             };

--- a/score/mw/com/example/com-api-example/basic-consumer-producer.rs
+++ b/score/mw/com/example/com-api-example/basic-consumer-producer.rs
@@ -396,17 +396,13 @@ mod test {
         for _ in 0..5 {
             let (returned_buf, result) = if is_timeout {
                 let timeout = tokio::time::sleep(Duration::from_millis(1000));
-                subscribed.receive_with_timeout(buffer, 2, 3, timeout).await
+                subscribed.receive_timeout(buffer, 2, 3, timeout).await
             } else {
                 subscribed.receive(buffer, 2, 3).await
             };
-            if let Err(e) = result {
-                println!("[RECEIVER] Error receiving data: {:?}", e);
-            } else {
-                let count = returned_buf.sample_count();
-                if count > 0 {
-                    println!("[RECEIVER] Received {} samples", count);
-                }
+            match result {
+                Ok(count) => println!("[RECEIVER] Received {} samples", count),
+                Err(e) => eprintln!("[RECEIVER] Failed to receive samples: {:?}", e),
             }
             let mut buf = returned_buf;
             while let Some(sample) = buf.pop_front() {

--- a/score/mw/com/example/com-api-example/basic-consumer-producer.rs
+++ b/score/mw/com/example/com-api-example/basic-consumer-producer.rs
@@ -388,7 +388,7 @@ mod test {
     //receiver function which use async receive to get data, it waits for new data and process it once it arrives,
     //it will receive data 10 times and print the received samples
     async fn async_data_processor_fn<R: Runtime>(
-        subscribed: impl Subscription<Tire, R> + Send + 'static,
+        subscribed: impl Subscription<Tire, R>,
         is_timeout: bool,
     ) {
         println!("[RECEIVER] Async data processor started");

--- a/score/mw/com/impl/rust/com-api/com-api-concept/com_api_concept.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-concept/com_api_concept.rs
@@ -865,19 +865,25 @@ pub trait Subscription<T: CommData + Debug, R: Runtime + ?Sized> {
         )
     }
 
-    /// This method is extension of `receive` with an additional `timeout` parameter
+    /// This method is an extension of `receive` with an additional `cancellation` parameter
     /// which allows the caller to specify a future that can be used to cancel the receive operation.
     /// It returns a future that resolves as soon as at least `new_samples` samples have been transferred
-    /// from the communication buffer to the sample container or the `timeout` future resolves.
+    /// from the communication buffer to the sample container or the `cancellation` future resolves.
     ///
     /// # Parameters
     /// * `scratch` - Container for events from this subscription
     /// * `new_samples` - Minimum number of new events before resolution, 0 value is treated as error
     /// * `max_samples` - Maximum number of events that shall be received from the communication
     ///   buffer and transferred to the container, 0 value is treated as error
-    /// * `timeout` - Future that resolves when the receive operation should time out. If the timeout
-    ///   future resolves before the required number of samples are received, the receive operation is
-    ///   considered to have timed out.
+    /// * `cancellation` - Future that resolves when the receive operation should be cancelled. If the
+    ///   cancellation future resolves before the required number of samples are received, the receive
+    ///   operation is considered to have been cancelled.
+    ///   This can be used to implement various cancellation strategies, such as:
+    ///   - **Timeouts**: `tokio::time::sleep(Duration::from_secs(5))`
+    ///   - **Channel-based cancellation**: Waiting for a signal on a channel to indicate cancellation
+    ///   - **User-triggered cancellation**: Waiting for a keyboard interrupt or UI signal or any other user input to trigger cancellation
+    ///   - **External event cancellation**: Any other future that signals when cancellation is needed like shutdown signal, etc.
+    ///
     ///
     /// # Returns
     /// Future that resolves to `(SampleContainer<Self::Sample<'a>>, Result<usize>)`.
@@ -890,12 +896,12 @@ pub trait Subscription<T: CommData + Debug, R: Runtime + ?Sized> {
     /// # Important Notes
     /// User can not concurrenly call `cancellable_receive` on the same subscription instance from
     /// multiple threads or tasks.
-    /// `timeout` must be `'static` because timeout futures (e.g. `tokio::time::sleep`) own all
+    /// `cancellation` must be `'static` because cancellation futures (e.g. `tokio::time::sleep`) own all
     /// their state and do not borrow anything from the caller's scope.
     /// And if you change to `'a` lifetime then it create lifetime bound not satisfied
     /// error from rust (see issue <https://github.com/rust-lang/rust/issues/100013> for more information)
     ///
-    /// The `timeout` future currently has `Output = ()` and returns nothing. However, it could be
+    /// The `cancellation` future currently has `Output = ()` and returns nothing. However, it could be
     /// enhanced in the future to return a value that would be propagated to the caller, as per the use-case.
     /// No use case for this enhancement has been identified yet, so it is deferred for later implementation.
     fn cancellable_receive<'a>(
@@ -903,7 +909,7 @@ pub trait Subscription<T: CommData + Debug, R: Runtime + ?Sized> {
         scratch: SampleContainer<Self::Sample<'a>>,
         new_samples: usize,
         max_samples: usize,
-        timeout: impl Future<Output = ()> + Send + 'static,
+        cancellation: impl Future<Output = ()> + Send + 'static,
     ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<usize>)> + 'a;
 }
 

--- a/score/mw/com/impl/rust/com-api/com-api-concept/com_api_concept.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-concept/com_api_concept.rs
@@ -858,7 +858,7 @@ pub trait Subscription<T: CommData + Debug, R: Runtime + ?Sized> {
         scratch: SampleContainer<Self::Sample<'a>>,
         new_samples: usize,
         max_samples: usize,
-        timeout_future: impl Future<Output = ()> + Unpin + 'a,
+        timeout_future: impl Future<Output = ()> + Send + 'static,
     ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a;
 }
 

--- a/score/mw/com/impl/rust/com-api/com-api-concept/com_api_concept.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-concept/com_api_concept.rs
@@ -232,7 +232,9 @@ impl InstanceSpecifier {
         }
 
         // Remove the single leading slash
-        let service_name = service_name.strip_prefix('/').unwrap();
+        let Some(service_name) = service_name.strip_prefix('/') else {
+            return false;
+        };
 
         // Check each character
         // Allowed: digits, lowercase, uppercase, underscore
@@ -828,10 +830,12 @@ pub trait Subscription<T: CommData + Debug, R: Runtime + ?Sized> {
     ///   buffer and transferred to the container, 0 value is treated as error
     ///
     /// # Returns
-    /// Future that resolves to `(SampleContainer<Self::Sample<'a>>, Result<()>)`.
-    /// The container is **always** returned (even on error or cancellation) so the caller
-    /// never loses samples that were collected before the future resolved.
-    /// `Ok(())` means at least `new_samples` were received; `Err(_)` describes the failure.
+    /// Future that resolves to `(SampleContainer<Self::Sample<'a>>, Result<usize>)`.
+    /// SampleContainer is **always** returned (even on error or cancellation)
+    /// Success case return contains the number of newly added samples to the container with
+    /// number of samples.
+    /// Failure case return the SampleContainer which user passed to the function and
+    /// an 'Error' indicating the reason for failure of the receive operation.
     ///
     /// # Important Notes
     /// User can not concurrenly call `receive` on the same subscription instance from
@@ -846,12 +850,20 @@ pub trait Subscription<T: CommData + Debug, R: Runtime + ?Sized> {
     // The `Future` cannot have a `'static` lifetime. If we enforced `'static`, then `self` would
     // also need to be `'static`, which is not semantically correct for this use case.
     // Multiple threads cannot concurrently read the same event from a single subscription.
+    #[allow(clippy::manual_async_fn)]
     fn receive<'a>(
         &'a self,
         scratch: SampleContainer<Self::Sample<'a>>,
         new_samples: usize,
         max_samples: usize,
-    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a;
+    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<usize>)> + 'a {
+        self.receive_timeout(
+            scratch,
+            new_samples,
+            max_samples,
+            core::future::pending::<()>(),
+        )
+    }
 
     /// This method is extension of `receive` with timeout support.
     /// It returns a future that resolves as soon as at least `new_samples` samples have been transferred
@@ -867,26 +879,27 @@ pub trait Subscription<T: CommData + Debug, R: Runtime + ?Sized> {
     /// considered to have timed out.
     ///
     /// # Returns
-    /// Future that resolves to `(SampleContainer<Self::Sample<'a>>, Result<()>)`.
-    /// The container is **always** returned (even on error, timeout, or cancellation) so the caller
-    /// never loses samples that were collected before the future resolved.
-    /// Error is returned if the receive operation fails or if the timeout future resolves before the required
-    /// number of samples are received.
+    /// Future that resolves to `(SampleContainer<Self::Sample<'a>>, Result<usize>)`.
+    /// SampleContainer is **always** returned (even on error or cancellation)
+    /// Success case return contains the number of newly added samples to the container with
+    /// number of samples.
+    /// Failure case return the SampleContainer which user passed to the function and
+    /// an 'Error' indicating the reason for failure of the receive operation.
     ///
     /// # Important Notes
-    /// User can not concurrenly call `receive_with_timeout` on the same subscription instance from
+    /// User can not concurrenly call `receive_timeout` on the same subscription instance from
     /// multiple threads or tasks.
     /// `timeout` must be `'static` because timeout futures (e.g. `tokio::time::sleep`) own all
     /// their state and do not borrow anything from the caller's scope.
     /// And if you change to `'a` lifetime then it create lifetime bound not satisfied
     /// error from rust (see issue <https://github.com/rust-lang/rust/issues/100013> for more information)
-    fn receive_with_timeout<'a>(
+    fn receive_timeout<'a>(
         &'a self,
         scratch: SampleContainer<Self::Sample<'a>>,
         new_samples: usize,
         max_samples: usize,
         timeout: impl Future<Output = ()> + Send + 'static,
-    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a;
+    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<usize>)> + 'a;
 }
 
 /// A trait for types that can be default-constructed in place, skipping intermediate moves.

--- a/score/mw/com/impl/rust/com-api/com-api-concept/com_api_concept.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-concept/com_api_concept.rs
@@ -800,7 +800,7 @@ pub trait Subscription<T: CommData + Debug, R: Runtime + ?Sized> {
     /// # Parameters
     /// * `scratch` - Container for events from this subscription; must not be reused across
     ///   different subscriptions
-    /// * `max_samples` - Maximum number of events to transfer
+    /// * `max_samples` - Maximum number of events to transfer, 0 value is treated as error
     ///
     /// # Returns
     ///
@@ -823,9 +823,9 @@ pub trait Subscription<T: CommData + Debug, R: Runtime + ?Sized> {
     /// TODO: See above for C++ limitations.
     /// # Parameters
     /// * `scratch` - Container for events from this subscription
-    /// * `new_samples` - Minimum number of new events before resolution
+    /// * `new_samples` - Minimum number of new events before resolution, 0 value is treated as error
     /// * `max_samples` - Maximum number of events that shall be received from the communication
-    ///   buffer and transferred to the container
+    ///   buffer and transferred to the container, 0 value is treated as error
     ///
     /// # Returns
     /// Future that resolves to `(SampleContainer<Self::Sample<'a>>, Result<()>)`.
@@ -853,12 +853,39 @@ pub trait Subscription<T: CommData + Debug, R: Runtime + ?Sized> {
         max_samples: usize,
     ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a;
 
+    /// This method is extension of `receive` with timeout support.
+    /// It returns a future that resolves as soon as at least `new_samples` samples have been transferred
+    /// from the communication buffer to the sample container or the `timeout` future resolves.
+    ///
+    /// # Parameters
+    /// * `scratch` - Container for events from this subscription
+    /// * `new_samples` - Minimum number of new events before resolution, 0 value is treated as error
+    /// * `max_samples` - Maximum number of events that shall be received from the communication
+    ///  buffer and transferred to the container, 0 value is treated as error
+    /// * `timeout` - Future that resolves when the receive operation should time out. If the timeout
+    ///  future resolves before the required number of samples are received, the receive operation is
+    /// considered to have timed out.
+    ///
+    /// # Returns
+    /// Future that resolves to `(SampleContainer<Self::Sample<'a>>, Result<()>)`.
+    /// The container is **always** returned (even on error, timeout, or cancellation) so the caller
+    /// never loses samples that were collected before the future resolved.
+    /// Error is returned if the receive operation fails or if the timeout future resolves before the required
+    /// number of samples are received.
+    ///
+    /// # Important Notes
+    /// User can not concurrenly call `receive_with_timeout` on the same subscription instance from
+    /// multiple threads or tasks.
+    /// `timeout` must be `'static` because timeout futures (e.g. `tokio::time::sleep`) own all
+    /// their state and do not borrow anything from the caller's scope.
+    /// And if you change to `'a` lifetime then it create lifetime bound not satisfied
+    /// error from rust (see issue <https://github.com/rust-lang/rust/issues/100013> for more information)
     fn receive_with_timeout<'a>(
         &'a self,
         scratch: SampleContainer<Self::Sample<'a>>,
         new_samples: usize,
         max_samples: usize,
-        timeout_future: impl Future<Output = ()> + Send + 'static,
+        timeout: impl Future<Output = ()> + Send + 'static,
     ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a;
 }
 

--- a/score/mw/com/impl/rust/com-api/com-api-concept/com_api_concept.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-concept/com_api_concept.rs
@@ -857,7 +857,7 @@ pub trait Subscription<T: CommData + Debug, R: Runtime + ?Sized> {
         new_samples: usize,
         max_samples: usize,
     ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<usize>)> + 'a {
-        self.receive_timeout(
+        self.cancellable_receive(
             scratch,
             new_samples,
             max_samples,
@@ -865,7 +865,8 @@ pub trait Subscription<T: CommData + Debug, R: Runtime + ?Sized> {
         )
     }
 
-    /// This method is extension of `receive` with timeout support.
+    /// This method is extension of `receive` with an additional `timeout` parameter
+    /// which allows the caller to specify a future that can be used to cancel the receive operation.
     /// It returns a future that resolves as soon as at least `new_samples` samples have been transferred
     /// from the communication buffer to the sample container or the `timeout` future resolves.
     ///
@@ -873,10 +874,10 @@ pub trait Subscription<T: CommData + Debug, R: Runtime + ?Sized> {
     /// * `scratch` - Container for events from this subscription
     /// * `new_samples` - Minimum number of new events before resolution, 0 value is treated as error
     /// * `max_samples` - Maximum number of events that shall be received from the communication
-    ///  buffer and transferred to the container, 0 value is treated as error
+    ///   buffer and transferred to the container, 0 value is treated as error
     /// * `timeout` - Future that resolves when the receive operation should time out. If the timeout
-    ///  future resolves before the required number of samples are received, the receive operation is
-    /// considered to have timed out.
+    ///   future resolves before the required number of samples are received, the receive operation is
+    ///   considered to have timed out.
     ///
     /// # Returns
     /// Future that resolves to `(SampleContainer<Self::Sample<'a>>, Result<usize>)`.
@@ -887,13 +888,17 @@ pub trait Subscription<T: CommData + Debug, R: Runtime + ?Sized> {
     /// an 'Error' indicating the reason for failure of the receive operation.
     ///
     /// # Important Notes
-    /// User can not concurrenly call `receive_timeout` on the same subscription instance from
+    /// User can not concurrenly call `cancellable_receive` on the same subscription instance from
     /// multiple threads or tasks.
     /// `timeout` must be `'static` because timeout futures (e.g. `tokio::time::sleep`) own all
     /// their state and do not borrow anything from the caller's scope.
     /// And if you change to `'a` lifetime then it create lifetime bound not satisfied
     /// error from rust (see issue <https://github.com/rust-lang/rust/issues/100013> for more information)
-    fn receive_timeout<'a>(
+    ///
+    /// The `timeout` future currently has `Output = ()` and returns nothing. However, it could be
+    /// enhanced in the future to return a value that would be propagated to the caller, as per the use-case.
+    /// No use case for this enhancement has been identified yet, so it is deferred for later implementation.
+    fn cancellable_receive<'a>(
         &'a self,
         scratch: SampleContainer<Self::Sample<'a>>,
         new_samples: usize,

--- a/score/mw/com/impl/rust/com-api/com-api-concept/com_api_concept.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-concept/com_api_concept.rs
@@ -858,7 +858,7 @@ pub trait Subscription<T: CommData + Debug, R: Runtime + ?Sized> {
         scratch: SampleContainer<Self::Sample<'a>>,
         new_samples: usize,
         max_samples: usize,
-        timeout_future: impl Future<Output = ()> + 'a,
+        timeout_future: impl Future<Output = ()> + Unpin + 'a,
     ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a;
 }
 

--- a/score/mw/com/impl/rust/com-api/com-api-concept/com_api_concept.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-concept/com_api_concept.rs
@@ -852,6 +852,14 @@ pub trait Subscription<T: CommData + Debug, R: Runtime + ?Sized> {
         new_samples: usize,
         max_samples: usize,
     ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a;
+
+    fn receive_with_timeout<'a>(
+        &'a self,
+        scratch: SampleContainer<Self::Sample<'a>>,
+        new_samples: usize,
+        max_samples: usize,
+        timeout_future: impl Future<Output = ()> + 'a,
+    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a;
 }
 
 /// A trait for types that can be default-constructed in place, skipping intermediate moves.

--- a/score/mw/com/impl/rust/com-api/com-api-concept/com_api_concept.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-concept/com_api_concept.rs
@@ -828,8 +828,10 @@ pub trait Subscription<T: CommData + Debug, R: Runtime + ?Sized> {
     ///   buffer and transferred to the container
     ///
     /// # Returns
-    /// Future that resolves to the number of newly added events to the container with at least
-    /// `new_samples` number of new events.
+    /// Future that resolves to `(SampleContainer<Self::Sample<'a>>, Result<()>)`.
+    /// The container is **always** returned (even on error or cancellation) so the caller
+    /// never loses samples that were collected before the future resolved.
+    /// `Ok(())` means at least `new_samples` were received; `Err(_)` describes the failure.
     ///
     /// # Important Notes
     /// User can not concurrenly call `receive` on the same subscription instance from
@@ -849,7 +851,7 @@ pub trait Subscription<T: CommData + Debug, R: Runtime + ?Sized> {
         scratch: SampleContainer<Self::Sample<'a>>,
         new_samples: usize,
         max_samples: usize,
-    ) -> impl Future<Output = Result<SampleContainer<Self::Sample<'a>>>> + 'a;
+    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a;
 }
 
 /// A trait for types that can be default-constructed in place, skipping intermediate moves.

--- a/score/mw/com/impl/rust/com-api/com-api-concept/error.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-concept/error.rs
@@ -73,6 +73,8 @@ pub enum ReceiveFailedReason {
     BufferUnavailable,
     #[error("Sample size out of bounds, expected at most {max}, but got {requested}")]
     SampleCountOutOfBounds { max: usize, requested: usize },
+    #[error("Receive operation was cancelled or timed out")]
+    Cancelled,
 }
 
 /// Comprehensive error reasons for event-related failures

--- a/score/mw/com/impl/rust/com-api/com-api-concept/error.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-concept/error.rs
@@ -75,6 +75,8 @@ pub enum ReceiveFailedReason {
     SampleCountOutOfBounds { max: usize, requested: usize },
     #[error("Receive operation was cancelled or timed out")]
     Cancelled,
+    #[error("Input value out of bounds, maximum sample {max}, but new sample is {requested}")]
+    InputValueOutOfBounds { max: usize, requested: usize },
 }
 
 /// Comprehensive error reasons for event-related failures

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/BUILD
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/BUILD
@@ -44,6 +44,12 @@ rust_test(
 rust_doc_test(
     name = "com-api-runtime-lola-doc-tests",
     crate = ":com-api-runtime-lola",
+    # LIMITATION: rust_doc_test has a issue in rules_rust where it inherits crate_type="lib"
+    # from the wrapped library instead of overriding to "bin" (like rust_test does).
+    # This causes _add_native_link_flags() to skip CC native dependencies.
+    # With LLVM's strict LLD linker, this results in undefined symbol errors when
+    # the crate depends on C++ libraries. GCC masks this with broader archive scanning.
+    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = [":com-api-runtime-lola"],
 )

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/BUILD
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/BUILD
@@ -44,12 +44,6 @@ rust_test(
 rust_doc_test(
     name = "com-api-runtime-lola-doc-tests",
     crate = ":com-api-runtime-lola",
-    # LIMITATION: rust_doc_test has a issue in rules_rust where it inherits crate_type="lib"
-    # from the wrapped library instead of overriding to "bin" (like rust_test does).
-    # This causes _add_native_link_flags() to skip CC native dependencies.
-    # With LLVM's strict LLD linker, this results in undefined symbol errors when
-    # the crate depends on C++ libraries. GCC masks this with broader archive scanning.
-    tags = ["manual"],
     target_compatible_with = ["@platforms//os:linux"],
     deps = [":com-api-runtime-lola"],
 )

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -571,47 +571,16 @@ where
 
     // Cannot use `async fn` because the trait mandates `-> impl Future + 'a`,
     // requiring the returned future to be explicitly bound to the lifetime of `&self`.
-    // we do not need to cancle timeout future when receive future resolved,
-    // because ReceiveFuture drop will take care of cancelling the timeout future.
-    //
-    /// Demonstrates passing a struct future that is `Unpin` via a `PhantomData` field
-    /// to `receive_with_timeout`.
-    ///
-    /// A struct with only a `PhantomData<T>` field has no self-referential state, so
-    /// the compiler derives `Unpin` automatically.
-    ///
-    /// ```
-    /// use com_api_concept::{CommData, SampleContainer, Subscription};
-    /// use com_api_runtime_lola::LolaRuntimeImpl;
-    /// use core::marker::PhantomData;
-    ///
-    /// struct UnpinTimeout<T>(PhantomData<T>);
-    ///
-    /// impl<T: Send + 'static> std::future::Future for UnpinTimeout<T> {
-    ///     type Output = ();
-    ///     fn poll(
-    ///         self: std::pin::Pin<&mut Self>,
-    ///         _cx: &mut std::task::Context<'_>,
-    ///     ) -> std::task::Poll<()> {
-    ///         std::task::Poll::Ready(())
-    ///     }
-    /// }
-    ///
-    /// fn demonstrate<'a, T, S>(sub: &'a S, scratch: SampleContainer<S::Sample<'a>>)
-    /// where
-    ///     T: CommData + std::fmt::Debug,
-    ///     S: Subscription<T, LolaRuntimeImpl>,
-    /// {
-    ///     let _future = sub.cancellable_receive(scratch, 1, 1, UnpinTimeout::<u8>(PhantomData));
-    /// }
-    /// ```
+    // Note: We do not need to explicitly cancel the cancellation future when the receive future
+    // resolves, because the `ReceiveFuture` drop will take care of dropping the cancellation
+    // future when this future completes.
     #[allow(clippy::manual_async_fn)]
     fn cancellable_receive<'a>(
         &'a self,
         scratch: SampleContainer<Self::Sample<'a>>,
         new_samples: usize,
         max_samples: usize,
-        timeout: impl Future<Output = ()> + Send + 'static,
+        cancellation: impl Future<Output = ()> + Send + 'static,
     ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<usize>)> + 'a {
         async move {
             // Validate parameters before proceeding with receive logic
@@ -635,7 +604,7 @@ where
                 new_samples,
                 max_samples,
                 total_received: 0,
-                timeout: core::pin::pin!(timeout),
+                cancellation: core::pin::pin!(cancellation),
             }
             .await
         }
@@ -647,8 +616,6 @@ where
 // a waker storage for async notifications, and parameters for managing the receive operation.
 // The Future implementation for ReceiveFuture defines the polling logic,
 // which attempts to receive samples and manages the state of the receive operation.
-// Unpin bound is required for the timeout future to allow it to be safely pinned on the stack without
-// heap allocation.
 struct ReceiveFuture<'a, T: CommData + Debug, F: Future<Output = ()>> {
     event_guard: Option<ProxyEventManagerGuard<'a>>,
     waker_storage: Arc<AtomicWaker>,
@@ -657,7 +624,7 @@ struct ReceiveFuture<'a, T: CommData + Debug, F: Future<Output = ()>> {
     new_samples: usize,
     max_samples: usize,
     total_received: usize,
-    timeout: Pin<&'a mut F>,
+    cancellation: Pin<&'a mut F>,
 }
 
 impl<'a, T: CommData + Debug, F: Future<Output = ()>> Future for ReceiveFuture<'a, T, F> {
@@ -670,13 +637,13 @@ impl<'a, T: CommData + Debug, F: Future<Output = ()>> Future for ReceiveFuture<'
         let max_num_samples = self.max_num_samples;
         let total_received = self.total_received;
 
-        // Poll cancel/timeout future first to ensure prompt cancellation if requested
-        if self.timeout.as_mut().poll(ctx).is_ready() {
+        // Poll the cancellation future first to ensure prompt handling of cancellation requests.
+        if self.cancellation.as_mut().poll(ctx).is_ready() {
             self.event_guard = None;
             return Poll::Ready((
                 self.scratch
                     .take()
-                    .expect("SampleContainer missing on timeout/cancel"),
+                    .expect("SampleContainer missing on cancellation"),
                 Err(Error::ReceiveError(ReceiveFailedReason::Cancelled)),
             ));
         }
@@ -685,7 +652,8 @@ impl<'a, T: CommData + Debug, F: Future<Output = ()>> Future for ReceiveFuture<'
         self.waker_storage.register(ctx.waker());
 
         let samples_received = {
-            // Temporarily take ownership of scratch to avoid borrow issues
+            // Temporarily take ownership of scratch to avoid borrow checker conflicts
+            // when passing to try_receive_samples
             if let Some(mut scratch) = self.scratch.take() {
                 if let Some(event_guard) = self.event_guard.as_mut() {
                     let result = try_receive_samples::<T>(
@@ -710,8 +678,7 @@ impl<'a, T: CommData + Debug, F: Future<Output = ()>> Future for ReceiveFuture<'
 
                 // Check if we've received enough samples
                 if self.total_received >= new_samples {
-                    //event_guard will be dropped here, allowing new receive calls to access the
-                    // proxy event
+                    // Release the event guard to allow new receive calls to access the proxy event
                     self.event_guard = None;
                     return Poll::Ready((
                         self.scratch.take().expect(

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -480,6 +480,39 @@ impl<T: CommData + Debug> SubscriberImpl<T> {
         }
         Ok(())
     }
+
+    /// Validates the parameters for the receive operation, ensuring that the requested number of samples
+    /// does not exceed the maximum allowed and that the input values are within acceptable bounds.
+    fn validate_receive_params(&self, new_samples: usize, max_samples: usize) -> Result<()> {
+        if new_samples == 0 {
+            return Err(Error::ReceiveError(
+                ReceiveFailedReason::InputValueOutOfBounds {
+                    max: self.max_num_samples,
+                    requested: 0,
+                },
+            ));
+        }
+
+        if new_samples > max_samples {
+            return Err(Error::ReceiveError(
+                ReceiveFailedReason::InputValueOutOfBounds {
+                    max: max_samples,
+                    requested: new_samples,
+                },
+            ));
+        }
+
+        if max_samples > self.max_num_samples || new_samples > self.max_num_samples {
+            return Err(Error::ReceiveError(
+                ReceiveFailedReason::InputValueOutOfBounds {
+                    max: self.max_num_samples,
+                    requested: max_samples.max(new_samples),
+                },
+            ));
+        }
+
+        Ok(())
+    }
 }
 
 impl<T> Subscription<T, LolaRuntimeImpl> for SubscriberImpl<T>
@@ -569,11 +602,11 @@ where
     ///     T: CommData + std::fmt::Debug,
     ///     S: Subscription<T, LolaRuntimeImpl>,
     /// {
-    ///     let _future = sub.receive_timeout(scratch, 1, 1, UnpinTimeout::<u8>(PhantomData));
+    ///     let _future = sub.cancellable_receive(scratch, 1, 1, UnpinTimeout::<u8>(PhantomData));
     /// }
     /// ```
     #[allow(clippy::manual_async_fn)]
-    fn receive_timeout<'a>(
+    fn cancellable_receive<'a>(
         &'a self,
         scratch: SampleContainer<Self::Sample<'a>>,
         new_samples: usize,
@@ -581,41 +614,9 @@ where
         timeout: impl Future<Output = ()> + Send + 'static,
     ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<usize>)> + 'a {
         async move {
-            match new_samples {
-                0 => {
-                    return (
-                        scratch,
-                        Err(Error::ReceiveError(
-                            ReceiveFailedReason::InputValueOutOfBounds {
-                                max: self.max_num_samples,
-                                requested: 0,
-                            },
-                        )),
-                    )
-                }
-                _ if new_samples > max_samples => {
-                    return (
-                        scratch,
-                        Err(Error::ReceiveError(
-                            ReceiveFailedReason::InputValueOutOfBounds {
-                                max: max_samples,
-                                requested: new_samples,
-                            },
-                        )),
-                    );
-                }
-                _ if max_samples > self.max_num_samples || new_samples > self.max_num_samples => {
-                    return (
-                        scratch,
-                        Err(Error::ReceiveError(
-                            ReceiveFailedReason::InputValueOutOfBounds {
-                                max: self.max_num_samples,
-                                requested: max_samples.max(new_samples),
-                            },
-                        )),
-                    );
-                }
-                _ => {}
+            // Validate parameters before proceeding with receive logic
+            if let Err(e) = self.validate_receive_params(new_samples, max_samples) {
+                return (scratch, Err(e));
             }
             // Get the event guard to ensure no concurrent receive calls
             // on the same subscriber instance.
@@ -648,7 +649,7 @@ where
 // which attempts to receive samples and manages the state of the receive operation.
 // Unpin bound is required for the timeout future to allow it to be safely pinned on the stack without
 // heap allocation.
-struct ReceiveFuture<'a, T: CommData + Debug, F: Future<Output = ()> + Unpin> {
+struct ReceiveFuture<'a, T: CommData + Debug, F: Future<Output = ()>> {
     event_guard: Option<ProxyEventManagerGuard<'a>>,
     waker_storage: Arc<AtomicWaker>,
     max_num_samples: usize,
@@ -656,10 +657,10 @@ struct ReceiveFuture<'a, T: CommData + Debug, F: Future<Output = ()> + Unpin> {
     new_samples: usize,
     max_samples: usize,
     total_received: usize,
-    timeout: F,
+    timeout: Pin<&'a mut F>,
 }
 
-impl<'a, T: CommData + Debug, F: Future<Output = ()> + Unpin> Future for ReceiveFuture<'a, T, F> {
+impl<'a, T: CommData + Debug, F: Future<Output = ()>> Future for ReceiveFuture<'a, T, F> {
     type Output = (SampleContainer<Sample<T>>, Result<usize>);
 
     fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -669,8 +670,8 @@ impl<'a, T: CommData + Debug, F: Future<Output = ()> + Unpin> Future for Receive
         let max_num_samples = self.max_num_samples;
         let total_received = self.total_received;
 
-        // Poll cancel/timeout future first — F: Unpin so Pin::new is safe, no allocation
-        if Pin::new(&mut self.timeout).poll(ctx).is_ready() {
+        // Poll cancel/timeout future first to ensure prompt cancellation if requested
+        if self.timeout.as_mut().poll(ctx).is_ready() {
             self.event_guard = None;
             return Poll::Ready((
                 self.scratch

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -555,6 +555,38 @@ where
     // requiring the returned future to be explicitly bound to the lifetime of `&self`.
     // we do not need to cancle timeout future when receive future resolved,
     // because ReceiveFuture drop will take care of cancelling the timeout future.
+    //
+    /// Demonstrates passing a struct future that is `Unpin` via a `PhantomData` field
+    /// to `receive_with_timeout`.
+    ///
+    /// A struct with only a `PhantomData<T>` field has no self-referential state, so
+    /// the compiler derives `Unpin` automatically.
+    ///
+    /// ```
+    /// use com_api_concept::{CommData, SampleContainer, Subscription};
+    /// use com_api_runtime_lola::LolaRuntimeImpl;
+    /// use core::marker::PhantomData;
+    ///
+    /// struct UnpinTimeout<T>(PhantomData<T>);
+    ///
+    /// impl<T: Send + 'static> std::future::Future for UnpinTimeout<T> {
+    ///     type Output = ();
+    ///     fn poll(
+    ///         self: std::pin::Pin<&mut Self>,
+    ///         _cx: &mut std::task::Context<'_>,
+    ///     ) -> std::task::Poll<()> {
+    ///         std::task::Poll::Ready(())
+    ///     }
+    /// }
+    ///
+    /// fn demonstrate<'a, T, S>(sub: &'a S, scratch: SampleContainer<S::Sample<'a>>)
+    /// where
+    ///     T: CommData + std::fmt::Debug,
+    ///     S: Subscription<T, LolaRuntimeImpl>,
+    /// {
+    ///     let _future = sub.receive_with_timeout(scratch, 1, 1, UnpinTimeout::<u8>(PhantomData));
+    /// }
+    /// ```
     #[allow(clippy::manual_async_fn)]
     fn receive_with_timeout<'a>(
         &'a self,

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -553,36 +553,52 @@ where
 
     // Cannot use `async fn` because the trait mandates `-> impl Future + 'a`,
     // requiring the returned future to be explicitly bound to the lifetime of `&self`.
+    // we do not need to cancle timeout future when receive future resolved,
+    // because ReceiveFuture drop will take care of cancelling the timeout future.
     #[allow(clippy::manual_async_fn)]
     fn receive_with_timeout<'a>(
         &'a self,
         scratch: SampleContainer<Self::Sample<'a>>,
         new_samples: usize,
         max_samples: usize,
-        timeout_future: impl Future<Output = ()> + Send + 'static,
+        timeout: impl Future<Output = ()> + Send + 'static,
     ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a {
         async move {
-            if new_samples > max_samples {
-                return (
-                    scratch,
-                    Err(Error::ReceiveError(
-                        ReceiveFailedReason::InputValueOutOfBounds {
-                            max: max_samples,
-                            requested: new_samples,
-                        },
-                    )),
-                );
-            }
-            if max_samples > self.max_num_samples || new_samples > self.max_num_samples {
-                return (
-                    scratch,
-                    Err(Error::ReceiveError(
-                        ReceiveFailedReason::SampleCountOutOfBounds {
-                            max: self.max_num_samples,
-                            requested: max_samples.max(new_samples),
-                        },
-                    )),
-                );
+            match new_samples {
+                0 => {
+                    return (
+                        scratch,
+                        Err(Error::ReceiveError(
+                            ReceiveFailedReason::InputValueOutOfBounds {
+                                max: self.max_num_samples,
+                                requested: 0,
+                            },
+                        )),
+                    )
+                }
+                _ if new_samples > max_samples => {
+                    return (
+                        scratch,
+                        Err(Error::ReceiveError(
+                            ReceiveFailedReason::InputValueOutOfBounds {
+                                max: max_samples,
+                                requested: new_samples,
+                            },
+                        )),
+                    );
+                }
+                _ if max_samples > self.max_num_samples || new_samples > self.max_num_samples => {
+                    return (
+                        scratch,
+                        Err(Error::ReceiveError(
+                            ReceiveFailedReason::InputValueOutOfBounds {
+                                max: self.max_num_samples,
+                                requested: max_samples.max(new_samples),
+                            },
+                        )),
+                    );
+                }
+                _ => {}
             }
             // Get the event guard to ensure no concurrent receive calls
             // on the same subscriber instance.
@@ -601,7 +617,7 @@ where
                 new_samples,
                 max_samples,
                 total_received: 0,
-                timeout_future: core::pin::pin!(timeout_future),
+                timeout: core::pin::pin!(timeout),
             }
             .await
         }
@@ -613,7 +629,9 @@ where
 // a waker storage for async notifications, and parameters for managing the receive operation.
 // The Future implementation for ReceiveFuture defines the polling logic,
 // which attempts to receive samples and manages the state of the receive operation.
-struct ReceiveFuture<'a, T: CommData + Debug, C: Future<Output = ()> + Unpin> {
+// Unpin bound is required for the timeout future to allow it to be safely pinned on the stack without
+// heap allocation.
+struct ReceiveFuture<'a, T: CommData + Debug, F: Future<Output = ()> + Unpin> {
     event_guard: Option<ProxyEventManagerGuard<'a>>,
     waker_storage: Arc<AtomicWaker>,
     max_num_samples: usize,
@@ -621,10 +639,10 @@ struct ReceiveFuture<'a, T: CommData + Debug, C: Future<Output = ()> + Unpin> {
     new_samples: usize,
     max_samples: usize,
     total_received: usize,
-    timeout_future: C,
+    timeout: F,
 }
 
-impl<'a, T: CommData + Debug, C: Future<Output = ()> + Unpin> Future for ReceiveFuture<'a, T, C> {
+impl<'a, T: CommData + Debug, F: Future<Output = ()> + Unpin> Future for ReceiveFuture<'a, T, F> {
     type Output = (SampleContainer<Sample<T>>, Result<()>);
 
     fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -634,8 +652,8 @@ impl<'a, T: CommData + Debug, C: Future<Output = ()> + Unpin> Future for Receive
         let max_num_samples = self.max_num_samples;
         let total_received = self.total_received;
 
-        // Poll cancel/timeout future first — C: Unpin so Pin::new is safe, no allocation
-        if Pin::new(&mut self.timeout_future).poll(ctx).is_ready() {
+        // Poll cancel/timeout future first — F: Unpin so Pin::new is safe, no allocation
+        if Pin::new(&mut self.timeout).poll(ctx).is_ready() {
             self.event_guard = None;
             return Poll::Ready((
                 self.scratch
@@ -687,12 +705,15 @@ impl<'a, T: CommData + Debug, C: Future<Output = ()> + Unpin> Future for Receive
                 // Have some samples but not enough yet, wait for more via waker
                 Poll::Pending
             }
-            Err(e) => Poll::Ready((
-                self.scratch.take().expect(
-                    "SampleContainer unavailable on error; was receive polled after completion?",
-                ),
-                Err(e),
-            )),
+            Err(e) => {
+                self.event_guard = None;
+                Poll::Ready((
+                    self.scratch.take().expect(
+                        "SampleContainer unavailable on error; was receive polled after completion?",
+                    ),
+                    Err(e),
+                ))
+            }
         }
     }
 }
@@ -973,6 +994,14 @@ fn try_receive_samples<T: CommData + Debug>(
     max_num_samples: usize,
     max_samples: usize,
 ) -> Result<usize> {
+    if max_samples == 0 {
+        return Err(Error::ReceiveError(
+            ReceiveFailedReason::InputValueOutOfBounds {
+                max: max_num_samples,
+                requested: 0,
+            },
+        ));
+    }
     if max_samples > max_num_samples {
         return Err(Error::ReceiveError(
             ReceiveFailedReason::SampleCountOutOfBounds {

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -30,7 +30,7 @@
 #![allow(clippy::needless_lifetimes)]
 
 use crate::Debug;
-use core::future::Future;
+use core::future::{self, Future};
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
 use core::ops::{Deref, DerefMut};
@@ -258,8 +258,9 @@ impl NativeProxyEventBase {
     pub fn new(proxy: &NonNull<ProxyBase>, interface_id: &str, identifier: &str) -> Result<Self> {
         //SAFETY: It is safe as we are passing valid proxy pointer and interface id to get event
         // proxy pointer is created during consumer creation
-        let raw_event_ptr =
-            unsafe { bridge_ffi_rs::get_event_from_proxy(proxy.as_ptr(), interface_id, identifier) };
+        let raw_event_ptr = unsafe {
+            bridge_ffi_rs::get_event_from_proxy(proxy.as_ptr(), interface_id, identifier)
+        };
         let proxy_event_ptr = std::ptr::NonNull::new(raw_event_ptr)
             .ok_or(Error::EventError(EventFailedReason::EventCreationFailed))?;
         Ok(Self { proxy_event_ptr })
@@ -535,14 +536,30 @@ where
         )
     }
 
-    // Cannot use `async fn` because the trait mandates `-> impl Future + 'a`,
-    // requiring the returned future to be explicitly bound to the lifetime of `&self`.
     #[allow(clippy::manual_async_fn)]
     fn receive<'a>(
         &'a self,
         scratch: SampleContainer<Self::Sample<'a>>,
         new_samples: usize,
         max_samples: usize,
+    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a {
+        self.receive_with_timeout(
+            scratch,
+            new_samples,
+            max_samples,
+            core::future::pending::<()>(),
+        )
+    }
+
+    // Cannot use `async fn` because the trait mandates `-> impl Future + 'a`,
+    // requiring the returned future to be explicitly bound to the lifetime of `&self`.
+    #[allow(clippy::manual_async_fn)]
+    fn receive_with_timeout<'a>(
+        &'a self,
+        scratch: SampleContainer<Self::Sample<'a>>,
+        new_samples: usize,
+        max_samples: usize,
+        timeout_future: impl Future<Output = ()> + 'a,
     ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a {
         async move {
             if max_samples > self.max_num_samples || new_samples > self.max_num_samples {
@@ -637,9 +654,9 @@ impl<'a, T: CommData + Debug> Future for ReceiveFuture<'a, T> {
                     // proxy event
                     self.event_guard = None;
                     return Poll::Ready((
-                        self.scratch
-                            .take()
-                            .expect("SampleContainer is not available when returning Future result"),
+                        self.scratch.take().expect(
+                            "SampleContainer is not available when returning Future result",
+                        ),
                         Ok(()),
                     ));
                 }
@@ -647,9 +664,9 @@ impl<'a, T: CommData + Debug> Future for ReceiveFuture<'a, T> {
                 Poll::Pending
             }
             Err(e) => Poll::Ready((
-                self.scratch
-                    .take()
-                    .expect("SampleContainer unavailable on error; was receive polled after completion?"),
+                self.scratch.take().expect(
+                    "SampleContainer unavailable on error; was receive polled after completion?",
+                ),
                 Err(e),
             )),
         }

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -536,21 +536,6 @@ where
         )
     }
 
-    #[allow(clippy::manual_async_fn)]
-    fn receive<'a>(
-        &'a self,
-        scratch: SampleContainer<Self::Sample<'a>>,
-        new_samples: usize,
-        max_samples: usize,
-    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a {
-        self.receive_with_timeout(
-            scratch,
-            new_samples,
-            max_samples,
-            core::future::pending::<()>(),
-        )
-    }
-
     // Cannot use `async fn` because the trait mandates `-> impl Future + 'a`,
     // requiring the returned future to be explicitly bound to the lifetime of `&self`.
     // we do not need to cancle timeout future when receive future resolved,
@@ -584,17 +569,17 @@ where
     ///     T: CommData + std::fmt::Debug,
     ///     S: Subscription<T, LolaRuntimeImpl>,
     /// {
-    ///     let _future = sub.receive_with_timeout(scratch, 1, 1, UnpinTimeout::<u8>(PhantomData));
+    ///     let _future = sub.receive_timeout(scratch, 1, 1, UnpinTimeout::<u8>(PhantomData));
     /// }
     /// ```
     #[allow(clippy::manual_async_fn)]
-    fn receive_with_timeout<'a>(
+    fn receive_timeout<'a>(
         &'a self,
         scratch: SampleContainer<Self::Sample<'a>>,
         new_samples: usize,
         max_samples: usize,
         timeout: impl Future<Output = ()> + Send + 'static,
-    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a {
+    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<usize>)> + 'a {
         async move {
             match new_samples {
                 0 => {
@@ -675,7 +660,7 @@ struct ReceiveFuture<'a, T: CommData + Debug, F: Future<Output = ()> + Unpin> {
 }
 
 impl<'a, T: CommData + Debug, F: Future<Output = ()> + Unpin> Future for ReceiveFuture<'a, T, F> {
-    type Output = (SampleContainer<Sample<T>>, Result<()>);
+    type Output = (SampleContainer<Sample<T>>, Result<usize>);
 
     fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
         // Extract all immutable values upfront to avoid borrow conflicts with self in the callback
@@ -731,7 +716,7 @@ impl<'a, T: CommData + Debug, F: Future<Output = ()> + Unpin> Future for Receive
                         self.scratch.take().expect(
                             "SampleContainer is not available when returning Future result",
                         ),
-                        Ok(()),
+                        Ok(self.total_received),
                     ));
                 }
                 // Have some samples but not enough yet, wait for more via waker

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -30,7 +30,7 @@
 #![allow(clippy::needless_lifetimes)]
 
 use crate::Debug;
-use core::future::{self, Future};
+use core::future::Future;
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
 use core::ops::{Deref, DerefMut};
@@ -559,9 +559,20 @@ where
         scratch: SampleContainer<Self::Sample<'a>>,
         new_samples: usize,
         max_samples: usize,
-        timeout_future: impl Future<Output = ()> + Unpin + 'a,
+        timeout_future: impl Future<Output = ()> + Send + 'static,
     ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a {
         async move {
+            if new_samples > max_samples {
+                return (
+                    scratch,
+                    Err(Error::ReceiveError(
+                        ReceiveFailedReason::InputValueOutOfBounds {
+                            max: max_samples,
+                            requested: new_samples,
+                        },
+                    )),
+                );
+            }
             if max_samples > self.max_num_samples || new_samples > self.max_num_samples {
                 return (
                     scratch,
@@ -590,7 +601,7 @@ where
                 new_samples,
                 max_samples,
                 total_received: 0,
-                timeout_future,
+                timeout_future: core::pin::pin!(timeout_future),
             }
             .await
         }

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -543,15 +543,18 @@ where
         scratch: SampleContainer<Self::Sample<'a>>,
         new_samples: usize,
         max_samples: usize,
-    ) -> impl Future<Output = Result<SampleContainer<Self::Sample<'a>>>> + 'a {
+    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a {
         async move {
             if max_samples > self.max_num_samples || new_samples > self.max_num_samples {
-                return Err(Error::ReceiveError(
-                    ReceiveFailedReason::SampleCountOutOfBounds {
-                        max: self.max_num_samples,
-                        requested: max_samples.max(new_samples),
-                    },
-                ));
+                return (
+                    scratch,
+                    Err(Error::ReceiveError(
+                        ReceiveFailedReason::SampleCountOutOfBounds {
+                            max: self.max_num_samples,
+                            requested: max_samples.max(new_samples),
+                        },
+                    )),
+                );
             }
             // Get the event guard to ensure no concurrent receive calls
             // on the same subscriber instance.
@@ -592,7 +595,7 @@ struct ReceiveFuture<'a, T: CommData + Debug> {
 }
 
 impl<'a, T: CommData + Debug> Future for ReceiveFuture<'a, T> {
-    type Output = Result<SampleContainer<Sample<T>>>;
+    type Output = (SampleContainer<Sample<T>>, Result<()>);
 
     fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
         // Extract all immutable values upfront to avoid borrow conflicts with self in the callback
@@ -617,6 +620,7 @@ impl<'a, T: CommData + Debug> Future for ReceiveFuture<'a, T> {
                     self.scratch = Some(scratch);
                     result
                 } else {
+                    self.scratch = Some(scratch);
                     Err(Error::ReceiveError(ReceiveFailedReason::ReceiveError))
                 }
             } else {
@@ -632,15 +636,22 @@ impl<'a, T: CommData + Debug> Future for ReceiveFuture<'a, T> {
                     //event_guard will be dropped here, allowing new receive calls to access the
                     // proxy event
                     self.event_guard = None;
-                    return Poll::Ready(Ok(self
-                        .scratch
-                        .take()
-                        .expect("SampleContainer is not available when returning Future result")));
+                    return Poll::Ready((
+                        self.scratch
+                            .take()
+                            .expect("SampleContainer is not available when returning Future result"),
+                        Ok(()),
+                    ));
                 }
                 // Have some samples but not enough yet, wait for more via waker
                 Poll::Pending
             }
-            Err(e) => Poll::Ready(Err(e)),
+            Err(e) => Poll::Ready((
+                self.scratch
+                    .take()
+                    .expect("SampleContainer unavailable on error; was receive polled after completion?"),
+                Err(e),
+            )),
         }
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -559,7 +559,7 @@ where
         scratch: SampleContainer<Self::Sample<'a>>,
         new_samples: usize,
         max_samples: usize,
-        timeout_future: impl Future<Output = ()> + 'a,
+        timeout_future: impl Future<Output = ()> + Unpin + 'a,
     ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a {
         async move {
             if max_samples > self.max_num_samples || new_samples > self.max_num_samples {
@@ -590,6 +590,7 @@ where
                 new_samples,
                 max_samples,
                 total_received: 0,
+                timeout_future,
             }
             .await
         }
@@ -601,7 +602,7 @@ where
 // a waker storage for async notifications, and parameters for managing the receive operation.
 // The Future implementation for ReceiveFuture defines the polling logic,
 // which attempts to receive samples and manages the state of the receive operation.
-struct ReceiveFuture<'a, T: CommData + Debug> {
+struct ReceiveFuture<'a, T: CommData + Debug, C: Future<Output = ()> + Unpin> {
     event_guard: Option<ProxyEventManagerGuard<'a>>,
     waker_storage: Arc<AtomicWaker>,
     max_num_samples: usize,
@@ -609,9 +610,10 @@ struct ReceiveFuture<'a, T: CommData + Debug> {
     new_samples: usize,
     max_samples: usize,
     total_received: usize,
+    timeout_future: C,
 }
 
-impl<'a, T: CommData + Debug> Future for ReceiveFuture<'a, T> {
+impl<'a, T: CommData + Debug, C: Future<Output = ()> + Unpin> Future for ReceiveFuture<'a, T, C> {
     type Output = (SampleContainer<Sample<T>>, Result<()>);
 
     fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
@@ -620,6 +622,17 @@ impl<'a, T: CommData + Debug> Future for ReceiveFuture<'a, T> {
         let new_samples = self.new_samples;
         let max_num_samples = self.max_num_samples;
         let total_received = self.total_received;
+
+        // Poll cancel/timeout future first — C: Unpin so Pin::new is safe, no allocation
+        if Pin::new(&mut self.timeout_future).poll(ctx).is_ready() {
+            self.event_guard = None;
+            return Poll::Ready((
+                self.scratch
+                    .take()
+                    .expect("SampleContainer missing on timeout/cancel"),
+                Err(Error::ReceiveError(ReceiveFailedReason::Cancelled)),
+            ));
+        }
 
         // Register the current waker to be notified when new samples arrive via FFI callback
         self.waker_storage.register(ctx.waker());

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-mock/runtime.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-mock/runtime.rs
@@ -336,6 +336,17 @@ where
     ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a {
         async { todo!() }
     }
+
+    #[allow(clippy::manual_async_fn)]
+    fn receive_with_timeout<'a>(
+        &'a self,
+        _scratch: SampleContainer<Self::Sample<'a>>,
+        _new_samples: usize,
+        _max_samples: usize,
+        _timeout_future: impl Future<Output = ()> + 'a,
+    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a {
+        async { todo!() }
+    }
 }
 
 pub struct Publisher<T> {

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-mock/runtime.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-mock/runtime.rs
@@ -328,7 +328,7 @@ where
     }
 
     #[allow(clippy::manual_async_fn)]
-    fn receive_timeout<'a>(
+    fn cancellable_receive<'a>(
         &'a self,
         _scratch: SampleContainer<Self::Sample<'a>>,
         _new_samples: usize,

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-mock/runtime.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-mock/runtime.rs
@@ -343,8 +343,9 @@ where
         _scratch: SampleContainer<Self::Sample<'a>>,
         _new_samples: usize,
         _max_samples: usize,
-        _timeout_future: impl Future<Output = ()> + Unpin + 'a,
-    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a {
+        _timeout_future: impl Future<Output = ()> + Send + 'static,
+    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a 
+    {
         async { todo!() }
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-mock/runtime.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-mock/runtime.rs
@@ -333,7 +333,7 @@ where
         _scratch: SampleContainer<Self::Sample<'a>>,
         _new_samples: usize,
         _max_samples: usize,
-    ) -> impl Future<Output = Result<SampleContainer<Self::Sample<'a>>>> + 'a {
+    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a {
         async { todo!() }
     }
 }
@@ -531,16 +531,10 @@ mod test {
         let test_subscriber = super::SubscriberImpl::<u32>::new();
         // block on an asynchronous reception of data from test_subscriber
         futures::executor::block_on(async {
-            let mut sample_buf = SampleContainer::new();
-            match test_subscriber.receive(&mut sample_buf, 1, 1).await {
-                Ok(0) => panic!("No sample received"),
-                Ok(x) => {
-                    println!(
-                        "{} samples received: sample[0] = {}",
-                        x,
-                        *sample_buf.front().unwrap()
-                    )
-                }
+            let sample_buf = SampleContainer::new(1);
+            let (_returned_buf, result) = test_subscriber.receive(sample_buf, 1, 1).await;
+            match result {
+                Ok(()) => {}
                 Err(e) => panic!("{:?}", e),
             }
         })

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-mock/runtime.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-mock/runtime.rs
@@ -343,7 +343,7 @@ where
         _scratch: SampleContainer<Self::Sample<'a>>,
         _new_samples: usize,
         _max_samples: usize,
-        _timeout_future: impl Future<Output = ()> + 'a,
+        _timeout_future: impl Future<Output = ()> + Unpin + 'a,
     ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a {
         async { todo!() }
     }

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-mock/runtime.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-mock/runtime.rs
@@ -343,9 +343,8 @@ where
         _scratch: SampleContainer<Self::Sample<'a>>,
         _new_samples: usize,
         _max_samples: usize,
-        _timeout_future: impl Future<Output = ()> + Send + 'static,
-    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a 
-    {
+        _timeout: impl Future<Output = ()> + Send + 'static,
+    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a {
         async { todo!() }
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-mock/runtime.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-mock/runtime.rs
@@ -333,7 +333,7 @@ where
         _scratch: SampleContainer<Self::Sample<'a>>,
         _new_samples: usize,
         _max_samples: usize,
-        _timeout: impl Future<Output = ()> + Send + 'static,
+        _cancellation: impl Future<Output = ()> + Send + 'static,
     ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<usize>)> + 'a {
         async { todo!() }
     }

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-mock/runtime.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-mock/runtime.rs
@@ -328,23 +328,13 @@ where
     }
 
     #[allow(clippy::manual_async_fn)]
-    fn receive<'a>(
-        &'a self,
-        _scratch: SampleContainer<Self::Sample<'a>>,
-        _new_samples: usize,
-        _max_samples: usize,
-    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a {
-        async { todo!() }
-    }
-
-    #[allow(clippy::manual_async_fn)]
-    fn receive_with_timeout<'a>(
+    fn receive_timeout<'a>(
         &'a self,
         _scratch: SampleContainer<Self::Sample<'a>>,
         _new_samples: usize,
         _max_samples: usize,
         _timeout: impl Future<Output = ()> + Send + 'static,
-    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<()>)> + 'a {
+    ) -> impl Future<Output = (SampleContainer<Self::Sample<'a>>, Result<usize>)> + 'a {
         async { todo!() }
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api/com_api.rs
+++ b/score/mw/com/impl/rust/com-api/com-api/com_api.rs
@@ -114,7 +114,8 @@
 //! }
 //!
 //! // 6. Or wait asynchronously for events
-//! let n = subscription.receive(&mut container, 1, 3).await?;
+//! let (container, result) = subscription.receive(container, 1, 3).await;
+//! result?;
 //! ```
 //! # Further reading
 //! - `com_api_concept` crate — trait definitions and full API documentation

--- a/score/mw/com/impl/rust/com-api/com-api/com_api.rs
+++ b/score/mw/com/impl/rust/com-api/com-api/com_api.rs
@@ -115,7 +115,6 @@
 //!
 //! // 6. Or wait asynchronously for events
 //! let (container, result) = subscription.receive(container, 1, 3).await;
-//! result?;
 //! ```
 //! # Further reading
 //! - `com_api_concept` crate — trait definitions and full API documentation

--- a/score/mw/com/test/basic_rust_api/consumer_async_apis/consumer_app.rs
+++ b/score/mw/com/test/basic_rust_api/consumer_async_apis/consumer_app.rs
@@ -96,6 +96,10 @@ async fn async_main() {
             eprintln!("[bigdata-consumer] Receive error: {:?}", e);
             return;
         }
+        // Process the received samples and prepare the buffer for the next call to `receive`.
+        // We are retuning the same buffer instance to `receive` to avoid unnecessary allocations.
+        // So emptying buffer means processing, and if user required it can pass with samples still in buffer
+        // and `receive` will add new samples to it until it reaches the max capacity of the buffer.
         sample_buf = {
             let count = returned_buf.sample_count();
             let mut buf = returned_buf;

--- a/score/mw/com/test/basic_rust_api/consumer_async_apis/consumer_app.rs
+++ b/score/mw/com/test/basic_rust_api/consumer_async_apis/consumer_app.rs
@@ -89,33 +89,27 @@ async fn async_main() {
     let mut sample_buf = SampleContainer::new(MAX_SAMPLES_PER_CALL);
     // `receive` awaits until at least `min_samples` (1) are available.
     while received_total < num_cycles {
-        sample_buf = match subscription
+        let (returned_buf, result) = subscription
             .receive(sample_buf, 1, MAX_SAMPLES_PER_CALL)
-            .await
-        {
-            Ok(returned_buf) => {
-                let count = returned_buf.sample_count();
-                if count > 0 {
-                    let mut buf = returned_buf;
-                    for _ in 0..count {
-                        if let Some(sample) = buf.pop_front() {
-                            println!("[bigdata-consumer] Received sample x={}", sample.x);
-                        }
-                    }
-                    received_total += count;
-                    println!(
-                        "[bigdata-consumer] Progress: {}/{}",
-                        received_total, num_cycles
-                    );
-                    buf
-                } else {
-                    returned_buf
+            .await;
+        if let Err(e) = result {
+            eprintln!("[bigdata-consumer] Receive error: {:?}", e);
+            return;
+        }
+        sample_buf = {
+            let count = returned_buf.sample_count();
+            let mut buf = returned_buf;
+            for _ in 0..count {
+                if let Some(sample) = buf.pop_front() {
+                    println!("[bigdata-consumer] Received sample x={}", sample.x);
                 }
             }
-            Err(e) => {
-                eprintln!("[bigdata-consumer] Receive error: {:?}", e);
-                return;
-            }
+            received_total += count;
+            println!(
+                "[bigdata-consumer] Progress: {}/{}",
+                received_total, num_cycles
+            );
+            buf
         };
     }
 


### PR DESCRIPTION
- Receive API now return the tuple of SampleContainer and Result.
- Receive API extended with timeout support for user to resolve / cancel the future.

https://github.com/eclipse-score/communication/issues/242