### PR TITLE
fix(static-analysis): use correct output group for clang-tidy findings

### DIFF
--- a/quality/static_analysis/static_analysis.bazelrc
+++ b/quality/static_analysis/static_analysis.bazelrc
@@ -14,7 +14,7 @@
 # Clang-tidy configuration
 # Run clang-tidy on all C++ targets with: bazel test --config=clang-tidy //...
 test:clang-tidy --aspects=//:tools/lint/linters.bzl%clang_tidy_aspect
-test:clang-tidy --output_groups=+rules_lint_report
+test:clang-tidy --output_groups=+rules_lint_human,+rules_lint_machine
 # Use LLVM toolchain for clang-tidy so it can find system headers
 test:clang-tidy --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux
 test:clang-tidy --extra_toolchains=@ferrocene_x86_64_unknown_linux_gnu_llvm//:rust_ferrocene_toolchain


### PR DESCRIPTION
The aspect_rules_lint clang-tidy aspect declares its output group as `rules_lint_human`, not `rules_lint_report`. The incorrect name caused Bazel to silently skip materializing findings files, resulting in empty clang_tidy_findings.txt in nightly reports.