### PR TITLE
feat: add strict/permissive compiler warning modes and fix warnings

### DIFF
--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance_methods_test.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance_methods_test.cpp
@@ -770,8 +770,9 @@ TEST_F(MessagePassingServiceInstanceHandleMessageWithReplyTest, RepliesWithError
 
     // When a MessageWithReply message is received which is empty
     std::vector<std::uint8_t> empty_message(0U);
-    const auto result = received_send_message_with_reply_callback_(
-        server_connection_mock_, score::cpp::span<std::uint8_t>{empty_message.data(), empty_message.size()});
+    // Return value intentionally discarded — test verifies side effects only (-Wunused-result)
+    static_cast<void>(received_send_message_with_reply_callback_(
+        server_connection_mock_, score::cpp::span<std::uint8_t>{empty_message.data(), empty_message.size()}));
 }
 
 TEST_F(MessagePassingServiceInstanceHandleMessageWithReplyTest, ReturnsErrorWhenUnexpectedMessageReceived)
@@ -805,9 +806,10 @@ TEST_F(MessagePassingServiceInstanceHandleMessageWithReplyTest, RepliesWithError
     // When a MessageWithReply message is received of unexpected type
     std::vector<std::uint8_t> payload_with_unexpected_type(sizeof(MethodCallUnserializedPayload) + 2U);
     payload_with_unexpected_type[0] = 20U;
-    const auto result = received_send_message_with_reply_callback_(
+    // Return value intentionally discarded — test verifies side effects only (-Wunused-result)
+    static_cast<void>(received_send_message_with_reply_callback_(
         server_connection_mock_,
-        score::cpp::span<std::uint8_t>{payload_with_unexpected_type.data(), payload_with_unexpected_type.size()});
+        score::cpp::span<std::uint8_t>{payload_with_unexpected_type.data(), payload_with_unexpected_type.size()}));
 }
 
 TEST_F(MessagePassingServiceInstanceHandleMessageWithReplyTest,

--- a/score/mw/com/impl/bindings/lola/provider_event_data_control_local_view_test.cpp
+++ b/score/mw/com/impl/bindings/lola/provider_event_data_control_local_view_test.cpp
@@ -39,7 +39,7 @@ using ::testing::_;
 using ::testing::Return;
 
 constexpr std::size_t kMaxSlots{5U};
-constexpr std::size_t kMaxSubscribers{5U};
+[[maybe_unused]] constexpr std::size_t kMaxSubscribers{5U};
 
 constexpr auto kSlotIsInWriting = std::numeric_limits<EventSlotStatus::SubscriberCount>::max();
 

--- a/score/mw/com/impl/bindings/lola/sample_allocatee_ptr_test.cpp
+++ b/score/mw/com/impl/bindings/lola/sample_allocatee_ptr_test.cpp
@@ -33,7 +33,7 @@ struct DummyStruct
 };
 
 constexpr std::size_t kMaxSlots{5U};
-constexpr std::size_t kMaxSubscribers{5U};
+[[maybe_unused]] constexpr std::size_t kMaxSubscribers{5U};
 
 class SampleAllocateePtrFixture : public ::testing::Test
 {

--- a/score/mw/com/impl/bindings/lola/skeleton_method_handling_test.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_method_handling_test.cpp
@@ -468,7 +468,7 @@ TEST_F(SkeletonPrepareOfferFixture, PrepareOfferWillNotCallUnregisterSubscribedM
         }));
 
     // When calling PrepareOffer
-    const auto result = PrepareOffer();
+    static_cast<void>(PrepareOffer());  // Return value intentionally discarded (-Wunused-result)
 
     // Then UnregisterOnServiceMethodSubscribedHandler was not called during PrepareOffer
     EXPECT_FALSE(*unregister_called);

--- a/score/mw/com/impl/bindings/lola/transaction_log_set_test.cpp
+++ b/score/mw/com/impl/bindings/lola/transaction_log_set_test.cpp
@@ -637,8 +637,8 @@ TEST_F(TransactionLogSetRegisterFixture, RegisterUnregisterMultipleTransactionLo
     // again.
     for (std::size_t thread_idx = 0; thread_idx < thread_count; ++thread_idx)
     {
-        threads.emplace_back([this,
-                              &unit,
+        // Removed unused 'this' capture to fix -Wunused-lambda-capture
+        threads.emplace_back([&unit,
                               thread_number = TransactionLogIndex(thread_idx + 1U),
                               &consumer_event_data_control_locals,
                               thread_idx]() noexcept {

--- a/score/mw/com/impl/skeleton_field_base_test.cpp
+++ b/score/mw/com/impl/skeleton_field_base_test.cpp
@@ -64,7 +64,8 @@ class MyDummyField : public SkeletonFieldBase
     {
     }
 
-    void UpdateSkeletonReference(SkeletonBase& skeleton_base) noexcept override {}
+    // Parameter name commented out to fix -Wunused-parameter
+    void UpdateSkeletonReference(SkeletonBase& /* skeleton_base */) noexcept override {}
 
     StrictMock<mock_binding::SkeletonEventBase>* GetMockEventBinding() noexcept
     {
@@ -97,7 +98,8 @@ class MyDummyField : public SkeletonFieldBase
 class MyDummyFieldFailingDeferredUpdate final : public MyDummyField
 {
   public:
-    void UpdateSkeletonReference(SkeletonBase& skeleton_base) noexcept override {}
+    // Parameter name commented out to fix -Wunused-parameter
+    void UpdateSkeletonReference(SkeletonBase& /* skeleton_base */) noexcept override {}
 
     Result<void> DoDeferredUpdate() noexcept override
     {

--- a/score/mw/com/impl/skeleton_field_test.cpp
+++ b/score/mw/com/impl/skeleton_field_test.cpp
@@ -912,7 +912,8 @@ TEST_F(SkeletonFieldSetHandlerTest, PrepareOfferFailsWhenSetHandlerNotRegistered
 
 TEST_F(SkeletonFieldSetHandlerTest, PrepareOfferSucceedsAfterRegisterSetHandler)
 {
-    const TestSampleType kDummyInitialValue{7U};
+    // Renamed from kDummyInitialValue to avoid shadowing the file-scope constant ([-Wshadow])
+    const TestSampleType kInitialValue{7U};
 
     // Given a skeleton containing a field with a setter enabled
     MySetterSkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
@@ -921,7 +922,7 @@ TEST_F(SkeletonFieldSetHandlerTest, PrepareOfferSucceedsAfterRegisterSetHandler)
     ASSERT_TRUE(unit.my_setter_field_.RegisterSetHandler([](TestSampleType& /*value*/) noexcept {}).has_value());
 
     // Set the initial field value
-    ASSERT_TRUE(unit.my_setter_field_.Update(kDummyInitialValue).has_value());
+    ASSERT_TRUE(unit.my_setter_field_.Update(kInitialValue).has_value());
 
     // When PrepareOffer is called
     const auto result = unit.my_setter_field_.PrepareOffer();
@@ -1137,17 +1138,18 @@ TEST_F(SkeletonFieldSetHandlerTest, IsSetHandlerRegisteredFlagIsSetAfterRegistra
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
-    const TestSampleType kDummyInitialValue{3U};
+    // Renamed from kDummyInitialValue to avoid shadowing the file-scope constant ([-Wshadow])
+    const TestSampleType kInitialValue{3U};
 
     EXPECT_CALL(skeleton_field_binding_mock_, PrepareOffer()).WillOnce(Return(Result<void>{}));
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _)).WillOnce(Return(Result<void>{}));
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(kInitialValue, _)).WillOnce(Return(Result<void>{}));
 
     EXPECT_CALL(skeleton_field_set_binding_mock_, RegisterHandler(_)).WillOnce(Return(Result<void>{}));
 
     MySetterSkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
 
     // Before registration PrepareOffer should fail with kSetHandlerNotSet
-    ASSERT_TRUE(unit.my_setter_field_.Update(kDummyInitialValue).has_value());
+    ASSERT_TRUE(unit.my_setter_field_.Update(kInitialValue).has_value());
     {
         // Separate scope: verify failure without handler
         // (We cannot call PrepareOffer twice without a stop-offer in between, so we

--- a/score/mw/com/impl/tracing/skeleton_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/skeleton_tracing_test.cpp
@@ -67,7 +67,8 @@ class MyDummyField : public SkeletonFieldBase
     {
     }
 
-    void UpdateSkeletonReference(SkeletonBase& skeleton_base) noexcept override {}
+    // Parameter name commented out to fix -Wunused-parameter
+    void UpdateSkeletonReference(SkeletonBase& /* skeleton_base */) noexcept override {}
 
     bool IsInitialValueSaved() const noexcept override
     {

--- a/score/mw/com/impl/tracing/type_erased_sample_ptr.h
+++ b/score/mw/com/impl/tracing/type_erased_sample_ptr.h
@@ -23,8 +23,9 @@ class TypeErasedSamplePtr
   public:
     template <typename SamplePtrType>
     explicit TypeErasedSamplePtr(SamplePtrType sample_ptr)
-        : type_erased_sample_ptr_{[sample_ptr = std::move(sample_ptr)]() {
-              static_cast<void>(sample_ptr);
+        // Rename capture to avoid -Wshadow (parameter name shadows capture name)
+        : type_erased_sample_ptr_{[captured_sample_ptr = std::move(sample_ptr)]() {
+              static_cast<void>(captured_sample_ptr);
           }}
     {
     }

--- a/score/mw/com/test/methods/non_trivial_constructors/consumer.cpp
+++ b/score/mw/com/test/methods/non_trivial_constructors/consumer.cpp
@@ -37,7 +37,8 @@ const InstanceSpecifier kInstanceSpecifier =
 void CallMethodWithInArgsAndReturn(NonTrivialConstructorProxy& proxy, const std::string& failure_message_prefix)
 {
     auto call_result =
-        [&proxy, &failure_message_prefix]() -> score::Result<impl::MethodReturnTypePtr<NonTriviallyConstructibleType>> {
+        // Removed unused 'failure_message_prefix' capture to fix -Wunused-lambda-capture
+        [&proxy]() -> score::Result<impl::MethodReturnTypePtr<NonTriviallyConstructibleType>> {
         std::cout << "\n=== Test: with_in_args_and_return (zero-copy) ===" << std::endl;
         auto allocated_args_result = proxy.with_in_args_and_return.Allocate();
         if (!allocated_args_result.has_value())
@@ -66,7 +67,8 @@ void CallMethodWithInArgsAndReturn(NonTrivialConstructorProxy& proxy, const std:
 
 void CallMethodWithInArgsOnly(NonTrivialConstructorProxy& proxy, const std::string& failure_message_prefix)
 {
-    auto call_result = [&proxy, &failure_message_prefix]() -> Result<void> {
+    // Removed unused 'failure_message_prefix' capture to fix -Wunused-lambda-capture
+    auto call_result = [&proxy]() -> Result<void> {
         std::cout << "\n=== Test: with_in_args_only (zero-copy) ===" << std::endl;
         auto allocated_args_result = proxy.with_in_args_only.Allocate();
         if (!allocated_args_result.has_value())

--- a/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/consumer.cpp
+++ b/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/consumer.cpp
@@ -37,8 +37,10 @@ const auto kInstanceSpecifier =
     score::mw::com::InstanceSpecifier::Create(std::string{kInstanceSpecifierString}).value();
 const std::chrono::seconds kMaxHandleNotificationWaitTime{15U};
 // uid 1312, 1313 is reserved for use. See broken_link_cf/display/ipnext/User+Management
-const uid_t kUidFirstConsumer{1312};
-const uid_t kUidSecondConsumer{1313};
+// NOLINTNEXTLINE(clang-diagnostic-unused-const-variable) - reserved for future use
+[[maybe_unused]] const uid_t kUidFirstConsumer{1312};
+// NOLINTNEXTLINE(clang-diagnostic-unused-const-variable) - reserved for future use
+[[maybe_unused]] const uid_t kUidSecondConsumer{1313};
 
 bool StartFindServiceAndWait(const std::string& tag,
                              HandleNotificationData& handle_notification_data,


### PR DESCRIPTION
- Add cc_feature definitions for GCC and Clang warning profiles
- Configure --config=strict (warnings as errors) and --config=permissive
- Move Clang-specific shadow flags to toolchain-conditional BUILD
- Fix unused variables, unused captures, and shadow warnings in source