### PR TITLE
Argue the usage of `std::terminate` being OK

### DIFF
--- a/coding-standards.yaml
+++ b/coding-standards.yaml
@@ -1,0 +1,1 @@
+quality/static_analysis/coding-standards.yaml

--- a/quality/static_analysis/coding-standards.yaml
+++ b/quality/static_analysis/coding-standards.yaml
@@ -1,1 +1,6 @@
 deviations:
+  - rule-id: "RULE-18-5-2"
+    query-id: "cpp/misra/avoid-program-terminating-functions"
+    justification: "The software is designed for a fail-silent system. The agreed safe-state for a process is the termination. Thus, we do not need to care about not cleaning up the environment, as this is exactly the desired behavior."
+    paths:
+      - "score/**"


### PR DESCRIPTION
In order to take the first global justification take effect, we need to link it from the root directory. As otherwise the path resolution within CodeQL is not working.