### PR TITLE
fix(codeql): correct target pattern and fail loudly on analysis errors

### DIFF
--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -71,7 +71,7 @@ jobs:
           bazel run //quality/static_analysis:codeql_lint -- \
             --phase create-database \
             --database-path /var/tmp/codeql_databases/codeql_db \
-            --target //score/message_passing/... //score/mw/com/...
+            --target //score/message_passing //score/mw/com
 
       - name: Upload CodeQL database artifact
         uses: actions/upload-artifact@v4

--- a/quality/static_analysis/codeql_lint.py
+++ b/quality/static_analysis/codeql_lint.py
@@ -52,10 +52,15 @@ def analyze_database(code_ql_path, database_path, source_root, query_spec=None, 
 
     query_arg = f" {query_spec}" if query_spec else ""
 
-    os.system(
-        f"{code_ql_path} database analyze -j=0 {database_path}{query_arg} --format=sarifv2.1.0 --output={output_base}/{output_prefix}.sarif")
-    os.system(
-        f"{code_ql_path} database analyze -j=0 {database_path}{query_arg} --format=csv --output={output_base}/{output_prefix}.csv")
+    sarif_path = f"{output_base}/{output_prefix}.sarif"
+    csv_path = f"{output_base}/{output_prefix}.csv"
+
+    subprocess.run(
+        f"{code_ql_path} database analyze -j=0 {database_path}{query_arg} --format=sarifv2.1.0 --output={sarif_path}",
+        shell=True, check=True)
+    subprocess.run(
+        f"{code_ql_path} database analyze -j=0 {database_path}{query_arg} --format=csv --output={csv_path}",
+        shell=True, check=True)
 
     # @todo it is possible to generate here also a full MISRA compliance report, which we could do in the future.
     # path/to/<output_database_name> <name-of-results-file>.sarif <output_directory>


### PR DESCRIPTION
Fixes two issues found in the nightly CodeQL workflow:

1. Corrected `--target` from `//score/message_passing/... //score/mw/com/...`
   to `//score/message_passing //score/mw/com` (removes recursive wildcard).

2. Replaced silent `os.system()` calls in `analyze_database` with
   `subprocess.run(..., check=True)` so analysis failures are caught
   immediately instead of silently producing missing output files.

Without this fix, the nightly job fails at the SARIF upload step with
"Path does not exist" because the analysis silently errored out earlier.
failed pr (https://github.com/eclipse-score/communication/pull/521)