### PR TITLE
Export com-api-example config for external bundling

### DIFF
--- a/score/mw/com/example/com-api-example/BUILD
+++ b/score/mw/com/example/com-api-example/BUILD
@@ -13,6 +13,10 @@
 
 load("@rules_rust//rust:defs.bzl", "rust_binary", "rust_test")
 
+exports_files([
+    "etc/mw_com_config.json",
+])
+
 rust_binary(
     name = "com-api-example",
     srcs = ["basic-consumer-producer.rs"],


### PR DESCRIPTION
## Summary

Adds an `exports_files` rule to `score/mw/com/example/com-api-example/BUILD`
to make the `etc/mw_com_config.json` config file accessible to external packages.

## Why

The `com-api-example` binary requires its `mw_com_config.json` at runtime. When
the binary is referenced externally (e.g. in a showcase bundle), the config file
must also be reachable via `@score_communication//score/mw/com/example/com-api-example:etc/mw_com_config.json`.
Without `exports_files`, Bazel blocks external access to the file even though the
binary target itself is already public.