### PR TITLE
fix: resolve strict warning build breaks in consumer test sources

### DIFF
--- a/score/mw/com/test/methods/non_trivial_constructors/consumer.cpp
+++ b/score/mw/com/test/methods/non_trivial_constructors/consumer.cpp
@@ -36,8 +36,7 @@ const InstanceSpecifier kInstanceSpecifier =
 
 void CallMethodWithInArgsAndReturn(NonTrivialConstructorProxy& proxy, const std::string& failure_message_prefix)
 {
-    auto call_result =
-        [&proxy, &failure_message_prefix]() -> score::Result<impl::MethodReturnTypePtr<NonTriviallyConstructibleType>> {
+    auto call_result = [&proxy]() -> score::Result<impl::MethodReturnTypePtr<NonTriviallyConstructibleType>> {
         std::cout << "\n=== Test: with_in_args_and_return (zero-copy) ===" << std::endl;
         auto allocated_args_result = proxy.with_in_args_and_return.Allocate();
         if (!allocated_args_result.has_value())
@@ -66,7 +65,7 @@ void CallMethodWithInArgsAndReturn(NonTrivialConstructorProxy& proxy, const std:
 
 void CallMethodWithInArgsOnly(NonTrivialConstructorProxy& proxy, const std::string& failure_message_prefix)
 {
-    auto call_result = [&proxy, &failure_message_prefix]() -> Result<void> {
+    auto call_result = [&proxy]() -> Result<void> {
         std::cout << "\n=== Test: with_in_args_only (zero-copy) ===" << std::endl;
         auto allocated_args_result = proxy.with_in_args_only.Allocate();
         if (!allocated_args_result.has_value())

--- a/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/consumer.cpp
+++ b/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/consumer.cpp
@@ -37,8 +37,8 @@ const auto kInstanceSpecifier =
     score::mw::com::InstanceSpecifier::Create(std::string{kInstanceSpecifierString}).value();
 const std::chrono::seconds kMaxHandleNotificationWaitTime{15U};
 // uid 1312, 1313 is reserved for use. See broken_link_cf/display/ipnext/User+Management
-const uid_t kUidFirstConsumer{1312};
-const uid_t kUidSecondConsumer{1313};
+[[maybe_unused]] const uid_t kUidFirstConsumer{1312};
+[[maybe_unused]] const uid_t kUidSecondConsumer{1313};
 
 bool StartFindServiceAndWait(const std::string& tag,
                              HandleNotificationData& handle_notification_data,


### PR DESCRIPTION
remove unused lambda capture and mark reserved UIDs as maybe_unused to pass strict warning-as-error builds