### PR TITLE
fix: bazel apt install with merged usr

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -329,6 +329,7 @@ apt.install(
     name = "ubuntu24_04",
     lock = "@@//quality/integration_testing/environments/ubuntu24_04_docker:ubuntu24_04.lock.json",
     manifest = "//quality/integration_testing/environments/ubuntu24_04_docker:ubuntu24_04.yaml",
+    mergedusr = True,
 )
 use_repo(apt, "ubuntu24_04")
 


### PR DESCRIPTION
Ubuntu 24.04 uses a merged /usr, where e.g. /bin, /lib or /sbin are symlinks into their respective /usr directories. In this case the option mergedusr has to be set to true. Otherwise bazel will produce a container image with missing applications. Which application is missing depends on the order of packages being installed.

I suppose currently this is not a problem, because very few packages are installed and none seem to trigger the errornous behavior.