### PR TITLE
fix(clang-tidy): correct aspect label path in static_analysis.bazelrc

### DIFF
--- a/quality/static_analysis/static_analysis.bazelrc
+++ b/quality/static_analysis/static_analysis.bazelrc
@@ -13,7 +13,7 @@
 
 # Clang-tidy configuration
 # Run clang-tidy on all C++ targets with: bazel test --config=clang-tidy //...
-test:clang-tidy --aspects=//:tools/lint/linters.bzl%clang_tidy_aspect
+test:clang-tidy --aspects=//tools/lint:linters.bzl%clang_tidy_aspect
 test:clang-tidy --output_groups=+rules_lint_human,+rules_lint_machine
 # Use LLVM toolchain for clang-tidy so it can find system headers
 test:clang-tidy --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux


### PR DESCRIPTION
PR#501 added tools/lint/BUILD making tools/lint/ its own Bazel package, but the aspect reference in static_analysis.bazelrc was not updated.