### PR TITLE
Remove unused null_termination_check dependency.

### DIFF
--- a/score/mw/com/test/common_test_resources/BUILD
+++ b/score/mw/com/test/common_test_resources/BUILD
@@ -92,9 +92,6 @@ cc_library(
         "shared_memory_object_creator.h",
     ],
     features = COMPILER_WARNING_FEATURES,
-    implementation_deps = [
-        "@score_baselibs//score/language/safecpp/string_view:null_termination_check",
-    ],
     visibility = [
         "//score/mw/com/test:__subpackages__",
     ],


### PR DESCRIPTION
Removed an unused null_termination_check dependency from test common resources. No code in the target  uses null_termination_check, so the dependency is stale.