### PR TITLE
workflow: fix deployment job name printed in nightly run

### DIFF
--- a/.github/workflows/nightly_quality.yml
+++ b/.github/workflows/nightly_quality.yml
@@ -144,4 +144,4 @@ jobs:
         run: |
           OWNER="${{ github.repository_owner }}"
           REPO="${{ github.event.repository.name }}"
-          echo "::notice::Quality reports will be published at https://${OWNER}.github.io/${REPO}/latest/quality/index.html once docs.yml completes."
+          echo "::notice::Quality reports will be published at https://${OWNER}.github.io/${REPO}/latest/quality/index.html once deploy_docs.yml completes."


### PR DESCRIPTION
replace docs.yml with the current name deploy_docs.yml