### PR TITLE
Rust::com FFI Type Lookup Optimization on Fast Path

### DIFF
--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
@@ -99,7 +99,7 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin + Default {
         &self,
         event_ptr: *mut SkeletonEventBase,
         allocatee_ptr: *mut std::ffi::c_void,
-        type_ops: &TypeOperationsManager
+        type_ops: &TypeOperationsManager,
     ) -> bool;
 
     /// # Safety
@@ -275,7 +275,8 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin + Default {
     /// Caller must ensure that the provided interface_id and member_name correspond to
     /// a valid TypeOperations instance in the C++ registry. The returned TypeOperationsManager
     /// must not be used after the underlying TypeOperations instance is destroyed on the C++ side.
-    unsafe fn get_type_ops_instance(&self,
+    unsafe fn get_type_ops_instance(
+        &self,
         interface_id: &str,
         member_name: &str,
     ) -> Option<TypeOperationsManager>;

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
@@ -275,7 +275,7 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin + Default {
     /// Caller must ensure that the provided interface_id and member_name correspond to
     /// a valid TypeOperations instance in the C++ registry. The returned TypeOperationsManager
     /// must not be used after the underlying TypeOperations instance is destroyed on the C++ side.
-    unsafe fn get_type_ops_instance(
+    unsafe fn get_type_ops_instance(&self,
         interface_id: &str,
         member_name: &str,
     ) -> Option<TypeOperationsManager>;
@@ -370,6 +370,7 @@ impl TypeOperationsManager {
 }
 
 unsafe impl Send for TypeOperationsManager {}
+unsafe impl Sync for TypeOperationsManager {}
 
 impl Debug for TypeOperationsManager {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
@@ -358,6 +358,7 @@ impl Debug for TypeOperations {
 }
 
 /// This struct manages the pointer to TypeOperations instance retrieved from C++ registry.
+#[derive(Copy, Clone)]
 pub struct TypeOperationsManager {
     inner: NonNull<TypeOperations>,
 }
@@ -375,19 +376,12 @@ impl TypeOperationsManager {
 // any interior mutability and the instance is statically allocated and managed on the C++ side.
 // Sharing the pointer across threads is safe as this is used with event instance of proxy or skeleton instance
 // which already handles the concurrent scenario.
-// Note: Sync is required by consumer SubscriberImpl type.
 unsafe impl Send for TypeOperationsManager {}
 unsafe impl Sync for TypeOperationsManager {}
 
 impl Debug for TypeOperationsManager {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("TypeOperationsManager").finish()
-    }
-}
-
-impl Clone for TypeOperationsManager {
-    fn clone(&self) -> Self {
-        TypeOperationsManager { inner: self.inner }
     }
 }
 

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
@@ -99,7 +99,7 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin + Default {
         &self,
         event_ptr: *mut SkeletonEventBase,
         allocatee_ptr: *mut std::ffi::c_void,
-        event_type: &str,
+        type_ops: &TypeOperationsManager
     ) -> bool;
 
     /// # Safety
@@ -371,7 +371,7 @@ impl TypeOperationsManager {
 
 // SAFETY: TypeOperationsManager can be sent and shared between threads because it does not provide
 // any interior mutability and the instance is statically allocated and managed on the C++ side.
-// Sharing the pointer across threads is safe as this is used with event insatnce of proxy or skeleton instance
+// Sharing the pointer across threads is safe as this is used with event instance of proxy or skeleton instance
 // which already handles the concurrent scenario.
 // Note: Sync is required by consumer SubscriberImpl type.
 unsafe impl Send for TypeOperationsManager {}

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
@@ -345,6 +345,7 @@ impl Debug for SkeletonEventBase {
 
 /// Opaque type operations struct
 #[repr(C)]
+#[derive(Default)]
 pub struct TypeOperations {
     dummy: [u8; 0],
 }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
@@ -355,7 +355,7 @@ impl Debug for TypeOperations {
     }
 }
 
-/// This struct wraps a raw pointer to a TypeOperations instance obtained from C++ and provides
+/// This struct manages the pointer to TypeOperations instance retrieved from C++ registry.
 pub struct TypeOperationsManager {
     inner: NonNull<TypeOperations>,
 }
@@ -369,6 +369,11 @@ impl TypeOperationsManager {
     }
 }
 
+// SAFETY: TypeOperationsManager can be sent and shared between threads because it does not provide
+// any interior mutability and the instance is statically allocated and managed on the C++ side.
+// Sharing the pointer across threads is safe as this is used with event insatnce of proxy or skeleton instance
+// which already handles the concurrent scenario.
+// Note: Sync is required by consumer SubscriberImpl type.
 unsafe impl Send for TypeOperationsManager {}
 unsafe impl Sync for TypeOperationsManager {}
 

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
@@ -69,6 +69,7 @@
 use core::fmt::{Debug, Formatter};
 use core::marker::Unpin;
 use std::ffi::c_char;
+use std::ptr::NonNull;
 
 /// Opaque C++ void* pointer wrapper
 pub type CVoidPtr = *const std::ffi::c_void;
@@ -103,26 +104,31 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin + Default {
 
     /// # Safety
     /// `allocatee_ptr` must be a valid pointer previously returned by `get_allocatee_ptr`
-    /// with the same `type_name`, and must not be used after this call.
-    unsafe fn delete_allocatee_ptr(&self, allocatee_ptr: *mut std::ffi::c_void, type_name: &str);
+    /// and `type_ops` must be the corresponding `TypeOperationsManager` for the type T.
+    unsafe fn delete_allocatee_ptr(
+        &self,
+        allocatee_ptr: *mut std::ffi::c_void,
+        type_ops: &TypeOperationsManager,
+    );
 
     /// # Safety
-    /// `allocatee_ptr` must be a valid pointer to a `SampleAllocateePtr<T>` of the specified
-    /// `type_name`, previously obtained from `get_allocatee_ptr`.
+    /// `allocatee_ptr` must be a valid pointer previously returned by `get_allocatee_ptr`
+    /// and `type_ops` must be the corresponding `TypeOperationsManager` for the type T.
     unsafe fn get_allocatee_data_ptr(
         &self,
         allocatee_ptr: *const std::ffi::c_void,
-        type_name: &str,
+        type_ops: &TypeOperationsManager,
     ) -> *mut std::ffi::c_void;
 
     /// # Safety
     /// `event_ptr` must be a valid pointer to a `SkeletonEventBase` obtained from
     /// `get_event_from_skeleton`. `allocatee_ptr` must be a valid `SampleAllocateePtr<T>`
-    /// whose type matches `event_type`.
+    /// previously returned by `get_allocatee_ptr` for the same event and type T, and `type_ops`
+    /// must be the corresponding `TypeOperationsManager` for type T.
     unsafe fn skeleton_event_send_sample_allocatee(
         &self,
         event_ptr: *mut SkeletonEventBase,
-        event_type: &str,
+        type_ops: &TypeOperationsManager,
         allocatee_ptr: *const std::ffi::c_void,
     ) -> bool;
 
@@ -131,13 +137,17 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin + Default {
     unsafe fn sample_ptr_get(
         &self,
         sample_ptr: *const std::ffi::c_void,
-        type_name: &str,
+        type_ops: &TypeOperationsManager,
     ) -> *const std::ffi::c_void;
 
     /// # Safety
     /// `sample_ptr` must be a valid pointer to a `SamplePtr<T>` of the specified `type_name`,
     /// and must not be used after this call.
-    unsafe fn sample_ptr_delete(&self, sample_ptr: *mut std::ffi::c_void, type_name: &str);
+    unsafe fn sample_ptr_delete(
+        &self,
+        sample_ptr: *mut std::ffi::c_void,
+        type_ops: &TypeOperationsManager,
+    );
 
     /// # Safety
     /// `skeleton_ptr` must be a valid, non-null pointer to a `SkeletonBase` previously created
@@ -200,7 +210,7 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin + Default {
     unsafe fn get_samples_from_event(
         &self,
         event_ptr: *mut ProxyEventBase,
-        event_type: &str,
+        type_ops: &TypeOperationsManager,
         callback: &FatPtr,
         max_samples: u32,
     ) -> u32;
@@ -212,7 +222,7 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin + Default {
     unsafe fn skeleton_send_event(
         &self,
         event_ptr: *mut SkeletonEventBase,
-        event_type: &str,
+        type_ops: &TypeOperationsManager,
         data_ptr: *const std::ffi::c_void,
     ) -> bool;
 
@@ -239,17 +249,12 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin + Default {
         &self,
         proxy_event_ptr: *mut ProxyEventBase,
         handler: &FatPtr,
-        event_type: &str,
     ) -> bool;
 
     /// # Safety
     /// `proxy_event_ptr` must be a valid pointer to a `ProxyEventBase` obtained from
     /// `get_event_from_proxy`. `event_type` must match the type used when the handler was set.
-    unsafe fn clear_event_receive_handler(
-        &self,
-        proxy_event_ptr: *mut ProxyEventBase,
-        event_type: &str,
-    );
+    unsafe fn clear_event_receive_handler(&self, proxy_event_ptr: *mut ProxyEventBase);
 
     /// # Safety
     /// `callback` must be a valid `FatPtr` referencing a callable compatible with the
@@ -265,6 +270,15 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin + Default {
     /// `handle` must be a valid pointer returned from `start_find_service` that has not
     /// been stopped yet. The handle must not be used after this call.
     unsafe fn stop_find_service(&self, handle: *mut FindServiceHandle);
+
+    /// # Safety
+    /// Caller must ensure that the provided interface_id and member_name correspond to
+    /// a valid TypeOperations instance in the C++ registry. The returned TypeOperationsManager
+    /// must not be used after the underlying TypeOperations instance is destroyed on the C++ side.
+    unsafe fn get_type_ops_instance(
+        interface_id: &str,
+        member_name: &str,
+    ) -> Option<TypeOperationsManager>;
 }
 
 /// Opaque proxy base struct
@@ -326,6 +340,46 @@ pub struct SkeletonEventBase {
 impl Debug for SkeletonEventBase {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         f.debug_struct("SkeletonEventBase").finish()
+    }
+}
+
+/// Opaque type operations struct
+#[repr(C)]
+pub struct TypeOperations {
+    dummy: [u8; 0],
+}
+
+impl Debug for TypeOperations {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TypeOperations").finish()
+    }
+}
+
+/// This struct wraps a raw pointer to a TypeOperations instance obtained from C++ and provides
+pub struct TypeOperationsManager {
+    inner: NonNull<TypeOperations>,
+}
+
+impl TypeOperationsManager {
+    pub fn new(inner: NonNull<TypeOperations>) -> Self {
+        Self { inner }
+    }
+    pub fn as_ptr(&self) -> *const TypeOperations {
+        self.inner.as_ptr()
+    }
+}
+
+unsafe impl Send for TypeOperationsManager {}
+
+impl Debug for TypeOperationsManager {
+    fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
+        f.debug_struct("TypeOperationsManager").finish()
+    }
+}
+
+impl Clone for TypeOperationsManager {
+    fn clone(&self) -> Self {
+        TypeOperationsManager { inner: self.inner }
     }
 }
 

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
@@ -244,7 +244,7 @@ unsafe extern "C" {
     fn mw_com_get_allocatee_ptr(
         event_ptr: *mut SkeletonEventBase,
         allocatee_ptr: *mut std::ffi::c_void,
-        event_type: StringView,
+        type_ops: *const TypeOperations,
     ) -> bool;
 
     /// Delete allocatee pointer of SampleAllocateePtr<T>
@@ -362,12 +362,11 @@ impl FFIBridge for LolaFFIBridge {
         &self,
         event_ptr: *mut SkeletonEventBase,
         allocatee_ptr: *mut std::ffi::c_void,
-        event_type: &str,
+        type_ops: &TypeOperationsManager,
     ) -> bool {
         // SAFETY: event_ptr is valid which is created using create_skeleton()
         // and allocatee_ptr has enough memory allocated for the construction of allocatee instance.
-        let event_type = StringView::from(event_type);
-        unsafe { mw_com_get_allocatee_ptr(event_ptr, allocatee_ptr, event_type) }
+        unsafe { mw_com_get_allocatee_ptr(event_ptr, allocatee_ptr, type_ops.as_ptr()) }
     }
 
     /// Delete allocatee pointer of SampleAllocateePtr<T>

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
@@ -842,6 +842,6 @@ impl FFIBridge for LolaFFIBridge {
         let member_name = StringView::from(member_name);
         // SAFETY: interface_id and member_name are valid ids that correspond to a TypeOperations instance in the C++ registry, as per the caller's contract.
         let ptr = unsafe { mw_com_get_type_ops_instance(interface_id, member_name) };
-        NonNull::new(ptr).map(|inner| TypeOperationsManager::new(inner))
+        NonNull::new(ptr).map(TypeOperationsManager::new)
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
@@ -12,6 +12,7 @@
  ********************************************************************************/
 
 use bridge_ffi_rs::*;
+use std::ptr::NonNull;
 
 #[derive(Debug, Clone, Default)]
 /// unit struct representing the FFI bridge for Lola runtime
@@ -124,7 +125,7 @@ unsafe extern "C" {
     ///
     /// # Arguments
     /// * `event_ptr` - Opaque event pointer
-    /// * `event_type` - Event type name string
+    /// * `type_ops` - Pointer to TypeOperations instance
     /// * `callback` - FatPtr to callback function
     /// * `max_samples` - Maximum number of samples to retrieve
     ///
@@ -132,7 +133,7 @@ unsafe extern "C" {
     /// Number of samples retrieved
     fn mw_com_type_registry_get_samples_from_event(
         event_ptr: *mut ProxyEventBase,
-        event_type: StringView,
+        type_ops: *const TypeOperations,
         callback: *const FatPtr,
         max_samples: u32,
     ) -> u32;
@@ -141,14 +142,14 @@ unsafe extern "C" {
     ///
     /// # Arguments
     /// * `event_ptr` - Opaque skeleton event pointer
-    /// * `event_type` - Event type name string
+    /// * `type_ops` - Pointer to TypeOperations instance
     /// * `data_ptr` - Pointer to event data
     ///
     /// # Returns
     /// None (void function)
     fn mw_com_skeleton_send_event(
         event_ptr: *mut SkeletonEventBase,
-        event_type: StringView,
+        type_ops: *const TypeOperations,
         data_ptr: CVoidPtr,
     ) -> bool;
 
@@ -215,21 +216,21 @@ unsafe extern "C" {
     ///
     /// # Arguments
     /// * `sample_ptr` - Opaque sample pointer
-    /// * `type_name` - Type name string
+    /// * `type_ops` - Pointer to TypeOperations instance
     ///
     /// # Returns
     /// Pointer to sample data, or nullptr if type mismatch
     fn mw_com_get_sample_ptr(
         sample_ptr: *const std::ffi::c_void,
-        type_name: StringView,
+        type_ops: *const TypeOperations,
     ) -> *const std::ffi::c_void;
 
     /// Delete sample pointer of SamplePtr<T>'
     ///
     /// # Arguments
     /// * `sample_ptr` - Opaque sample pointer
-    /// * `type_name` - Type name string
-    fn mw_com_delete_sample_ptr(sample_ptr: *mut std::ffi::c_void, type_name: StringView);
+    /// * `type_ops` - Pointer to TypeOperations instance
+    fn mw_com_delete_sample_ptr(sample_ptr: *mut std::ffi::c_void, type_ops: *const TypeOperations);
 
     /// Get allocatee pointer from skeleton event of specific type
     ///
@@ -250,34 +251,37 @@ unsafe extern "C" {
     ///
     /// # Arguments
     /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
-    /// * `type_name` - Type name string
-    fn mw_com_delete_allocatee_ptr(allocatee_ptr: *mut std::ffi::c_void, type_name: StringView);
+    /// * `type_ops` - Pointer to TypeOperations instance
+    fn mw_com_delete_allocatee_ptr(
+        allocatee_ptr: *mut std::ffi::c_void,
+        type_ops: *const TypeOperations,
+    );
 
     /// Get allocatee data pointer from allocatee of specific type
     ///
     /// # Arguments
     /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
-    /// * `type_name` - Type name string
+    /// * `type_ops` - Pointer to TypeOperations instance
     ///
     /// # Returns
     /// Pointer to allocatee data, or nullptr if type mismatch
     fn mw_com_get_allocatee_data_ptr(
         allocatee_ptr: *const std::ffi::c_void,
-        type_name: StringView,
+        type_ops: *const TypeOperations,
     ) -> *mut std::ffi::c_void;
 
     /// Send event via skeleton using allocatee pointer of specific type
     ///
     /// # Arguments
     /// * `event_ptr` - Opaque skeleton event pointer
-    /// * `event_type` - Type name string
+    /// * `type_ops` - Pointer to TypeOperations instance
     /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
     ///
     /// # Returns
     /// True if event was sent successfully, false otherwise
     fn mw_com_skeleton_send_event_allocatee(
         event_ptr: *mut SkeletonEventBase,
-        event_type: StringView,
+        type_ops: *const TypeOperations,
         allocatee_ptr: *const std::ffi::c_void,
     ) -> bool;
 
@@ -292,17 +296,13 @@ unsafe extern "C" {
     fn mw_com_proxy_set_event_receive_handler(
         proxy_event_ptr: *mut ProxyEventBase,
         handler: *const FatPtr,
-        event_type: StringView,
     ) -> bool;
 
     /// Clear event receive handler for proxy event
     ///
     /// # Arguments
     /// * `proxy_event_ptr` - Opaque proxy event pointer
-    fn mw_com_proxy_clear_event_receive_handler(
-        proxy_event_ptr: *mut ProxyEventBase,
-        event_type: StringView,
-    );
+    fn mw_com_proxy_clear_event_receive_handler(proxy_event_ptr: *mut ProxyEventBase);
 
     /// Start finding services with callback for results
     ///
@@ -328,6 +328,19 @@ unsafe extern "C" {
     /// # Arguments
     /// * `event_ptr` - Opaque event pointer
     fn mw_com_proxy_event_unsubscribe(event_ptr: *mut ProxyEventBase);
+
+    /// Get type operations instance for a given interface and member
+    ///
+    /// # Arguments
+    /// * `interface_id` - UTF-8 string view of interface ID
+    /// * `member_name` - UTF-8 string view of member name (event name Id)
+    ///
+    /// # Returns
+    /// Pointer to TypeOperations instance, or nullptr on failure
+    fn mw_com_get_type_ops_instance(
+        interface_id: StringView,
+        member_name: StringView,
+    ) -> *mut TypeOperations;
 }
 
 impl FFIBridge for LolaFFIBridge {
@@ -361,16 +374,20 @@ impl FFIBridge for LolaFFIBridge {
     ///
     /// # Arguments
     /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
-    /// * `type_name` - Type name string
+    /// * `type_ops` - Reference to TypeOperationsManager for the type
     ///
     /// # Safety
-    /// allocatee_ptr must point to a valid SampleAllocateePtr<T> of the specified type.
-    unsafe fn delete_allocatee_ptr(&self, allocatee_ptr: *mut std::ffi::c_void, type_name: &str) {
+    /// `allocatee_ptr` must be a valid pointer previously returned by `get_allocatee_ptr`
+    /// and `type_ops` must be the corresponding `TypeOperationsManager` for the type T.
+    unsafe fn delete_allocatee_ptr(
+        &self,
+        allocatee_ptr: *mut std::ffi::c_void,
+        type_ops: &TypeOperationsManager,
+    ) {
         // SAFETY: allocatee_ptr is valid which is created using get_allocatee_ptr() and
-        // type_name is constructed using static str.
-        let type_name = StringView::from(type_name);
+        // type_ops provides the correct type operations for this allocatee.
         unsafe {
-            mw_com_delete_allocatee_ptr(allocatee_ptr, type_name);
+            mw_com_delete_allocatee_ptr(allocatee_ptr, type_ops.as_ptr());
         }
     }
 
@@ -378,84 +395,90 @@ impl FFIBridge for LolaFFIBridge {
     ///
     /// # Arguments
     /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
-    /// * `type_name` - Type name string
+    /// * `type_ops` - Reference to TypeOperationsManager for the type
     ///
     /// # Returns
     /// Pointer to allocatee data, or nullptr if type mismatch
     ///
     /// # Safety
-    /// allocatee_ptr must point to a valid SampleAllocateePtr<T> of the specified type
+    /// `allocatee_ptr` must be a valid pointer previously returned by `get_allocatee_ptr`
+    /// and `type_ops` must be the corresponding `TypeOperationsManager` for type T.
     unsafe fn get_allocatee_data_ptr(
         &self,
         allocatee_ptr: *const std::ffi::c_void,
-        type_name: &str,
+        type_ops: &TypeOperationsManager,
     ) -> *mut std::ffi::c_void {
         // SAFETY: allocatee_ptr is valid which is created using get_allocatee_ptr() and
-        // type_name is constructed using static str.
-        let type_name = StringView::from(type_name);
-        unsafe { mw_com_get_allocatee_data_ptr(allocatee_ptr, type_name) }
+        // type_ops provides the correct type operations for this allocatee.
+        unsafe { mw_com_get_allocatee_data_ptr(allocatee_ptr, type_ops.as_ptr()) }
     }
 
     /// Send event via skeleton using allocatee pointer of specific type
     ///
     /// # Arguments
     /// * `event_ptr` - Opaque skeleton event pointer
-    /// * `event_type` - Type name string
+    /// * `type_ops` - Reference to TypeOperationsManager for the type
     /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
     ///
     /// # Returns
     /// True if event was sent successfully, false otherwise
     ///
     /// # Safety
-    /// event_ptr must point to a valid SkeletonEventBase,
-    /// allocatee_ptr must point to a valid SampleAllocateePtr<T>,
-    /// and event_type must be a valid UTF-8 string representing the event type.
+    /// `event_ptr` must be a valid pointer to a `SkeletonEventBase` obtained from
+    /// `get_event_from_skeleton`. `allocatee_ptr` must be a valid `SampleAllocateePtr<T>`
+    /// previously returned by `get_allocatee_ptr` for the same event and type T, and `type_ops`
+    /// must be the corresponding `TypeOperationsManager` for type T.
     unsafe fn skeleton_event_send_sample_allocatee(
         &self,
         event_ptr: *mut SkeletonEventBase,
-        event_type: &str,
+        type_ops: &TypeOperationsManager,
         allocatee_ptr: *const std::ffi::c_void,
     ) -> bool {
-        // SAFETY: event_ptr is valid which is created using create_skeleton() and allocatee_ptr is
-        // valid which is created using get_allocatee_ptr().
-        let event_type = StringView::from(event_type);
-        unsafe { mw_com_skeleton_send_event_allocatee(event_ptr, event_type, allocatee_ptr) }
+        // SAFETY: event_ptr is valid which is created using create_skeleton(), allocatee_ptr is
+        // valid which is created using get_allocatee_ptr(), and type_ops provides the correct
+        // type operations for this allocatee.
+        unsafe { mw_com_skeleton_send_event_allocatee(event_ptr, type_ops.as_ptr(), allocatee_ptr) }
     }
 
     /// Get SamplePtr<T> data pointer
     ///
     /// # Arguments
     /// * `sample_ptr` - Opaque sample pointer
-    /// * `type_name` - Type name string
+    /// * `type_ops` - Reference to TypeOperationsManager for the type
     ///
     /// # Returns
     /// Pointer to sample data, or nullptr if type mismatch
+    ///
     /// # Safety
-    /// sample_ptr must point to a valid SamplePtr<T> of the specified type.
+    /// `sample_ptr` must be a valid pointer to a `SamplePtr<T>` of the specified `type_name`.
     unsafe fn sample_ptr_get(
         &self,
         sample_ptr: *const std::ffi::c_void,
-        type_name: &str,
+        type_ops: &TypeOperationsManager,
     ) -> *const std::ffi::c_void {
         // SAFETY: sample_ptr is guaranteed to be valid per the caller's contract.
-        // The C++ implementation handles type checking and data retrieval safely.
-        let type_name = StringView::from(type_name);
-        unsafe { mw_com_get_sample_ptr(sample_ptr, type_name) }
+        // The C++ implementation handles type checking and data retrieval safely using type_ops.
+        unsafe { mw_com_get_sample_ptr(sample_ptr, type_ops.as_ptr()) }
     }
 
     /// Delete SamplePtr<T>
     ///
     /// # Arguments
     /// * `sample_ptr` - Opaque sample pointer
-    /// * `type_name` - Type name string
+    /// * `type_ops` - Reference to TypeOperationsManager for the type
+    ///
     /// # Safety
-    /// sample_ptr must point to a valid SamplePtr<T> of the specified type.
-    unsafe fn sample_ptr_delete(&self, sample_ptr: *mut std::ffi::c_void, type_name: &str) {
+    /// `sample_ptr` must be a valid pointer to a `SamplePtr<T>` of the specified `type_name`,
+    /// and must not be used after this call.
+    unsafe fn sample_ptr_delete(
+        &self,
+        sample_ptr: *mut std::ffi::c_void,
+        type_ops: &TypeOperationsManager,
+    ) {
         // SAFETY: sample_ptr is guaranteed to be valid per the caller's contract.
-        // The C++ implementation handles type checking and deletion safely.
-        let type_name = StringView::from(type_name);
+        // The C++ implementation handles type checking and deletion safely using type_ops.
         unsafe {
-            mw_com_delete_sample_ptr(sample_ptr, type_name);
+            mw_com_delete_sample_ptr(sample_ptr, type_ops.as_ptr());
         }
     }
 
@@ -628,7 +651,7 @@ impl FFIBridge for LolaFFIBridge {
     ///
     /// # Arguments
     /// * `event_ptr` - Opaque event pointer
-    /// * `event_type` - Event type name string
+    /// * `type_ops` - Reference to TypeOperationsManager for the type
     /// * `callback` - FatPtr to callback function
     /// * `max_samples` - Maximum number of samples to retrieve
     ///
@@ -636,23 +659,26 @@ impl FFIBridge for LolaFFIBridge {
     /// Number of samples retrieved, or u32::MAX on error
     ///
     /// # Safety
-    /// event_ptr must be a valid pointer to a ProxyEventBase previously obtained
-    /// from get_event_from_proxy().
-    /// callback must be a valid FatPtr referencing a callable compatible with the event type.
-    /// The event must have been subscribed to via subscribe_to_event() before calling this function.
+    /// `event_ptr` must be a valid pointer to a `ProxyEventBase` obtained from
+    /// `get_event_from_proxy`. `callback` must be a valid `FatPtr` referencing a callable
+    /// compatible with `event_type`. The event must have been subscribed via `subscribe_to_event`.
     unsafe fn get_samples_from_event(
         &self,
         event_ptr: *mut ProxyEventBase,
-        event_type: &str,
+        type_ops: &TypeOperationsManager,
         callback: &FatPtr,
         max_samples: u32,
     ) -> u32 {
-        // SAFETY: event_ptr, callback, and event_type are guaranteed
-        // to be valid per the caller's contract.
+        // SAFETY: event_ptr and callback are guaranteed to be valid per the caller's contract.
+        // type_ops provides the correct type operations for sample handling.
         // The C++ implementation handles sample retrieval and callback invocation safely.
-        let c_name = StringView::from(event_type);
         unsafe {
-            mw_com_type_registry_get_samples_from_event(event_ptr, c_name, callback, max_samples)
+            mw_com_type_registry_get_samples_from_event(
+                event_ptr,
+                type_ops.as_ptr(),
+                callback,
+                max_samples,
+            )
         }
     }
 
@@ -660,24 +686,23 @@ impl FFIBridge for LolaFFIBridge {
     ///
     /// # Arguments
     /// * `event_ptr` - Opaque skeleton event pointer
-    /// * `event_type` - Event type name string
+    /// * `type_ops` - Reference to TypeOperationsManager for the type
     /// * `data_ptr` - Pointer to event data of the matching type
     ///
     /// # Safety
-    /// event_ptr must be a valid pointer to a SkeletonEventBase previously obtained
-    /// from get_event_from_skeleton().
-    /// data_ptr must point to valid data whose type matches the event_type.
-    /// The lifetime of the data must extend through this function call.
+    /// `event_ptr` must be a valid pointer to a `SkeletonEventBase` obtained from
+    /// `get_event_from_skeleton`. `data_ptr` must point to valid data whose type matches
+    /// `event_type` and must remain valid for the duration of this call.
     unsafe fn skeleton_send_event(
         &self,
         event_ptr: *mut SkeletonEventBase,
-        event_type: &str,
+        type_ops: &TypeOperationsManager,
         data_ptr: *const std::ffi::c_void,
     ) -> bool {
         // SAFETY: event_ptr and data_ptr are guaranteed to be valid per the caller's contract.
+        // type_ops provides the correct type operations for this event.
         // The C++ implementation handles type matching and data sending safely.
-        let c_name = StringView::from(event_type);
-        unsafe { mw_com_skeleton_send_event(event_ptr, c_name, data_ptr) }
+        unsafe { mw_com_skeleton_send_event(event_ptr, type_ops.as_ptr(), data_ptr) }
     }
 
     /// Unsafe wrapper around mw_com_proxy_event_subscribe
@@ -729,41 +754,32 @@ impl FFIBridge for LolaFFIBridge {
     /// true if handler was set successfully, false otherwise
     ///
     /// # Safety
-    /// proxy_event_ptr must be a valid pointer to a ProxyEventBase previously obtained
-    /// from get_event_from_proxy().
-    /// handler must be a valid FatPtr which is used for notifying the proxy of incoming events.
+    /// `proxy_event_ptr` must be a valid pointer to a `ProxyEventBase` obtained from
+    /// `get_event_from_proxy`. `handler` must be a valid `FatPtr` referencing a callable
+    /// compatible with the receive-handler signature expected by the implementation.
     unsafe fn set_event_receive_handler(
         &self,
         proxy_event_ptr: *mut ProxyEventBase,
         handler: &FatPtr,
-        event_type: &str,
     ) -> bool {
         // SAFETY: proxy_event_ptr must be valid per the caller's contract,
         // and handler must be a valid FatPtr referencing a callable compatible with the callback
         // signature expected by the C++ implementation.
-        let c_name = StringView::from(event_type);
-        unsafe { mw_com_proxy_set_event_receive_handler(proxy_event_ptr, handler, c_name) }
+        unsafe { mw_com_proxy_set_event_receive_handler(proxy_event_ptr, handler) }
     }
 
     /// Unsafe wrapper around mw_com_proxy_clear_event_receive_handler
     ///
     /// # Arguments
     /// * `proxy_event_ptr` - Opaque proxy event pointer
-    /// * `event_type` - Event type name string
     ///
     /// # Safety
-    /// proxy_event_ptr must be a valid pointer to a ProxyEventBase previously obtained
-    /// from get_event_from_proxy().
-    /// event_type must be a valid string corresponding to the event type.
-    unsafe fn clear_event_receive_handler(
-        &self,
-        proxy_event_ptr: *mut ProxyEventBase,
-        event_type: &str,
-    ) {
+    /// `proxy_event_ptr` must be a valid pointer to a `ProxyEventBase` obtained from
+    /// `get_event_from_proxy`. `event_type` must match the type used when the handler was set.
+    unsafe fn clear_event_receive_handler(&self, proxy_event_ptr: *mut ProxyEventBase) {
         // SAFETY: proxy_event_ptr must be valid per the caller's contract.
-        let c_name = StringView::from(event_type);
         unsafe {
-            mw_com_proxy_clear_event_receive_handler(proxy_event_ptr, c_name);
+            mw_com_proxy_clear_event_receive_handler(proxy_event_ptr);
         }
     }
 
@@ -803,5 +819,29 @@ impl FFIBridge for LolaFFIBridge {
         unsafe {
             mw_com_stop_find_service(handle);
         }
+    }
+
+    /// Get type operations instance for a given interface and member ID
+    ///
+    /// # Arguments
+    /// * `interface_id` - Interface ID string
+    /// * `member_name` - Member name string (e.g., event name)
+    ///
+    /// # Returns
+    /// Option<TypeOperationsManager> instance wrapping the pointer to TypeOperations, or None if retrieval fails
+    ///
+    /// # Safety
+    /// Caller must ensure that the provided interface_id and member_name correspond to
+    /// a valid TypeOperations instance in the C++ registry. The returned TypeOperationsManager
+    /// must not be used after the underlying TypeOperations instance is destroyed on the C++ side.
+    unsafe fn get_type_ops_instance(
+        interface_id: &str,
+        member_name: &str,
+    ) -> Option<TypeOperationsManager> {
+        let interface_id = StringView::from(interface_id);
+        let member_name = StringView::from(member_name);
+        // SAFETY: interface_id and member_name are valid ids that correspond to a TypeOperations instance in the C++ registry, as per the caller's contract.
+        let ptr = unsafe { mw_com_get_type_ops_instance(interface_id, member_name) };
+        NonNull::new(ptr).map(|inner| TypeOperationsManager::new(inner))
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
@@ -835,6 +835,7 @@ impl FFIBridge for LolaFFIBridge {
     /// a valid TypeOperations instance in the C++ registry. The returned TypeOperationsManager
     /// must not be used after the underlying TypeOperations instance is destroyed on the C++ side.
     unsafe fn get_type_ops_instance(
+        &self,
         interface_id: &str,
         member_name: &str,
     ) -> Option<TypeOperationsManager> {

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -191,9 +191,10 @@ mock! {
         unsafe fn stop_find_service(&self, handle: *mut FindServiceHandle);
 
         unsafe fn get_type_ops_instance(
-        &self,
-        interface_id: &str,
-        member_name: &str,) -> Option<TypeOperationsManager>;
+            &self,
+            interface_id: &str,
+            member_name: &str,
+        ) -> Option<TypeOperationsManager>;
 }
 }
 
@@ -249,7 +250,11 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
         }
     }
 
-    unsafe fn delete_allocatee_ptr(&self, allocatee_ptr: *mut std::ffi::c_void, type_ops: &TypeOperationsManager) {
+    unsafe fn delete_allocatee_ptr(
+        &self,
+        allocatee_ptr: *mut std::ffi::c_void,
+        type_ops: &TypeOperationsManager,
+    ) {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
         unsafe { self.locked().delete_allocatee_ptr(allocatee_ptr, type_ops) }
     }
@@ -287,7 +292,11 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
         unsafe { self.locked().sample_ptr_get(sample_ptr, type_ops) }
     }
 
-    unsafe fn sample_ptr_delete(&self, sample_ptr: *mut std::ffi::c_void, type_ops: &TypeOperationsManager) {
+    unsafe fn sample_ptr_delete(
+        &self,
+        sample_ptr: *mut std::ffi::c_void,
+        type_ops: &TypeOperationsManager,
+    ) {
         unsafe { self.locked().sample_ptr_delete(sample_ptr, type_ops) }
     }
 
@@ -397,18 +406,12 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
         callback: &FatPtr,
     ) -> bool {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
-        unsafe {
-            self.locked()
-                .set_event_receive_handler(event_ptr, callback)
-        }
+        unsafe { self.locked().set_event_receive_handler(event_ptr, callback) }
     }
 
     unsafe fn clear_event_receive_handler(&self, event_ptr: *mut ProxyEventBase) {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
-        unsafe {
-            self.locked()
-                .clear_event_receive_handler(event_ptr)
-        }
+        unsafe { self.locked().clear_event_receive_handler(event_ptr) }
     }
 
     unsafe fn start_find_service(

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -220,7 +220,7 @@ impl SharedMockBridge {
         F: FnOnce(&mut MockFFIBridge) -> R,
     {
         let mut guard = self.0.lock().expect("Failed to acquire lock");
-        f(&mut *guard)
+        f(&mut guard)
     }
 
     fn locked(&self) -> std::sync::MutexGuard<'_, MockFFIBridge> {
@@ -487,7 +487,7 @@ impl<T: Default> MockPointerAllocator<T> {
     pub fn free(&self, ptr: *mut T) -> bool {
         let mut allocs = self.locked();
         allocs
-            .extract_if(.., |b| b.as_mut() as *mut T == ptr)
+            .extract_if(.., |b| std::ptr::eq(b.as_mut(), ptr))
             .next()
             .is_some()
     }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -70,9 +70,9 @@
 //!
 //! This mock back-end is used for unit testing of Lola-Runtime.
 
-use bridge_ffi_rs::{
+use bridge_ffi_rs::
     FatPtr, FindServiceHandle, HandleType, InstanceSpecifier, NativeInstanceSpecifier, ProxyBase,
-    ProxyEventBase, SkeletonBase, SkeletonEventBase,
+    ProxyEventBase, SkeletonBase, SkeletonEventBase, TypeOperationsManager,
 };
 use mockall::mock;
 
@@ -95,28 +95,28 @@ mock! {
             event_type: &str,
         ) -> bool;
 
-        unsafe fn delete_allocatee_ptr(&self, allocatee_ptr: *mut std::ffi::c_void, type_name: &str);
+        unsafe fn delete_allocatee_ptr(&self, allocatee_ptr: *mut std::ffi::c_void, type_ops: &TypeOperationsManager);
 
         unsafe fn get_allocatee_data_ptr(
             &self,
             allocatee_ptr: *const std::ffi::c_void,
-            type_name: &str,
+            type_ops: &TypeOperationsManager,
         ) -> *mut std::ffi::c_void;
 
         unsafe fn skeleton_event_send_sample_allocatee(
             &self,
             event_ptr: *mut SkeletonEventBase,
-            event_type: &str,
+            type_ops: &TypeOperationsManager,
             allocatee_ptr: *const std::ffi::c_void,
         ) -> bool;
 
         unsafe fn sample_ptr_get(
             &self,
             sample_ptr: *const std::ffi::c_void,
-            type_name: &str,
+            type_ops: &TypeOperationsManager,
         ) -> *const std::ffi::c_void;
 
-        unsafe fn sample_ptr_delete(&self, sample_ptr: *mut std::ffi::c_void, type_name: &str);
+        unsafe fn sample_ptr_delete(&self, sample_ptr: *mut std::ffi::c_void, type_ops: &TypeOperationsManager);
 
         unsafe fn skeleton_offer_service(&self, skeleton_ptr: *mut SkeletonBase) -> bool;
 
@@ -151,7 +151,7 @@ mock! {
         unsafe fn get_samples_from_event(
             &self,
             event_ptr: *mut ProxyEventBase,
-            event_type: &str,
+            type_ops: &TypeOperationsManager,
             callback: &FatPtr,
             max_samples: u32,
         ) -> u32;
@@ -159,7 +159,7 @@ mock! {
         unsafe fn skeleton_send_event(
             &self,
             event_ptr: *mut SkeletonEventBase,
-            event_type: &str,
+            type_ops: &TypeOperationsManager,
             data_ptr: *const std::ffi::c_void,
         ) -> bool;
 
@@ -175,13 +175,11 @@ mock! {
             &self,
             proxy_event_ptr: *mut ProxyEventBase,
             handler: &FatPtr,
-            event_type: &str,
         ) -> bool;
 
         unsafe fn clear_event_receive_handler(
             &self,
             proxy_event_ptr: *mut ProxyEventBase,
-            event_type: &str,
         );
 
         unsafe fn start_find_service(
@@ -191,6 +189,10 @@ mock! {
         ) -> *mut FindServiceHandle;
 
         unsafe fn stop_find_service(&self, handle: *mut FindServiceHandle);
+
+        unsafe fn get_type_ops_instance(
+        interface_id: &str,
+        member_name: &str,) -> Option<TypeOperationsManager>;
 }
 }
 
@@ -246,46 +248,46 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
         }
     }
 
-    unsafe fn delete_allocatee_ptr(&self, allocatee_ptr: *mut std::ffi::c_void, type_name: &str) {
+    unsafe fn delete_allocatee_ptr(&self, allocatee_ptr: *mut std::ffi::c_void, type_ops: &TypeOperationsManager) {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
-        unsafe { self.locked().delete_allocatee_ptr(allocatee_ptr, type_name) }
+        unsafe { self.locked().delete_allocatee_ptr(allocatee_ptr, type_ops) }
     }
 
     unsafe fn get_allocatee_data_ptr(
         &self,
         allocatee_ptr: *const std::ffi::c_void,
-        type_name: &str,
+        type_ops: &TypeOperationsManager,
     ) -> *mut std::ffi::c_void {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
         unsafe {
             self.locked()
-                .get_allocatee_data_ptr(allocatee_ptr, type_name)
+                .get_allocatee_data_ptr(allocatee_ptr, type_ops)
         }
     }
 
     unsafe fn skeleton_event_send_sample_allocatee(
         &self,
         event_ptr: *mut SkeletonEventBase,
-        event_type: &str,
+        type_ops: &TypeOperationsManager,
         allocatee_ptr: *const std::ffi::c_void,
     ) -> bool {
         unsafe {
             self.locked()
-                .skeleton_event_send_sample_allocatee(event_ptr, event_type, allocatee_ptr)
+                .skeleton_event_send_sample_allocatee(event_ptr, type_ops, allocatee_ptr)
         }
     }
 
     unsafe fn sample_ptr_get(
         &self,
         sample_ptr: *const std::ffi::c_void,
-        type_name: &str,
+        type_ops: &TypeOperationsManager,
     ) -> *const std::ffi::c_void {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
-        unsafe { self.locked().sample_ptr_get(sample_ptr, type_name) }
+        unsafe { self.locked().sample_ptr_get(sample_ptr, type_ops) }
     }
 
-    unsafe fn sample_ptr_delete(&self, sample_ptr: *mut std::ffi::c_void, type_name: &str) {
-        unsafe { self.locked().sample_ptr_delete(sample_ptr, type_name) }
+    unsafe fn sample_ptr_delete(&self, sample_ptr: *mut std::ffi::c_void, type_ops: &TypeOperationsManager) {
+        unsafe { self.locked().sample_ptr_delete(sample_ptr, type_ops) }
     }
 
     unsafe fn skeleton_offer_service(&self, skeleton_ptr: *mut SkeletonBase) -> bool {
@@ -364,27 +366,27 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
     unsafe fn get_samples_from_event(
         &self,
         event_ptr: *mut ProxyEventBase,
-        event_type: &str,
+        type_ops: &TypeOperationsManager,
         callback: &FatPtr,
         max_num_samples: u32,
     ) -> u32 {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
         unsafe {
             self.locked()
-                .get_samples_from_event(event_ptr, event_type, callback, max_num_samples)
+                .get_samples_from_event(event_ptr, type_ops, callback, max_num_samples)
         }
     }
 
     unsafe fn skeleton_send_event(
         &self,
         event_ptr: *mut SkeletonEventBase,
-        event_type: &str,
+        type_ops: &TypeOperationsManager,
         data_ptr: *const std::ffi::c_void,
     ) -> bool {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
         unsafe {
             self.locked()
-                .skeleton_send_event(event_ptr, event_type, data_ptr)
+                .skeleton_send_event(event_ptr, type_ops, data_ptr)
         }
     }
 
@@ -392,20 +394,19 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
         &self,
         event_ptr: *mut ProxyEventBase,
         callback: &FatPtr,
-        event_type: &str,
     ) -> bool {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
         unsafe {
             self.locked()
-                .set_event_receive_handler(event_ptr, callback, event_type)
+                .set_event_receive_handler(event_ptr, callback)
         }
     }
 
-    unsafe fn clear_event_receive_handler(&self, event_ptr: *mut ProxyEventBase, event_type: &str) {
+    unsafe fn clear_event_receive_handler(&self, event_ptr: *mut ProxyEventBase) {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
         unsafe {
             self.locked()
-                .clear_event_receive_handler(event_ptr, event_type)
+                .clear_event_receive_handler(event_ptr)
         }
     }
 
@@ -421,6 +422,17 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
     unsafe fn stop_find_service(&self, find_service_handle: *mut FindServiceHandle) {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
         unsafe { self.locked().stop_find_service(find_service_handle) }
+    }
+
+    unsafe fn get_type_ops_instance(
+        interface_id: &str,
+        member_name: &str,
+    ) -> Option<TypeOperationsManager> {
+        //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
+        unsafe {
+            self.locked()
+                .get_type_ops_instance(interface_id, member_name)
+        }
     }
 }
 

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -191,6 +191,7 @@ mock! {
         unsafe fn stop_find_service(&self, handle: *mut FindServiceHandle);
 
         unsafe fn get_type_ops_instance(
+        &self,
         interface_id: &str,
         member_name: &str,) -> Option<TypeOperationsManager>;
 }
@@ -425,6 +426,7 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
     }
 
     unsafe fn get_type_ops_instance(
+        &self,
         interface_id: &str,
         member_name: &str,
     ) -> Option<TypeOperationsManager> {

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -92,7 +92,7 @@ mock! {
             &self,
             event_ptr: *mut SkeletonEventBase,
             allocatee_ptr: *mut std::ffi::c_void,
-            event_type: &str,
+            type_ops: &TypeOperationsManager,
         ) -> bool;
 
         unsafe fn delete_allocatee_ptr(&self, allocatee_ptr: *mut std::ffi::c_void, type_ops: &TypeOperationsManager);
@@ -240,12 +240,12 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
         &self,
         event_ptr: *mut SkeletonEventBase,
         allocatee_ptr: *mut std::ffi::c_void,
-        event_type: &str,
+        type_ops: &TypeOperationsManager,
     ) -> bool {
         //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
         unsafe {
             self.locked()
-                .get_allocatee_ptr(event_ptr, allocatee_ptr, event_type)
+                .get_allocatee_ptr(event_ptr, allocatee_ptr, type_ops)
         }
     }
 

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -70,7 +70,7 @@
 //!
 //! This mock back-end is used for unit testing of Lola-Runtime.
 
-use bridge_ffi_rs::
+use bridge_ffi_rs::{
     FatPtr, FindServiceHandle, HandleType, InstanceSpecifier, NativeInstanceSpecifier, ProxyBase,
     ProxyEventBase, SkeletonBase, SkeletonEventBase, TypeOperationsManager,
 };

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.cpp
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.cpp
@@ -329,65 +329,41 @@ void mw_com_delete_sample_ptr(void* sample_ptr, StringView type_name)
 /// @param event_type Type name string
 /// @param allocatee_ptr Pointer to pre-allocated memory for allocatee
 /// @return True if allocatee pointer was retrieved successfully, false otherwise
-bool mw_com_get_allocatee_ptr(SkeletonEventBase* event_ptr, void* allocatee_ptr, StringView event_type)
+bool mw_com_get_allocatee_ptr(SkeletonEventBase* event_ptr, void* allocatee_ptr, TypeOperations* type_ops)
 {
-    if (event_ptr == nullptr || event_type.data == nullptr)
+    if (event_ptr == nullptr || type_ops == nullptr)
     {
         return false;
     }
 
-    auto name = static_cast<std::string_view>(event_type);
-
-    auto registry = GlobalRegistryMapping::FindTypeInformation(name);
-
-    if (registry == nullptr)
-    {
-        return false;
-    }
-    return registry->GetAllocateePtr(event_ptr, allocatee_ptr);
+    return type_ops->GetAllocateePtr(event_ptr, allocatee_ptr);
 }
 
 /// @brief Delete allocatee pointer of specific type
 /// @param allocatee_ptr Pointer to SampleAllocateePtr<T>
 /// @param event_type Type name string
-void mw_com_delete_allocatee_ptr(void* allocatee_ptr, StringView event_type)
+void mw_com_delete_allocatee_ptr(void* allocatee_ptr, TypeOperations* type_ops)
 {
-    if (allocatee_ptr == nullptr || event_type.data == nullptr)
+    if (allocatee_ptr == nullptr || type_ops == nullptr)
     {
         return;
     }
 
-    auto name = static_cast<std::string_view>(event_type);
-
-    auto registry = GlobalRegistryMapping::FindTypeInformation(name);
-
-    if (registry == nullptr)
-    {
-        return;
-    }
-    registry->DeleteAllocateePtr(allocatee_ptr);
+    type_ops->DeleteAllocateePtr(allocatee_ptr);
 }
 
 /// @brief Get allocatee data pointer from allocatee of specific type
 /// @param allocatee_ptr Pointer to SampleAllocateePtr<T>
 /// @param event_type Type name string
 /// @return Pointer to allocatee data, or nullptr if type mismatch
-void* mw_com_get_allocatee_data_ptr(void* allocatee_ptr, StringView event_type)
+void* mw_com_get_allocatee_data_ptr(void* allocatee_ptr, TypeOperations* type_ops)
 {
-    if (allocatee_ptr == nullptr || event_type.data == nullptr)
+    if (allocatee_ptr == nullptr || type_ops == nullptr)
     {
         return nullptr;
     }
 
-    auto name = static_cast<std::string_view>(event_type);
-
-    auto registry = GlobalRegistryMapping::FindTypeInformation(name);
-
-    if (registry == nullptr)
-    {
-        return nullptr;
-    }
-    return registry->GetAllocateeDataPtr(allocatee_ptr);
+    return type_ops->GetAllocateeDataPtr(allocatee_ptr);
 }
 
 /// @brief  Send event via skeleton using allocatee pointer of specific type
@@ -395,22 +371,14 @@ void* mw_com_get_allocatee_data_ptr(void* allocatee_ptr, StringView event_type)
 /// @param event_type Type name string
 /// @param allocatee_ptr Pointer to SampleAllocateePtr<T>
 /// @return True if event was sent successfully, false otherwise
-bool mw_com_skeleton_send_event_allocatee(SkeletonEventBase* event_ptr, StringView event_type, void* allocatee_ptr)
+bool mw_com_skeleton_send_event_allocatee(SkeletonEventBase* event_ptr, TypeOperations* type_ops, void* allocatee_ptr)
 {
-    if (event_type.data == nullptr || allocatee_ptr == nullptr)
+    if (type_ops == nullptr || allocatee_ptr == nullptr)
     {
         return false;
     }
 
-    auto name = static_cast<std::string_view>(event_type);
-
-    auto registry = GlobalRegistryMapping::FindTypeInformation(name);
-
-    if (registry == nullptr)
-    {
-        return false;
-    }
-    return registry->SkeletonSendEventAllocatee(event_ptr, allocatee_ptr);
+    return type_ops->SkeletonSendEventAllocatee(event_ptr, allocatee_ptr);
 }
 
 /// \brief Set event receive handler for proxy event
@@ -505,6 +473,26 @@ void mw_com_stop_find_service(void* find_service_handle_ptr)
     }
 
     delete find_service_handle;
+}
+
+void* mw_com_get_type_ops_instance(StringView interface_id, StringView member_name)
+{
+    if (interface_id.data == nullptr || member_name.data == nullptr)
+    {
+        return nullptr;
+    }
+
+    auto id = static_cast<std::string_view>(interface_id);
+    auto member = static_cast<std::string_view>(member_name);
+
+    auto registry = GlobalRegistryMapping::FindMemberOperation(id, member);
+
+    if (registry == nullptr)
+    {
+        return nullptr;
+    }
+
+    return registry->GetTypeOps();
 }
 
 }  // extern "C"

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.cpp
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.cpp
@@ -342,7 +342,7 @@ void* mw_com_get_allocatee_data_ptr(void* allocatee_ptr, TypeOperations* type_op
 /// @return True if event was sent successfully, false otherwise
 bool mw_com_skeleton_send_event_allocatee(SkeletonEventBase* event_ptr, TypeOperations* type_ops, void* allocatee_ptr)
 {
-    if (type_ops == nullptr || allocatee_ptr == nullptr)
+    if (event_ptr == nullptr || type_ops == nullptr || allocatee_ptr == nullptr)
     {
         return false;
     }

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.cpp
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.cpp
@@ -95,25 +95,17 @@ SkeletonEventBase* mw_com_get_event_from_skeleton(SkeletonBase* skeleton_ptr,
 /// \brief Send data via a skeleton event by name
 /// \details Sends event data to all subscribed proxy instances.
 /// \param event_ptr Opaque skeleton event pointer (SkeletonEvent<T>*)
-/// \param event_type UTF-8 string view of event type name
+/// \param type_ops Pointer to TypeOperations for the event data type T
 /// \param data_ptr Pointer to event data (T*)
 /// \return true if send successful, false otherwise
-bool mw_com_skeleton_send_event(SkeletonEventBase* event_ptr, StringView event_type, void* data_ptr)
+bool mw_com_skeleton_send_event(SkeletonEventBase* event_ptr, TypeOperations* type_ops, void* data_ptr)
 {
-    if (event_ptr == nullptr || event_type.data == nullptr || data_ptr == nullptr)
+    if (event_ptr == nullptr || type_ops == nullptr || data_ptr == nullptr)
     {
         return false;
     }
 
-    auto name = static_cast<std::string_view>(event_type);
-
-    auto registry = GlobalRegistryMapping::FindTypeInformation(name);
-
-    if (registry == nullptr)
-    {
-        return false;
-    }
-    return registry->SkeletonSendEvent(event_ptr, data_ptr);
+    return type_ops->SkeletonSendEvent(event_ptr, data_ptr);
 }
 
 /// \brief Subscribe to a proxy event to allocate sample buffers
@@ -250,12 +242,12 @@ void mw_com_destroy_skeleton(SkeletonBase* skeleton_ptr)
 /// \brief Get samples from proxy event of specific type
 /// \details Retrieves new samples from a proxy event using the type operations registry.
 /// \param event_ptr Opaque proxy event pointer (ProxyEventBase*)
-/// \param event_type UTF-8 string view of event type name
+/// \param type_ops Pointer to TypeOperations for the event data type T
 /// \param callback Pointer to FatPtr callback for sample processing
 /// \param max_samples Maximum number of samples to retrieve
 /// \return Number of samples retrieved, or std::numeric_limits<std::uint32_t>::max() on error
 std::uint32_t mw_com_type_registry_get_samples_from_event(ProxyEventBase* event_ptr,
-                                                         TypeOperations* type_ops,
+                                                          TypeOperations* type_ops,
                                                           const FatPtr* callback,
                                                           uint32_t max_samples)
 {
@@ -303,8 +295,8 @@ void mw_com_delete_sample_ptr(void* sample_ptr, TypeOperations* type_ops)
 
 /// @brief Get allocatee pointer from skeleton event of specific type
 /// @param event_ptr Opaque skeleton event pointer
-/// @param event_type Type name string
 /// @param allocatee_ptr Pointer to pre-allocated memory for allocatee
+/// @param type_ops Type operations pointer
 /// @return True if allocatee pointer was retrieved successfully, false otherwise
 bool mw_com_get_allocatee_ptr(SkeletonEventBase* event_ptr, void* allocatee_ptr, TypeOperations* type_ops)
 {
@@ -318,7 +310,7 @@ bool mw_com_get_allocatee_ptr(SkeletonEventBase* event_ptr, void* allocatee_ptr,
 
 /// @brief Delete allocatee pointer of specific type
 /// @param allocatee_ptr Pointer to SampleAllocateePtr<T>
-/// @param event_type Type name string
+/// @param type_ops Type operations pointer
 void mw_com_delete_allocatee_ptr(void* allocatee_ptr, TypeOperations* type_ops)
 {
     if (allocatee_ptr == nullptr || type_ops == nullptr)
@@ -331,7 +323,7 @@ void mw_com_delete_allocatee_ptr(void* allocatee_ptr, TypeOperations* type_ops)
 
 /// @brief Get allocatee data pointer from allocatee of specific type
 /// @param allocatee_ptr Pointer to SampleAllocateePtr<T>
-/// @param event_type Type name string
+/// @param type_ops Type operations pointer
 /// @return Pointer to allocatee data, or nullptr if type mismatch
 void* mw_com_get_allocatee_data_ptr(void* allocatee_ptr, TypeOperations* type_ops)
 {
@@ -345,7 +337,7 @@ void* mw_com_get_allocatee_data_ptr(void* allocatee_ptr, TypeOperations* type_op
 
 /// @brief  Send event via skeleton using allocatee pointer of specific type
 /// @param event_ptr Opaque skeleton event pointer
-/// @param event_type Type name string
+/// @param type_ops Type operations pointer
 /// @param allocatee_ptr Pointer to SampleAllocateePtr<T>
 /// @return True if event was sent successfully, false otherwise
 bool mw_com_skeleton_send_event_allocatee(SkeletonEventBase* event_ptr, TypeOperations* type_ops, void* allocatee_ptr)
@@ -452,6 +444,13 @@ void mw_com_stop_find_service(void* find_service_handle_ptr)
     delete find_service_handle;
 }
 
+/// \brief Get type operations instance for a given interface and member id
+/// \details Retrieves a pointer to the TypeOperations instance associated with the specified interface ID and member id
+/// (e.g., event name). This allows Rust code to perform type-specific operations for events without using the
+/// registry-based approach.
+/// \param interface_id UTF-8 string view of interface ID
+/// \param member_name UTF-8 string view of member name (e.g., event name)
+/// \return Pointer to TypeOperations instance if found, nullptr otherwise
 void* mw_com_get_type_ops_instance(StringView interface_id, StringView member_name)
 {
     if (interface_id.data == nullptr || member_name.data == nullptr)

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.cpp
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.cpp
@@ -255,23 +255,16 @@ void mw_com_destroy_skeleton(SkeletonBase* skeleton_ptr)
 /// \param max_samples Maximum number of samples to retrieve
 /// \return Number of samples retrieved, or std::numeric_limits<std::uint32_t>::max() on error
 std::uint32_t mw_com_type_registry_get_samples_from_event(ProxyEventBase* event_ptr,
-                                                          StringView event_type,
+                                                         TypeOperations* type_ops,
                                                           const FatPtr* callback,
                                                           uint32_t max_samples)
 {
-    if (event_ptr == nullptr || event_type.data == nullptr || callback == nullptr)
+    if (event_ptr == nullptr || type_ops == nullptr || callback == nullptr)
     {
         return std::numeric_limits<std::uint32_t>::max();
     }
 
-    auto id = static_cast<std::string_view>(event_type);
-    auto registry = GlobalRegistryMapping::FindTypeInformation(id);
-    if (registry == nullptr)
-    {
-        return std::numeric_limits<std::uint32_t>::max();
-    }
-
-    auto result = registry->GetSamplesFromEvent(event_ptr, max_samples, *callback);
+    auto result = type_ops->GetSamplesFromEvent(event_ptr, max_samples, *callback);
 
     if (result.has_value() == false)
     {
@@ -283,45 +276,29 @@ std::uint32_t mw_com_type_registry_get_samples_from_event(ProxyEventBase* event_
 
 /// @brief Get sample data pointer from SamplePtr<T>
 /// @param sample_ptr Opaque sample pointer
-/// @param type_name Type name string
+/// @param type_ops Type operations pointer
 /// @return Pointer to sample data, or nullptr if type mismatch
-const void* mw_com_get_sample_ptr(const void* sample_ptr, StringView type_name)
+const void* mw_com_get_sample_ptr(const void* sample_ptr, TypeOperations* type_ops)
 {
-    if (sample_ptr == nullptr || type_name.data == nullptr)
+    if (sample_ptr == nullptr || type_ops == nullptr)
     {
         return nullptr;
     }
 
-    auto name = static_cast<std::string_view>(type_name);
-
-    auto registry = GlobalRegistryMapping::FindTypeInformation(name);
-    if (registry == nullptr)
-    {
-        return nullptr;
-    }
-
-    return registry->GetSamplePtrData(sample_ptr);
+    return type_ops->GetSamplePtrData(sample_ptr);
 }
 
 /// @brief Delete sample pointer of specific type
 /// @param sample_ptr Opaque sample pointer
-/// @param type_name Type name string
-void mw_com_delete_sample_ptr(void* sample_ptr, StringView type_name)
+/// @param type_ops Type operations pointer
+void mw_com_delete_sample_ptr(void* sample_ptr, TypeOperations* type_ops)
 {
-    if (sample_ptr == nullptr || type_name.data == nullptr)
+    if (sample_ptr == nullptr || type_ops == nullptr)
     {
         return;
     }
 
-    auto name = static_cast<std::string_view>(type_name);
-
-    auto registry = GlobalRegistryMapping::FindTypeInformation(name);
-    if (registry == nullptr)
-    {
-        return;
-    }
-
-    registry->DeleteSamplePtr(sample_ptr);
+    type_ops->DeleteSamplePtr(sample_ptr);
 }
 
 /// @brief Get allocatee pointer from skeleton event of specific type

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.cpp
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.cpp
@@ -98,7 +98,7 @@ SkeletonEventBase* mw_com_get_event_from_skeleton(SkeletonBase* skeleton_ptr,
 /// \param type_ops Pointer to TypeOperations for the event data type T
 /// \param data_ptr Pointer to event data (T*)
 /// \return true if send successful, false otherwise
-bool mw_com_skeleton_send_event(SkeletonEventBase* event_ptr, TypeOperations* type_ops, void* data_ptr)
+bool mw_com_skeleton_send_event(SkeletonEventBase* event_ptr, const TypeOperations* type_ops, void* data_ptr)
 {
     if (event_ptr == nullptr || type_ops == nullptr || data_ptr == nullptr)
     {
@@ -247,7 +247,7 @@ void mw_com_destroy_skeleton(SkeletonBase* skeleton_ptr)
 /// \param max_samples Maximum number of samples to retrieve
 /// \return Number of samples retrieved, or std::numeric_limits<std::uint32_t>::max() on error
 std::uint32_t mw_com_type_registry_get_samples_from_event(ProxyEventBase* event_ptr,
-                                                          TypeOperations* type_ops,
+                                                          const TypeOperations* type_ops,
                                                           const FatPtr* callback,
                                                           uint32_t max_samples)
 {
@@ -270,7 +270,7 @@ std::uint32_t mw_com_type_registry_get_samples_from_event(ProxyEventBase* event_
 /// @param sample_ptr Opaque sample pointer
 /// @param type_ops Type operations pointer
 /// @return Pointer to sample data, or nullptr if type mismatch
-const void* mw_com_get_sample_ptr(const void* sample_ptr, TypeOperations* type_ops)
+const void* mw_com_get_sample_ptr(const void* sample_ptr, const TypeOperations* type_ops)
 {
     if (sample_ptr == nullptr || type_ops == nullptr)
     {
@@ -283,7 +283,7 @@ const void* mw_com_get_sample_ptr(const void* sample_ptr, TypeOperations* type_o
 /// @brief Delete sample pointer of specific type
 /// @param sample_ptr Opaque sample pointer
 /// @param type_ops Type operations pointer
-void mw_com_delete_sample_ptr(void* sample_ptr, TypeOperations* type_ops)
+void mw_com_delete_sample_ptr(void* sample_ptr, const TypeOperations* type_ops)
 {
     if (sample_ptr == nullptr || type_ops == nullptr)
     {
@@ -298,7 +298,7 @@ void mw_com_delete_sample_ptr(void* sample_ptr, TypeOperations* type_ops)
 /// @param allocatee_ptr Pointer to pre-allocated memory for allocatee
 /// @param type_ops Type operations pointer
 /// @return True if allocatee pointer was retrieved successfully, false otherwise
-bool mw_com_get_allocatee_ptr(SkeletonEventBase* event_ptr, void* allocatee_ptr, TypeOperations* type_ops)
+bool mw_com_get_allocatee_ptr(SkeletonEventBase* event_ptr, void* allocatee_ptr, const TypeOperations* type_ops)
 {
     if (event_ptr == nullptr || type_ops == nullptr)
     {
@@ -311,7 +311,7 @@ bool mw_com_get_allocatee_ptr(SkeletonEventBase* event_ptr, void* allocatee_ptr,
 /// @brief Delete allocatee pointer of specific type
 /// @param allocatee_ptr Pointer to SampleAllocateePtr<T>
 /// @param type_ops Type operations pointer
-void mw_com_delete_allocatee_ptr(void* allocatee_ptr, TypeOperations* type_ops)
+void mw_com_delete_allocatee_ptr(void* allocatee_ptr, const TypeOperations* type_ops)
 {
     if (allocatee_ptr == nullptr || type_ops == nullptr)
     {
@@ -325,7 +325,7 @@ void mw_com_delete_allocatee_ptr(void* allocatee_ptr, TypeOperations* type_ops)
 /// @param allocatee_ptr Pointer to SampleAllocateePtr<T>
 /// @param type_ops Type operations pointer
 /// @return Pointer to allocatee data, or nullptr if type mismatch
-void* mw_com_get_allocatee_data_ptr(void* allocatee_ptr, TypeOperations* type_ops)
+void* mw_com_get_allocatee_data_ptr(void* allocatee_ptr, const TypeOperations* type_ops)
 {
     if (allocatee_ptr == nullptr || type_ops == nullptr)
     {
@@ -340,7 +340,9 @@ void* mw_com_get_allocatee_data_ptr(void* allocatee_ptr, TypeOperations* type_op
 /// @param type_ops Type operations pointer
 /// @param allocatee_ptr Pointer to SampleAllocateePtr<T>
 /// @return True if event was sent successfully, false otherwise
-bool mw_com_skeleton_send_event_allocatee(SkeletonEventBase* event_ptr, TypeOperations* type_ops, void* allocatee_ptr)
+bool mw_com_skeleton_send_event_allocatee(SkeletonEventBase* event_ptr,
+                                          const TypeOperations* type_ops,
+                                          void* allocatee_ptr)
 {
     if (event_ptr == nullptr || type_ops == nullptr || allocatee_ptr == nullptr)
     {
@@ -450,8 +452,8 @@ void mw_com_stop_find_service(void* find_service_handle_ptr)
 /// registry-based approach.
 /// \param interface_id UTF-8 string view of interface ID
 /// \param member_name UTF-8 string view of member name (e.g., event name)
-/// \return Pointer to TypeOperations instance if found, nullptr otherwise
-void* mw_com_get_type_ops_instance(StringView interface_id, StringView member_name)
+/// \return Const pointer to TypeOperations instance if found, nullptr otherwise
+const void* mw_com_get_type_ops_instance(StringView interface_id, StringView member_name)
 {
     if (interface_id.data == nullptr || member_name.data == nullptr)
     {

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.h
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.h
@@ -333,8 +333,12 @@ template <typename ProxyType,
 class MemberOperationImpl : public MemberOperation
 {
   public:
-    /// Constructor to accept cached TypeOperations pointer
-    // TODO: Why explicit constructor we need to do ?
+    /// Constructor to cache TypeOperations pointer for efficient member access
+    /// 
+    /// This clarifies the ownership contract, the caller must explicitly construct MemberOperationImpl
+    /// and is responsible for ensuring the TypeOperations* pointer remains valid for the lifetime of
+    /// this MemberOperationImpl instance. The TypeOperations pointer is managed by the registry and
+    /// remains valid as long as the global registry exists (static lifetime).
     explicit MemberOperationImpl(TypeOperations* type_ops) : type_ops_ptr_(type_ops) {}
 
     ProxyEventBase* GetProxyEvent(ProxyBase* proxy_ptr) override

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.h
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.h
@@ -318,6 +318,8 @@ class MemberOperation
     /// \param skeleton_ptr Pointer to SkeletonBase instance
     /// \return Pointer to SkeletonEventBase if found, nullptr otherwise
     virtual SkeletonEventBase* GetSkeletonEvent(SkeletonBase* skeleton_ptr) = 0;
+
+    virtual TypeOperations* GetTypeOps() = 0;
 };
 
 /// \brief Template implementation of MemberOperation for specific ProxyType and SkeletonType
@@ -331,6 +333,10 @@ template <typename ProxyType,
 class MemberOperationImpl : public MemberOperation
 {
   public:
+    /// Constructor to accept cached TypeOperations pointer
+    //TODO: Why explicit constructor we need to do ?
+    explicit MemberOperationImpl(TypeOperations* type_ops) : type_ops_ptr_(type_ops) {}
+
     ProxyEventBase* GetProxyEvent(ProxyBase* proxy_ptr) override
     {
         auto proxy = dynamic_cast<ProxyType*>(proxy_ptr);
@@ -357,6 +363,14 @@ class MemberOperationImpl : public MemberOperation
 
         return static_cast<SkeletonEventBase*>(&(skeleton->*skeleton_event_member));
     }
+
+    TypeOperations* GetTypeOps() override
+    {
+        return type_ops_ptr_;
+    }
+
+  private:
+    TypeOperations* type_ops_ptr_;
 };
 
 /// \brief Interface for type-erased proxy and skeleton creation operations
@@ -672,21 +686,22 @@ class RustBoxedCallable<void,
     {                                                                                                               \
         event_member##_EventRegistrationHelper()                                                                    \
         {                                                                                                           \
+            /* Get or create shared TypeOperations for this event_type */                                           \
+            static ::score::mw::com::impl::rust::TypeOperationImpl<event_type> s_shared_type_ops;                   \
                                                                                                                     \
             auto event_info =                                                                                       \
                 std::make_unique<::score::mw::com::impl::rust::MemberOperationImpl<ProxyType,                       \
                                                                                    SkeletonType,                    \
                                                                                    event_type,                      \
                                                                                    &ProxyType::event_member,        \
-                                                                                   &SkeletonType::event_member>>(); \
+                                                                                   &SkeletonType::event_member>>(   \
+                    &s_shared_type_ops);  /* ← Pass shared instance */                                             \
                                                                                                                     \
-            /* Register this event in the LOCAL interface registry (not global) */                                  \
             ::score::mw::com::impl::rust::GlobalRegistryMapping::RegisterMemberOperation(                           \
                 std::string_view(id_interface), std::string_view(#event_member), std::move(event_info));            \
         }                                                                                                           \
     };                                                                                                              \
                                                                                                                     \
-    /* Force instantiation at startup */                                                                            \
     static event_member##_EventRegistrationHelper event_member##_event_reg_instance;
 
 #define END_EXPORT_MW_COM_INTERFACE() }  // namespace id##_detail

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.h
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.h
@@ -334,7 +334,7 @@ class MemberOperationImpl : public MemberOperation
 {
   public:
     /// Constructor to accept cached TypeOperations pointer
-    //TODO: Why explicit constructor we need to do ?
+    // TODO: Why explicit constructor we need to do ?
     explicit MemberOperationImpl(TypeOperations* type_ops) : type_ops_ptr_(type_ops) {}
 
     ProxyEventBase* GetProxyEvent(ProxyBase* proxy_ptr) override
@@ -681,27 +681,27 @@ class RustBoxedCallable<void,
 /// \param event_type Data type of the event
 /// \param event_member Event member name in Proxy and Skeleton classes
 /// \note Example usage: EXPORT_MW_COM_EVENT(Tire, left_tire)
-#define EXPORT_MW_COM_EVENT(event_type, event_member)                                                               \
-    struct event_member##_EventRegistrationHelper                                                                   \
-    {                                                                                                               \
-        event_member##_EventRegistrationHelper()                                                                    \
-        {                                                                                                           \
-            /* Get or create shared TypeOperations for this event_type */                                           \
-            static ::score::mw::com::impl::rust::TypeOperationImpl<event_type> s_shared_type_ops;                   \
-                                                                                                                    \
-            auto event_info =                                                                                       \
-                std::make_unique<::score::mw::com::impl::rust::MemberOperationImpl<ProxyType,                       \
-                                                                                   SkeletonType,                    \
-                                                                                   event_type,                      \
-                                                                                   &ProxyType::event_member,        \
-                                                                                   &SkeletonType::event_member>>(   \
-                    &s_shared_type_ops);  /* ← Pass shared instance */                                             \
-                                                                                                                    \
-            ::score::mw::com::impl::rust::GlobalRegistryMapping::RegisterMemberOperation(                           \
-                std::string_view(id_interface), std::string_view(#event_member), std::move(event_info));            \
-        }                                                                                                           \
-    };                                                                                                              \
-                                                                                                                    \
+#define EXPORT_MW_COM_EVENT(event_type, event_member)                                                             \
+    struct event_member##_EventRegistrationHelper                                                                 \
+    {                                                                                                             \
+        event_member##_EventRegistrationHelper()                                                                  \
+        {                                                                                                         \
+            /* Get or create shared TypeOperations for this event_type */                                         \
+            static ::score::mw::com::impl::rust::TypeOperationImpl<event_type> s_shared_type_ops;                 \
+                                                                                                                  \
+            auto event_info =                                                                                     \
+                std::make_unique<::score::mw::com::impl::rust::MemberOperationImpl<ProxyType,                     \
+                                                                                   SkeletonType,                  \
+                                                                                   event_type,                    \
+                                                                                   &ProxyType::event_member,      \
+                                                                                   &SkeletonType::event_member>>( \
+                    &s_shared_type_ops); /* ← Pass shared instance */                                             \
+                                                                                                                  \
+            ::score::mw::com::impl::rust::GlobalRegistryMapping::RegisterMemberOperation(                         \
+                std::string_view(id_interface), std::string_view(#event_member), std::move(event_info));          \
+        }                                                                                                         \
+    };                                                                                                            \
+                                                                                                                  \
     static event_member##_EventRegistrationHelper event_member##_event_reg_instance;
 
 #define END_EXPORT_MW_COM_INTERFACE() }  // namespace id##_detail

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.h
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.h
@@ -30,31 +30,31 @@
 //  - We can not rely on static macros alone to achieve runtime independence
 //
 //  Key design elements:
-//  - GlobalRegistryMapping: Central registry that maps string identifiers to type/interface operations
+//  - GlobalRegistryMapping: Central registry that maps interface identifiers to InterfaceOperations
 //    - InterfaceOperationMap: Maps interface_id (string) -> InterfaceOperations (proxy/skeleton creation)
-//    - TypeOperationMap: Maps type_name (string) -> TypeOperations (sample handling, event sending)
+//    - get_type_operations<T>(): Template function providing per-type singleton TypeOperationImpl<T>
 //
 //  How it works:
-//  - Registry is filled at COMPILE TIME using macros (BEGIN_EXPORT_MW_COM_INTERFACE, EXPORT_MW_COM_EVENT,
-//  EXPORT_MW_COM_TYPE)
-//  - Macros create static helper structs that register operations in GlobalRegistryMapping at program startup
-//  - Operations are looked up at RUNTIME using string keys (interface_id, event_id, type_name)
-//  - Rust calls FFI functions with string identifiers
-//  - C++ resolves actual types via registry and invokes appropriate virtual methods
+//  - Registry is filled at COMPILE TIME using macros (BEGIN_EXPORT_MW_COM_INTERFACE, EXPORT_MW_COM_EVENT)
+//  - Macros create static helper structs that register InterfaceOperationImpl and MemberOperationImpl at startup
+//  - Type operations are resolved at COMPILE TIME via template specialization (get_type_operations<T>)
+//  - Each type T has a single static TypeOperationImpl<T> instance shared across all events of that type
+//  - Interface and member lookups use string keys (interface_id, event_id), type dispatch uses direct pointers
 //
 //  Example flow for event subscription:
-//  - Rust calls: get_event_from_proxy(proxy_ptr, "VehicleInterface", "TireEvent")
-//  - C++: FindMemberOperation("VehicleInterface", "TireEvent") -> returns MemberOperationImpl<VehicleProxy,
+//  - Rust calls: get_event_from_proxy(proxy_ptr, "VehicleInterface", "left_tire")
+//  - C++: FindMemberOperation("VehicleInterface", "left_tire") -> returns MemberOperationImpl<VehicleProxy,
 //  VehicleSkeleton, Tire, ...>
 //  - C++: Calls GetProxyEvent() on the returned MemberOperation
 //  - C++: Returns ProxyEventBase* which is actually ProxyEvent<Tire>*
-//  - Rust receives opaque ProxyEventBase* and can use it with type-name strings in subsequent calls
+//  - Rust receives opaque ProxyEventBase* and uses get_type_ops_instance() to retrieve TypeOperations pointer
+//  - Direct pointer dispatch avoids string-based type lookup overhead on every send/receive operation
 //
 //  Template specialization pattern:
-//  - EXPORT_MW_COM_TYPE macro specializes RustRefMutCallable template for each type
-//  - This allows C++ to invoke Rust FnMut closures with type-specific SamplePtr<T>
+//  - get_type_operations<T>() provides singleton access to TypeOperationImpl<T> via function-scoped static
+//  - Each template specialization (e.g., get_type_operations<Tire>, get_type_operations<Exhaust>) has one instance
+//  - EXPORT_MW_COM_TYPE macro specializes RustRefMutCallable template for closure invocation with SamplePtr<T>
 //  - SamplePtr<T> is wrapped in placement-new storage and passed to mw_com_impl_call_dyn_ref_fnmut_sample()
-//  - The Rust side reconstructs the FatPtr and invokes the original closure
 //
 //  Application side usage:
 //  - Generated C++ code invokes these macros to fill registry for each interface and type
@@ -319,6 +319,8 @@ class MemberOperation
     /// \return Pointer to SkeletonEventBase if found, nullptr otherwise
     virtual SkeletonEventBase* GetSkeletonEvent(SkeletonBase* skeleton_ptr) = 0;
 
+    /// \brief Get TypeOperations for type-erased sample handling
+    /// \return Pointer to TypeOperations instance for the event data type
     virtual TypeOperations* GetTypeOps() = 0;
 };
 
@@ -334,11 +336,6 @@ class MemberOperationImpl : public MemberOperation
 {
   public:
     /// Constructor to cache TypeOperations pointer for efficient member access
-    /// 
-    /// This clarifies the ownership contract, the caller must explicitly construct MemberOperationImpl
-    /// and is responsible for ensuring the TypeOperations* pointer remains valid for the lifetime of
-    /// this MemberOperationImpl instance. The TypeOperations pointer is managed by the registry and
-    /// remains valid as long as the global registry exists (static lifetime).
     explicit MemberOperationImpl(TypeOperations* type_ops) : type_ops_ptr_(type_ops) {}
 
     ProxyEventBase* GetProxyEvent(ProxyBase* proxy_ptr) override
@@ -613,6 +610,14 @@ class RustBoxedCallable<void,
     static void dispose(FatPtr) noexcept {}
 };
 
+/// Helper function to get singleton TypeOperations instance for each type T
+template <typename T>
+inline ::score::mw::com::impl::rust::TypeOperationImpl<T>& get_type_operations()
+{
+    static ::score::mw::com::impl::rust::TypeOperationImpl<T> ops;
+    return ops;
+}
+
 /// \brief Macro to begin registration of interface operations
 /// \details Creates registry and type aliases for a specific interface. Uses a static struct to register
 /// interface operations at startup/before main(). Declares the Rust FFI function for closure invocation.
@@ -647,17 +652,19 @@ class RustBoxedCallable<void,
 
 /// \brief Macro to register event member operations
 /// \details Creates registry for event member operations for a specific interface and event name.
-/// Uses a static struct to register member operations at startup/before main().
-/// \param event_type Data type of the event
-/// \param event_member Event member name in Proxy and Skeleton classes
+/// Uses a static struct to register MemberOperationImpl at startup/before main().
+/// All events with the same event_type share a single TypeOperationImpl<event_type> instance obtained via
+/// get_type_operations<event_type>(), eliminating per-event type operation overhead.
+/// \param event_type Data type of the event (e.g., Tire, Exhaust)
+/// \param event_member Event member name in Proxy and Skeleton classes (e.g., left_tire, right_tire)
 /// \note Example usage: EXPORT_MW_COM_EVENT(Tire, left_tire)
 #define EXPORT_MW_COM_EVENT(event_type, event_member)                                                             \
     struct event_member##_EventRegistrationHelper                                                                 \
     {                                                                                                             \
         event_member##_EventRegistrationHelper()                                                                  \
         {                                                                                                         \
-            /* Get or create shared TypeOperations for this event_type */                                         \
-            static ::score::mw::com::impl::rust::TypeOperationImpl<event_type> s_shared_type_ops;                 \
+            /* Get reference to shared TypeOperations - same for all events of same type */                       \
+            auto& type_ops = ::score::mw::com::impl::rust::get_type_operations<event_type>();                     \
                                                                                                                   \
             auto event_info =                                                                                     \
                 std::make_unique<::score::mw::com::impl::rust::MemberOperationImpl<ProxyType,                     \
@@ -665,7 +672,7 @@ class RustBoxedCallable<void,
                                                                                    event_type,                    \
                                                                                    &ProxyType::event_member,      \
                                                                                    &SkeletonType::event_member>>( \
-                    &s_shared_type_ops);                                                                          \
+                    &type_ops);                                                                                   \
                                                                                                                   \
             ::score::mw::com::impl::rust::GlobalRegistryMapping::RegisterMemberOperation(                         \
                 std::string_view(id_interface), std::string_view(#event_member), std::move(event_info));          \
@@ -679,7 +686,7 @@ class RustBoxedCallable<void,
 /// \brief Macro to create type specific class and support functions
 /// \details RustRefMutCallable template is specialized for SamplePtr<type> to allow C++ to call Rust closures with
 /// type-erased sample pointers.
-/// \param type_tag Type name tag used in macros as the registry key
+/// \param type_tag Type name tag is currently not used but we may need for method and field.
 /// \param type Actual C++ type for which operations are registered
 /// \note Example usage: EXPORT_MW_COM_TYPE(TireType, Tire)
 #define EXPORT_MW_COM_TYPE(type_tag, type)                                                                    \

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.h
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.h
@@ -464,26 +464,6 @@ class GlobalRegistryMapping
   public:
     using InterfaceOperationMap = std::unordered_map<std::string_view, std::unique_ptr<InterfaceOperations>>;
 
-    using TypeOperationMap = std::unordered_map<std::string_view, std::unique_ptr<TypeOperations>>;
-
-    /// \brief Get the type operation map
-    /// \details Creates static map on first call and returns reference to it for subsequent calls.
-    /// \return Reference to the static type operation map
-    static TypeOperationMap& GetTypeOperationMap()
-    {
-        static TypeOperationMap s_type_operation_map;
-        return s_type_operation_map;
-    }
-
-    /// \brief Register type operation for a specific type name
-    /// \details Called by EXPORT_MW_COM_TYPE macro to register type operations.
-    /// \param type_name Name of the type used as key in registry
-    /// \param impl Unique pointer to TypeOperations implementation
-    static void RegisterTypeOperation(const std::string_view type_name, std::unique_ptr<TypeOperations> impl)
-    {
-        GetTypeOperationMap()[type_name] = std::move(impl);
-    }
-
     /// \brief Get the interface operation map
     /// \details Creates static map on first call and returns reference to it for subsequent calls.
     /// \return Reference to the static interface operation map
@@ -526,20 +506,6 @@ class GlobalRegistryMapping
     {
         auto it = GetInterfaceOperationMap().find(interface_id);
         if (it != GetInterfaceOperationMap().end())
-        {
-            return it->second.get();
-        }
-        return nullptr;
-    }
-
-    /// \brief Get type operation for a specific type name
-    /// \param type_name Name of the type used as registry key
-    /// \return Pointer to TypeOperations implementation if found, nullptr otherwise
-    static TypeOperations* FindTypeInformation(const std::string_view type_name)
-    {
-        auto& type_ops_map = GetTypeOperationMap();
-        auto it = type_ops_map.find(type_name);
-        if (it != type_ops_map.end())
         {
             return it->second.get();
         }
@@ -695,7 +661,7 @@ class RustBoxedCallable<void,
                                                                                    event_type,                    \
                                                                                    &ProxyType::event_member,      \
                                                                                    &SkeletonType::event_member>>( \
-                    &s_shared_type_ops); /* ← Pass shared instance */                                             \
+                    &s_shared_type_ops);                                                                          \
                                                                                                                   \
             ::score::mw::com::impl::rust::GlobalRegistryMapping::RegisterMemberOperation(                         \
                 std::string_view(id_interface), std::string_view(#event_member), std::move(event_info));          \
@@ -706,9 +672,9 @@ class RustBoxedCallable<void,
 
 #define END_EXPORT_MW_COM_INTERFACE() }  // namespace id##_detail
 
-/// \brief Macro to register type operations
-/// \details Creates registry for type operations for a specific type name. Specializes the
-/// RustRefMutCallable template and uses a static struct to register type operations at startup/before main().
+/// \brief Macro to create type specific class and support functions
+/// \details RustRefMutCallable template is specialized for SamplePtr<type> to allow C++ to call Rust closures with
+/// type-erased sample pointers.
 /// \param type_tag Type name tag used in macros as the registry key
 /// \param type Actual C++ type for which operations are registered
 /// \note Example usage: EXPORT_MW_COM_TYPE(TireType, Tire)
@@ -727,19 +693,8 @@ class RustBoxedCallable<void,
             ::score::mw::com::impl::rust::mw_com_impl_call_dyn_ref_fnmut_sample(&ptr_, placement_sample);     \
         }                                                                                                     \
         static void dispose(::score::mw::com::impl::rust::FatPtr) noexcept {}                                 \
-    };                                                                                                        \
-                                                                                                              \
-    struct type_tag##_TypeRegistrationHelper                                                                  \
-    {                                                                                                         \
-        type_tag##_TypeRegistrationHelper()                                                                   \
-        {                                                                                                     \
-            auto type_ops = std::make_unique<::score::mw::com::impl::rust::TypeOperationImpl<type>>();        \
-            ::score::mw::com::impl::rust::GlobalRegistryMapping::RegisterTypeOperation(#type_tag,             \
-                                                                                       std::move(type_ops));  \
-        }                                                                                                     \
-    };                                                                                                        \
-                                                                                                              \
-    static type_tag##_TypeRegistrationHelper type_tag##_type_reg_instance;
+    };
+
 }  // namespace score::mw::com::impl::rust
 
 #endif  // SCORE_MW_COM_REGISTRY_BRIDGE_MACROS_H

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.h
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.h
@@ -143,50 +143,52 @@ class TypeOperations
     /// \param max_sample Maximum number of samples to process
     /// \param callBack FatPtr of Rust FnMut callable that takes SamplePtr<T>
     /// \return Result containing the number of samples processed on success, or error code on failure
-    virtual Result<uint32_t> GetSamplesFromEvent(ProxyEventBase* event_ptr, uint32_t max_sample, FatPtr callBack) = 0;
+    virtual Result<uint32_t> GetSamplesFromEvent(ProxyEventBase* event_ptr,
+                                                 uint32_t max_sample,
+                                                 FatPtr callBack) const = 0;
 
     /// \brief Send event data through SkeletonEvent of specific type
     /// \details Casts the type-erased data pointer back to the actual type and sends it via SkeletonEvent.
     /// \param event_ptr Pointer to SkeletonEventBase instance
     /// \param data_ptr Pointer to type T (erased as void*, casted back to T* in implementation)
     /// \return true if send successful, false otherwise
-    virtual bool SkeletonSendEvent(SkeletonEventBase* event_ptr, void* data_ptr) = 0;
+    virtual bool SkeletonSendEvent(SkeletonEventBase* event_ptr, void* data_ptr) const = 0;
 
     /// \brief Get data pointer from SamplePtr of specific type
     /// \details Casts the type-erased SamplePtr back to SamplePtr<T> and retrieves the underlying data pointer.
     /// \param sample_ptr Pointer to type-erased SamplePtr
     /// \return Pointer to the underlying data of type T
-    virtual const void* GetSamplePtrData(const void* sample_ptr) = 0;
+    virtual const void* GetSamplePtrData(const void* sample_ptr) const = 0;
 
     /// \brief Delete SamplePtr of specific type
     /// \details Casts the type-erased SamplePtr back to SamplePtr<T> and deletes it properly.
     /// \param sample_ptr Pointer to type-erased SamplePtr
-    virtual void DeleteSamplePtr(void* sample_ptr) = 0;
+    virtual void DeleteSamplePtr(void* sample_ptr) const = 0;
 
     /// @brief Get allocatee pointer from SkeletonEvent of specific type
     /// \details Allocates a SampleAllocateePtr<T> from the SkeletonEvent and places it into the provided storage.
     /// \param event_ptr Pointer to SkeletonEventBase instance
     /// \param allocatee_ptr Pointer to storage for SampleAllocateePtr<T>
     /// \return true if allocation successful, false otherwise
-    virtual bool GetAllocateePtr(SkeletonEventBase* event_ptr, void* allocatee_ptr) = 0;
+    virtual bool GetAllocateePtr(SkeletonEventBase* event_ptr, void* allocatee_ptr) const = 0;
 
     /// \brief Get data pointer from SampleAllocateePtr of specific type
     /// \details Casts the type-erased SampleAllocateePtr back to SampleAllocateePtr<T>
     /// \param allocatee_ptr Pointer to SampleAllocateePtr<T>
     /// \return Pointer to the underlying data of type T
-    virtual void* GetAllocateeDataPtr(void* allocatee_ptr) = 0;
+    virtual void* GetAllocateeDataPtr(void* allocatee_ptr) const = 0;
 
     /// \brief Delete SampleAllocateePtr of specific type
     /// \details Casts the type-erased SampleAllocateePtr back to SampleAllocateePtr<T> and deletes it properly.
     /// \param allocatee_ptr Pointer to type-erased SampleAllocateePtr
-    virtual void DeleteAllocateePtr(void* allocatee_ptr) = 0;
+    virtual void DeleteAllocateePtr(void* allocatee_ptr) const = 0;
 
     /// @brief Send allocatee data through SkeletonEvent of specific type
     /// \details Casts the type-erased allocatee pointer back to SampleAllocateePtr<T> and sends it via SkeletonEvent.
     /// \param event_ptr Pointer to SkeletonEventBase instance
     /// \param allocatee_ptr Pointer SampleAllocateePtr (of type T)
     /// \return true if send successful, false otherwise
-    virtual bool SkeletonSendEventAllocatee(SkeletonEventBase* event_ptr, void* allocatee_ptr) = 0;
+    virtual bool SkeletonSendEventAllocatee(SkeletonEventBase* event_ptr, void* allocatee_ptr) const = 0;
 };
 
 /// \brief Template implementation of TypeOperations for a specific type T
@@ -196,7 +198,7 @@ template <typename T>
 class TypeOperationImpl : public TypeOperations
 {
   public:
-    Result<uint32_t> GetSamplesFromEvent(ProxyEventBase* event_ptr, uint32_t max_sample, FatPtr callBack) override
+    Result<uint32_t> GetSamplesFromEvent(ProxyEventBase* event_ptr, uint32_t max_sample, FatPtr callBack) const override
     {
         auto proxy_event = dynamic_cast<ProxyEvent<T>*>(event_ptr);
         if (proxy_event == nullptr)
@@ -206,7 +208,7 @@ class TypeOperationImpl : public TypeOperations
         return details::GetSamplesFromEvent<T>(*proxy_event, callBack, max_sample);
     }
 
-    bool SkeletonSendEvent(SkeletonEventBase* event_ptr, void* data_ptr) override
+    bool SkeletonSendEvent(SkeletonEventBase* event_ptr, void* data_ptr) const override
     {
 
         auto skeleton_event = dynamic_cast<SkeletonEvent<T>*>(event_ptr);
@@ -223,7 +225,7 @@ class TypeOperationImpl : public TypeOperations
         return skeleton_event->Send(*typed_data).has_value();
     }
 
-    const void* GetSamplePtrData(const void* sample_ptr) override
+    const void* GetSamplePtrData(const void* sample_ptr) const override
     {
         if (sample_ptr == nullptr)
             return nullptr;
@@ -232,7 +234,7 @@ class TypeOperationImpl : public TypeOperations
         return typed_ptr->Get();
     }
 
-    void DeleteSamplePtr(void* sample_ptr) override
+    void DeleteSamplePtr(void* sample_ptr) const override
     {
         if (sample_ptr == nullptr)
             return;
@@ -241,7 +243,7 @@ class TypeOperationImpl : public TypeOperations
         typed_ptr->~SamplePtr<T>();
     }
 
-    bool GetAllocateePtr(SkeletonEventBase* event_ptr, void* allocatee_ptr) override
+    bool GetAllocateePtr(SkeletonEventBase* event_ptr, void* allocatee_ptr) const override
     {
         if (event_ptr == nullptr)
         {
@@ -263,7 +265,7 @@ class TypeOperationImpl : public TypeOperations
         return true;
     }
 
-    void DeleteAllocateePtr(void* allocatee_ptr) override
+    void DeleteAllocateePtr(void* allocatee_ptr) const override
     {
         if (allocatee_ptr == nullptr)
         {
@@ -274,7 +276,7 @@ class TypeOperationImpl : public TypeOperations
         typed_ptr->~SampleAllocateePtr<T>();
     }
 
-    void* GetAllocateeDataPtr(void* allocatee_ptr) override
+    void* GetAllocateeDataPtr(void* allocatee_ptr) const override
     {
         if (allocatee_ptr == nullptr)
         {
@@ -285,7 +287,7 @@ class TypeOperationImpl : public TypeOperations
         return typed_ptr->Get();
     }
 
-    bool SkeletonSendEventAllocatee(SkeletonEventBase* event_ptr, void* allocatee_ptr) override
+    bool SkeletonSendEventAllocatee(SkeletonEventBase* event_ptr, void* allocatee_ptr) const override
     {
         if (event_ptr == nullptr || allocatee_ptr == nullptr)
         {
@@ -321,7 +323,7 @@ class MemberOperation
 
     /// \brief Get TypeOperations for type-erased sample handling
     /// \return Pointer to TypeOperations instance for the event data type
-    virtual TypeOperations* GetTypeOps() = 0;
+    virtual const TypeOperations* GetTypeOps() const noexcept = 0;
 };
 
 /// \brief Template implementation of MemberOperation for specific ProxyType and SkeletonType
@@ -336,7 +338,7 @@ class MemberOperationImpl : public MemberOperation
 {
   public:
     /// Constructor to cache TypeOperations pointer for efficient member access
-    explicit MemberOperationImpl(TypeOperations* type_ops) : type_ops_ptr_(type_ops) {}
+    explicit MemberOperationImpl(const TypeOperations* type_ops) noexcept : type_ops_ptr_{type_ops} {}
 
     ProxyEventBase* GetProxyEvent(ProxyBase* proxy_ptr) override
     {
@@ -365,13 +367,13 @@ class MemberOperationImpl : public MemberOperation
         return static_cast<SkeletonEventBase*>(&(skeleton->*skeleton_event_member));
     }
 
-    TypeOperations* GetTypeOps() override
+    const TypeOperations* GetTypeOps() const noexcept override
     {
         return type_ops_ptr_;
     }
 
   private:
-    TypeOperations* type_ops_ptr_;
+    const TypeOperations* type_ops_ptr_;
 };
 
 /// \brief Interface for type-erased proxy and skeleton creation operations

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -355,7 +355,9 @@ impl<T: CommData + Debug, B: FFIBridge> Subscriber<T, LolaRuntimeImpl<B>>
         }
         let type_ops = unsafe {
             self.instance_info.bridge.get_type_ops_instance(self.instance_info.interface_id, self.identifier)
-        };
+        }
+        .ok_or(Error::EventError(EventFailedReason::EventNotAvailable))?;
+
         // Store in SubscriberImpl with event, max_num_samples
         Ok(SubscriberImpl {
             event: ProxyEventManager::new(

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -828,6 +828,7 @@ impl<'a, T: CommData + Debug, B: FFIBridge> Stream for SampleStream<'a, T, B> {
             &mut this.sample_container,
             max_num_samples,
             max_num_samples,
+            &this.subscriber.type_ops,
         );
 
         match samples_received {

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -354,7 +354,9 @@ impl<T: CommData + Debug, B: FFIBridge> Subscriber<T, LolaRuntimeImpl<B>>
             return Err(Error::EventError(EventFailedReason::EventNotAvailable));
         }
         let type_ops = unsafe {
-            self.instance_info.bridge.get_type_ops_instance(self.instance_info.interface_id, self.identifier)
+            self.instance_info
+                .bridge
+                .get_type_ops_instance(self.instance_info.interface_id, self.identifier)
         }
         .ok_or(Error::EventError(EventFailedReason::EventNotAvailable))?;
 
@@ -519,10 +521,9 @@ impl<T: CommData + Debug, B: FFIBridge> SubscriberImpl<T, B> {
         // and the lifetime of the callback is managed by Rust, it will not outlive the scope of
         // this function call.
         let status = unsafe {
-            self.instance_info.bridge.set_event_receive_handler(
-                event_guard.deref_mut(),
-                &fat_ptr,
-            )
+            self.instance_info
+                .bridge
+                .set_event_receive_handler(event_guard.deref_mut(), &fat_ptr)
         };
         if !status {
             // SAFETY: ptr was allocated as Box<dyn FnMut() + Send + 'static> via Box::into_raw
@@ -667,7 +668,7 @@ where
                 total_received: 0,
                 cancellation: core::pin::pin!(cancellation),
                 bridge: self.instance_info.bridge.clone(),
-                type_ops: Some(self.type_ops.clone()),
+                type_ops: self.type_ops.clone(),
             }
             .await
         }
@@ -704,8 +705,7 @@ struct ReceiveFuture<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBrid
     total_received: usize,
     cancellation: Pin<&'a mut F>,
     bridge: B,
-    // We need to store in Option because of borrow checker issues in poll method.
-    type_ops: Option<TypeOperationsManager>,
+    type_ops: TypeOperationsManager,
 }
 
 impl<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBridge> Future
@@ -714,12 +714,11 @@ impl<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBridge> Future
     type Output = (SampleContainer<Sample<T, B>>, Result<usize>);
 
     fn poll(mut self: Pin<&mut Self>, ctx: &mut Context<'_>) -> Poll<Self::Output> {
-        // Extract all immutable values upfront to avoid borrow conflicts with self in the callback
+        // Extract Copy values upfront, the rest are accessed via `this` below.
         let max_samples = self.max_samples;
         let new_samples = self.new_samples;
         let max_num_samples = self.max_num_samples;
         let total_received = self.total_received;
-        let bridge = self.bridge.clone();
 
         // Poll the cancellation future first to ensure prompt handling of cancellation requests.
         if self.cancellation.as_mut().poll(ctx).is_ready() {
@@ -735,55 +734,46 @@ impl<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBridge> Future
         // Register the current waker to be notified when new samples arrive via FFI callback
         self.waker_storage.register(ctx.waker());
 
-        let samples_received = {
-            // Take type_ops FIRST, before any other borrows
-            if let Some(type_ops) = self.type_ops.take() {
-                // Temporarily take ownership of scratch to avoid borrow issues
-                if let Some(mut scratch) = self.scratch.take() {
-                    if let Some(event_guard) = self.event_guard.as_mut() {
-                        let result = try_receive_samples::<T,B>(
-                            &bridge,
-                            event_guard.deref_mut(),
-                            &mut scratch,
-                            max_num_samples,
-                            max_samples - total_received,
-                            &type_ops,
-                        );
-                        self.scratch = Some(scratch);
-                        self.type_ops = Some(type_ops);
-                        result
-                    } else {
-                        Err(Error::ReceiveError(ReceiveFailedReason::ReceiveError))
-                    }
-                } else {
-                    Err(Error::ReceiveError(ReceiveFailedReason::BufferUnavailable))
-                }
-            } else {
-                Err(Error::ReceiveError(ReceiveFailedReason::ReceiveError))
-            }
+        // Use get_mut() to split-borrow multiple fields simultaneously, mirroring the approach
+        // used in poll_next. This avoids the scratch take, instead of moving
+        // `scratch` out of the Option, then putting it back, we borrow it in-place via as_mut().
+        let this = self.as_mut().get_mut();
+
+        let samples_received = match (this.scratch.as_mut(), this.event_guard.as_mut()) {
+            (Some(scratch), Some(event_guard)) => try_receive_samples::<T, B>(
+                &this.bridge,
+                event_guard.deref_mut(),
+                scratch,
+                max_num_samples,
+                max_samples - total_received,
+                &this.type_ops,
+            ),
+            (None, _) => Err(Error::ReceiveError(ReceiveFailedReason::BufferUnavailable)),
+            (_, None) => Err(Error::ReceiveError(ReceiveFailedReason::ReceiveError)),
         };
+
         match samples_received {
             Ok(count) => {
-                self.total_received += count;
-
+                this.total_received += count;
                 // Check if we've received enough samples
-                if self.total_received >= new_samples {
+                if this.total_received >= new_samples {
                     // Release the event guard to allow new receive calls to access the proxy event
-                    self.event_guard = None;
-                    return Poll::Ready((
-                        self.scratch.take().expect(
+                    this.event_guard = None;
+                    Poll::Ready((
+                        this.scratch.take().expect(
                             "SampleContainer is not available when returning Future result",
                         ),
-                        Ok(self.total_received),
-                    ));
+                        Ok(this.total_received),
+                    ))
+                } else {
+                    // Have some samples but not enough yet, wait for more via waker
+                    Poll::Pending
                 }
-                // Have some samples but not enough yet, wait for more via waker
-                Poll::Pending
             }
             Err(e) => {
-                self.event_guard = None;
+                this.event_guard = None;
                 Poll::Ready((
-                    self.scratch.take().expect(
+                    this.scratch.take().expect(
                         "SampleContainer unavailable on error; was receive polled after completion?",
                     ),
                     Err(e),
@@ -1164,13 +1154,13 @@ fn try_receive_samples<T: CommData + Debug, B: FFIBridge>(
             event as *mut ProxyEventBase,
             type_ops,
             &fat_ptr,
-            max_num_samples as u32,
+            max_samples as u32,
         )
     };
-    if count > max_num_samples as u32 {
+    if count > max_samples as u32 {
         return Err(Error::ReceiveError(
             ReceiveFailedReason::SampleCountOutOfBounds {
-                max: max_num_samples,
+                max: max_samples,
                 requested: count as usize,
             },
         ));
@@ -1300,9 +1290,13 @@ mod test {
         mock.expect_subscribe_to_event()
             .in_sequence(&mut seq)
             .returning(|_, _| true);
-         mock.expect_get_type_ops_instance()
+        mock.expect_get_type_ops_instance()
             .in_sequence(&mut seq)
-            .returning(move |_,_| Some(TypeOperationsManager::new(NonNull::new(type_ops_alloc.allocate()).unwrap())));
+            .returning(move |_, _| {
+                Some(TypeOperationsManager::new(
+                    NonNull::new(type_ops_alloc.allocate()).unwrap(),
+                ))
+            });
 
         let evt_cleanup = event_alloc.clone();
         mock.expect_unsubscribe_to_event()
@@ -1365,9 +1359,13 @@ mod test {
         mock.expect_subscribe_to_event()
             .in_sequence(&mut seq)
             .returning(|_, _| true);
-         mock.expect_get_type_ops_instance()
+        mock.expect_get_type_ops_instance()
             .in_sequence(&mut seq)
-            .returning(move |_,_| Some(TypeOperationsManager::new(NonNull::new(type_ops_alloc.allocate()).unwrap())));
+            .returning(move |_, _| {
+                Some(TypeOperationsManager::new(
+                    NonNull::new(type_ops_alloc.allocate()).unwrap(),
+                ))
+            });
         mock.expect_get_samples_from_event()
             .in_sequence(&mut seq)
             .returning(|_, _, _, _| 1);
@@ -1416,5 +1414,60 @@ mod test {
             count, 1,
             "one sample should be returned by try_receive when the mock event has one sample"
         );
+    }
+
+    // Verify that `subscribe` returns `EventNotAvailable` when `get_type_ops_instance`
+    // returns `None`. The proxy must still be destroyed to avoid a resource leak.
+    #[test]
+    fn test_subscribe_type_ops_none_returns_event_not_available() {
+        let mut mock = MockFFIBridge::new();
+        let mut seq = mockall::Sequence::new();
+        let proxy_alloc = MockPointerAllocator::<ProxyBase>::new();
+        let event_alloc = MockPointerAllocator::<ProxyEventBase>::new();
+        let prox = proxy_alloc.clone();
+        let evt = event_alloc.clone();
+
+        mock.expect_create_proxy()
+            .in_sequence(&mut seq)
+            .returning(move |_, _| prox.allocate());
+        mock.expect_get_event_from_proxy()
+            .in_sequence(&mut seq)
+            .returning(move |_, _, _| evt.allocate());
+        mock.expect_subscribe_to_event()
+            .in_sequence(&mut seq)
+            .returning(|_, _| true);
+        // Returning None here is the scenario under test, TypeOperations lookup failed.
+        mock.expect_get_type_ops_instance()
+            .in_sequence(&mut seq)
+            .returning(|_, _| None);
+
+        let prox_cleanup = proxy_alloc.clone();
+        mock.expect_destroy_proxy()
+            .in_sequence(&mut seq)
+            .returning(move |ptr| {
+                assert!(
+                    prox_cleanup.free(ptr),
+                    "destroy_proxy called with unknown pointer"
+                );
+            });
+
+        let bridge = SharedMockBridge::new(mock);
+        let subscribable = SubscribableImpl::<TestData, SharedMockBridge> {
+            identifier: "TestEvent",
+            instance_info: make_instance_info(bridge.clone()),
+            proxy_instance: make_proxy_instance(bridge.clone(), "TestInterface"),
+            data: PhantomData,
+        };
+
+        let result = subscribable.subscribe(3);
+        assert!(
+            matches!(
+                result,
+                Err(Error::EventError(EventFailedReason::EventNotAvailable))
+            ),
+            "subscribe must return EventNotAvailable when get_type_ops_instance returns None"
+        );
+
+        proxy_alloc.assert_all_freed();
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -702,6 +702,7 @@ struct ReceiveFuture<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBrid
     total_received: usize,
     cancellation: Pin<&'a mut F>,
     bridge: B,
+    // We need to store in Option because of borrow checker issues in poll method.
     type_ops: Option<TypeOperationsManager>,
 }
 

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -1287,6 +1287,7 @@ mod test {
         let mut seq = mockall::Sequence::new();
         let proxy_alloc = MockPointerAllocator::<ProxyBase>::new();
         let event_alloc = MockPointerAllocator::<ProxyEventBase>::new();
+        let type_ops_alloc = MockPointerAllocator::<TypeOperations>::new();
         let prox = proxy_alloc.clone();
         let evt = event_alloc.clone();
 
@@ -1299,6 +1300,9 @@ mod test {
         mock.expect_subscribe_to_event()
             .in_sequence(&mut seq)
             .returning(|_, _| true);
+         mock.expect_get_type_ops_instance()
+            .in_sequence(&mut seq)
+            .returning(move |_,_| Some(TypeOperationsManager::new(NonNull::new(type_ops_alloc.allocate()).unwrap())));
 
         let evt_cleanup = event_alloc.clone();
         mock.expect_unsubscribe_to_event()
@@ -1345,6 +1349,7 @@ mod test {
     fn test_event_try_receive() {
         let proxy_alloc = MockPointerAllocator::<ProxyBase>::new();
         let event_alloc = MockPointerAllocator::<ProxyEventBase>::new();
+        let type_ops_alloc = MockPointerAllocator::<TypeOperations>::new();
         let mut seq = mockall::Sequence::new();
         let mut mock = MockFFIBridge::new();
 
@@ -1360,15 +1365,18 @@ mod test {
         mock.expect_subscribe_to_event()
             .in_sequence(&mut seq)
             .returning(|_, _| true);
+         mock.expect_get_type_ops_instance()
+            .in_sequence(&mut seq)
+            .returning(move |_,_| Some(TypeOperationsManager::new(NonNull::new(type_ops_alloc.allocate()).unwrap())));
         mock.expect_get_samples_from_event()
             .in_sequence(&mut seq)
             .returning(|_, _, _, _| 1);
         mock.expect_set_event_receive_handler()
             .in_sequence(&mut seq)
-            .returning(|_, _, _| true);
+            .returning(|_, _| true);
         mock.expect_clear_event_receive_handler()
             .in_sequence(&mut seq)
-            .returning(|_, _| ());
+            .returning(|_| ());
 
         mock.expect_unsubscribe_to_event()
             .in_sequence(&mut seq)

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -1294,7 +1294,8 @@ mod test {
             .in_sequence(&mut seq)
             .returning(move |_, _| {
                 Some(TypeOperationsManager::new(
-                    NonNull::new(type_ops_alloc.allocate()).unwrap(),
+                    NonNull::new(type_ops_alloc.allocate())
+                        .expect("Failed to allocate TypeOperations for mock"),
                 ))
             });
 
@@ -1363,7 +1364,8 @@ mod test {
             .in_sequence(&mut seq)
             .returning(move |_, _| {
                 Some(TypeOperationsManager::new(
-                    NonNull::new(type_ops_alloc.allocate()).unwrap(),
+                    NonNull::new(type_ops_alloc.allocate())
+                        .expect("Failed to allocate TypeOperations for mock"),
                 ))
             });
         mock.expect_get_samples_from_event()

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -82,6 +82,7 @@ where
 {
     data: ManuallyDrop<sample_ptr_rs::SamplePtr<T>>,
     bridge: B,
+    type_ops: TypeOperationsManager,
 }
 
 impl<T, B: FFIBridge> Drop for LolaBinding<T, B>
@@ -95,7 +96,7 @@ where
             let mut sample_ptr = ManuallyDrop::take(&mut self.data);
             self.bridge.sample_ptr_delete(
                 std::ptr::from_mut(&mut sample_ptr) as *mut std::ffi::c_void,
-                T::ID,
+                &self.type_ops,
             );
         }
     }
@@ -124,7 +125,7 @@ where
         unsafe {
             let data_ptr = self.inner.bridge.sample_ptr_get(
                 std::ptr::from_ref(&(*self.inner.data)) as *const std::ffi::c_void,
-                T::ID,
+                &self.inner.type_ops,
             );
             (data_ptr as *const T)
                 .as_ref()
@@ -352,6 +353,9 @@ impl<T: CommData + Debug, B: FFIBridge> Subscriber<T, LolaRuntimeImpl<B>>
         if !status {
             return Err(Error::EventError(EventFailedReason::EventNotAvailable));
         }
+        let type_ops = unsafe {
+            self.instance_info.bridge.get_type_ops_instance(self.instance_info.interface_id, self.identifier)
+        };
         // Store in SubscriberImpl with event, max_num_samples
         Ok(SubscriberImpl {
             event: ProxyEventManager::new(
@@ -362,6 +366,7 @@ impl<T: CommData + Debug, B: FFIBridge> Subscriber<T, LolaRuntimeImpl<B>>
             instance_info,
             waker_storage: Arc::default(),
             async_init_status: std::sync::OnceLock::new(),
+            type_ops,
             _proxy: self.proxy_instance.clone(),
             _phantom: PhantomData,
         })
@@ -468,6 +473,7 @@ where
     instance_info: LolaConsumerInfo<B>,
     waker_storage: Arc<AtomicWaker>,
     async_init_status: std::sync::OnceLock<()>,
+    type_ops: TypeOperationsManager,
     _proxy: ProxyInstanceManager<B>,
     _phantom: PhantomData<T>,
 }
@@ -486,7 +492,7 @@ impl<T: CommData + Debug, B: FFIBridge> Drop for SubscriberImpl<T, B> {
             {
                 self.instance_info
                     .bridge
-                    .clear_event_receive_handler(guard.deref_mut(), T::ID);
+                    .clear_event_receive_handler(guard.deref_mut());
             }
             self.instance_info
                 .bridge
@@ -514,7 +520,6 @@ impl<T: CommData + Debug, B: FFIBridge> SubscriberImpl<T, B> {
             self.instance_info.bridge.set_event_receive_handler(
                 event_guard.deref_mut(),
                 &fat_ptr,
-                T::ID,
             )
         };
         if !status {
@@ -613,6 +618,7 @@ where
             scratch,
             self.max_num_samples,
             max_samples,
+            &self.type_ops,
         )
     }
 
@@ -659,6 +665,7 @@ where
                 total_received: 0,
                 cancellation: core::pin::pin!(cancellation),
                 bridge: self.instance_info.bridge.clone(),
+                type_ops: Some(self.type_ops.clone()),
             }
             .await
         }
@@ -695,6 +702,7 @@ struct ReceiveFuture<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBrid
     total_received: usize,
     cancellation: Pin<&'a mut F>,
     bridge: B,
+    type_ops: Option<TypeOperationsManager>,
 }
 
 impl<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBridge> Future
@@ -725,25 +733,30 @@ impl<'a, T: CommData + Debug, F: Future<Output = ()>, B: FFIBridge> Future
         self.waker_storage.register(ctx.waker());
 
         let samples_received = {
-            // Temporarily take ownership of scratch to avoid borrow checker conflicts
-            // when passing to try_receive_samples
-            if let Some(mut scratch) = self.scratch.take() {
-                if let Some(event_guard) = self.event_guard.as_mut() {
-                    let result = try_receive_samples::<T, B>(
-                        &bridge,
-                        event_guard.deref_mut(),
-                        &mut scratch,
-                        max_num_samples,
-                        max_samples - total_received,
-                    );
-                    self.scratch = Some(scratch);
-                    result
+            // Take type_ops FIRST, before any other borrows
+            if let Some(type_ops) = self.type_ops.take() {
+                // Temporarily take ownership of scratch to avoid borrow issues
+                if let Some(mut scratch) = self.scratch.take() {
+                    if let Some(event_guard) = self.event_guard.as_mut() {
+                        let result = try_receive_samples::<T,B>(
+                            &bridge,
+                            event_guard.deref_mut(),
+                            &mut scratch,
+                            max_num_samples,
+                            max_samples - total_received,
+                            &type_ops,
+                        );
+                        self.scratch = Some(scratch);
+                        self.type_ops = Some(type_ops);
+                        result
+                    } else {
+                        Err(Error::ReceiveError(ReceiveFailedReason::ReceiveError))
+                    }
                 } else {
-                    self.scratch = Some(scratch);
-                    Err(Error::ReceiveError(ReceiveFailedReason::ReceiveError))
+                    Err(Error::ReceiveError(ReceiveFailedReason::BufferUnavailable))
                 }
             } else {
-                Err(Error::ReceiveError(ReceiveFailedReason::BufferUnavailable))
+                Err(Error::ReceiveError(ReceiveFailedReason::ReceiveError))
             }
         };
         match samples_received {
@@ -1115,6 +1128,7 @@ fn try_receive_samples<T: CommData + Debug, B: FFIBridge>(
     scratch: &mut SampleContainer<Sample<T, B>>,
     max_num_samples: usize,
     max_samples: usize,
+    type_ops: &TypeOperationsManager,
 ) -> Result<usize> {
     if max_samples == 0 {
         return Err(Error::ReceiveError(
@@ -1133,7 +1147,7 @@ fn try_receive_samples<T: CommData + Debug, B: FFIBridge>(
         ));
     }
     // Create a callback that will be called by the C++ side for each new sample arrival
-    let mut callback = create_sample_callback::<T, B>(bridge, scratch, max_samples);
+    let mut callback = create_sample_callback::<T, B>(bridge, scratch, max_samples, type_ops);
     // Convert closure to FatPtr for C++ callback
     let dyn_callback: &mut dyn FnMut(*mut sample_ptr_rs::SamplePtr<T>) = &mut callback;
     // SAFETY: it is safe to transmute the closure reference to a FatPtr because
@@ -1144,7 +1158,7 @@ fn try_receive_samples<T: CommData + Debug, B: FFIBridge>(
     let count = unsafe {
         bridge.get_samples_from_event(
             event as *mut ProxyEventBase,
-            T::ID,
+            type_ops,
             &fat_ptr,
             max_num_samples as u32,
         )
@@ -1177,6 +1191,7 @@ pub fn create_sample_callback<'a, T: CommData + Debug, B: FFIBridge>(
     bridge: &B,
     scratch: &'a mut SampleContainer<Sample<T, B>>,
     max_samples: usize,
+    type_ops: &'a TypeOperationsManager,
 ) -> impl FnMut(*mut sample_ptr_rs::SamplePtr<T>) + 'a {
     let bridge = bridge.clone();
     move |raw_sample: *mut sample_ptr_rs::SamplePtr<T>| {
@@ -1192,6 +1207,7 @@ pub fn create_sample_callback<'a, T: CommData + Debug, B: FFIBridge>(
                 inner: LolaBinding {
                     data: ManuallyDrop::new(sample_ptr),
                     bridge: bridge.clone(),
+                    type_ops: type_ops.clone(),
                 },
             };
 

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -30,6 +30,7 @@
 #![allow(clippy::needless_lifetimes)]
 
 use crate::Debug;
+use core::clone::Clone;
 use core::future::Future;
 use core::marker::PhantomData;
 use core::mem::ManuallyDrop;
@@ -668,7 +669,7 @@ where
                 total_received: 0,
                 cancellation: core::pin::pin!(cancellation),
                 bridge: self.instance_info.bridge.clone(),
-                type_ops: self.type_ops.clone(),
+                type_ops: self.type_ops,
             }
             .await
         }

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
@@ -623,7 +623,8 @@ mod test {
             .in_sequence(&mut seq)
             .returning(move |_, _| {
                 Some(TypeOperationsManager::new(
-                    NonNull::new(type_ops_alloc.allocate()).unwrap(),
+                    NonNull::new(type_ops_alloc.allocate())
+                        .expect("Failed to allocate TypeOperations for mock"),
                 ))
             });
 

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
@@ -604,6 +604,7 @@ mod test {
     fn test_publisher_allocate_and_send() {
         let skeleton_alloc = MockPointerAllocator::<SkeletonBase>::new();
         let event_alloc = MockPointerAllocator::<SkeletonEventBase>::new();
+        let type_ops_alloc = MockPointerAllocator::<TypeOperations>::new();
         let data_alloc = MockPointerAllocator::<TestData>::new();
         let mut seq = Sequence::new();
         let mut mock = MockFFIBridge::new();
@@ -616,6 +617,9 @@ mod test {
         mock.expect_get_event_from_skeleton()
             .in_sequence(&mut seq)
             .returning(move |_, _, _| event_alloc_clone.allocate());
+        mock.expect_get_type_ops_instance()
+            .in_sequence(&mut seq)
+            .returning(move |_,_| Some(TypeOperationsManager::new(NonNull::new(type_ops_alloc.allocate()).unwrap())));
 
         mock.expect_get_allocatee_ptr()
             .in_sequence(&mut seq)

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
@@ -448,13 +448,12 @@ where
         })
     }
 
-    fn new(identifier: &str, instance_info: LolaProviderInfo<B>) -> Result<Self> {
+   fn new(identifier: &str, instance_info: LolaProviderInfo<B>) -> Result<Self> {
         let skeleton_event = NativeSkeletonEventBase::new::<B>(&instance_info, identifier)?;
         let type_ops = unsafe {
             instance_info
-                .bridge
-                .get_type_ops_instance(instance_info.interface_id, identifier)
-        };
+                .bridge.get_type_ops_instance(instance_info.interface_id, identifier) }
+                .ok_or(Error::EventError(EventFailedReason::EventNotAvailable))?;
         Ok(Self {
             skeleton_event,
             type_ops,

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
@@ -133,7 +133,6 @@ where
 {
     skeleton_event: NativeSkeletonEventBase,
     allocatee_ptr: AllocateePtrWrapper<T, B>,
-    type_ops: TypeOperationsManager,
     lifetime: PhantomData<&'a T>,
 }
 
@@ -147,7 +146,7 @@ where
         unsafe {
             let data_ptr = self.allocatee_ptr.bridge.get_allocatee_data_ptr(
                 std::ptr::from_ref(&(*self.allocatee_ptr.inner)) as *const std::ffi::c_void,
-                &self.type_ops,
+                &self.allocatee_ptr.type_ops,
             );
             (data_ptr as *const T).as_ref()
         }
@@ -159,7 +158,7 @@ where
         unsafe {
             let data_ptr = self.allocatee_ptr.bridge.get_allocatee_data_ptr(
                 std::ptr::from_mut(&mut (*self.allocatee_ptr.inner)) as *mut std::ffi::c_void,
-                &self.type_ops,
+                &self.allocatee_ptr.type_ops,
             );
             (data_ptr as *mut T).as_mut()
         }
@@ -198,13 +197,13 @@ where
         // We've taken ownership via self (consumed, not borrowed), and
         // FFI call will complete before drop run on AllocateePtrWrapper and NativeSkeletonEventBase
         let status = unsafe {
-            self.allocatee_ptr
+          self.allocatee_ptr
                 .bridge
                 .skeleton_event_send_sample_allocatee(
-                    self.skeleton_event.skeleton_event_ptr.as_ptr(),
-                    &self.type_ops,
-                    std::ptr::from_ref(self.allocatee_ptr.as_ref()) as *const std::ffi::c_void,
-                )
+                self.skeleton_event.skeleton_event_ptr.as_ptr(),
+                &self.allocatee_ptr.type_ops,
+                std::ptr::from_ref(self.allocatee_ptr.as_ref()) as *const std::ffi::c_void,
+            )
         };
         if !status {
             return Err(Error::EventError(EventFailedReason::SendingDataFailed));
@@ -220,7 +219,6 @@ where
 {
     skeleton_event: NativeSkeletonEventBase,
     allocatee_ptr: AllocateePtrWrapper<T, B>,
-    type_ops: TypeOperationsManager,
     lifetime: PhantomData<&'a T>,
 }
 
@@ -234,7 +232,7 @@ where
         let data_ptr = unsafe {
             self.allocatee_ptr.bridge.get_allocatee_data_ptr(
                 std::ptr::from_ref(self.allocatee_ptr.as_ref()) as *const std::ffi::c_void,
-                &self.type_ops,
+                &self.allocatee_ptr.type_ops,
             ) as *mut core::mem::MaybeUninit<T>
         };
         unsafe { data_ptr.as_mut() }
@@ -259,7 +257,6 @@ where
         SampleMut {
             skeleton_event: self.skeleton_event,
             allocatee_ptr: self.allocatee_ptr,
-            type_ops: self.type_ops,
             lifetime: PhantomData,
         }
     }
@@ -268,7 +265,6 @@ where
         SampleMut {
             skeleton_event: self.skeleton_event,
             allocatee_ptr: self.allocatee_ptr,
-            type_ops: self.type_ops,
             lifetime: PhantomData,
         }
     }
@@ -438,7 +434,6 @@ where
 
         Ok(SampleMaybeUninit {
             skeleton_event: self.skeleton_event.clone(),
-            type_ops: self.type_ops.clone(),
             allocatee_ptr: AllocateePtrWrapper {
                 inner: ManuallyDrop::new(allocatee_ptr),
                 bridge: self.skeleton_instance.0.bridge.clone(),

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
@@ -94,9 +94,9 @@ pub struct AllocateePtrWrapper<T, B: FFIBridge>
 where
     T: CommData + Debug,
 {
-    pub inner: ManuallyDrop<sample_allocatee_ptr_rs::SampleAllocateePtr<T>>,
-    pub bridge: B,
-    pub type_ops: TypeOperationsManager,
+    inner: ManuallyDrop<sample_allocatee_ptr_rs::SampleAllocateePtr<T>>,
+    bridge: B,
+    type_ops: TypeOperationsManager,
 }
 
 impl<T, B: FFIBridge> Drop for AllocateePtrWrapper<T, B>
@@ -197,13 +197,13 @@ where
         // We've taken ownership via self (consumed, not borrowed), and
         // FFI call will complete before drop run on AllocateePtrWrapper and NativeSkeletonEventBase
         let status = unsafe {
-          self.allocatee_ptr
+            self.allocatee_ptr
                 .bridge
                 .skeleton_event_send_sample_allocatee(
-                self.skeleton_event.skeleton_event_ptr.as_ptr(),
-                &self.allocatee_ptr.type_ops,
-                std::ptr::from_ref(self.allocatee_ptr.as_ref()) as *const std::ffi::c_void,
-            )
+                    self.skeleton_event.skeleton_event_ptr.as_ptr(),
+                    &self.allocatee_ptr.type_ops,
+                    std::ptr::from_ref(self.allocatee_ptr.as_ref()) as *const std::ffi::c_void,
+                )
         };
         if !status {
             return Err(Error::EventError(EventFailedReason::SendingDataFailed));
@@ -443,12 +443,14 @@ where
         })
     }
 
-   fn new(identifier: &str, instance_info: LolaProviderInfo<B>) -> Result<Self> {
+    fn new(identifier: &str, instance_info: LolaProviderInfo<B>) -> Result<Self> {
         let skeleton_event = NativeSkeletonEventBase::new::<B>(&instance_info, identifier)?;
         let type_ops = unsafe {
             instance_info
-                .bridge.get_type_ops_instance(instance_info.interface_id, identifier) }
-                .ok_or(Error::EventError(EventFailedReason::EventNotAvailable))?;
+                .bridge
+                .get_type_ops_instance(instance_info.interface_id, identifier)
+        }
+        .ok_or(Error::EventError(EventFailedReason::EventNotAvailable))?;
         Ok(Self {
             skeleton_event,
             type_ops,
@@ -619,7 +621,11 @@ mod test {
             .returning(move |_, _, _| event_alloc_clone.allocate());
         mock.expect_get_type_ops_instance()
             .in_sequence(&mut seq)
-            .returning(move |_,_| Some(TypeOperationsManager::new(NonNull::new(type_ops_alloc.allocate()).unwrap())));
+            .returning(move |_, _| {
+                Some(TypeOperationsManager::new(
+                    NonNull::new(type_ops_alloc.allocate()).unwrap(),
+                ))
+            });
 
         mock.expect_get_allocatee_ptr()
             .in_sequence(&mut seq)

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
@@ -437,7 +437,7 @@ where
             allocatee_ptr: AllocateePtrWrapper {
                 inner: ManuallyDrop::new(allocatee_ptr),
                 bridge: self.skeleton_instance.0.bridge.clone(),
-                type_ops: self.type_ops.clone(),
+                type_ops: self.type_ops,
             },
             lifetime: PhantomData,
         })

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
@@ -96,6 +96,7 @@ where
 {
     pub inner: ManuallyDrop<sample_allocatee_ptr_rs::SampleAllocateePtr<T>>,
     pub bridge: B,
+    pub type_ops: TypeOperationsManager,
 }
 
 impl<T, B: FFIBridge> Drop for AllocateePtrWrapper<T, B>
@@ -109,7 +110,7 @@ where
             let mut allocatee_ptr = ManuallyDrop::take(&mut self.inner);
             self.bridge.delete_allocatee_ptr(
                 std::ptr::from_mut(&mut allocatee_ptr) as *mut std::ffi::c_void,
-                T::ID,
+                &self.type_ops,
             );
         }
     }
@@ -132,6 +133,7 @@ where
 {
     skeleton_event: NativeSkeletonEventBase,
     allocatee_ptr: AllocateePtrWrapper<T, B>,
+    type_ops: TypeOperationsManager,
     lifetime: PhantomData<&'a T>,
 }
 
@@ -145,7 +147,7 @@ where
         unsafe {
             let data_ptr = self.allocatee_ptr.bridge.get_allocatee_data_ptr(
                 std::ptr::from_ref(&(*self.allocatee_ptr.inner)) as *const std::ffi::c_void,
-                T::ID,
+                &self.type_ops,
             );
             (data_ptr as *const T).as_ref()
         }
@@ -157,7 +159,7 @@ where
         unsafe {
             let data_ptr = self.allocatee_ptr.bridge.get_allocatee_data_ptr(
                 std::ptr::from_mut(&mut (*self.allocatee_ptr.inner)) as *mut std::ffi::c_void,
-                T::ID,
+                &self.type_ops,
             );
             (data_ptr as *mut T).as_mut()
         }
@@ -200,7 +202,7 @@ where
                 .bridge
                 .skeleton_event_send_sample_allocatee(
                     self.skeleton_event.skeleton_event_ptr.as_ptr(),
-                    T::ID,
+                    &self.type_ops,
                     std::ptr::from_ref(self.allocatee_ptr.as_ref()) as *const std::ffi::c_void,
                 )
         };
@@ -218,6 +220,7 @@ where
 {
     skeleton_event: NativeSkeletonEventBase,
     allocatee_ptr: AllocateePtrWrapper<T, B>,
+    type_ops: TypeOperationsManager,
     lifetime: PhantomData<&'a T>,
 }
 
@@ -231,7 +234,7 @@ where
         let data_ptr = unsafe {
             self.allocatee_ptr.bridge.get_allocatee_data_ptr(
                 std::ptr::from_ref(self.allocatee_ptr.as_ref()) as *const std::ffi::c_void,
-                T::ID,
+                &self.type_ops,
             ) as *mut core::mem::MaybeUninit<T>
         };
         unsafe { data_ptr.as_mut() }
@@ -256,6 +259,7 @@ where
         SampleMut {
             skeleton_event: self.skeleton_event,
             allocatee_ptr: self.allocatee_ptr,
+            type_ops: self.type_ops,
             lifetime: PhantomData,
         }
     }
@@ -264,6 +268,7 @@ where
         SampleMut {
             skeleton_event: self.skeleton_event,
             allocatee_ptr: self.allocatee_ptr,
+            type_ops: self.type_ops,
             lifetime: PhantomData,
         }
     }
@@ -395,6 +400,7 @@ impl std::fmt::Debug for NativeSkeletonEventBase {
 #[derive(Debug)]
 pub struct Publisher<T, B: FFIBridge> {
     skeleton_event: NativeSkeletonEventBase,
+    type_ops: TypeOperationsManager,
     _data: PhantomData<T>,
     skeleton_instance: SkeletonInstanceManager<B>,
 }
@@ -411,7 +417,7 @@ where
     fn allocate<'a>(&'a self) -> Result<Self::SampleMaybeUninit<'a>> {
         //SAFETY: It is safe to get the allocatee ptr because skeleton_event is valid
         // skeleton_event is created during publisher creation and valid as long as publisher is valid
-        // T::ID is valid as it is associated with CommData type
+        // type_ops is valid as it is created during publisher creation using valid interface id and identifier
         // allocatee_ptr is same type pointer which is allocated for T type and
         // it will be constructed in cpp side and moved back to rust side
         let allocatee_ptr = unsafe {
@@ -420,7 +426,7 @@ where
             let status = self.skeleton_instance.0.bridge.get_allocatee_ptr(
                 self.skeleton_event.skeleton_event_ptr.as_ptr(),
                 sample.as_mut_ptr() as *mut std::ffi::c_void,
-                T::ID,
+                &self.type_ops,
             );
             if !status {
                 return Err(Error::AllocateError(
@@ -432,9 +438,11 @@ where
 
         Ok(SampleMaybeUninit {
             skeleton_event: self.skeleton_event.clone(),
+            type_ops: self.type_ops.clone(),
             allocatee_ptr: AllocateePtrWrapper {
                 inner: ManuallyDrop::new(allocatee_ptr),
                 bridge: self.skeleton_instance.0.bridge.clone(),
+                type_ops: self.type_ops.clone(),
             },
             lifetime: PhantomData,
         })
@@ -442,8 +450,14 @@ where
 
     fn new(identifier: &str, instance_info: LolaProviderInfo<B>) -> Result<Self> {
         let skeleton_event = NativeSkeletonEventBase::new::<B>(&instance_info, identifier)?;
+        let type_ops = unsafe {
+            instance_info
+                .bridge
+                .get_type_ops_instance(instance_info.interface_id, identifier)
+        };
         Ok(Self {
             skeleton_event,
+            type_ops,
             _data: PhantomData,
             skeleton_instance: instance_info.skeleton_handle.clone(),
         })


### PR DESCRIPTION
- Replaces string-based event/type identifiers across C++ and Rust FFI with an opaque` TypeOperations `handle propagated as a Rust `TypeOperationsManager.`

- Adds `mw_com_get_type_ops_instance` and `get_type_ops_instance` , updates all sample/allocatee/event FFI paths to accept/forward `TypeOperations` and removes event-type params from proxy receive-handler APIs.

**Approach:**
Store the `TypeOperations` instance pointer within `MemberOperation` and pass it to the Rust side using a getter. On the Rust side, we define an opaque struct that holds this pointer during subscription and publisher creation. Instead of passing `T::ID,` we now pass the type_operation pointer as a parameter to C++. This removes the need for repeated lookups on the C++ side, allowing us to directly invoke the underlying `TypeOperations` functions and APIs.