### PR TITLE
refactor: replace detail::Runtime log calls with public API

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -30,7 +30,7 @@ bazel_dep(name = "score_baselibs", version = "0.2.7")
 git_override(
     module_name = "score_baselibs",
     # Required until a new release of baselibs is available that includes the tracing API
-    commit = "e0ed8b15ea6aa4195c6df3891846bbda9d83c431",
+    commit = "a0bae98d65bda42e02d3d5732a55895e1a66cdaa",
     patch_strip = 1,
     # Patch baselibs with a QNX8 workaround for poll
     # until a fix is provided by the QNX SDP

--- a/examples/MODULE.bazel
+++ b/examples/MODULE.bazel
@@ -9,7 +9,7 @@ bazel_dep(name = "score_baselibs", version = "0.2.7")
 git_override(
     module_name = "score_baselibs",
     # Required until a new release of baselibs is available that includes the tracing API
-    commit = "e0ed8b15ea6aa4195c6df3891846bbda9d83c431",
+    commit = "a0bae98d65bda42e02d3d5732a55895e1a66cdaa",
     remote = "https://github.com/eclipse-score/baselibs.git",
 )
 

--- a/score/mw/com/impl/runtime.cpp
+++ b/score/mw/com/impl/runtime.cpp
@@ -68,8 +68,8 @@ inline void error_double_init()
 ///            MemoryResourceRegistry is available.
 void TouchStaticDependencies()
 {
-    score::cpp::ignore = score::mw::log::detail::Runtime::GetRecorder();
-    score::cpp::ignore = score::mw::log::detail::Runtime::GetFallbackRecorder();
+    score::cpp::ignore = score::mw::log::GetDefaultLogRecorder();
+    score::cpp::ignore = score::mw::log::GetFallbackLogRecorder();
     score::cpp::ignore = score::memory::shared::MemoryResourceRegistry::getInstance();
 }
 


### PR DESCRIPTION
-Use score::mw::log::GetDefaultLogRecorder() and
score::mw::log::GetFallbackLogRecorder() instead of accessing score::mw::log::detail::Runtime directly in TouchStaticDependencies().
-update score_baselibs commit to latest main (a0bae98d)