### PR TITLE
mw::com: fix potential conflicts of MemoryResourceIdentifier

### DIFF
--- a/score/mw/com/impl/bindings/lola/test_doubles/fake_mocked_service_data.cpp
+++ b/score/mw/com/impl/bindings/lola/test_doubles/fake_mocked_service_data.cpp
@@ -14,6 +14,7 @@
 
 #include "score/memory/shared/shared_memory_resource_heap_allocator_mock.h"
 
+#include <limits>
 #include <memory>
 
 namespace score::mw::com::impl::lola
@@ -24,8 +25,11 @@ namespace
 
 using ::score::memory::shared::SharedMemoryResourceHeapAllocatorMock;
 
-const std::uint64_t kControlMemoryResourceId{10U};
-const std::uint64_t kDataMemoryResourceId{11U};
+// \todo: This needs to be revisited on why this should be hardcoded in the first place. until then we use the maximum
+// possible value for the memory resource ID to avoid any potential conflicts with memory
+//  resource IDs that are be generated during tests.
+const std::uint64_t kControlMemoryResourceId{std::numeric_limits<std::uint64_t>::max()};
+const std::uint64_t kDataMemoryResourceId{std::numeric_limits<std::uint64_t>::max() - 1U};
 
 }  // namespace
 


### PR DESCRIPTION
While adding new tests for proxy method handling, it was found that that some new tests could cause existing ones to fail because of MemoryResourceIdentifier collisions in the registry map. The fake bounded memory resource uses a static counter that increments every time a new fake memory resource is created, but FakeMockedServiceData was still using hardcoded IDs 10 and 11. Once the counter reached those values, both paths tried to register the same IDs, which triggered the test failures.