### PR TITLE
mw/com: remove unused dynamic_array dependency from method_data

### DIFF
--- a/score/mw/com/impl/bindings/lola/methods/BUILD
+++ b/score/mw/com/impl/bindings/lola/methods/BUILD
@@ -47,7 +47,6 @@ cc_library(
         ":type_erased_call_queue",
         ":unique_method_identifier",
         "//score/mw/com/impl/configuration",
-        "@score_baselibs//score/containers:dynamic_array",
         "@score_baselibs//score/containers:non_relocatable_vector",
         "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/memory/shared:managed_memory_resource",


### PR DESCRIPTION
- Removing the unused dynamic_array dependency from method_data