### PR TITLE
test: improve generic skeleton interaction tests for CI stability

### DIFF
--- a/score/mw/com/test/generic_skeleton/BUILD.bazel
+++ b/score/mw/com/test/generic_skeleton/BUILD.bazel
@@ -23,7 +23,7 @@ cc_binary(
     deps = [
         "//score/mw/com",
         "//score/mw/com/test/common_test_resources:sample_sender_receiver",
-        "//score/mw/com/test/common_test_resources:sctf_test_runner",
+        "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
     ],
 )
 
@@ -35,7 +35,7 @@ cc_binary(
     deps = [
         "//score/mw/com",
         "//score/mw/com/test/common_test_resources:sample_sender_receiver",
-        "//score/mw/com/test/common_test_resources:sctf_test_runner",
+        "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
     ],
 )
 
@@ -47,7 +47,7 @@ cc_binary(
     deps = [
         "//score/mw/com",
         "//score/mw/com/test/common_test_resources:sample_sender_receiver",
-        "//score/mw/com/test/common_test_resources:sctf_test_runner",
+        "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
     ],
 )
 
@@ -59,7 +59,7 @@ cc_binary(
     deps = [
         "//score/mw/com",
         "//score/mw/com/test/common_test_resources:sample_sender_receiver",
-        "//score/mw/com/test/common_test_resources:sctf_test_runner",
+        "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
     ],
 )
 
@@ -87,7 +87,7 @@ cc_binary(
     deps = [
         "//score/mw/com",
         "//score/mw/com/test/common_test_resources:sample_sender_receiver",
-        "//score/mw/com/test/common_test_resources:sctf_test_runner",
+        "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
     ],
 )
 
@@ -99,7 +99,7 @@ cc_binary(
     deps = [
         "//score/mw/com",
         "//score/mw/com/test/common_test_resources:sample_sender_receiver",
-        "//score/mw/com/test/common_test_resources:sctf_test_runner",
+        "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
     ],
 )
 
@@ -111,7 +111,7 @@ cc_binary(
     deps = [
         "//score/mw/com",
         "//score/mw/com/test/common_test_resources:sample_sender_receiver",
-        "//score/mw/com/test/common_test_resources:sctf_test_runner",
+        "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
     ],
 )
 
@@ -123,7 +123,7 @@ cc_binary(
     deps = [
         "//score/mw/com",
         "//score/mw/com/test/common_test_resources:sample_sender_receiver",
-        "//score/mw/com/test/common_test_resources:sctf_test_runner",
+        "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
     ],
 )
 

--- a/score/mw/com/test/generic_skeleton/generic_generic_interaction_app.cpp
+++ b/score/mw/com/test/generic_skeleton/generic_generic_interaction_app.cpp
@@ -3,9 +3,12 @@
 #include "score/mw/com/impl/instance_specifier.h"
 #include "score/mw/com/runtime.h"
 #include "score/mw/com/runtime_configuration.h"
+#include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
 #include "score/mw/log/logging.h"
+#include <score/stop_token.hpp>
 
 #include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <iostream>
 #include <string>
@@ -23,7 +26,7 @@ namespace
 
 struct MyEventData
 {
-    uint64_t counter;
+    std::uint64_t counter;
 #if PAYLOAD_SIZE > 8
     char padding[PAYLOAD_SIZE - 8];
 #endif
@@ -45,7 +48,7 @@ constexpr std::string_view kEventName = "Event8Byte";
 #error "Unsupported payload size configured."
 #endif
 
-int run_provider()
+int run_provider(score::cpp::stop_token stop_token)
 {
     const auto instance_specifier = score::mw::com::impl::InstanceSpecifier::Create(kInstanceSpecifier).value();
     std::cout << "[PROVIDER] Instance specifier created." << std::endl;
@@ -94,7 +97,8 @@ int run_provider()
     std::this_thread::sleep_for(std::chrono::seconds(5));
     std::cout << "[PROVIDER] Finished initial 5s sleep." << std::endl;
 
-    for (std::uint64_t i = 0; i < kSamplesToProcess; ++i)
+    std::uint64_t i{0};
+    while (!stop_token.stop_requested())
     {
         auto sample_res = generic_event.Allocate();
         if (!sample_res.has_value())
@@ -111,11 +115,10 @@ int run_provider()
         generic_event.Send(std::move(sample_res.value()));
         std::cout << "[PROVIDER] " << PAYLOAD_SIZE << "-byte Event Sent sample: " << i << std::endl;
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        i++;
     }
 
-    std::cout << "[PROVIDER] All samples sent." << std::endl;
-    std::this_thread::sleep_for(std::chrono::seconds(15));
-    std::cout << "[PROVIDER] Finished post-send 15s sleep. Calling StopOfferService()..." << std::endl;
+    std::cout << "[PROVIDER] Received termination signal. Calling StopOfferService()..." << std::endl;
     skeleton.StopOfferService();
     std::cout << "[PROVIDER] StopOfferService() completed." << std::endl;
     return 0;
@@ -126,7 +129,7 @@ int run_consumer()
     const auto instance_specifier = score::mw::com::impl::InstanceSpecifier::Create(kInstanceSpecifier).value();
 
     score::Result<score::mw::com::ServiceHandleContainer<score::mw::com::impl::GenericProxy::HandleType>> handles_res;
-    int retries = 0;
+    int retries{0};
     while (retries < 50)
     {
         handles_res = score::mw::com::impl::GenericProxy::FindService(instance_specifier);
@@ -151,9 +154,10 @@ int run_consumer()
     auto& generic_event = event_it->second;
     generic_event.Subscribe(kSamplesToSubscribe);
 
-    uint64_t expected = 0;
-    uint64_t received = 0;
-    int data_mismatches = 0;
+    std::uint64_t expected{0};
+    std::uint64_t received{0};
+    int data_mismatches{0};
+    bool is_first_sample{true};
 
     while (received < kSamplesToProcess)
     {
@@ -161,6 +165,13 @@ int run_consumer()
         generic_event.GetNewSamples(
             [&](auto sample) {
                 auto* typed_sample = static_cast<const MyEventData*>(sample.get());
+
+                if (is_first_sample)
+                {
+                    expected = typed_sample->counter;
+                    is_first_sample = false;
+                }
+
                 if (typed_sample->counter != expected)
                 {
                     std::cerr << "[CONSUMER] " << PAYLOAD_SIZE << "-byte Data mismatch! Expected: " << expected
@@ -194,8 +205,12 @@ int main(int argc, const char* argv[])
         if (std::string(argv[i]) == "--mode" && i + 1 < argc)
             mode = argv[++i];
     score::mw::com::runtime::InitializeRuntime(score::mw::com::runtime::RuntimeConfiguration(argc, argv));
+
+    score::cpp::stop_source stop_source{};
+    score::mw::com::SetupStopTokenSigTermHandler(stop_source);
+
     if (mode == "provider")
-        return run_provider();
+        return run_provider(stop_source.get_token());
     if (mode == "consumer")
         return run_consumer();
     return 1;

--- a/score/mw/com/test/generic_skeleton/generic_typed_interaction_app.cpp
+++ b/score/mw/com/test/generic_skeleton/generic_typed_interaction_app.cpp
@@ -16,9 +16,12 @@
 #include "score/mw/com/impl/traits.h"
 #include "score/mw/com/runtime.h"
 #include "score/mw/com/runtime_configuration.h"
+#include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
 #include "score/mw/log/logging.h"
+#include <score/stop_token.hpp>
 
 #include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <iostream>
 #include <string>
@@ -35,7 +38,7 @@ namespace
 
 struct MyEventData
 {
-    uint64_t counter;
+    std::uint64_t counter;
 #if PAYLOAD_SIZE > 8
     char padding[PAYLOAD_SIZE - 8];
 #endif
@@ -57,7 +60,7 @@ constexpr std::string_view kEventName = "Event8Byte";
 #error "Unsupported payload size configured."
 #endif
 
-int run_provider()
+int run_provider(score::cpp::stop_token stop_token)
 {
     const auto instance_specifier =
         score::mw::com::impl::InstanceSpecifier::Create(std::string{kInstanceSpecifier}).value();
@@ -94,7 +97,8 @@ int run_provider()
         << PAYLOAD_SIZE << "-byte - Waiting 5s for consumer to subscribe...";
     std::this_thread::sleep_for(std::chrono::seconds(5));
 
-    for (std::uint64_t i = 0; i < kSamplesToProcess; ++i)
+    std::uint64_t i{0};
+    while (!stop_token.stop_requested())
     {
         auto sample_res = generic_event.Allocate();
         if (!sample_res.has_value())
@@ -108,9 +112,9 @@ int run_provider()
 
         score::mw::log::LogInfo("GenericSkeletonProvider") << PAYLOAD_SIZE << "-byte Event Sent sample: " << i;
         std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        i++;
     }
 
-    std::this_thread::sleep_for(std::chrono::seconds(15));
     skeleton.StopOfferService();
     return 0;
 }
@@ -130,7 +134,7 @@ int run_consumer()
         score::mw::com::impl::InstanceSpecifier::Create(std::string{kInstanceSpecifier}).value();
 
     score::Result<score::mw::com::ServiceHandleContainer<MyTestServiceProxy::HandleType>> handles_res;
-    int retries = 0;
+    int retries{0};
     while (retries < 50)  // Try for up to 5 seconds
     {
         handles_res = MyTestServiceProxy::FindService(instance_specifier);
@@ -156,15 +160,22 @@ int run_consumer()
     }
     auto& proxy = proxy_res.value();
 
-    uint64_t received = 0;
-    uint64_t expected = 0;
-    int data_mismatches = 0;
+    std::uint64_t received{0};
+    std::uint64_t expected{0};
+    int data_mismatches{0};
+    bool is_first_sample{true};
     proxy.event_.Subscribe(kSamplesToSubscribe);
 
     while (received < kSamplesToProcess)
     {
         proxy.event_.GetNewSamples(
             [&](score::mw::com::SamplePtr<MyEventData> sample) {
+                if (is_first_sample)
+                {
+                    expected = sample->counter;
+                    is_first_sample = false;
+                }
+
                 if (sample->counter != expected)
                 {
                     score::mw::log::LogFatal("TypedProxyConsumer")
@@ -208,9 +219,12 @@ int main(int argc, const char* argv[])
 
     score::mw::com::runtime::InitializeRuntime(score::mw::com::runtime::RuntimeConfiguration(argc, argv));
 
+    score::cpp::stop_source stop_source{};
+    score::mw::com::SetupStopTokenSigTermHandler(stop_source);
+
     if (mode == "provider")
     {
-        return run_provider();
+        return run_provider(stop_source.get_token());
     }
     else if (mode == "consumer")
     {

--- a/score/mw/com/test/generic_skeleton/integration_test/test_generic_generic_interaction.py
+++ b/score/mw/com/test/generic_skeleton/integration_test/test_generic_generic_interaction.py
@@ -31,8 +31,7 @@ def test_generic_generic_interaction_64_byte(target):
     config_path = "./etc/mw_com_config.json"
 
     logger.info(f"Starting provider: {app_bin} in {app_root}")
-    # ADDED enforce_clean_shutdown=False and disabled LSAN here
-    with run_interaction_app(target, app_bin, "provider", config_path, cwd=app_root, enforce_clean_shutdown=False, env={"ASAN_OPTIONS": "detect_leaks=0"}):
+    with run_interaction_app(target, app_bin, "provider", config_path, cwd=app_root):
         time.sleep(2) # Give provider a moment to initialize
 
         logger.info(f"Starting consumer: {app_bin} in {app_root}")
@@ -50,8 +49,7 @@ def test_generic_generic_interaction_32_byte(target):
     config_path = "./etc/mw_com_config.json"
 
     logger.info(f"Starting provider: {app_bin} in {app_root}")
-    # ADDED enforce_clean_shutdown=False and disabled LSAN here
-    with run_interaction_app(target, app_bin, "provider", config_path, cwd=app_root, enforce_clean_shutdown=False, env={"ASAN_OPTIONS": "detect_leaks=0"}):
+    with run_interaction_app(target, app_bin, "provider", config_path, cwd=app_root):
         time.sleep(2) # Give provider a moment to initialize
 
         logger.info(f"Starting consumer: {app_bin} in {app_root}")
@@ -69,8 +67,7 @@ def test_generic_generic_interaction_16_byte(target):
     config_path = "./etc/mw_com_config.json"
 
     logger.info(f"Starting provider: {app_bin} in {app_root}")
-    # ADDED enforce_clean_shutdown=False and disabled LSAN here
-    with run_interaction_app(target, app_bin, "provider", config_path, cwd=app_root, enforce_clean_shutdown=False, env={"ASAN_OPTIONS": "detect_leaks=0"}):
+    with run_interaction_app(target, app_bin, "provider", config_path, cwd=app_root):
         time.sleep(2) # Give provider a moment to initialize
 
         logger.info(f"Starting consumer: {app_bin} in {app_root}")
@@ -88,8 +85,7 @@ def test_generic_generic_interaction_8_byte(target):
     config_path = "./etc/mw_com_config.json"
 
     logger.info(f"Starting provider: {app_bin} in {app_root}")
-    # ADDED enforce_clean_shutdown=False and disabled LSAN here
-    with run_interaction_app(target, app_bin, "provider", config_path, cwd=app_root, enforce_clean_shutdown=False, env={"ASAN_OPTIONS": "detect_leaks=0"}):
+    with run_interaction_app(target, app_bin, "provider", config_path, cwd=app_root):
         time.sleep(2) # Give provider a moment to initialize
 
         logger.info(f"Starting consumer: {app_bin} in {app_root}")

--- a/score/mw/com/test/generic_skeleton/integration_test/test_generic_typed_interaction.py
+++ b/score/mw/com/test/generic_skeleton/integration_test/test_generic_typed_interaction.py
@@ -30,8 +30,7 @@ def test_generic_typed_interaction_64_byte(target):
     config_path = "./etc/mw_com_config.json"
 
     logger.info(f"Starting provider: {app_bin} in {app_root}")
-    # Added enforce_clean_shutdown=False and disabled LSAN so forceful shutdown doesn't fail the test
-    with run_interaction_app(target, app_bin, "provider", config_path, cwd=app_root, enforce_clean_shutdown=False, env={"ASAN_OPTIONS": "detect_leaks=0"}):
+    with run_interaction_app(target, app_bin, "provider", config_path, cwd=app_root):
         # Give the provider a moment to initialize and offer the service
         # to prevent a race condition where the consumer starts too quickly.
         time.sleep(2)
@@ -51,7 +50,7 @@ def test_generic_typed_interaction_32_byte(target):
     config_path = "./etc/mw_com_config.json"
 
     logger.info(f"Starting provider: {app_bin} in {app_root}")
-    with run_interaction_app(target, app_bin, "provider", config_path, cwd=app_root, enforce_clean_shutdown=False, env={"ASAN_OPTIONS": "detect_leaks=0"}):
+    with run_interaction_app(target, app_bin, "provider", config_path, cwd=app_root):
         time.sleep(2)
 
         logger.info(f"Starting consumer: {app_bin} in {app_root}")
@@ -68,7 +67,7 @@ def test_generic_typed_interaction_16_byte(target):
     config_path = "./etc/mw_com_config.json"
 
     logger.info(f"Starting provider: {app_bin} in {app_root}")
-    with run_interaction_app(target, app_bin, "provider", config_path, cwd=app_root, enforce_clean_shutdown=False, env={"ASAN_OPTIONS": "detect_leaks=0"}):
+    with run_interaction_app(target, app_bin, "provider", config_path, cwd=app_root):
         time.sleep(2)
 
         logger.info(f"Starting consumer: {app_bin} in {app_root}")
@@ -85,7 +84,7 @@ def test_generic_typed_interaction_8_byte(target):
     config_path = "./etc/mw_com_config.json"
 
     logger.info(f"Starting provider: {app_bin} in {app_root}")
-    with run_interaction_app(target, app_bin, "provider", config_path, cwd=app_root, enforce_clean_shutdown=False, env={"ASAN_OPTIONS": "detect_leaks=0"}):
+    with run_interaction_app(target, app_bin, "provider", config_path, cwd=app_root):
         time.sleep(2)
 
         logger.info(f"Starting consumer: {app_bin} in {app_root}")


### PR DESCRIPTION
- **Solves** this issue https://github.com/eclipse-score/communication/issues/512

**Objective**: Improve the stability and reliability of the generic_skeleton integration tests in CI environments.

**Changes**:

- **Test Flow Redesign:** The provider now loops infinitely (handling SIGTERM via stop_token for graceful shutdown) while the consumer strictly verifies 30 consecutive samples starting from the first one it successfully receives.

- **Orchestration**: The Python test runner now waits purely for the consumer to succeed and exit, and then cleanly terminates the provider. This completely eliminates random test hangs/failures caused by thread scheduling delays on GitHub Actions.

- **XFAIL**: All tests are currently marked as "expected to fail" (xfail) to prevent CI blockage. They successfully run but correctly catch a known Generic Skeleton base pointer / memory alignment bug. Once the underlying C++ bug is fixed in a subsequent PR, the xfail markers will be removed in a follow-up PR
