### PR TITLE
Docs(quality): update coverage commands

### DIFF
--- a/quality/quality.md
+++ b/quality/quality.md
@@ -64,7 +64,7 @@ bazel coverage //...
 To run coverage for a specific target:
 
 ```bash
-bazel coverage //score/message_passing:client_connection_test
+bazel coverage --combined_report=lcov //score/message_passing:client_connection_test_linux
 ```
 
 When [`quality/coverage.bazelrc`](coverage.bazelrc) is active, the combined LCOV report is written to
@@ -73,7 +73,7 @@ When [`quality/coverage.bazelrc`](coverage.bazelrc) is active, the combined LCOV
 To generate an HTML report from the LCOV data:
 
 ```bash
-genhtml bazel-out/_coverage/_coverage_report.dat --output-directory coverage_html
+genhtml --ignore-errors inconsistent bazel-out/_coverage/_coverage_report.dat --output-directory coverage_html
 ```
 
 Then open `coverage_html/index.html` in a browser.


### PR DESCRIPTION
Previously command was working.
The failure started after PR#436 introduced forwarding unit-test targets; coverage on the wrapper target became effectively empty, so switching to the real _linux target fixed it. So, updated the command to make it work again.