### PR TITLE
Provide implicit coverage attributes

### DIFF
--- a/quality/unit_testing/unit_testing.bzl
+++ b/quality/unit_testing/unit_testing.bzl
@@ -49,6 +49,17 @@ _forwarding_test = rule(
             default = [],
             allow_files = True,
         ),
+        # Implicit dependencies used by Bazel to generate coverage reports.
+        "_lcov_merger": attr.label(
+            default = configuration_field(fragment = "coverage", name = "output_generator"),
+            executable = True,
+            cfg = config.exec(exec_group = "test"),
+        ),
+        "_collect_cc_coverage": attr.label(
+            default = "@bazel_tools//tools/test:collect_cc_coverage",
+            executable = True,
+            cfg = config.exec(exec_group = "test"),
+        ),
     },
 )
 


### PR DESCRIPTION
Without this, no coverage files are created.