### PR TITLE
feat: add strict/permissive compiler warning profiles

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -64,12 +64,20 @@ bazel_dep(name = "gcc_toolchain", version = "0.9.0", dev_dependency = True)
 gcc_toolchains = use_extension("@gcc_toolchain//toolchain:module_extensions.bzl", "gcc_toolchains", dev_dependency = True)
 gcc_toolchains.toolchain(
     name = "gcc_toolchain_x86_64",
+    # TODO: Add extra_known_features once gcc_toolchain supports it.
+    # See: https://github.com/f0rmiga/gcc-toolchain/issues/219
     extra_cxxflags = [
-        "-fdiagnostics-color=always",  # Adds copt to always use coloring in build output
-        "-Wsign-conversion",
-        "-Wswitch-enum",
-        "-Werror",
-        "-Wno-error=deprecated-declarations",
+        # Diagnostics
+        "-fdiagnostics-color=always",
+        # Minimal warning baseline (mirrors quality/compiler_warnings/gcc minimal_warnings)
+        # Ref: https://gcc.gnu.org/onlinedocs/gcc/Warning-Options.html
+        "-Wall",  # Foundation warning set (MISRA Dir 1.1)
+        "-Wswitch-enum",  # Warn on unhandled enum in switch (MISRA Rule 9.6.4)
+        "-Wno-error=deprecated-declarations",  # Allow deprecated API as warning
+        "-Wno-error=cpp",  # Allow #warning as warning
+        "-Wno-maybe-uninitialized",  # GCC 8/9 false positives (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=80635)
+        "-Wno-free-nonheap-object",  # GCC false positive (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=99578)
+        "-Wunused-but-set-parameter",  # Dead store detection (MISRA Rule 0.1.1)
     ],
     extra_ldflags = [
         "-lstdc++",
@@ -84,8 +92,31 @@ use_repo(gcc_toolchains, "gcc_toolchain_x86_64")
 bazel_dep(name = "score_bazel_cpp_toolchains", version = "0.5.4", dev_dependency = True)
 
 score_gcc = use_extension("@score_bazel_cpp_toolchains//extensions:gcc.bzl", "gcc", dev_dependency = True)
+
+# Minimal warning baseline for the S-CORE GCC/QCC toolchains.
+# Mirrors //quality/compiler_warnings/gcc:minimal_warnings. The S-CORE GCC
+# toolchain extension does not consume cc_features, so the baseline is applied
+# directly as compiler flags. Warning-as-error enforcement stays in the
+# score_communication_* cc_features (currently consumed by the LLVM toolchain).
+SCORE_GCC_MINIMAL_WARNING_COMPILE_FLAGS = [
+    "-Wall",
+    "-Wno-error=deprecated-declarations",
+    "-Wno-error=cpp",
+    "-Wno-format-y2k",
+    "-Wno-free-nonheap-object",
+    "-Wno-maybe-uninitialized",
+    "-Wunused-but-set-parameter",
+]
+
+SCORE_GCC_MINIMAL_WARNING_CXX_FLAGS = [
+    "-Wno-literal-suffix",
+    "-Wno-noexcept-type",
+]
+
 score_gcc.toolchain(
     name = "score_gcc_x86_64_toolchain",
+    extra_compile_flags = SCORE_GCC_MINIMAL_WARNING_COMPILE_FLAGS,
+    extra_cxx_compile_flags = SCORE_GCC_MINIMAL_WARNING_CXX_FLAGS,
     target_cpu = "x86_64",
     target_os = "linux",
     use_base_constraints_only = True,
@@ -94,6 +125,8 @@ score_gcc.toolchain(
 )
 score_gcc.toolchain(
     name = "score_gcc_aarch64_toolchain",
+    extra_compile_flags = SCORE_GCC_MINIMAL_WARNING_COMPILE_FLAGS,
+    extra_cxx_compile_flags = SCORE_GCC_MINIMAL_WARNING_CXX_FLAGS,
     target_cpu = "aarch64",
     target_os = "linux",
     use_base_constraints_only = True,
@@ -102,6 +135,8 @@ score_gcc.toolchain(
 )
 score_gcc.toolchain(
     name = "score_qcc_x86_64_toolchain",
+    extra_compile_flags = SCORE_GCC_MINIMAL_WARNING_COMPILE_FLAGS,
+    extra_cxx_compile_flags = SCORE_GCC_MINIMAL_WARNING_CXX_FLAGS,
     sdp_version = "8.0.4",
     target_cpu = "x86_64",
     target_os = "qnx",
@@ -110,6 +145,8 @@ score_gcc.toolchain(
 )
 score_gcc.toolchain(
     name = "score_qcc_aarch64_toolchain",
+    extra_compile_flags = SCORE_GCC_MINIMAL_WARNING_COMPILE_FLAGS,
+    extra_cxx_compile_flags = SCORE_GCC_MINIMAL_WARNING_CXX_FLAGS,
     sdp_version = "8.0.4",
     target_cpu = "aarch64",
     target_os = "qnx",
@@ -239,26 +276,23 @@ llvm = use_extension(
     dev_dependency = True,
 )
 llvm.toolchain(
-    compile_flags = {"": [
-        "-march=nehalem",
-        "-ffp-model=strict",
-        # Security
-        "-U_FORTIFY_SOURCE",  # https://github.com/google/sanitizers/issues/247
-        "-fstack-protector",
-        "-fno-omit-frame-pointer",
-        # Diagnostics
-        "-fcolor-diagnostics",
-        "-Wno-deprecated-declarations",
-        "-Wno-error=self-assign-overloaded",
-        "-Wthread-safety",
-    ]},
     cxx_standard = {"": "c++17"},
+    extra_enabled_features = [
+        "//quality/compiler_warnings:default_flags",
+        "//quality/compiler_warnings:default_link_flags",
+        "//quality/compiler_warnings/clang:minimal_warnings",
+    ],
     extra_known_features = [
         "@score_cpp_policies//sanitizers/features:debug_symbols",
         "@score_cpp_policies//sanitizers/features:asan",
         "@score_cpp_policies//sanitizers/features:ubsan",
         "@score_cpp_policies//sanitizers/features:lsan",
         "@score_cpp_policies//sanitizers/features:tsan",
+        "//quality/compiler_warnings:treat_warnings_as_errors",
+        "//quality/compiler_warnings:additional_warnings",
+        "//quality/compiler_warnings/clang:strict_warnings",
+        "//quality/compiler_warnings/clang:strict_warnings_no_error",
+        "//quality/compiler_warnings/clang:third_party_warnings",
     ],
     link_libs = {"": [
         "-lrt",
@@ -326,6 +360,7 @@ download_file(
 
 bazel_dep(name = "aspect_rules_lint", version = "2.5.0", dev_dependency = True)
 bazel_dep(name = "rules_shell", version = "0.6.1", dev_dependency = True)
+bazel_dep(name = "rules_build_error", version = "0.11.0", dev_dependency = True)
 bazel_dep(name = "google_benchmark", version = "1.9.5", dev_dependency = True)
 bazel_dep(name = "buildifier_prebuilt", version = "8.5.1", dev_dependency = True)
 bazel_dep(name = "hedron_compile_commands", dev_dependency = True)

--- a/quality/compiler_warnings/BUILD
+++ b/quality/compiler_warnings/BUILD
@@ -1,0 +1,138 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+# Common compiler warning features shared across GCC and Clang.
+
+load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
+load("@rules_cc//cc/toolchains:feature.bzl", "cc_feature")
+
+cc_args(
+    name = "default_compile_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    args = [
+        "-march=nehalem",
+        "-ffp-model=strict",
+        # Undefine _FORTIFY_SOURCE to avoid conflict with sanitizers.
+        # See https://github.com/google/sanitizers/issues/247
+        "-U_FORTIFY_SOURCE",
+        "-fstack-protector",
+        "-fno-omit-frame-pointer",
+        "-fcolor-diagnostics",
+    ],
+)
+
+cc_feature(
+    name = "default_flags",
+    args = [
+        ":default_compile_args",
+    ],
+    feature_name = "score_communication_default_flags",
+    visibility = ["//visibility:public"],
+)
+
+cc_args(
+    name = "default_link_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:link_actions",
+    ],
+    args = [
+        "-lrt",
+        # Required for targets using std::atomic.
+        "-latomic",
+    ],
+)
+
+cc_feature(
+    name = "default_link_flags",
+    args = [
+        ":default_link_args",
+    ],
+    feature_name = "score_communication_default_link_flags",
+    visibility = ["//visibility:public"],
+)
+
+cc_args(
+    name = "treat_warnings_as_errors_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    args = [
+        "-Werror",
+    ],
+)
+
+cc_feature(
+    name = "treat_warnings_as_errors",
+    args = [
+        ":treat_warnings_as_errors_args",
+    ],
+    feature_name = "score_communication_treat_warnings_as_errors",
+    visibility = ["//visibility:public"],
+)
+
+cc_args(
+    name = "minimal_warnings_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    args = [
+        "-Wall",
+        # Keep #warning visible without failing the build.
+        "-Wno-error=cpp",
+        "-Wno-error=deprecated-declarations",
+    ],
+    visibility = ["//quality/compiler_warnings:__subpackages__"],
+)
+
+cc_args(
+    name = "strict_warnings_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    args = [
+        "-Wextra",
+        "-Wpedantic",
+        "-Wconversion",
+        "-Wsign-conversion",
+    ],
+    visibility = ["//quality/compiler_warnings:__subpackages__"],
+)
+
+cc_args(
+    name = "additional_warnings_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    args = [
+        "-Wcast-align",
+        "-Wcast-qual",
+        "-Wdouble-promotion",
+        "-Wformat-nonliteral",
+        "-Wpointer-arith",
+        "-Wredundant-decls",
+        "-Wundef",
+        "-Wwrite-strings",
+    ],
+    visibility = ["//quality/compiler_warnings:__subpackages__"],
+)
+
+cc_feature(
+    name = "additional_warnings",
+    args = [
+        ":additional_warnings_args",
+    ],
+    feature_name = "score_communication_additional_warnings",
+    visibility = ["//visibility:public"],
+)

--- a/quality/compiler_warnings/clang/BUILD
+++ b/quality/compiler_warnings/clang/BUILD
@@ -1,0 +1,117 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+# Clang warning features.
+# Diagnostics reference: https://clang.llvm.org/docs/DiagnosticsReference.html
+
+load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
+load("@rules_cc//cc/toolchains:feature.bzl", "cc_feature")
+
+cc_args(
+    name = "minimal_warnings_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    args = [
+        # Suppress false positive from Clang's self-assignment overloaded check.
+        # See https://bugs.llvm.org/show_bug.cgi?id=43124
+        "-Wno-error=self-assign-overloaded",
+    ],
+)
+
+cc_feature(
+    name = "minimal_warnings",
+    args = [
+        "//quality/compiler_warnings:minimal_warnings_args",
+        ":minimal_warnings_args",
+    ],
+    feature_name = "score_communication_minimal_warnings",
+    visibility = ["//visibility:public"],
+)
+
+cc_args(
+    name = "strict_warnings_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    args = [
+        "-Wfloat-equal",
+        "-Wformat-security",
+        "-Wshadow-all",
+        # Demote shadow-uncaptured-local from error to warning. This diagnostic
+        # fires for code in external headers (e.g. score_baselibs simple_task.h)
+        # which we cannot fix.
+        # raised a ticket in score_baselibs to fix this issue, but for now we demote it to warning
+        # Bug ticket: (https://github.com/eclipse-score/baselibs/issues/304)
+        "-Wno-error=shadow-uncaptured-local",
+    ],
+)
+
+cc_feature(
+    name = "strict_warnings",
+    args = [
+        "//quality/compiler_warnings:strict_warnings_args",
+        ":strict_warnings_args",
+    ],
+    feature_name = "score_communication_strict_warnings",
+    implies = ["minimal_warnings"],
+    visibility = ["//visibility:public"],
+)
+
+cc_args(
+    name = "strict_warnings_no_error_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    args = [
+        "-Wno-error",
+    ],
+)
+
+cc_feature(
+    name = "strict_warnings_no_error",
+    args = [
+        ":strict_warnings_no_error_args",
+    ],
+    feature_name = "score_communication_strict_warnings_no_error",
+    implies = ["strict_warnings"],
+    visibility = ["//visibility:public"],
+)
+
+cc_args(
+    name = "third_party_warnings_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    args = [
+        "--no-warnings",
+        # Keep default-error diagnostics non-fatal in third-party code.
+        "-Wno-error=implicit-function-declaration",
+        "-Wno-error=missing-template-arg-list-after-template-kw",
+    ],
+)
+
+cc_feature(
+    name = "third_party_warnings",
+    args = [
+        ":third_party_warnings_args",
+    ],
+    feature_name = "score_communication_third_party_warnings",
+    mutually_exclusive = [
+        "//quality/compiler_warnings:additional_warnings",
+        "//quality/compiler_warnings:treat_warnings_as_errors",
+        ":minimal_warnings",
+        ":strict_warnings",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/quality/compiler_warnings/gcc/BUILD
+++ b/quality/compiler_warnings/gcc/BUILD
@@ -1,0 +1,165 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+# GCC warning features.
+
+load("@rules_cc//cc/toolchains:args.bzl", "cc_args")
+load("@rules_cc//cc/toolchains:feature.bzl", "cc_feature")
+
+cc_args(
+    name = "minimal_warnings_args_for_all_compile_actions",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    args = [
+        "-Wno-format-y2k",
+        "-Wno-free-nonheap-object",
+        # Reduce known GCC false positives.
+        "-Wno-maybe-uninitialized",
+        "-Wunused-but-set-parameter",
+    ],
+)
+
+cc_args(
+    name = "minimal_warnings_args_for_cpp_compile_actions",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:cpp_compile_actions",
+    ],
+    args = [
+        "-Wno-literal-suffix",
+        "-Wno-noexcept-type",
+    ],
+)
+
+cc_feature(
+    name = "minimal_warnings",
+    args = [
+        "//quality/compiler_warnings:minimal_warnings_args",
+        ":minimal_warnings_args_for_all_compile_actions",
+        ":minimal_warnings_args_for_cpp_compile_actions",
+    ],
+    feature_name = "score_communication_minimal_warnings",
+    visibility = ["//visibility:public"],
+)
+
+cc_args(
+    name = "strict_warnings_args_for_all_compile_actions",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    args = [
+        "-Warray-bounds=2",
+        "-Wcast-align",
+        "-Wcast-qual",
+        "-Wdisabled-optimization",
+        "-Wfloat-conversion",
+        "-Wformat=2",
+        "-Wimplicit-fallthrough=4",
+        "-Winvalid-pch",
+        "-Wmissing-format-attribute",
+        "-Wmultichar",
+        "-Wpacked",
+        "-Wscalar-storage-order",
+        "-Wsuggest-attribute=format",
+        "-Wundef",
+        "-Wunused-macros",
+        "-Wvector-operation-performance",
+        "-Wwrite-strings",
+        "-Wlogical-op",
+        "-Wredundant-decls",
+        "-Wshadow",
+    ],
+)
+
+cc_args(
+    name = "strict_warnings_args_for_cpp_compile_actions",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:cpp_compile_actions",
+    ],
+    args = [
+        "-Wdelete-non-virtual-dtor",
+        "-Woverloaded-virtual",
+        "-Wregister",
+        "-Wstrict-null-sentinel",
+    ],
+)
+
+cc_args(
+    name = "strict_warnings_args_for_c_compile_actions",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:c_compile_actions",
+    ],
+    args = [
+        "-Wold-style-definition",
+        "-Wstrict-prototypes",
+    ],
+)
+
+cc_feature(
+    name = "strict_warnings",
+    args = [
+        "//quality/compiler_warnings:strict_warnings_args",
+        ":strict_warnings_args_for_all_compile_actions",
+        ":strict_warnings_args_for_cpp_compile_actions",
+        ":strict_warnings_args_for_c_compile_actions",
+    ],
+    feature_name = "score_communication_strict_warnings",
+    implies = ["minimal_warnings"],
+    visibility = ["//visibility:public"],
+)
+
+cc_args(
+    name = "strict_warnings_no_error_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    args = [
+        # Must come after -Werror so it takes effect.
+        "-Wno-error",
+    ],
+)
+
+cc_feature(
+    name = "strict_warnings_no_error",
+    args = [
+        ":strict_warnings_no_error_args",
+    ],
+    feature_name = "score_communication_strict_warnings_no_error",
+    implies = ["strict_warnings"],
+    visibility = ["//visibility:public"],
+)
+
+cc_args(
+    name = "third_party_warnings_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    args = [
+        "-w",
+    ],
+)
+
+cc_feature(
+    name = "third_party_warnings",
+    args = [
+        ":third_party_warnings_args",
+    ],
+    feature_name = "score_communication_third_party_warnings",
+    mutually_exclusive = [
+        "//quality/compiler_warnings:additional_warnings",
+        "//quality/compiler_warnings:treat_warnings_as_errors",
+        ":minimal_warnings",
+        ":strict_warnings",
+    ],
+    visibility = ["//visibility:public"],
+)

--- a/quality/compiler_warnings/test/BUILD
+++ b/quality/compiler_warnings/test/BUILD
@@ -1,0 +1,80 @@
+# *******************************************************************************
+# Copyright (c) 2025 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://apache.org
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@bazel_skylib//rules:build_test.bzl", "build_test")
+load("@rules_build_error//lang/cc:defs.bzl", "cc_build_error_test")
+load("@rules_build_error//matcher:defs.bzl", "matcher")
+load("//score/mw:common_features.bzl", "COMPILER_WARNING_FEATURES")
+
+# Compiler warning feature tests.
+WARNING_FLAGS_BY_CASE = {
+    "conversion": ["-Wfloat-conversion"],
+    "shadow": ["-Wshadow"],
+    "sign_compare": ["-Wsign-compare"],
+    "unused_parameter": ["-Wunused-parameter"],
+    "cast_qual": ["-Wcast-qual"],
+    "format_nonliteral": ["-Wformat-nonliteral"],
+    "undef": ["-Wundef"],
+    "delete_non_virtual_dtor": ["-Wdelete-non-virtual-dtor"],
+    "overloaded_virtual": ["-Woverloaded-virtual"],
+}
+
+# Case 1: warning code should compile when warnings are not treated as errors.
+[
+    cc_library(
+        name = "tp_{}".format(case),
+        srcs = ["has_warnings/{}.cpp".format(case)],
+        copts = warning,
+        features = ["-score_communication_treat_warnings_as_errors"],
+        tags = ["manual"],
+    )
+    for case, warning in WARNING_FLAGS_BY_CASE.items()
+]
+
+build_test(
+    name = "tp_build_test",
+    targets = [":tp_{}".format(case) for case, _ in WARNING_FLAGS_BY_CASE.items()],
+)
+
+# Case 2: clean code should compile with warning features enabled.
+cc_library(
+    name = "fp_all",
+    srcs = ["no_warnings/clean.cpp"],
+    features = COMPILER_WARNING_FEATURES,
+)
+
+build_test(
+    name = "fp_build_test",
+    targets = [":fp_all"],
+)
+
+# Case 3: warning code should fail when built with -Werror.
+[
+    cc_build_error_test(
+        name = "fail_{}_build_error_test".format(case),
+        src = "has_warnings/{}.cpp".format(case),
+        compile_stderr = matcher.contains_extended_regex(
+            # Convert e.g. -Wsign-compare to a flexible regex for stderr matching.
+            "Werror.*{}".format(
+                warning[0][2:].replace("-", ".*"),
+            ),
+        ),
+        copts = ["-Werror"] + warning,
+    )
+    for case, warning in WARNING_FLAGS_BY_CASE.items()
+]
+
+test_suite(
+    name = "warnings_negative_test",
+    tests = [":fail_{}_build_error_test".format(case) for case, _ in WARNING_FLAGS_BY_CASE.items()],
+)

--- a/quality/compiler_warnings/test/README.md
+++ b/quality/compiler_warnings/test/README.md
@@ -1,0 +1,68 @@
+# Compiler Warnings Test
+
+Verifies that warning features work correctly using two complementary test cases.
+
+## Test Strategy
+
+| Case | Target | Features | Code | Expected result |
+|------|--------|----------|------|-----------------|
+| 1 | `tp_build_test` | `treat_warnings_as_errors` disabled | `has_warnings/<flag>.cpp` — one bug per flag | ✅ compiles (warnings visible, not fatal) |
+| 2 | `fp_build_test` | all enabled (via `COMPILER_WARNING_FEATURES`) | `clean.cpp` — no bugs | ✅ compiles |
+| 3 | `warnings_negative_test` | `-Werror` + per-flag warning option | `has_warnings/<flag>.cpp` — one bug per flag | ❌ build fails |
+
+Each warning flag has its own source file and its own bazel target (`tp_<flag>`)
+so every flag is exercised independently. A single combined target would only
+surface the first flag that triggers, hiding the rest.
+
+## Files
+
+| File | Purpose |
+|------|---------|
+| [`no_warnings/clean.cpp`](no_warnings/clean.cpp) | False-positive baseline — must compile with all warning features enabled |
+| [`has_warnings/`](has_warnings) | True-positive baseline — one source file per warning flag |
+| [`BUILD`](BUILD) | Defines `fp_all`/`fp_build_test`, per-flag `tp_<flag>`/`tp_build_test`, and per-flag `fail_<flag>_build_error_test` targets |
+
+## Running the Tests
+
+```bash
+bazel test //quality/compiler_warnings/test:tp_build_test
+
+bazel test //quality/compiler_warnings/test:fp_build_test
+
+bazel test //quality/compiler_warnings/test:fp_build_test //quality/compiler_warnings/test:tp_build_test
+
+bazel test //quality/compiler_warnings/test:warnings_negative_test --test_output=all
+```
+
+> **Note:** `cc_feature` targets only work with the **LLVM toolchain**. The default GCC toolchain
+> ignores them. To exercise features with LLVM:
+
+```bash
+bazel test //quality/compiler_warnings/test:fp_build_test \
+  --extra_toolchains=@llvm_toolchain//:cc-toolchain-x86_64-linux
+```
+
+## Warning Coverage
+
+### True Positives (`has_warnings/`)
+
+One source file per flag, each triggering exactly one warning category:
+
+| Source file | Warning flag | Feature | MISRA / CWE |
+|-------------|-------------|---------|-------------|
+| `conversion.cpp` | `-Wconversion` / `-Wfloat-conversion` | `score_communication_strict_warnings` | MISRA Rule 7.0.5, CWE-681 |
+| `shadow.cpp` | `-Wshadow` | `score_communication_strict_warnings` | MISRA Rule 6.4.1, CWE-398 |
+| `sign_compare.cpp` | `-Wsign-compare` | `score_communication_strict_warnings` | CWE-195, CWE-697 |
+| `unused_parameter.cpp` | `-Wunused-parameter` | `score_communication_strict_warnings` | MISRA Rule 0.1.1, CWE-561 |
+| `delete_non_virtual_dtor.cpp` | `-Wdelete-non-virtual-dtor` | `score_communication_strict_warnings` (C++) | MISRA Rule 15.7.1 |
+| `overloaded_virtual.cpp` | `-Woverloaded-virtual` | `score_communication_strict_warnings` (C++) | MISRA Rule 10.2.0 |
+| `cast_qual.cpp` | `-Wcast-qual` | `score_communication_additional_warnings` | MISRA Rule 8.2.3 |
+| `format_nonliteral.cpp` | `-Wformat-nonliteral` | `score_communication_additional_warnings` | CWE-134 |
+| `undef.cpp` | `-Wundef` | `score_communication_additional_warnings` | MISRA Dir 4.4 |
+
+### False Positives (`clean.cpp`)
+
+Demonstrates correct coding patterns that avoid triggering the above warnings:
+`static_cast<>`, guarded comparisons, `std::ignore`, `[[maybe_unused]]`,
+distinct variable names, const-safe access, literal format strings, defined macros,
+virtual destructors, and `using` declarations.

--- a/quality/compiler_warnings/test/has_warnings/cast_qual.cpp
+++ b/quality/compiler_warnings/test/has_warnings/cast_qual.cpp
@@ -1,0 +1,28 @@
+// *******************************************************************************
+// Copyright (c) 2025 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+// *******************************************************************************
+
+/// @file cast_qual.cpp
+/// @brief Triggers warning: -Wcast-qual.
+
+#include <cstdint>
+
+namespace compiler_warnings_test
+{
+
+void cast_away_const(const std::int32_t* ptr)
+{
+    std::int32_t* mutable_ptr = (std::int32_t*)ptr;
+    *mutable_ptr = 42;
+}
+
+}  // namespace compiler_warnings_test

--- a/quality/compiler_warnings/test/has_warnings/conversion.cpp
+++ b/quality/compiler_warnings/test/has_warnings/conversion.cpp
@@ -1,0 +1,28 @@
+// *******************************************************************************
+// Copyright (c) 2025 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+// *******************************************************************************
+
+/// @file conversion.cpp
+/// @brief Triggers warning: -Wfloat-conversion.
+
+#include <cstdint>
+
+namespace compiler_warnings_test
+{
+
+std::int32_t implicit_narrowing(double input)
+{
+    std::int32_t result = input;
+    return result;
+}
+
+}  // namespace compiler_warnings_test

--- a/quality/compiler_warnings/test/has_warnings/delete_non_virtual_dtor.cpp
+++ b/quality/compiler_warnings/test/has_warnings/delete_non_virtual_dtor.cpp
@@ -1,0 +1,36 @@
+// *******************************************************************************
+// Copyright (c) 2025 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+// *******************************************************************************
+
+/// @file delete_non_virtual_dtor.cpp
+/// @brief Triggers warning: -Wdelete-non-virtual-dtor.
+
+namespace compiler_warnings_test
+{
+
+struct Base
+{
+    virtual void method() {}
+    ~Base() {}
+};
+
+struct Derived : Base
+{
+    void method() override {}
+};
+
+void delete_polymorphic(Base* b)
+{
+    delete b;
+}
+
+}  // namespace compiler_warnings_test

--- a/quality/compiler_warnings/test/has_warnings/format_nonliteral.cpp
+++ b/quality/compiler_warnings/test/has_warnings/format_nonliteral.cpp
@@ -1,0 +1,28 @@
+// *******************************************************************************
+// Copyright (c) 2025 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+// *******************************************************************************
+
+/// @file format_nonliteral.cpp
+/// @brief Triggers warning: -Wformat-nonliteral.
+
+#include <cstdint>
+#include <cstdio>
+
+namespace compiler_warnings_test
+{
+
+void format_nonliteral(const char* fmt, std::int32_t value)
+{
+    std::printf(fmt, value);
+}
+
+}  // namespace compiler_warnings_test

--- a/quality/compiler_warnings/test/has_warnings/overloaded_virtual.cpp
+++ b/quality/compiler_warnings/test/has_warnings/overloaded_virtual.cpp
@@ -1,0 +1,40 @@
+// *******************************************************************************
+// Copyright (c) 2025 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+// *******************************************************************************
+
+/// @file overloaded_virtual.cpp
+/// @brief Triggers warning: -Woverloaded-virtual.
+
+#include <cstdint>
+#include <tuple>
+
+namespace compiler_warnings_test
+{
+
+struct VBase
+{
+    virtual void process(std::int32_t x)
+    {
+        std::ignore = x;
+    }
+    virtual ~VBase() = default;
+};
+
+struct VDerived : VBase
+{
+    void process(double x)
+    {
+        std::ignore = x;
+    }
+};
+
+}  // namespace compiler_warnings_test

--- a/quality/compiler_warnings/test/has_warnings/shadow.cpp
+++ b/quality/compiler_warnings/test/has_warnings/shadow.cpp
@@ -1,0 +1,33 @@
+// *******************************************************************************
+// Copyright (c) 2025 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+// *******************************************************************************
+
+/// @file shadow.cpp
+/// @brief Triggers warning: -Wshadow.
+
+#include <cstdint>
+
+namespace compiler_warnings_test
+{
+
+std::int32_t variable_shadowing(std::int32_t value)
+{
+    std::int32_t result = value + 1;
+    if (result > 0)
+    {
+        std::int32_t result = value * 2;
+        return result;
+    }
+    return result;
+}
+
+}  // namespace compiler_warnings_test

--- a/quality/compiler_warnings/test/has_warnings/sign_compare.cpp
+++ b/quality/compiler_warnings/test/has_warnings/sign_compare.cpp
@@ -1,0 +1,28 @@
+// *******************************************************************************
+// Copyright (c) 2025 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+// *******************************************************************************
+
+/// @file sign_compare.cpp
+/// @brief Triggers warning: -Wsign-compare.
+
+#include <cstddef>
+#include <cstdint>
+
+namespace compiler_warnings_test
+{
+
+bool signed_unsigned_compare(std::int32_t index, std::size_t size)
+{
+    return index < size;
+}
+
+}  // namespace compiler_warnings_test

--- a/quality/compiler_warnings/test/has_warnings/undef.cpp
+++ b/quality/compiler_warnings/test/has_warnings/undef.cpp
@@ -1,0 +1,26 @@
+// *******************************************************************************
+// Copyright (c) 2025 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+// *******************************************************************************
+
+/// @file undef.cpp
+/// @brief Triggers warning: -Wundef.
+
+#include <cstdint>
+
+namespace compiler_warnings_test
+{
+
+#if UNDEFINED_MACRO
+static const std::int32_t undef_guard = 1;
+#endif
+
+}  // namespace compiler_warnings_test

--- a/quality/compiler_warnings/test/has_warnings/unused_parameter.cpp
+++ b/quality/compiler_warnings/test/has_warnings/unused_parameter.cpp
@@ -1,0 +1,27 @@
+// *******************************************************************************
+// Copyright (c) 2025 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+// *******************************************************************************
+
+/// @file unused_parameter.cpp
+/// @brief Triggers warning: -Wunused-parameter.
+
+#include <cstdint>
+
+namespace compiler_warnings_test
+{
+
+std::int32_t unused_parameter(std::int32_t input, std::int32_t unused_param)
+{
+    return input * 2;
+}
+
+}  // namespace compiler_warnings_test

--- a/quality/compiler_warnings/test/no_warnings/clean.cpp
+++ b/quality/compiler_warnings/test/no_warnings/clean.cpp
@@ -1,0 +1,130 @@
+// *******************************************************************************
+// Copyright (c) 2025 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+// *******************************************************************************
+
+/// @file clean.cpp
+/// @brief False-positive baseline: should compile cleanly with warning features enabled.
+
+#include <cstddef>
+#include <cstdint>
+#include <cstdio>
+#include <tuple>
+
+namespace compiler_warnings_test
+{
+
+// strict_warnings: clean patterns
+
+std::int32_t truncate_to_int(double value)
+{
+    return static_cast<std::int32_t>(value);
+}
+
+bool is_valid_index(std::int32_t index, std::size_t size)
+{
+    if (index < 0)
+    {
+        return false;
+    }
+    return static_cast<std::size_t>(index) < size;
+}
+
+std::int32_t callback_handler(std::int32_t event_id, std::int32_t context, std::int32_t reserved)
+{
+    std::ignore = context;
+    std::ignore = reserved;
+    return event_id + 1;
+}
+
+std::int32_t modern_handler([[maybe_unused]] std::int32_t event_id, [[maybe_unused]] std::int32_t flags)
+{
+    return 0;
+}
+
+std::int32_t no_shadowing(std::int32_t value)
+{
+    std::int32_t outer = value + 1;
+    if (outer > 0)
+    {
+        std::int32_t inner = value * 2;
+        return inner;
+    }
+    return outer;
+}
+
+// additional_warnings: clean patterns
+
+std::int32_t use_const_safely(const std::int32_t* ptr)
+{
+    std::int32_t copy = *ptr;
+    copy += 1;
+    return copy;
+}
+
+void safe_format_print(std::int32_t value)
+{
+    std::printf("value = %d\n", value);
+}
+
+#define FEATURE_ENABLED 1
+#if FEATURE_ENABLED
+static const std::int32_t feature_constant = 42;
+#endif
+
+void aligned_copy(const void* src, std::int32_t* dst)
+{
+    const auto* typed_src = static_cast<const std::int32_t*>(src);
+    *dst = *typed_src;
+}
+
+// strict_warnings (C++ specific): clean patterns
+
+struct SafeBase
+{
+    virtual void method() {}
+    virtual ~SafeBase() = default;
+};
+
+struct SafeDerived : SafeBase
+{
+    void method() override {}
+};
+
+struct ProcessBase
+{
+    virtual void process(std::int32_t x)
+    {
+        std::ignore = x;
+    }
+    virtual ~ProcessBase() = default;
+};
+
+struct ProcessDerived : ProcessBase
+{
+    using ProcessBase::process;  // brings base version into scope
+    void process(double x)
+    {
+        std::ignore = x;
+    }
+};
+
+std::size_t safe_subtract(std::size_t a, std::size_t b)
+{
+    return (a > b) ? (a - b) : 0U;
+}
+
+inline std::int32_t get_feature_constant()
+{
+    return feature_constant;
+}
+
+}  // namespace compiler_warnings_test

--- a/quality/coverage/coverage.bazelrc
+++ b/quality/coverage/coverage.bazelrc
@@ -48,3 +48,6 @@ coverage --cxxopt -runtime-counter-relocation
 # Then the first object is used, and it is pure luck if it contains the correct data or not. Even worse, small changes can change the order and then lead
 # to big coverage gaps. All these problems do not arise if no dynamic libs are used. Thus, we rather take bigger build times and binaries in advance for correct data.
 coverage --dynamic_mode=off
+
+# Disable treat_warnings_as_errors for coverage builds to avoid build failures from instrumentation-related warnings
+coverage --features=-score_communication_treat_warnings_as_errors

--- a/quality/quality.md
+++ b/quality/quality.md
@@ -194,6 +194,52 @@ bazel test --config=asan //...
 bazel test --config=tsan //...
 ```
 
+## Compiler Warnings
+
+Compiler warning features are defined in [`quality/compiler_warnings/`](compiler_warnings/) and referenced in targets through the shared bundle in [`score/mw/common_features.bzl`](../score/mw/common_features.bzl). Warning features are prefixed with `score_communication_` to avoid collisions with other modules.
+
+Features are enabled per-target via the `features` attribute. The LLVM toolchain enables `score_communication_default_flags` and `score_communication_minimal_warnings` by default (see [`MODULE.bazel`](../MODULE.bazel)).
+
+### Adding Warning Features to a Target
+
+Load the shared bundle and set it in your `cc_library` or `cc_unit_test`:
+
+```starlark
+load("//score/mw:common_features.bzl", "COMPILER_WARNING_FEATURES")
+
+cc_library(
+    name = "my_lib",
+    srcs = ["my_lib.cpp"],
+    hdrs = ["my_lib.h"],
+    features = COMPILER_WARNING_FEATURES,
+)
+```
+
+### Disabling Warnings for a Single Target
+
+Use the `-` prefix to opt out of a feature on a specific target:
+
+```starlark
+cc_library(
+    name = "third_party_wrapper",
+    srcs = ["wrapper.cpp"],
+    features = ["-score_communication_treat_warnings_as_errors"],
+)
+```
+
+### Disabling a Feature Globally
+
+Use `--features=-<feature_name>` on the command line:
+
+```bash
+bazel build //... --features=-score_communication_treat_warnings_as_errors
+```
+
+### Coverage Builds
+
+Coverage builds (`bazel coverage //...`) automatically disable `-Werror` via [`quality/coverage.bazelrc`](coverage.bazelrc).
+
+
 ## Linting
 
 ### Copyright Checker

--- a/score/message_passing/BUILD
+++ b/score/message_passing/BUILD
@@ -15,6 +15,7 @@ load("@rules_cc//cc:defs.bzl", "cc_library")
 load("@score_baselibs//third_party/itf:py_unittest_qnx_test.bzl", "py_unittest_qnx_test")
 load("@score_tooling//bazel/rules/rules_score:rules_score.bzl", "unit")
 load("//quality/unit_testing:unit_testing.bzl", "cc_unit_test")
+load("//score/mw:common_features.bzl", "COMPILER_WARNING_FEATURES")
 
 py_unittest_qnx_test(
     name = "unit_tests_qnx",
@@ -55,11 +56,7 @@ cc_library(
         "engine.h",
         "server_factory.h",
     ],
-    features = [
-        "treat_warnings_as_errors",
-        "strict_warnings",
-        "additional_warnings",
-    ],
+    features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     visibility = ["//visibility:public"],
     deps = select({
@@ -85,11 +82,7 @@ cc_library(
         "service_protocol_config.h",
         "timed_command_queue_entry.h",
     ],
-    features = [
-        "treat_warnings_as_errors",
-        "strict_warnings",
-        "additional_warnings",
-    ],
+    features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     visibility = [
         "//score/mw/com/impl:__subpackages__",
@@ -113,11 +106,7 @@ cc_library(
         "client_server_communication.h",
         "timed_command_queue.h",
     ],
-    features = [
-        "treat_warnings_as_errors",
-        "strict_warnings",
-        "additional_warnings",
-    ],
+    features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     visibility = [
         "//score/mw/com/impl:__subpackages__",
@@ -171,11 +160,7 @@ cc_library(
         "unix_domain/unix_domain_server_factory.h",
         "unix_domain/unix_domain_socket_address.h",
     ],
-    features = [
-        "treat_warnings_as_errors",
-        "strict_warnings",
-        "additional_warnings",
-    ],
+    features = COMPILER_WARNING_FEATURES,
     visibility = [
         "//score/mw/com/impl:__subpackages__",
     ],
@@ -211,11 +196,7 @@ cc_library(
     hdrs = [
         "qnx_dispatch/qnx_resource_path.h",
     ],
-    features = [
-        "treat_warnings_as_errors",
-        "strict_warnings",
-        "additional_warnings",
-    ],
+    features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     visibility = [
         "//score/mw/com/impl:__subpackages__",
@@ -239,11 +220,7 @@ cc_library(
         "qnx_dispatch/qnx_dispatch_server.h",
         "qnx_dispatch/qnx_dispatch_server_factory.h",
     ],
-    features = [
-        "treat_warnings_as_errors",
-        "strict_warnings",
-        "additional_warnings",
-    ],
+    features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     visibility = ["//score/mw/com/impl:__subpackages__"],
     deps = [
@@ -286,11 +263,7 @@ cc_library(
         "mock/shared_resource_engine_mock.h",
     ],
     deprecation = "DEPRECATED: use @score_communication//score/message_passing:mock instead",
-    features = [
-        "treat_warnings_as_errors",
-        "strict_warnings",
-        "additional_warnings",
-    ],
+    features = COMPILER_WARNING_FEATURES,
     visibility = ["//visibility:public"],
     deps = [
         ":common_headers",
@@ -303,11 +276,7 @@ cc_unit_test(
     srcs = [
         "client_connection_test.cpp",
     ],
-    features = [
-        "treat_warnings_as_errors",
-        "strict_warnings",
-        "additional_warnings",
-    ],
+    features = COMPILER_WARNING_FEATURES,
     deps = [
         ":message_passing_common",
         ":mock",
@@ -320,11 +289,7 @@ cc_unit_test(
         "unix_domain_server_test.cpp",
         "unix_domain_server_to_client_test.cpp",
     ],
-    features = [
-        "treat_warnings_as_errors",
-        "strict_warnings",
-        "additional_warnings",
-    ],
+    features = COMPILER_WARNING_FEATURES,
     deps = [
         ":message_passing_unix_domain",
     ],
@@ -371,11 +336,7 @@ cc_unit_test(
     srcs = [
         "timed_command_queue_test.cpp",
     ],
-    features = [
-        "treat_warnings_as_errors",
-        "strict_warnings",
-        "additional_warnings",
-    ],
+    features = COMPILER_WARNING_FEATURES,
     deps = [
         ":message_passing_common",
     ],

--- a/score/message_passing/log/BUILD
+++ b/score/message_passing/log/BUILD
@@ -13,6 +13,7 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//quality/unit_testing:unit_testing.bzl", "cc_unit_test")
+load("//score/mw:common_features.bzl", "COMPILER_WARNING_FEATURES")
 
 cc_library(
     name = "log",
@@ -26,11 +27,7 @@ cc_library(
         "log_on_timeout.h",
         "logging_callback.h",
     ],
-    features = [
-        "treat_warnings_as_errors",
-        "strict_warnings",
-        "additional_warnings",
-    ],
+    features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     visibility = ["//score:__subpackages__"],
     deps = [

--- a/score/message_passing/non_allocating_future/BUILD
+++ b/score/message_passing/non_allocating_future/BUILD
@@ -13,6 +13,7 @@
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
 load("//quality/unit_testing:unit_testing.bzl", "cc_unit_test")
+load("//score/mw:common_features.bzl", "COMPILER_WARNING_FEATURES")
 
 cc_library(
     name = "non_allocating_future",
@@ -22,11 +23,7 @@ cc_library(
     hdrs = [
         "non_allocating_future.h",
     ],
-    features = [
-        "treat_warnings_as_errors",
-        "strict_warnings",
-        "additional_warnings",
-    ],
+    features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     visibility = ["//visibility:public"],
 )

--- a/score/mw/common_features.bzl
+++ b/score/mw/common_features.bzl
@@ -11,7 +11,7 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 COMPILER_WARNING_FEATURES = [
-    "treat_warnings_as_errors",
-    "additional_warnings",
-    "strict_warnings",
+    "score_communication_treat_warnings_as_errors",
+    "score_communication_strict_warnings",
+    "score_communication_additional_warnings",
 ]


### PR DESCRIPTION
Introduce configurable warning features for GCC and Clang toolchains with two build modes controlled via --config=strict and --config=permissive.

- Add quality/compiler_warnings/{BUILD,clang/BUILD,gcc/BUILD} with cc_feature definitions for minimal, strict, and additional warnings
- Configure LLVM toolchain with extra_known_features (toolchains_llvm 1.7.0)
- Configure GCC toolchain with extra_cxxflags baseline matching minimal_warnings
- Add selective -Wno-error overrides in .bazelrc for permissive mode
- Refactor score/message_passing BUILD files to use COMPILER_WARNING_FEATURES
- Add FP/TP test targets with build_test verification
- Document usage in quality/quality.md