### PR TITLE
message_passing: fix race condition in send queue

### DIFF
--- a/score/message_passing/client_connection.cpp
+++ b/score/message_passing/client_connection.cpp
@@ -519,7 +519,8 @@ void ClientConnection::ProcessSendQueueUnderLock(std::unique_lock<std::mutex>& l
     {
         SendCommand& send = send_queue_.front();
         send_queue_.pop_front();
-        send_pool_.push_front(send);  // LIFO for better cache locality
+        // below, we will need to return the SendCommand to the send_pool_ under lock
+        // (LIFO for better cache locality) right after we use its buffer to send the message
         if (!send.callback.empty())
         {
             waiting_for_reply_ = std::move(send.callback);
@@ -531,6 +532,7 @@ void ClientConnection::ProcessSendQueueUnderLock(std::unique_lock<std::mutex>& l
             const auto expected = engine_->SendProtocolMessage(
                 client_fd_, score::cpp::to_underlying(ClientToServer::REQUEST), send.message);
             lock.lock();
+            send_pool_.push_front(send);
             if (expected.has_value())
             {
                 break;
@@ -554,6 +556,7 @@ void ClientConnection::ProcessSendQueueUnderLock(std::unique_lock<std::mutex>& l
             score::cpp::ignore =
                 engine_->SendProtocolMessage(client_fd_, score::cpp::to_underlying(ClientToServer::SEND), send.message);
             lock.lock();
+            send_pool_.push_front(send);
             waiting_for_reply_.reset();
         }
     }

--- a/score/message_passing/client_connection_test.cpp
+++ b/score/message_passing/client_connection_test.cpp
@@ -964,6 +964,39 @@ TEST_F(ClientConnectionTest, SendWithCallbackReportsFailureWhenQueuedSendFailsTr
     StopCurrentConnection(connection);
 }
 
+TEST_F(ClientConnectionTest, SendWithCallbackStillHasItsSlotBusyWhenQueuedSendHappensTrulyAsync)
+{
+    client_config_.truly_async = true;
+    client_config_.max_async_replies = 1;
+    client_config_.max_queued_sends = 0;
+    detail::ClientConnection connection(engine_, protocol_config_, client_config_);
+    MakeSuccessfulConnection(connection);
+
+    std::array<std::uint8_t, kMaxSendSize> send_buffer;
+
+    CatchSendQueueCommand();
+
+    // the send itself shall succeed
+    auto send_with_callback_result = connection.SendWithCallback(send_buffer, [](auto&& message_expected) {
+        EXPECT_FALSE(message_expected);
+        EXPECT_EQ(message_expected.error().GetOsDependentErrorCode(), EPIPE);
+    });
+    EXPECT_TRUE(send_with_callback_result);
+
+    EXPECT_CALL(*engine_, SendProtocolMessage).WillOnce([&](auto&&...) {
+        // with max_async_replies = 1, that single internal slot queued data shall still be busy.
+        // (if it's not the case, we may have data corruption if we try to send data concurrently)
+        auto send_expected = connection.SendWithCallback(send_buffer, [](auto&&) {});
+        EXPECT_FALSE(send_expected);
+        EXPECT_EQ(send_expected.error().GetOsDependentErrorCode(), ENOBUFS);
+        return score::cpp::make_unexpected(score::os::Error::createFromErrno(EPIPE));
+    });
+
+    InvokeSendQueueCommand();
+
+    StopCurrentConnection(connection);
+}
+
 TEST_F(ClientConnectionTest, QueuedSendsCancelIfConnectionClosed)
 {
     client_config_.max_queued_sends = 4;


### PR DESCRIPTION
We were releasing SendCommand objects too early to the "free" pool, while temporarily unlocking the access to this pool for the time we spend in a SendProtocolMessage() call (as this call may result in a blocked IPC). During this temporary unlocking, another thread could obtain and reuse the same object, which could lead to message payload corruption under concurrent load.

Now we are releasing these objects under re-obtained lock right after the message was sent.