### PR TITLE
mw/com: add missing non_relocatable_vector dependency to method_data

### DIFF
--- a/score/mw/com/impl/bindings/lola/methods/BUILD
+++ b/score/mw/com/impl/bindings/lola/methods/BUILD
@@ -48,6 +48,7 @@ cc_library(
         ":unique_method_identifier",
         "//score/mw/com/impl/configuration",
         "@score_baselibs//score/containers:dynamic_array",
+        "@score_baselibs//score/containers:non_relocatable_vector",
         "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/memory/shared:managed_memory_resource",
         "@score_baselibs//score/memory/shared:polymorphic_offset_ptr_allocator",


### PR DESCRIPTION
- Adding the missing non_relocatable_vector dependency to method_data