### PR TITLE
Avoid time penalty when unregistering receive handler after the producer is unreachable

### DIFF
--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_client_cache.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_client_cache.cpp
@@ -50,18 +50,37 @@ MessagePassingClientCache::MessagePassingClientCache(const ClientQualityType asi
 {
 }
 
+std::shared_ptr<score::message_passing::IClientConnection>
+MessagePassingClientCache::UnlockedGetCachedMessagePassingClient(const pid_t target_node_id) noexcept
+{
+    auto search = clients_.find(target_node_id);
+    if (search != clients_.end())
+    {
+        return search->second;
+    }
+
+    return nullptr;
+}
+
+std::shared_ptr<score::message_passing::IClientConnection> MessagePassingClientCache::GetCachedMessagePassingClient(
+    const pid_t target_node_id) noexcept
+{
+    std::lock_guard<std::mutex> lck(mutex_);
+    return UnlockedGetCachedMessagePassingClient(target_node_id);
+}
+
 std::shared_ptr<score::message_passing::IClientConnection> MessagePassingClientCache::GetMessagePassingClient(
     const pid_t target_node_id) noexcept
 {
     std::lock_guard<std::mutex> lck(mutex_);
 
-    auto search = clients_.find(target_node_id);
-    if (search != clients_.end())
+    const auto cached_client = UnlockedGetCachedMessagePassingClient(target_node_id);
+    if (cached_client != nullptr)
     {
-        const auto state = search->second->GetState();
+        const auto state = cached_client->GetState();
         if (state == score::message_passing::IClientConnection::State::kReady)
         {
-            return search->second;
+            return cached_client;
         }
         // Evict a cached client that is not in kReady state. This covers:
         // - kStopped/kStopping: connection was lost (e.g. peer was SIGKILL'd)
@@ -71,10 +90,10 @@ std::shared_ptr<score::message_passing::IClientConnection> MessagePassingClientC
                                         << " (state=" << static_cast<std::uint32_t>(score::cpp::to_underlying(state))
                                         << ", reason="
                                         << static_cast<std::uint32_t>(
-                                               score::cpp::to_underlying(search->second->GetStopReason()))
+                                               score::cpp::to_underlying(cached_client->GetStopReason()))
                                         << ")";
-        search->second->Stop();
-        score::cpp::ignore = clients_.erase(search);
+        cached_client->Stop();
+        score::cpp::ignore = clients_.erase(target_node_id);
         // Fall through to create a new client below
     }
 

--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_client_cache.h
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_client_cache.h
@@ -37,6 +37,8 @@ class MessagePassingClientCache
     MessagePassingClientCache(const MessagePassingClientCache&) = delete;
     MessagePassingClientCache& operator=(const MessagePassingClientCache&) = delete;
 
+    std::shared_ptr<score::message_passing::IClientConnection> GetCachedMessagePassingClient(
+        const pid_t target_node_id) noexcept;
     std::shared_ptr<score::message_passing::IClientConnection> GetMessagePassingClient(
         const pid_t target_node_id) noexcept;
     void RemoveMessagePassingClient(const pid_t target_node_id) noexcept;
@@ -45,6 +47,8 @@ class MessagePassingClientCache
 
   private:
     std::shared_ptr<score::message_passing::IClientConnection> CreateNewClient(const pid_t target_node_id) noexcept;
+    std::shared_ptr<score::message_passing::IClientConnection> UnlockedGetCachedMessagePassingClient(
+        const pid_t target_node_id) noexcept;
 
     const ClientQualityType asil_level_;
     score::message_passing::IClientFactory& client_factory_;

--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_client_cache_test.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_client_cache_test.cpp
@@ -300,5 +300,29 @@ TEST_P(MessagePassingClientCacheTest, GetMessagePassingClientEvictsStartingClien
     EXPECT_EQ(client2.get(), fresh_connection_ptr);
 }
 
+TEST_P(MessagePassingClientCacheTest, GetCachedMessagePassingClientReturnsNullWhenNoClientExists)
+{
+    EXPECT_CALL(client_factory_mock_, Create(::testing::_, ::testing::_)).Times(0);
+
+    auto client = client_cache_.GetCachedMessagePassingClient(pid_);
+
+    EXPECT_EQ(client, nullptr);
+}
+
+TEST_P(MessagePassingClientCacheTest, GetCachedMessagePassingClientReturnsExistingNonReadyClient)
+{
+    EXPECT_CALL(*client_connection_mock_, GetState())
+        .WillRepeatedly(::testing::Return(IClientConnection::State::kStarting));
+    EXPECT_CALL(client_factory_mock_, Create(::testing::_, ::testing::_))
+        .WillOnce(::testing::Return(::testing::ByMove(std::move(client_connection_mock_))));
+
+    auto client1 = client_cache_.GetMessagePassingClient(pid_);
+
+    EXPECT_CALL(client_factory_mock_, Create(::testing::_, ::testing::_)).Times(0);
+    auto client2 = client_cache_.GetCachedMessagePassingClient(pid_);
+
+    EXPECT_EQ(client1, client2);
+}
+
 }  // namespace
 }  // namespace score::mw::com::impl::lola

--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance.cpp
@@ -37,6 +37,7 @@
 #include <score/assert.hpp>
 #include <score/span.hpp>
 
+#include <sys/socket.h>
 #include <sys/types.h>
 #include <algorithm>
 #include <array>
@@ -1404,7 +1405,23 @@ void MessagePassingServiceInstance::UnregisterEventNotificationRemote(
         // Suppress "AUTOSAR C++14 A18-5-8" rule finding. This rule states: "Objects that do not outlive a function
         // shall have automatic storage duration". The object is a shared_ptr which is allocated in the heap.
         // coverity[autosar_cpp14_a18_5_8_violation]
-        auto sender = client_cache_.GetMessagePassingClient(target_node_id);
+        auto sender = client_cache_.GetCachedMessagePassingClient(target_node_id);
+
+        // Unregistering is best-effort. There are two possible scenarios when the channel might not be ready when we
+        // try to unregister for event notifications:
+        // 1. Partial restart: The skeleton will anyway come back without knowing about the registration
+        // 2. Shutdown of skeleton: Nobody will ever care about this message ever again
+        //
+        // To avoid the potential block of the caller thread until message_passing fails setting up the channel, we
+        // skip sending the message in this scenario.
+        if (sender == nullptr || sender->GetState() != message_passing::IClientConnection::State::kReady)
+        {
+            score::mw::log::LogInfo("lola")
+                << "MessagePassingService: Skipping UnregisterEventNotificationMessage to node_id " << target_node_id
+                << " because message passing client is not ready.";
+            return;
+        }
+
         const auto result = sender->Send(message);
         if (!result.has_value())
         {

--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance_test.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance_test.cpp
@@ -482,6 +482,30 @@ TEST_F(MessagePassingServiceInstanceTest,
     instance.UnregisterEventNotification(event_id_, registration_no, remote_pid_);
 }
 
+TEST_F(MessagePassingServiceInstanceTest,
+       UnregisterEventNotificationRemoteDoesNotSendUnregisterMessageWhenClientIsNotReady)
+{
+    // Given service instance
+    MessagePassingServiceInstance instance{
+        quality_type_, asil_cfg_, server_factory_mock_, client_factory_mock_, executor_mock_};
+
+    // Expect only the registration message to be sent.
+    EXPECT_CALL(client_connection_mock_, Send(::testing::_))
+        .Times(1)
+        .WillOnce(testing::Return(score::cpp::expected_blank<score::os::Error>{}));
+
+    // and the cached client is not ready when unregistration happens
+    EXPECT_CALL(client_connection_mock_, GetState())
+        .Times(::testing::AtLeast(1))
+        .WillRepeatedly(testing::Return(IClientConnection::State::kStopped));
+
+    // Given handler being registered for event with pid != local_pid
+    auto registration_no = instance.RegisterEventNotification(event_id_, {}, remote_pid_);
+
+    // When UnregisterEventNotification is called with received registration handler
+    instance.UnregisterEventNotification(event_id_, registration_no, remote_pid_);
+}
+
 TEST_F(MessagePassingServiceInstanceTest, UnregisterEventNotificationRemoteDoesNotUnregisterOnPidMismatch)
 {
     // Given service instance


### PR DESCRIPTION
Assume you have two applications.
One application offers an event. The second receives notifications for this event.

Now the sender shuts down. Afterwards, the receiver also tries to shut down.

When the receiver has a receive handler registered, he sends a message to the sender to unregister.

But the sender is not there and the communication channel is not ready.

The receiver will therefor try to recreate the channel. This will block him until the attempt times out.

Since the API is synchronous, this will block the shutdown of the application.

From resource POV, loosing this message has no drawbacks (see comment in code). Hence, we try to send it based on best-effort.