### PR TITLE
mw/com: Add integration tests for moving SkeletonEvent

### DIFF
--- a/score/mw/com/test/common_test_resources/skeleton_container.h
+++ b/score/mw/com/test/common_test_resources/skeleton_container.h
@@ -37,6 +37,13 @@ class SkeletonContainer
         return *skeleton_;
     }
 
+    Skeleton&& Extract()
+    {
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(skeleton_ != nullptr,
+                                                    "Skeleton was not successfully created! Cannot extract it!");
+        return std::move(*skeleton_);
+    }
+
   private:
     std::unique_ptr<Skeleton> skeleton_;
 };

--- a/score/mw/com/test/methods/methods_test_resources/BUILD
+++ b/score/mw/com/test/methods/methods_test_resources/BUILD
@@ -55,7 +55,7 @@ cc_library(
     hdrs = ["process_synchronizer.h"],
     features = COMPILER_WARNING_FEATURES,
     visibility = [
-        "//score/mw/com/test/methods:__subpackages__",
+        "//score/mw/com/test:__subpackages__",
     ],
     deps = [
         "//score/mw/com/test/common_test_resources:fail_test",

--- a/score/mw/com/test/methods/methods_test_resources/process_synchronizer.cpp
+++ b/score/mw/com/test/methods/methods_test_resources/process_synchronizer.cpp
@@ -70,4 +70,9 @@ bool ProcessSynchronizer::WaitWithAbort(score::cpp::stop_token stop_token)
     return interprocess_notifier_.waitWithAbort(stop_token);
 }
 
+void ProcessSynchronizer::Reset()
+{
+    interprocess_notifier_.reset();
+}
+
 }  // namespace score::mw::com::test

--- a/score/mw/com/test/methods/methods_test_resources/process_synchronizer.h
+++ b/score/mw/com/test/methods/methods_test_resources/process_synchronizer.h
@@ -38,6 +38,8 @@ class ProcessSynchronizer
 
     bool WaitWithAbort(score::cpp::stop_token stop_token);
 
+    void Reset();
+
   private:
     SharedMemoryObjectCreator<os::InterprocessNotification> interprocess_notifier_creator_;
     SharedMemoryObjectGuard<os::InterprocessNotification> interprocess_notifier_guard_;

--- a/score/mw/com/test/skeleton_move_semantics/BUILD
+++ b/score/mw/com/test/skeleton_move_semantics/BUILD
@@ -39,6 +39,7 @@ cc_library(
     hdrs = ["test_parameters.h"],
     features = COMPILER_WARNING_FEATURES,
     deps = [
+        "//score/mw/com",
         "//score/mw/com/test/common_test_resources:command_line_parser",
         "//score/mw/com/test/common_test_resources:fail_test",
     ],
@@ -54,8 +55,8 @@ cc_library(
         ":test_parameters",
         "//score/mw/com",
         "//score/mw/com/test/common_test_resources:fail_test",
+        "//score/mw/com/test/common_test_resources:skeleton_container",
         "//score/mw/com/test/methods/methods_test_resources:process_synchronizer",
-        "//score/mw/com/test/methods/methods_test_resources:skeleton_container",
     ],
 )
 
@@ -69,8 +70,8 @@ cc_library(
         ":test_parameters",
         "//score/mw/com",
         "//score/mw/com/test/common_test_resources:fail_test",
+        "//score/mw/com/test/common_test_resources:proxy_container",
         "//score/mw/com/test/methods/methods_test_resources:process_synchronizer",
-        "//score/mw/com/test/methods/methods_test_resources:proxy_container",
     ],
 )
 

--- a/score/mw/com/test/skeleton_move_semantics/BUILD
+++ b/score/mw/com/test/skeleton_move_semantics/BUILD
@@ -1,0 +1,166 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@score_baselibs//score/language/safecpp:toolchain_features.bzl", "COMPILER_WARNING_FEATURES")
+load("//bazel/tools:json_schema_validator.bzl", "validate_json_schema_test")
+load("//score/mw/com/test:pkg_application.bzl", "pkg_application")
+
+validate_json_schema_test(
+    name = "validate_config_schema",
+    json = "config/mw_com_config.json",
+    schema = "//score/mw/com:config_schema",
+    tags = ["lint"],
+)
+
+cc_library(
+    name = "test_event_datatype",
+    srcs = ["test_event_datatype.cpp"],
+    hdrs = ["test_event_datatype.h"],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        "//score/mw/com",
+    ],
+)
+
+cc_library(
+    name = "test_parameters",
+    srcs = ["test_parameters.cpp"],
+    hdrs = ["test_parameters.h"],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        "//score/mw/com/test/common_test_resources:command_line_parser",
+        "//score/mw/com/test/common_test_resources:fail_test",
+    ],
+)
+
+cc_library(
+    name = "provider",
+    srcs = ["provider.cpp"],
+    hdrs = ["provider.h"],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        ":test_event_datatype",
+        ":test_parameters",
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:fail_test",
+        "//score/mw/com/test/methods/methods_test_resources:process_synchronizer",
+        "//score/mw/com/test/methods/methods_test_resources:skeleton_container",
+    ],
+)
+
+cc_library(
+    name = "consumer",
+    srcs = ["consumer.cpp"],
+    hdrs = ["consumer.h"],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        ":test_event_datatype",
+        ":test_parameters",
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:fail_test",
+        "//score/mw/com/test/methods/methods_test_resources:process_synchronizer",
+        "//score/mw/com/test/methods/methods_test_resources:proxy_container",
+    ],
+)
+
+cc_binary(
+    name = "main_provider",
+    srcs = ["main_provider.cpp"],
+    data = ["config/mw_com_config.json"],
+    features = COMPILER_WARNING_FEATURES + [
+        "aborts_upon_exception",
+    ],
+    deps = [
+        ":provider",
+        ":test_parameters",
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:assert_handler",
+        "//score/mw/com/test/common_test_resources:fail_test",
+        "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
+    ],
+)
+
+cc_binary(
+    name = "main_consumer",
+    srcs = ["main_consumer.cpp"],
+    data = ["config/mw_com_config.json"],
+    features = COMPILER_WARNING_FEATURES + [
+        "aborts_upon_exception",
+    ],
+    deps = [
+        ":consumer",
+        ":test_parameters",
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:assert_handler",
+        "//score/mw/com/test/common_test_resources:fail_test",
+        "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
+    ],
+)
+
+cc_binary(
+    name = "main_consumer_and_provider",
+    srcs = ["main_consumer_and_provider.cpp"],
+    data = ["config/mw_com_config.json"],
+    features = COMPILER_WARNING_FEATURES + [
+        "aborts_upon_exception",
+    ],
+    deps = [
+        ":consumer",
+        ":provider",
+        ":test_parameters",
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:assert_handler",
+        "//score/mw/com/test/common_test_resources:fail_test",
+        "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
+    ],
+)
+
+pkg_application(
+    name = "main_provider-pkg",
+    app_name = "MainProviderApp",
+    bin = [":main_provider"],
+    etc = [
+        "config/mw_com_config.json",
+        "config/logging.json",
+    ],
+    visibility = [
+        "//score/mw/com/test/skeleton_move_semantics:__subpackages__",
+    ],
+)
+
+pkg_application(
+    name = "main_consumer-pkg",
+    app_name = "MainConsumerApp",
+    bin = [":main_consumer"],
+    etc = [
+        "config/mw_com_config.json",
+        "config/logging.json",
+    ],
+    visibility = [
+        "//score/mw/com/test/skeleton_move_semantics:__subpackages__",
+    ],
+)
+
+pkg_application(
+    name = "main_consumer_and_provider-pkg",
+    app_name = "MainConsumerAndProviderApp",
+    bin = [":main_consumer_and_provider"],
+    etc = [
+        "config/mw_com_config.json",
+        "config/logging.json",
+    ],
+    visibility = [
+        "//score/mw/com/test/skeleton_move_semantics:__subpackages__",
+    ],
+)

--- a/score/mw/com/test/skeleton_move_semantics/config/logging.json
+++ b/score/mw/com/test/skeleton_move_semantics/config/logging.json
@@ -1,0 +1,7 @@
+{
+  "appId": "SMSM",
+  "appDesc": "skeleton_move_semantics",
+  "logLevel": "kDebug",
+  "logLevelThresholdConsole": "kDebug",
+  "logMode": "kRemote|kConsole"
+}

--- a/score/mw/com/test/skeleton_move_semantics/config/mw_com_config.json
+++ b/score/mw/com/test/skeleton_move_semantics/config/mw_com_config.json
@@ -1,0 +1,105 @@
+{
+  "serviceTypes": [
+    {
+      "serviceTypeName": "/test/skeleton_move_semantics/MoveEventInterface",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "bindings": [
+        {
+          "binding": "SHM",
+          "serviceId": 2100,
+          "events": [
+            {
+              "eventName": "moved_event",
+              "eventId": 1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "serviceInstances": [
+    {
+      "instanceSpecifier": "test/skeleton_move_semantics/MoveEventInterfaceMovedTo",
+      "serviceTypeName": "/test/skeleton_move_semantics/MoveEventInterface",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "instances": [
+        {
+          "instanceId": 1,
+          "asil-level": "QM",
+          "binding": "SHM",
+          "events": [
+            {
+              "eventName": "moved_event",
+              "numberOfSampleSlots": 15,
+              "maxSubscribers": 1
+            }
+          ],
+          "allowedConsumer": {
+            "QM": [
+              0
+            ],
+            "B": [
+              0
+            ]
+          },
+          "allowedProvider": {
+            "QM": [
+              0
+            ],
+            "B": [
+              0
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "instanceSpecifier": "test/skeleton_move_semantics/MoveEventInterfaceMovedFrom",
+      "serviceTypeName": "/test/skeleton_move_semantics/MoveEventInterface",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "instances": [
+        {
+          "instanceId": 2,
+          "asil-level": "QM",
+          "binding": "SHM",
+          "events": [
+            {
+              "eventName": "moved_event",
+              "numberOfSampleSlots": 15,
+              "maxSubscribers": 1
+            }
+          ],
+          "allowedConsumer": {
+            "QM": [
+              0
+            ],
+            "B": [
+              0
+            ]
+          },
+          "allowedProvider": {
+            "QM": [
+              0
+            ],
+            "B": [
+              0
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "global": {
+    "asil-level": "QM",
+    "applicationID": 4001
+  }
+}

--- a/score/mw/com/test/skeleton_move_semantics/consumer.cpp
+++ b/score/mw/com/test/skeleton_move_semantics/consumer.cpp
@@ -13,8 +13,8 @@
 #include "score/mw/com/test/skeleton_move_semantics/consumer.h"
 
 #include "score/mw/com/test/common_test_resources/fail_test.h"
+#include "score/mw/com/test/common_test_resources/proxy_container.h"
 #include "score/mw/com/test/methods/methods_test_resources/process_synchronizer.h"
-#include "score/mw/com/test/methods/methods_test_resources/proxy_container.h"
 #include "score/mw/com/test/skeleton_move_semantics/test_event_datatype.h"
 #include "score/mw/com/types.h"
 

--- a/score/mw/com/test/skeleton_move_semantics/consumer.cpp
+++ b/score/mw/com/test/skeleton_move_semantics/consumer.cpp
@@ -1,0 +1,212 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/test/skeleton_move_semantics/consumer.h"
+
+#include "score/mw/com/test/common_test_resources/fail_test.h"
+#include "score/mw/com/test/methods/methods_test_resources/process_synchronizer.h"
+#include "score/mw/com/test/methods/methods_test_resources/proxy_container.h"
+#include "score/mw/com/test/skeleton_move_semantics/test_event_datatype.h"
+#include "score/mw/com/types.h"
+
+#include <cstdint>
+
+namespace score::mw::com::test
+{
+namespace
+{
+
+const std::string kInterprocessNotificationShmPath{"/skeleton_move_semantics_interprocess_notification"};
+
+template <typename ProxyEventType>
+class ProxyStateChangeNotifier
+{
+  public:
+    explicit ProxyStateChangeNotifier(ProxyEventType& proxy_event) : proxy_event_{proxy_event}
+    {
+        auto state_change_handler = [this](const SubscriptionState new_state) -> bool {
+            std::cout << "Service state changed, new state: " << static_cast<std::uint32_t>(new_state) << std::endl;
+            std::lock_guard lock(mutex_);
+            last_seen_state_ = new_state;
+            condition_variable_.notify_all();
+            return true;
+        };
+        proxy_event_.SetSubscriptionStateChangeHandler(state_change_handler);
+    }
+
+    ~ProxyStateChangeNotifier()
+    {
+        proxy_event_.UnsetSubscriptionStateChangeHandler();
+    }
+
+    ProxyStateChangeNotifier(const ProxyStateChangeNotifier&) = delete;
+    ProxyStateChangeNotifier& operator=(const ProxyStateChangeNotifier&) = delete;
+    ProxyStateChangeNotifier(const ProxyStateChangeNotifier&&) = delete;
+    ProxyStateChangeNotifier& operator=(const ProxyStateChangeNotifier&&) = delete;
+
+    bool WaitForStateChange(const score::cpp::stop_token& stop_token, SubscriptionState desired_state)
+    {
+        std::unique_lock lock(mutex_);
+        return condition_variable_.wait(lock, stop_token, [this, desired_state]() {
+            return last_seen_state_.has_value() && last_seen_state_.value() == desired_state;
+        });
+    }
+
+  private:
+    std::mutex mutex_{};
+    concurrency::InterruptibleConditionalVariable condition_variable_{};
+    std::optional<SubscriptionState> last_seen_state_{};
+    ProxyEventType& proxy_event_;
+};
+
+template <typename ProxyEventType>
+class ProxyEventReceiver
+{
+  public:
+    explicit ProxyEventReceiver(ProxyEventType& proxy_event) : proxy_event_{proxy_event}
+    {
+        auto receive_handler = [&received_sample_notification = received_sample_notification_]() {
+            std::cout << "Received event notification" << std::endl;
+            received_sample_notification.notify();
+        };
+        proxy_event_.SetReceiveHandler(receive_handler);
+    }
+
+    ~ProxyEventReceiver()
+    {
+        proxy_event_.UnsetReceiveHandler();
+    }
+
+    ProxyEventReceiver(const ProxyEventReceiver&) = delete;
+    ProxyEventReceiver& operator=(const ProxyEventReceiver&) = delete;
+    ProxyEventReceiver(const ProxyEventReceiver&&) = delete;
+    ProxyEventReceiver& operator=(const ProxyEventReceiver&&) = delete;
+
+    void WaitForSamples(const score::cpp::stop_token& stop_token, const std::size_t num_samples_to_receive)
+    {
+        std::size_t received_count{0U};
+        while (!stop_token.stop_requested())
+        {
+            auto get_samples_result = proxy_event_.GetNewSamples(
+                [this](SamplePtr<std::uint32_t> sample) {
+                    GetNewSamplesCallback(std::move(sample));
+                },
+                num_samples_to_receive);
+            if (!get_samples_result.has_value())
+            {
+                FailTest("skeleton_move_semantics consumer failed: GetNewSamples failed: ", get_samples_result.error());
+            }
+
+            received_count += get_samples_result.value();
+            std::cout << "Received " << get_samples_result.value() << " samples. " << received_count
+                      << " samples so far" << std::endl;
+
+            if (received_count == num_samples_to_receive)
+            {
+                break;
+            }
+
+            const auto notification_received = received_sample_notification_.waitWithAbort(stop_token);
+            if (!notification_received)
+            {
+                // spurious wake-up or stop requested, either way we should check the stop token and exit if stop was
+                // requested
+                continue;
+            }
+
+            received_sample_notification_.reset();
+        }
+        std::cout << "\nConsumer: Done receiving samples, received " << received_count << " samples in total\n";
+    }
+
+  private:
+    void GetNewSamplesCallback(SamplePtr<std::uint32_t> sample)
+    {
+        if (sample == nullptr)
+        {
+            FailTest("skeleton_move_semantics consumer failed: received null sample");
+        }
+        const std::uint32_t expected_value = latest_value_.has_value() ? latest_value_.value() + 1U : 1U;
+        if (*sample != expected_value)
+        {
+            FailTest("skeleton_move_semantics consumer failed: received value ",
+                     *sample,
+                     " does not match expected value ",
+                     expected_value);
+        }
+        latest_value_ = *sample;
+    }
+
+    score::concurrency::Notification received_sample_notification_{};
+    std::mutex mutex_{};
+    concurrency::InterruptibleConditionalVariable condition_variable_{};
+    std::optional<std::uint32_t> latest_value_{};
+    ProxyEventType& proxy_event_;
+};
+
+}  // namespace
+
+void RunConsumer(const InstanceSpecifier& instance_specifier,
+                 const std::size_t num_samples_to_receive,
+                 const std::size_t num_send_iterations,
+                 const score::cpp::stop_token& stop_token)
+{
+    const auto name = filesystem::Path{instance_specifier.ToString()}.Filename().Native();
+    auto process_synchronizer_result =
+        ProcessSynchronizer::Create(kInterprocessNotificationShmPath + std::string{name});
+    if (!process_synchronizer_result.has_value())
+    {
+        FailTest("skeleton_move_semantics consumer failed: could not create ready synchronizer");
+    }
+
+    ExitFunctionGuard done_guard{[&process_synchronizer_result]() {
+        process_synchronizer_result->Notify();
+    }};
+
+    ProxyContainer<SkeletonMoveSemanticsProxy> proxy_container{};
+
+    // Step 1. Find service and create proxy
+    std::cout << "\nConsumer: Step 1 - Find service and create proxy" << std::endl;
+    proxy_container.CreateProxy(instance_specifier, "skeleton_move_semantics");
+    auto& proxy = proxy_container.GetProxy();
+
+    // Step 2. Register receive handler
+    std::cout << "\nConsumer: Step 2 - Register receive handler" << std::endl;
+    ProxyEventReceiver proxy_event_receiver{proxy.moved_event_};
+
+    // Step 3. Register state change handler
+    std::cout << "\nConsumer: Step 3 - Register state change handler" << std::endl;
+    ProxyStateChangeNotifier proxy_state_change_notifier{proxy.moved_event_};
+
+    // Step 4. Subscribe
+    std::cout << "\nConsumer: Step 4 - Subscribe" << std::endl;
+    auto subscribe_result = proxy.moved_event_.Subscribe(num_samples_to_receive);
+    if (!subscribe_result.has_value())
+    {
+        FailTest("skeleton_move_semantics consumer failed: Subscribe failed: ", subscribe_result.error());
+    }
+
+    // Step 5. Wait for provider to send values and notify
+    std::cout << "\nConsumer: Step 5 - Wait for provider to send values and notify" << std::endl;
+    for (std::size_t iteration = 0U; iteration < num_send_iterations; ++iteration)
+    {
+        std::cout << "\nConsumer: Iteration " << (iteration + 1) << " of " << num_send_iterations << std::endl;
+        proxy_state_change_notifier.WaitForStateChange(stop_token, SubscriptionState::kSubscribed);
+
+        proxy_event_receiver.WaitForSamples(stop_token, num_samples_to_receive);
+        std::cout << "\nConsumer: Done receiving samples, received " << num_samples_to_receive << " samples in total\n";
+        process_synchronizer_result->Notify();
+    }
+    std::cout << "Consumer: Done with all iterations, exiting" << std::endl;
+}
+
+}  // namespace score::mw::com::test

--- a/score/mw/com/test/skeleton_move_semantics/consumer.h
+++ b/score/mw/com/test/skeleton_move_semantics/consumer.h
@@ -1,0 +1,31 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_TEST_SKELETON_MOVE_SEMANTICS_CONSUMER_H
+#define SCORE_MW_COM_TEST_SKELETON_MOVE_SEMANTICS_CONSUMER_H
+
+#include "score/mw/com/test/skeleton_move_semantics/test_parameters.h"
+#include "score/mw/com/types.h"
+
+#include <score/stop_token.hpp>
+
+namespace score::mw::com::test
+{
+
+void RunConsumer(const InstanceSpecifier& instance_specifier,
+                 const std::size_t num_samples_to_receive,
+                 const std::size_t num_send_iterations,
+                 const score::cpp::stop_token& stop_token);
+
+}  // namespace score::mw::com::test
+
+#endif  // SCORE_MW_COM_TEST_SKELETON_MOVE_SEMANTICS_CONSUMER_H

--- a/score/mw/com/test/skeleton_move_semantics/integration_test/BUILD
+++ b/score/mw/com/test/skeleton_move_semantics/integration_test/BUILD
@@ -1,0 +1,95 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
+load("//quality/integration_testing:integration_testing.bzl", "integration_test")
+
+integration_test(
+    name = "move_construct_not_offered_skeleton_same_process_test",
+    srcs = [
+        "move_construct_not_offered_skeleton_same_process_test.py",
+        "test_fixture.py",
+    ],
+    filesystem = "//score/mw/com/test/skeleton_move_semantics:main_consumer_and_provider-pkg",
+)
+
+integration_test(
+    name = "move_construct_offered_skeleton_same_process_test",
+    srcs = [
+        "move_construct_offered_skeleton_same_process_test.py",
+        "test_fixture.py",
+    ],
+    filesystem = "//score/mw/com/test/skeleton_move_semantics:main_consumer_and_provider-pkg",
+)
+
+integration_test(
+    name = "move_assign_not_offered_skeleton_same_process_test",
+    srcs = [
+        "move_assign_not_offered_skeleton_same_process_test.py",
+        "test_fixture.py",
+    ],
+    filesystem = "//score/mw/com/test/skeleton_move_semantics:main_consumer_and_provider-pkg",
+)
+
+integration_test(
+    name = "move_assign_offered_skeleton_same_process_test",
+    srcs = [
+        "move_assign_offered_skeleton_same_process_test.py",
+        "test_fixture.py",
+    ],
+    filesystem = "//score/mw/com/test/skeleton_move_semantics:main_consumer_and_provider-pkg",
+)
+
+pkg_filegroup(
+    name = "different_processes_filesystem",
+    srcs = [
+        "//score/mw/com/test/skeleton_move_semantics:main_consumer-pkg",
+        "//score/mw/com/test/skeleton_move_semantics:main_provider-pkg",
+    ],
+)
+
+integration_test(
+    name = "move_construct_not_offered_skeleton_different_process_test",
+    srcs = [
+        "move_construct_not_offered_skeleton_different_process_test.py",
+        "test_fixture.py",
+    ],
+    filesystem = ":different_processes_filesystem",
+)
+
+integration_test(
+    name = "move_construct_offered_skeleton_different_process_test",
+    srcs = [
+        "move_construct_offered_skeleton_different_process_test.py",
+        "test_fixture.py",
+    ],
+    filesystem = ":different_processes_filesystem",
+)
+
+integration_test(
+    name = "move_assign_not_offered_skeleton_different_process_test",
+    srcs = [
+        "move_assign_not_offered_skeleton_different_process_test.py",
+        "test_fixture.py",
+    ],
+    filesystem = ":different_processes_filesystem",
+)
+
+integration_test(
+    name = "move_assign_offered_skeleton_different_process_test",
+    srcs = [
+        "move_assign_offered_skeleton_different_process_test.py",
+        "test_fixture.py",
+    ],
+    filesystem = ":different_processes_filesystem",
+)

--- a/score/mw/com/test/skeleton_move_semantics/integration_test/move_assign_not_offered_skeleton_different_process_test.py
+++ b/score/mw/com/test/skeleton_move_semantics/integration_test/move_assign_not_offered_skeleton_different_process_test.py
@@ -12,11 +12,9 @@
 # *******************************************************************************
 from test_fixture import consumer, provider, SkeletonMoveScenario
 
-NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER = 10
-
 
 def test_move_assign_not_offered_same_process(target):
-    with consumer(target, SkeletonMoveScenario.MOVE_ASSIGN_NOT_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
-        with provider(target, SkeletonMoveScenario.MOVE_ASSIGN_NOT_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
+    with consumer(target, SkeletonMoveScenario.MOVE_ASSIGN_NOT_OFFERED):
+        with provider(target, SkeletonMoveScenario.MOVE_ASSIGN_NOT_OFFERED):
             pass
 

--- a/score/mw/com/test/skeleton_move_semantics/integration_test/move_assign_not_offered_skeleton_different_process_test.py
+++ b/score/mw/com/test/skeleton_move_semantics/integration_test/move_assign_not_offered_skeleton_different_process_test.py
@@ -1,0 +1,22 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from test_fixture import consumer, provider, SkeletonMoveScenario
+
+NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER = 10
+
+
+def test_move_assign_not_offered_same_process(target):
+    with consumer(target, SkeletonMoveScenario.MOVE_ASSIGN_NOT_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
+        with provider(target, SkeletonMoveScenario.MOVE_ASSIGN_NOT_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
+            pass
+

--- a/score/mw/com/test/skeleton_move_semantics/integration_test/move_assign_not_offered_skeleton_same_process_test.py
+++ b/score/mw/com/test/skeleton_move_semantics/integration_test/move_assign_not_offered_skeleton_same_process_test.py
@@ -12,10 +12,8 @@
 # *******************************************************************************
 from test_fixture import consumer_and_provider, SkeletonMoveScenario
 
-NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER = 10
-
 
 def test_move_assign_not_offered_same_process(target):
-    with consumer_and_provider(target, SkeletonMoveScenario.MOVE_ASSIGN_NOT_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
+    with consumer_and_provider(target, SkeletonMoveScenario.MOVE_ASSIGN_NOT_OFFERED):
         pass
 

--- a/score/mw/com/test/skeleton_move_semantics/integration_test/move_assign_not_offered_skeleton_same_process_test.py
+++ b/score/mw/com/test/skeleton_move_semantics/integration_test/move_assign_not_offered_skeleton_same_process_test.py
@@ -1,0 +1,21 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from test_fixture import consumer_and_provider, SkeletonMoveScenario
+
+NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER = 10
+
+
+def test_move_assign_not_offered_same_process(target):
+    with consumer_and_provider(target, SkeletonMoveScenario.MOVE_ASSIGN_NOT_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
+        pass
+

--- a/score/mw/com/test/skeleton_move_semantics/integration_test/move_assign_offered_skeleton_different_process_test.py
+++ b/score/mw/com/test/skeleton_move_semantics/integration_test/move_assign_offered_skeleton_different_process_test.py
@@ -12,11 +12,9 @@
 # *******************************************************************************
 from test_fixture import consumer, provider, SkeletonMoveScenario
 
-NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER = 10
-
 
 def test_move_assign_offered_same_process(target):
-    with consumer(target, SkeletonMoveScenario.MOVE_ASSIGN_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
-        with provider(target, SkeletonMoveScenario.MOVE_ASSIGN_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
+    with consumer(target, SkeletonMoveScenario.MOVE_ASSIGN_OFFERED):
+        with provider(target, SkeletonMoveScenario.MOVE_ASSIGN_OFFERED):
             pass
 

--- a/score/mw/com/test/skeleton_move_semantics/integration_test/move_assign_offered_skeleton_different_process_test.py
+++ b/score/mw/com/test/skeleton_move_semantics/integration_test/move_assign_offered_skeleton_different_process_test.py
@@ -1,0 +1,22 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from test_fixture import consumer, provider, SkeletonMoveScenario
+
+NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER = 10
+
+
+def test_move_assign_offered_same_process(target):
+    with consumer(target, SkeletonMoveScenario.MOVE_ASSIGN_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
+        with provider(target, SkeletonMoveScenario.MOVE_ASSIGN_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
+            pass
+

--- a/score/mw/com/test/skeleton_move_semantics/integration_test/move_assign_offered_skeleton_same_process_test.py
+++ b/score/mw/com/test/skeleton_move_semantics/integration_test/move_assign_offered_skeleton_same_process_test.py
@@ -12,10 +12,8 @@
 # *******************************************************************************
 from test_fixture import consumer_and_provider, SkeletonMoveScenario
 
-NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER = 10
-
 
 def test_move_assign_offered_same_process(target):
-    with consumer_and_provider(target, SkeletonMoveScenario.MOVE_ASSIGN_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
+    with consumer_and_provider(target, SkeletonMoveScenario.MOVE_ASSIGN_OFFERED):
         pass
 

--- a/score/mw/com/test/skeleton_move_semantics/integration_test/move_assign_offered_skeleton_same_process_test.py
+++ b/score/mw/com/test/skeleton_move_semantics/integration_test/move_assign_offered_skeleton_same_process_test.py
@@ -1,0 +1,21 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from test_fixture import consumer_and_provider, SkeletonMoveScenario
+
+NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER = 10
+
+
+def test_move_assign_offered_same_process(target):
+    with consumer_and_provider(target, SkeletonMoveScenario.MOVE_ASSIGN_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
+        pass
+

--- a/score/mw/com/test/skeleton_move_semantics/integration_test/move_construct_not_offered_skeleton_different_process_test.py
+++ b/score/mw/com/test/skeleton_move_semantics/integration_test/move_construct_not_offered_skeleton_different_process_test.py
@@ -1,0 +1,22 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from test_fixture import consumer, provider, SkeletonMoveScenario
+
+NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER = 10
+
+
+def test_move_construct_not_offered_same_process(target):
+    with consumer(target, SkeletonMoveScenario.MOVE_CONSTRUCT_NOT_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
+        with provider(target, SkeletonMoveScenario.MOVE_CONSTRUCT_NOT_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
+            pass
+

--- a/score/mw/com/test/skeleton_move_semantics/integration_test/move_construct_not_offered_skeleton_different_process_test.py
+++ b/score/mw/com/test/skeleton_move_semantics/integration_test/move_construct_not_offered_skeleton_different_process_test.py
@@ -12,11 +12,9 @@
 # *******************************************************************************
 from test_fixture import consumer, provider, SkeletonMoveScenario
 
-NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER = 10
-
 
 def test_move_construct_not_offered_same_process(target):
-    with consumer(target, SkeletonMoveScenario.MOVE_CONSTRUCT_NOT_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
-        with provider(target, SkeletonMoveScenario.MOVE_CONSTRUCT_NOT_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
+    with consumer(target, SkeletonMoveScenario.MOVE_CONSTRUCT_NOT_OFFERED):
+        with provider(target, SkeletonMoveScenario.MOVE_CONSTRUCT_NOT_OFFERED):
             pass
 

--- a/score/mw/com/test/skeleton_move_semantics/integration_test/move_construct_not_offered_skeleton_same_process_test.py
+++ b/score/mw/com/test/skeleton_move_semantics/integration_test/move_construct_not_offered_skeleton_same_process_test.py
@@ -1,0 +1,21 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from test_fixture import consumer_and_provider, SkeletonMoveScenario
+
+NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER = 10
+
+
+def test_move_construct_not_offered_same_process(target):
+    with consumer_and_provider(target, SkeletonMoveScenario.MOVE_CONSTRUCT_NOT_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
+        pass
+

--- a/score/mw/com/test/skeleton_move_semantics/integration_test/move_construct_not_offered_skeleton_same_process_test.py
+++ b/score/mw/com/test/skeleton_move_semantics/integration_test/move_construct_not_offered_skeleton_same_process_test.py
@@ -12,10 +12,8 @@
 # *******************************************************************************
 from test_fixture import consumer_and_provider, SkeletonMoveScenario
 
-NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER = 10
-
 
 def test_move_construct_not_offered_same_process(target):
-    with consumer_and_provider(target, SkeletonMoveScenario.MOVE_CONSTRUCT_NOT_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
+    with consumer_and_provider(target, SkeletonMoveScenario.MOVE_CONSTRUCT_NOT_OFFERED):
         pass
 

--- a/score/mw/com/test/skeleton_move_semantics/integration_test/move_construct_offered_skeleton_different_process_test.py
+++ b/score/mw/com/test/skeleton_move_semantics/integration_test/move_construct_offered_skeleton_different_process_test.py
@@ -1,0 +1,22 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from test_fixture import consumer, provider, SkeletonMoveScenario
+
+NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER = 10
+
+
+def test_move_construct_offered_same_process(target):
+    with consumer(target, SkeletonMoveScenario.MOVE_CONSTRUCT_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
+        with provider(target, SkeletonMoveScenario.MOVE_CONSTRUCT_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
+            pass
+

--- a/score/mw/com/test/skeleton_move_semantics/integration_test/move_construct_offered_skeleton_different_process_test.py
+++ b/score/mw/com/test/skeleton_move_semantics/integration_test/move_construct_offered_skeleton_different_process_test.py
@@ -12,11 +12,9 @@
 # *******************************************************************************
 from test_fixture import consumer, provider, SkeletonMoveScenario
 
-NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER = 10
-
 
 def test_move_construct_offered_same_process(target):
-    with consumer(target, SkeletonMoveScenario.MOVE_CONSTRUCT_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
-        with provider(target, SkeletonMoveScenario.MOVE_CONSTRUCT_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
+    with consumer(target, SkeletonMoveScenario.MOVE_CONSTRUCT_OFFERED):
+        with provider(target, SkeletonMoveScenario.MOVE_CONSTRUCT_OFFERED):
             pass
 

--- a/score/mw/com/test/skeleton_move_semantics/integration_test/move_construct_offered_skeleton_same_process_test.py
+++ b/score/mw/com/test/skeleton_move_semantics/integration_test/move_construct_offered_skeleton_same_process_test.py
@@ -1,0 +1,21 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from test_fixture import consumer_and_provider, SkeletonMoveScenario
+
+NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER = 10
+
+
+def test_move_construct_offered_same_process(target):
+    with consumer_and_provider(target, SkeletonMoveScenario.MOVE_CONSTRUCT_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
+        pass
+

--- a/score/mw/com/test/skeleton_move_semantics/integration_test/move_construct_offered_skeleton_same_process_test.py
+++ b/score/mw/com/test/skeleton_move_semantics/integration_test/move_construct_offered_skeleton_same_process_test.py
@@ -12,10 +12,8 @@
 # *******************************************************************************
 from test_fixture import consumer_and_provider, SkeletonMoveScenario
 
-NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER = 10
-
 
 def test_move_construct_offered_same_process(target):
-    with consumer_and_provider(target, SkeletonMoveScenario.MOVE_CONSTRUCT_OFFERED, NUMBER_OF_SAMPLES_TO_SEND_PER_OFFER):
+    with consumer_and_provider(target, SkeletonMoveScenario.MOVE_CONSTRUCT_OFFERED):
         pass
 

--- a/score/mw/com/test/skeleton_move_semantics/integration_test/test_fixture.py
+++ b/score/mw/com/test/skeleton_move_semantics/integration_test/test_fixture.py
@@ -1,0 +1,40 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from enum import IntEnum
+
+
+class SkeletonMoveScenario(IntEnum):
+    MOVE_CONSTRUCT_NOT_OFFERED = 0
+    MOVE_CONSTRUCT_OFFERED = 1
+    MOVE_ASSIGN_NOT_OFFERED = 2
+    MOVE_ASSIGN_OFFERED = 3
+
+
+def consumer_and_provider(target, scenario, number_of_samples_to_send_per_offer, **kwargs):
+    args = ["--scenario", str(int(scenario)), "--number-of-samples-to-send", str(number_of_samples_to_send_per_offer), "--service-instance-manifest", f"./etc/mw_com_config.json"]
+    return target.wrap_exec(
+        "bin/main_consumer_and_provider", args, cwd="/opt/MainConsumerAndProviderApp", wait_on_exit=True, **kwargs
+    )
+
+def consumer(target, scenario, number_of_samples_to_send_per_offer, **kwargs):
+    args = ["--scenario", str(int(scenario)), "--number-of-samples-to-send", str(number_of_samples_to_send_per_offer), "--service-instance-manifest", f"./etc/mw_com_config.json"]
+    return target.wrap_exec(
+        "bin/main_consumer", args, cwd="/opt/MainConsumerApp", wait_on_exit=True, **kwargs
+    )
+
+def provider(target, scenario, number_of_samples_to_send_per_offer, **kwargs):
+    args = ["--scenario", str(int(scenario)), "--number-of-samples-to-send", str(number_of_samples_to_send_per_offer), "--service-instance-manifest", f"./etc/mw_com_config.json"]
+    return target.wrap_exec(
+        "bin/main_provider", args, cwd="/opt/MainProviderApp", wait_on_exit=True, **kwargs
+    )
+

--- a/score/mw/com/test/skeleton_move_semantics/integration_test/test_fixture.py
+++ b/score/mw/com/test/skeleton_move_semantics/integration_test/test_fixture.py
@@ -20,20 +20,20 @@ class SkeletonMoveScenario(IntEnum):
     MOVE_ASSIGN_OFFERED = 3
 
 
-def consumer_and_provider(target, scenario, number_of_samples_to_send_per_offer, **kwargs):
-    args = ["--scenario", str(int(scenario)), "--number-of-samples-to-send", str(number_of_samples_to_send_per_offer), "--service-instance-manifest", f"./etc/mw_com_config.json"]
+def consumer_and_provider(target, scenario, **kwargs):
+    args = ["--scenario", str(int(scenario)), "--service-instance-manifest", f"./etc/mw_com_config.json"]
     return target.wrap_exec(
         "bin/main_consumer_and_provider", args, cwd="/opt/MainConsumerAndProviderApp", wait_on_exit=True, **kwargs
     )
 
-def consumer(target, scenario, number_of_samples_to_send_per_offer, **kwargs):
-    args = ["--scenario", str(int(scenario)), "--number-of-samples-to-send", str(number_of_samples_to_send_per_offer), "--service-instance-manifest", f"./etc/mw_com_config.json"]
+def consumer(target, scenario, **kwargs):
+    args = ["--scenario", str(int(scenario)), "--service-instance-manifest", f"./etc/mw_com_config.json"]
     return target.wrap_exec(
         "bin/main_consumer", args, cwd="/opt/MainConsumerApp", wait_on_exit=True, **kwargs
     )
 
-def provider(target, scenario, number_of_samples_to_send_per_offer, **kwargs):
-    args = ["--scenario", str(int(scenario)), "--number-of-samples-to-send", str(number_of_samples_to_send_per_offer), "--service-instance-manifest", f"./etc/mw_com_config.json"]
+def provider(target, scenario, **kwargs):
+    args = ["--scenario", str(int(scenario)), "--service-instance-manifest", f"./etc/mw_com_config.json"]
     return target.wrap_exec(
         "bin/main_provider", args, cwd="/opt/MainProviderApp", wait_on_exit=True, **kwargs
     )

--- a/score/mw/com/test/skeleton_move_semantics/main_consumer.cpp
+++ b/score/mw/com/test/skeleton_move_semantics/main_consumer.cpp
@@ -1,0 +1,138 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/runtime.h"
+#include "score/mw/com/types.h"
+
+#include "score/mw/com/test/common_test_resources/assert_handler.h"
+#include "score/mw/com/test/common_test_resources/fail_test.h"
+#include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
+#include "score/mw/com/test/skeleton_move_semantics/consumer.h"
+#include "score/mw/com/test/skeleton_move_semantics/test_parameters.h"
+
+#include <cstddef>
+#include <cstdlib>
+#include <future>
+#include <iostream>
+#include <string>
+
+namespace
+{
+
+const score::mw::com::InstanceSpecifier kInstanceSpecifierMovedTo =
+    score::mw::com::InstanceSpecifier::Create(std::string{"test/skeleton_move_semantics/MoveEventInterfaceMovedTo"})
+        .value();
+const score::mw::com::InstanceSpecifier kInstanceSpecifierMovedFrom =
+    score::mw::com::InstanceSpecifier::Create(std::string{"test/skeleton_move_semantics/MoveEventInterfaceMovedFrom"})
+        .value();
+
+}  // namespace
+
+int main(int argc, const char** argv)
+{
+    auto test_configuration{score::mw::com::test::ReadCommandLineArguments(argc, argv)};
+
+    score::mw::com::test::SetupAssertHandler();
+    score::mw::com::runtime::InitializeRuntime(argc, argv);
+
+    score::cpp::stop_source stop_source{};
+    const bool sig_term_handler_setup_success = score::mw::com::SetupStopTokenSigTermHandler(stop_source);
+    if (!sig_term_handler_setup_success)
+    {
+        std::cerr << "Unable to set signal handler for SIGINT and/or SIGTERM, cautiously continuing" << std::endl;
+    }
+
+    const auto num_send_iterations = [&test_configuration]() {
+        if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveConstructNotOffered)
+        {
+            // In this scenario, the provider will:
+            //   - Create a skeleton
+            //   - move construct the skeleton
+            //   - offer the service
+            //   - send samples
+            //   - stop offering the service
+            //   - offer the service again
+            //   - send samples again
+            // The receiver therefore expects two send iterations.
+            return 2U;
+        }
+        else if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveConstructOffered)
+        {
+            // In this scenario, the provider will:
+            //   - Create a skeleton
+            //   - offer the service
+            //   - send samples
+            //   - move construct the skeleton while the service is offered
+            //   - send samples
+            //   - stop offering the service
+            //   - offer the service again
+            //   - send samples again
+            // The receiver therefore expects three send iterations.
+            return 3U;
+        }
+        else if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveAssignNotOffered)
+        {
+            // In this scenario, the provider will:
+            //   - Create 2 skeletons
+            //   - move assign the skeleton
+            //   - offer the moved-to service
+            //   - send samples
+            //   - stop offering the service
+            //   - offer the service again
+            //   - send samples again
+            // The receiver therefore expects two send iterations.
+            return 2U;
+        }
+        else if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveAssignOffered)
+        {
+            // In this scenario, the provider will:
+            //   - Create 2 skeletons
+            //   - offer both services
+            //   - send samples in both services
+            //   - move assign the skeleton
+            //   - send samples from moved-to service
+            //   - stop offering the moved-to service
+            //   - offer the moved-to service again
+            //   - send samples again
+            // The receiver connected to the moved-from service expects one send iteration. The receiver connected to
+            // the moved-to service expects three send iterations.
+            return 3U;
+        }
+
+        score::mw::com::test::FailTest("Unknown scenario, cannot determine number of send iterations");
+        return 0U;
+    }();
+
+    std::cout << "Starting provider and consumer with scenario "
+              << static_cast<std::size_t>(test_configuration.scenario) << ", number of samples to send per offer "
+              << test_configuration.number_of_samples_to_send_per_offer << " and number of send iterations"
+              << num_send_iterations << std::endl;
+
+    auto consumer_future = std::async(score::mw::com::test::RunConsumer,
+                                      kInstanceSpecifierMovedTo,
+                                      test_configuration.number_of_samples_to_send_per_offer,
+                                      num_send_iterations,
+                                      stop_source.get_token());
+
+    if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveAssignOffered)
+    {
+        const std::size_t num_moved_to_send_iterations{1U};
+        score::mw::com::test::RunConsumer(kInstanceSpecifierMovedFrom,
+                                          test_configuration.number_of_samples_to_send_per_offer,
+                                          num_moved_to_send_iterations,
+                                          stop_source.get_token());
+    }
+
+    consumer_future.get();
+
+    return EXIT_SUCCESS;
+}

--- a/score/mw/com/test/skeleton_move_semantics/main_consumer.cpp
+++ b/score/mw/com/test/skeleton_move_semantics/main_consumer.cpp
@@ -11,31 +11,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 #include "score/mw/com/runtime.h"
-#include "score/mw/com/types.h"
 
 #include "score/mw/com/test/common_test_resources/assert_handler.h"
-#include "score/mw/com/test/common_test_resources/fail_test.h"
 #include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
 #include "score/mw/com/test/skeleton_move_semantics/consumer.h"
 #include "score/mw/com/test/skeleton_move_semantics/test_parameters.h"
-
-#include <cstddef>
-#include <cstdlib>
-#include <future>
-#include <iostream>
-#include <string>
-
-namespace
-{
-
-const score::mw::com::InstanceSpecifier kInstanceSpecifierMovedTo =
-    score::mw::com::InstanceSpecifier::Create(std::string{"test/skeleton_move_semantics/MoveEventInterfaceMovedTo"})
-        .value();
-const score::mw::com::InstanceSpecifier kInstanceSpecifierMovedFrom =
-    score::mw::com::InstanceSpecifier::Create(std::string{"test/skeleton_move_semantics/MoveEventInterfaceMovedFrom"})
-        .value();
-
-}  // namespace
 
 int main(int argc, const char** argv)
 {
@@ -51,83 +31,24 @@ int main(int argc, const char** argv)
         std::cerr << "Unable to set signal handler for SIGINT and/or SIGTERM, cautiously continuing" << std::endl;
     }
 
-    const auto num_send_iterations = [&test_configuration]() {
-        if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveConstructNotOffered)
-        {
-            // In this scenario, the provider will:
-            //   - Create a skeleton
-            //   - move construct the skeleton
-            //   - offer the service
-            //   - send samples
-            //   - stop offering the service
-            //   - offer the service again
-            //   - send samples again
-            // The receiver therefore expects two send iterations.
-            return 2U;
-        }
-        else if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveConstructOffered)
-        {
-            // In this scenario, the provider will:
-            //   - Create a skeleton
-            //   - offer the service
-            //   - send samples
-            //   - move construct the skeleton while the service is offered
-            //   - send samples
-            //   - stop offering the service
-            //   - offer the service again
-            //   - send samples again
-            // The receiver therefore expects three send iterations.
-            return 3U;
-        }
-        else if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveAssignNotOffered)
-        {
-            // In this scenario, the provider will:
-            //   - Create 2 skeletons
-            //   - move assign the skeleton
-            //   - offer the moved-to service
-            //   - send samples
-            //   - stop offering the service
-            //   - offer the service again
-            //   - send samples again
-            // The receiver therefore expects two send iterations.
-            return 2U;
-        }
-        else if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveAssignOffered)
-        {
-            // In this scenario, the provider will:
-            //   - Create 2 skeletons
-            //   - offer both services
-            //   - send samples in both services
-            //   - move assign the skeleton
-            //   - send samples from moved-to service
-            //   - stop offering the moved-to service
-            //   - offer the moved-to service again
-            //   - send samples again
-            // The receiver connected to the moved-from service expects one send iteration. The receiver connected to
-            // the moved-to service expects three send iterations.
-            return 3U;
-        }
-
-        score::mw::com::test::FailTest("Unknown scenario, cannot determine number of send iterations");
-        return 0U;
-    }();
+    const auto num_send_iterations = score::mw::com::test::GetNumberOfSendIterations(test_configuration.scenario);
 
     std::cout << "Starting provider and consumer with scenario "
               << static_cast<std::size_t>(test_configuration.scenario) << ", number of samples to send per offer "
-              << test_configuration.number_of_samples_to_send_per_offer << " and number of send iterations"
+              << score::mw::com::test::kNumberOfSamplesToSendPerOffer << " and number of send iterations"
               << num_send_iterations << std::endl;
 
     auto consumer_future = std::async(score::mw::com::test::RunConsumer,
-                                      kInstanceSpecifierMovedTo,
-                                      test_configuration.number_of_samples_to_send_per_offer,
+                                      score::mw::com::test::kInstanceSpecifierMovedTo,
+                                      score::mw::com::test::kNumberOfSamplesToSendPerOffer,
                                       num_send_iterations,
                                       stop_source.get_token());
 
     if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveAssignOffered)
     {
         const std::size_t num_moved_to_send_iterations{1U};
-        score::mw::com::test::RunConsumer(kInstanceSpecifierMovedFrom,
-                                          test_configuration.number_of_samples_to_send_per_offer,
+        score::mw::com::test::RunConsumer(score::mw::com::test::kInstanceSpecifierMovedFrom,
+                                          score::mw::com::test::kNumberOfSamplesToSendPerOffer,
                                           num_moved_to_send_iterations,
                                           stop_source.get_token());
     }

--- a/score/mw/com/test/skeleton_move_semantics/main_consumer_and_provider.cpp
+++ b/score/mw/com/test/skeleton_move_semantics/main_consumer_and_provider.cpp
@@ -1,0 +1,146 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/runtime.h"
+#include "score/mw/com/types.h"
+
+#include "score/mw/com/test/common_test_resources/assert_handler.h"
+#include "score/mw/com/test/common_test_resources/fail_test.h"
+#include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
+#include "score/mw/com/test/skeleton_move_semantics/consumer.h"
+#include "score/mw/com/test/skeleton_move_semantics/provider.h"
+#include "score/mw/com/test/skeleton_move_semantics/test_parameters.h"
+
+#include <cstddef>
+#include <cstdlib>
+#include <future>
+#include <iostream>
+#include <string>
+
+namespace
+{
+
+const score::mw::com::InstanceSpecifier kInstanceSpecifierMovedTo =
+    score::mw::com::InstanceSpecifier::Create(std::string{"test/skeleton_move_semantics/MoveEventInterfaceMovedTo"})
+        .value();
+const score::mw::com::InstanceSpecifier kInstanceSpecifierMovedFrom =
+    score::mw::com::InstanceSpecifier::Create(std::string{"test/skeleton_move_semantics/MoveEventInterfaceMovedFrom"})
+        .value();
+
+}  // namespace
+
+int main(int argc, const char** argv)
+{
+    auto test_configuration{score::mw::com::test::ReadCommandLineArguments(argc, argv)};
+
+    score::mw::com::test::SetupAssertHandler();
+    score::mw::com::runtime::InitializeRuntime(argc, argv);
+
+    score::cpp::stop_source stop_source{};
+    const bool sig_term_handler_setup_success = score::mw::com::SetupStopTokenSigTermHandler(stop_source);
+    if (!sig_term_handler_setup_success)
+    {
+        std::cerr << "Unable to set signal handler for SIGINT and/or SIGTERM, cautiously continuing" << std::endl;
+    }
+
+    const auto num_send_iterations = [&test_configuration]() {
+        if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveConstructNotOffered)
+        {
+            // In this scenario, the provider will:
+            //   - Create a skeleton
+            //   - move construct the skeleton
+            //   - offer the service
+            //   - send samples
+            //   - stop offering the service
+            //   - offer the service again
+            //   - send samples again
+            // The receiver therefore expects two send iterations.
+            return 2U;
+        }
+        else if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveConstructOffered)
+        {
+            // In this scenario, the provider will:
+            //   - Create a skeleton
+            //   - offer the service
+            //   - send samples
+            //   - move construct the skeleton while the service is offered
+            //   - send samples
+            //   - stop offering the service
+            //   - offer the service again
+            //   - send samples again
+            // The receiver therefore expects three send iterations.
+            return 3U;
+        }
+        else if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveAssignNotOffered)
+        {
+            // In this scenario, the provider will:
+            //   - Create 2 skeletons
+            //   - move assign the skeleton
+            //   - offer the moved-to service
+            //   - send samples
+            //   - stop offering the service
+            //   - offer the service again
+            //   - send samples again
+            // The receiver therefore expects two send iterations.
+            return 2U;
+        }
+        else if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveAssignOffered)
+        {
+            // In this scenario, the provider will:
+            //   - Create 2 skeletons
+            //   - offer both services
+            //   - send samples in both services
+            //   - move assign the skeleton
+            //   - send samples from moved-to service
+            //   - stop offering the moved-to service
+            //   - offer the moved-to service again
+            //   - send samples again
+            // The receiver connected to the moved-from service expects one send iteration. The receiver connected to
+            // the moved-to service expects three send iterations.
+            return 3U;
+        }
+
+        score::mw::com::test::FailTest("Unknown scenario, cannot determine number of send iterations");
+        return 0U;
+    }();
+
+    std::cout << "Starting provider and consumer with scenario "
+              << static_cast<std::size_t>(test_configuration.scenario) << ", number of samples to send per offer "
+              << test_configuration.number_of_samples_to_send_per_offer << " and number of send iterations"
+              << num_send_iterations << std::endl;
+
+    auto provider_future = std::async(score::mw::com::test::RunProvider,
+                                      test_configuration.scenario,
+                                      test_configuration.number_of_samples_to_send_per_offer,
+                                      stop_source.get_token());
+    auto consumer_future = std::async(score::mw::com::test::RunConsumer,
+                                      kInstanceSpecifierMovedTo,
+                                      test_configuration.number_of_samples_to_send_per_offer,
+                                      num_send_iterations,
+                                      stop_source.get_token());
+
+    if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveAssignOffered)
+    {
+        const std::size_t num_moved_to_send_iterations{1U};
+        auto moved_from_consumer_future = std::async(score::mw::com::test::RunConsumer,
+                                                     kInstanceSpecifierMovedFrom,
+                                                     test_configuration.number_of_samples_to_send_per_offer,
+                                                     num_moved_to_send_iterations,
+                                                     stop_source.get_token());
+        moved_from_consumer_future.get();
+    }
+
+    provider_future.get();
+    consumer_future.get();
+
+    return EXIT_SUCCESS;
+}

--- a/score/mw/com/test/skeleton_move_semantics/main_consumer_and_provider.cpp
+++ b/score/mw/com/test/skeleton_move_semantics/main_consumer_and_provider.cpp
@@ -11,32 +11,12 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 #include "score/mw/com/runtime.h"
-#include "score/mw/com/types.h"
 
 #include "score/mw/com/test/common_test_resources/assert_handler.h"
-#include "score/mw/com/test/common_test_resources/fail_test.h"
 #include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
 #include "score/mw/com/test/skeleton_move_semantics/consumer.h"
 #include "score/mw/com/test/skeleton_move_semantics/provider.h"
 #include "score/mw/com/test/skeleton_move_semantics/test_parameters.h"
-
-#include <cstddef>
-#include <cstdlib>
-#include <future>
-#include <iostream>
-#include <string>
-
-namespace
-{
-
-const score::mw::com::InstanceSpecifier kInstanceSpecifierMovedTo =
-    score::mw::com::InstanceSpecifier::Create(std::string{"test/skeleton_move_semantics/MoveEventInterfaceMovedTo"})
-        .value();
-const score::mw::com::InstanceSpecifier kInstanceSpecifierMovedFrom =
-    score::mw::com::InstanceSpecifier::Create(std::string{"test/skeleton_move_semantics/MoveEventInterfaceMovedFrom"})
-        .value();
-
-}  // namespace
 
 int main(int argc, const char** argv)
 {
@@ -52,79 +32,20 @@ int main(int argc, const char** argv)
         std::cerr << "Unable to set signal handler for SIGINT and/or SIGTERM, cautiously continuing" << std::endl;
     }
 
-    const auto num_send_iterations = [&test_configuration]() {
-        if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveConstructNotOffered)
-        {
-            // In this scenario, the provider will:
-            //   - Create a skeleton
-            //   - move construct the skeleton
-            //   - offer the service
-            //   - send samples
-            //   - stop offering the service
-            //   - offer the service again
-            //   - send samples again
-            // The receiver therefore expects two send iterations.
-            return 2U;
-        }
-        else if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveConstructOffered)
-        {
-            // In this scenario, the provider will:
-            //   - Create a skeleton
-            //   - offer the service
-            //   - send samples
-            //   - move construct the skeleton while the service is offered
-            //   - send samples
-            //   - stop offering the service
-            //   - offer the service again
-            //   - send samples again
-            // The receiver therefore expects three send iterations.
-            return 3U;
-        }
-        else if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveAssignNotOffered)
-        {
-            // In this scenario, the provider will:
-            //   - Create 2 skeletons
-            //   - move assign the skeleton
-            //   - offer the moved-to service
-            //   - send samples
-            //   - stop offering the service
-            //   - offer the service again
-            //   - send samples again
-            // The receiver therefore expects two send iterations.
-            return 2U;
-        }
-        else if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveAssignOffered)
-        {
-            // In this scenario, the provider will:
-            //   - Create 2 skeletons
-            //   - offer both services
-            //   - send samples in both services
-            //   - move assign the skeleton
-            //   - send samples from moved-to service
-            //   - stop offering the moved-to service
-            //   - offer the moved-to service again
-            //   - send samples again
-            // The receiver connected to the moved-from service expects one send iteration. The receiver connected to
-            // the moved-to service expects three send iterations.
-            return 3U;
-        }
-
-        score::mw::com::test::FailTest("Unknown scenario, cannot determine number of send iterations");
-        return 0U;
-    }();
+    const auto num_send_iterations = score::mw::com::test::GetNumberOfSendIterations(test_configuration.scenario);
 
     std::cout << "Starting provider and consumer with scenario "
               << static_cast<std::size_t>(test_configuration.scenario) << ", number of samples to send per offer "
-              << test_configuration.number_of_samples_to_send_per_offer << " and number of send iterations"
+              << score::mw::com::test::kNumberOfSamplesToSendPerOffer << " and number of send iterations"
               << num_send_iterations << std::endl;
 
     auto provider_future = std::async(score::mw::com::test::RunProvider,
                                       test_configuration.scenario,
-                                      test_configuration.number_of_samples_to_send_per_offer,
+                                      score::mw::com::test::kNumberOfSamplesToSendPerOffer,
                                       stop_source.get_token());
     auto consumer_future = std::async(score::mw::com::test::RunConsumer,
-                                      kInstanceSpecifierMovedTo,
-                                      test_configuration.number_of_samples_to_send_per_offer,
+                                      score::mw::com::test::kInstanceSpecifierMovedTo,
+                                      score::mw::com::test::kNumberOfSamplesToSendPerOffer,
                                       num_send_iterations,
                                       stop_source.get_token());
 
@@ -132,8 +53,8 @@ int main(int argc, const char** argv)
     {
         const std::size_t num_moved_to_send_iterations{1U};
         auto moved_from_consumer_future = std::async(score::mw::com::test::RunConsumer,
-                                                     kInstanceSpecifierMovedFrom,
-                                                     test_configuration.number_of_samples_to_send_per_offer,
+                                                     score::mw::com::test::kInstanceSpecifierMovedFrom,
+                                                     score::mw::com::test::kNumberOfSamplesToSendPerOffer,
                                                      num_moved_to_send_iterations,
                                                      stop_source.get_token());
         moved_from_consumer_future.get();

--- a/score/mw/com/test/skeleton_move_semantics/main_provider.cpp
+++ b/score/mw/com/test/skeleton_move_semantics/main_provider.cpp
@@ -1,0 +1,123 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/runtime.h"
+#include "score/mw/com/types.h"
+
+#include "score/mw/com/test/common_test_resources/assert_handler.h"
+#include "score/mw/com/test/common_test_resources/fail_test.h"
+#include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
+#include "score/mw/com/test/skeleton_move_semantics/provider.h"
+#include "score/mw/com/test/skeleton_move_semantics/test_parameters.h"
+
+#include <cstddef>
+#include <cstdlib>
+#include <iostream>
+#include <string>
+
+namespace
+{
+
+const score::mw::com::InstanceSpecifier kInstanceSpecifierMovedTo =
+    score::mw::com::InstanceSpecifier::Create(std::string{"test/skeleton_move_semantics/MoveEventInterfaceMovedTo"})
+        .value();
+const score::mw::com::InstanceSpecifier kInstanceSpecifierMovedFrom =
+    score::mw::com::InstanceSpecifier::Create(std::string{"test/skeleton_move_semantics/MoveEventInterfaceMovedFrom"})
+        .value();
+
+}  // namespace
+
+int main(int argc, const char** argv)
+{
+    auto test_configuration{score::mw::com::test::ReadCommandLineArguments(argc, argv)};
+
+    score::mw::com::test::SetupAssertHandler();
+    score::mw::com::runtime::InitializeRuntime(argc, argv);
+
+    score::cpp::stop_source stop_source{};
+    const bool sig_term_handler_setup_success = score::mw::com::SetupStopTokenSigTermHandler(stop_source);
+    if (!sig_term_handler_setup_success)
+    {
+        std::cerr << "Unable to set signal handler for SIGINT and/or SIGTERM, cautiously continuing" << std::endl;
+    }
+
+    const auto num_send_iterations = [&test_configuration]() {
+        if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveConstructNotOffered)
+        {
+            // In this scenario, the provider will:
+            //   - Create a skeleton
+            //   - move construct the skeleton
+            //   - offer the service
+            //   - send samples
+            //   - stop offering the service
+            //   - offer the service again
+            //   - send samples again
+            // The receiver therefore expects two send iterations.
+            return 2U;
+        }
+        else if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveConstructOffered)
+        {
+            // In this scenario, the provider will:
+            //   - Create a skeleton
+            //   - offer the service
+            //   - send samples
+            //   - move construct the skeleton while the service is offered
+            //   - send samples
+            //   - stop offering the service
+            //   - offer the service again
+            //   - send samples again
+            // The receiver therefore expects three send iterations.
+            return 3U;
+        }
+        else if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveAssignNotOffered)
+        {
+            // In this scenario, the provider will:
+            //   - Create 2 skeletons
+            //   - move assign the skeleton
+            //   - offer the moved-to service
+            //   - send samples
+            //   - stop offering the service
+            //   - offer the service again
+            //   - send samples again
+            // The receiver therefore expects two send iterations.
+            return 2U;
+        }
+        else if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveAssignOffered)
+        {
+            // In this scenario, the provider will:
+            //   - Create 2 skeletons
+            //   - offer both services
+            //   - send samples in both services
+            //   - move assign the skeleton
+            //   - send samples from moved-to service
+            //   - stop offering the moved-to service
+            //   - offer the moved-to service again
+            //   - send samples again
+            // The receiver connected to the moved-from service expects one send iteration. The receiver connected to
+            // the moved-to service expects three send iterations.
+            return 3U;
+        }
+
+        score::mw::com::test::FailTest("Unknown scenario, cannot determine number of send iterations");
+        return 0U;
+    }();
+
+    std::cout << "Starting provider and consumer with scenario "
+              << static_cast<std::size_t>(test_configuration.scenario) << ", number of samples to send per offer "
+              << test_configuration.number_of_samples_to_send_per_offer << " and number of send iterations"
+              << num_send_iterations << std::endl;
+
+    score::mw::com::test::RunProvider(
+        test_configuration.scenario, test_configuration.number_of_samples_to_send_per_offer, stop_source.get_token());
+
+    return EXIT_SUCCESS;
+}

--- a/score/mw/com/test/skeleton_move_semantics/main_provider.cpp
+++ b/score/mw/com/test/skeleton_move_semantics/main_provider.cpp
@@ -11,30 +11,11 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 #include "score/mw/com/runtime.h"
-#include "score/mw/com/types.h"
 
 #include "score/mw/com/test/common_test_resources/assert_handler.h"
-#include "score/mw/com/test/common_test_resources/fail_test.h"
 #include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
 #include "score/mw/com/test/skeleton_move_semantics/provider.h"
 #include "score/mw/com/test/skeleton_move_semantics/test_parameters.h"
-
-#include <cstddef>
-#include <cstdlib>
-#include <iostream>
-#include <string>
-
-namespace
-{
-
-const score::mw::com::InstanceSpecifier kInstanceSpecifierMovedTo =
-    score::mw::com::InstanceSpecifier::Create(std::string{"test/skeleton_move_semantics/MoveEventInterfaceMovedTo"})
-        .value();
-const score::mw::com::InstanceSpecifier kInstanceSpecifierMovedFrom =
-    score::mw::com::InstanceSpecifier::Create(std::string{"test/skeleton_move_semantics/MoveEventInterfaceMovedFrom"})
-        .value();
-
-}  // namespace
 
 int main(int argc, const char** argv)
 {
@@ -50,74 +31,15 @@ int main(int argc, const char** argv)
         std::cerr << "Unable to set signal handler for SIGINT and/or SIGTERM, cautiously continuing" << std::endl;
     }
 
-    const auto num_send_iterations = [&test_configuration]() {
-        if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveConstructNotOffered)
-        {
-            // In this scenario, the provider will:
-            //   - Create a skeleton
-            //   - move construct the skeleton
-            //   - offer the service
-            //   - send samples
-            //   - stop offering the service
-            //   - offer the service again
-            //   - send samples again
-            // The receiver therefore expects two send iterations.
-            return 2U;
-        }
-        else if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveConstructOffered)
-        {
-            // In this scenario, the provider will:
-            //   - Create a skeleton
-            //   - offer the service
-            //   - send samples
-            //   - move construct the skeleton while the service is offered
-            //   - send samples
-            //   - stop offering the service
-            //   - offer the service again
-            //   - send samples again
-            // The receiver therefore expects three send iterations.
-            return 3U;
-        }
-        else if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveAssignNotOffered)
-        {
-            // In this scenario, the provider will:
-            //   - Create 2 skeletons
-            //   - move assign the skeleton
-            //   - offer the moved-to service
-            //   - send samples
-            //   - stop offering the service
-            //   - offer the service again
-            //   - send samples again
-            // The receiver therefore expects two send iterations.
-            return 2U;
-        }
-        else if (test_configuration.scenario == score::mw::com::test::SkeletonMoveScenario::kMoveAssignOffered)
-        {
-            // In this scenario, the provider will:
-            //   - Create 2 skeletons
-            //   - offer both services
-            //   - send samples in both services
-            //   - move assign the skeleton
-            //   - send samples from moved-to service
-            //   - stop offering the moved-to service
-            //   - offer the moved-to service again
-            //   - send samples again
-            // The receiver connected to the moved-from service expects one send iteration. The receiver connected to
-            // the moved-to service expects three send iterations.
-            return 3U;
-        }
-
-        score::mw::com::test::FailTest("Unknown scenario, cannot determine number of send iterations");
-        return 0U;
-    }();
+    const auto num_send_iterations = score::mw::com::test::GetNumberOfSendIterations(test_configuration.scenario);
 
     std::cout << "Starting provider and consumer with scenario "
               << static_cast<std::size_t>(test_configuration.scenario) << ", number of samples to send per offer "
-              << test_configuration.number_of_samples_to_send_per_offer << " and number of send iterations"
+              << score::mw::com::test::kNumberOfSamplesToSendPerOffer << " and number of send iterations"
               << num_send_iterations << std::endl;
 
     score::mw::com::test::RunProvider(
-        test_configuration.scenario, test_configuration.number_of_samples_to_send_per_offer, stop_source.get_token());
+        test_configuration.scenario, score::mw::com::test::kNumberOfSamplesToSendPerOffer, stop_source.get_token());
 
     return EXIT_SUCCESS;
 }

--- a/score/mw/com/test/skeleton_move_semantics/provider.cpp
+++ b/score/mw/com/test/skeleton_move_semantics/provider.cpp
@@ -1,0 +1,361 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/test/skeleton_move_semantics/provider.h"
+
+#include "score/mw/com/test/common_test_resources/fail_test.h"
+#include "score/mw/com/test/methods/methods_test_resources/process_synchronizer.h"
+#include "score/mw/com/test/methods/methods_test_resources/skeleton_container.h"
+#include "score/mw/com/test/skeleton_move_semantics/test_event_datatype.h"
+
+#include <cstdint>
+#include <utility>
+
+namespace score::mw::com::test
+{
+namespace
+{
+
+const std::string kInterprocessNotificationShmPath{"/skeleton_move_semantics_interprocess_notification"};
+
+const InstanceSpecifier kInstanceSpecifierMovedTo =
+    InstanceSpecifier::Create(std::string{"test/skeleton_move_semantics/MoveEventInterfaceMovedTo"}).value();
+const InstanceSpecifier kInstanceSpecifierMovedFrom =
+    InstanceSpecifier::Create(std::string{"test/skeleton_move_semantics/MoveEventInterfaceMovedFrom"}).value();
+
+void SendSamples(SkeletonMoveSemanticsSkeleton& skeleton,
+                 const std::size_t number_of_samples_to_send_per_offer,
+                 const std::uint32_t initial_value)
+{
+    std::cout << "\nProvider: Sending " << number_of_samples_to_send_per_offer << " samples" << std::endl;
+    for (std::uint32_t i = 0; i < number_of_samples_to_send_per_offer; ++i)
+    {
+        auto send_result = skeleton.moved_event_.Send(i + initial_value);
+        if (!send_result.has_value())
+        {
+            FailTest("Provider: Send failed: ", send_result.error());
+        }
+        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+    }
+}
+
+void RunProviderMoveConstructNotOfferedSkeleton(const score::cpp::stop_token& stop_token,
+                                                const std::size_t number_of_samples_to_send_per_offer,
+                                                ProcessSynchronizer& proxy_done_synchronizer)
+{
+    // Step 1. Create skeleton
+    std::cout << "\nProvider: Step 1 - Create skeleton" << std::endl;
+    SkeletonContainer<SkeletonMoveSemanticsSkeleton> skeleton_container{};
+    skeleton_container.CreateSkeleton(kInstanceSpecifierMovedTo, "skeleton_move_semantics");
+    auto original_skeleton = skeleton_container.Extract();
+
+    // Step 2. Move construct skeleton
+    std::cout << "\nProvider: Step 2 - Move construct skeleton" << std::endl;
+    auto moved_to_skeleton = std::move(original_skeleton);
+
+    // Step 3. Offer skeleton
+    std::cout << "\nProvider: Step 3 - Offer skeleton" << std::endl;
+    auto offer_service_result = moved_to_skeleton.OfferService();
+    if (!offer_service_result.has_value())
+    {
+        FailTest("Provider: OfferService failed: ", offer_service_result.error());
+    }
+
+    // Step 4. Send n values
+    std::cout << "\nProvider: Step 4 - Send " << number_of_samples_to_send_per_offer << " samples" << std::endl;
+    SendSamples(moved_to_skeleton, number_of_samples_to_send_per_offer, 1U);
+
+    // Step 5. Wait for consumer to notify that it received the first n values
+    if (!proxy_done_synchronizer.WaitWithAbort(stop_token))
+    {
+        FailTest("skeleton_move_semantics provider failed: waiting for consumer done was aborted");
+    }
+    proxy_done_synchronizer.Reset();
+
+    // Step 6. Stop offering skeleton
+    std::cout << "\nProvider: Step 6 - Stop offering skeleton" << std::endl;
+    moved_to_skeleton.StopOfferService();
+
+    // Step 7. Offer skeleton again
+    std::cout << "\nProvider: Step 7 - Offer skeleton again" << std::endl;
+    offer_service_result = moved_to_skeleton.OfferService();
+    if (!offer_service_result.has_value())
+    {
+        FailTest("Provider: OfferService failed: ", offer_service_result.error());
+    }
+
+    // Step 8. Send n values
+    std::cout << "\nProvider: Step 8 - Send " << number_of_samples_to_send_per_offer
+              << " samples again after re-offering" << std::endl;
+    SendSamples(moved_to_skeleton, number_of_samples_to_send_per_offer, number_of_samples_to_send_per_offer + 1U);
+
+    // Step 9. Wait for consumer to notify that it received the second n values
+    if (!proxy_done_synchronizer.WaitWithAbort(stop_token))
+    {
+        FailTest("skeleton_move_semantics provider failed: waiting for consumer done was aborted");
+    }
+}
+
+void RunProviderMoveConstructOfferedSkeleton(const score::cpp::stop_token& stop_token,
+                                             const std::size_t number_of_samples_to_send_per_offer,
+                                             ProcessSynchronizer& proxy_done_synchronizer)
+{
+    // Step 1. Create skeleton
+    std::cout << "\nProvider: Step 1 - Create skeleton" << std::endl;
+    SkeletonContainer<SkeletonMoveSemanticsSkeleton> skeleton_container{};
+    skeleton_container.CreateSkeleton(kInstanceSpecifierMovedTo, "skeleton_move_semantics");
+
+    // Step 2. Offer skeleton
+    std::cout << "\nProvider: Step 2 - Offer skeleton" << std::endl;
+    skeleton_container.OfferService("skeleton_move_semantics");
+
+    // Step 3. Send n values
+    std::cout << "\nProvider: Step 3 - Send " << number_of_samples_to_send_per_offer << " samples" << std::endl;
+    SendSamples(skeleton_container.GetSkeleton(), number_of_samples_to_send_per_offer, 1U);
+
+    // Step 4. Wait for consumer to notify that it received the first n values
+    if (!proxy_done_synchronizer.WaitWithAbort(stop_token))
+    {
+        FailTest("skeleton_move_semantics provider failed: waiting for consumer done was aborted");
+    }
+    proxy_done_synchronizer.Reset();
+
+    // Step 5. Move construct skeleton while offered
+    std::cout << "\nProvider: Step 5 - Move construct skeleton while offered" << std::endl;
+    auto moved_to_skeleton = std::move(skeleton_container.GetSkeleton());
+
+    // Step 6. Send n values
+    std::cout << "\nProvider: Step 6 - Send " << number_of_samples_to_send_per_offer
+              << " samples again after re-offering" << std::endl;
+    SendSamples(moved_to_skeleton, number_of_samples_to_send_per_offer, number_of_samples_to_send_per_offer + 1U);
+
+    // Step 7. Wait for consumer to notify that it received the second n values
+    if (!proxy_done_synchronizer.WaitWithAbort(stop_token))
+    {
+        FailTest("skeleton_move_semantics provider failed: waiting for consumer done was aborted");
+    }
+    proxy_done_synchronizer.Reset();
+
+    // Step 8. Stop offering skeleton
+    std::cout << "\nProvider: Step 8 - Stop offering skeleton" << std::endl;
+    moved_to_skeleton.StopOfferService();
+
+    // Step 9. Offer skeleton again
+    std::cout << "\nProvider: Step 9 - Offer skeleton again" << std::endl;
+    auto offer_service_result = moved_to_skeleton.OfferService();
+    if (!offer_service_result.has_value())
+    {
+        FailTest("Provider: OfferService failed: ", offer_service_result.error());
+    }
+
+    // Step 10. Send n values
+    std::cout << "\nProvider: Step 10 - Send " << number_of_samples_to_send_per_offer
+              << " samples again after re-offering" << std::endl;
+    SendSamples(moved_to_skeleton, number_of_samples_to_send_per_offer, number_of_samples_to_send_per_offer * 2U + 1U);
+
+    // Step 11. Wait for consumer to notify that it received the third n values
+    if (!proxy_done_synchronizer.WaitWithAbort(stop_token))
+    {
+        FailTest("skeleton_move_semantics provider failed: waiting for consumer done was aborted");
+    }
+    proxy_done_synchronizer.Reset();
+}
+
+void RunProviderMoveAssignNotOfferedSkeleton(const score::cpp::stop_token& stop_token,
+                                             const std::size_t number_of_samples_to_send_per_offer,
+                                             ProcessSynchronizer& proxy_done_synchronizer)
+{
+    // Step 1. Create two skeletons
+    std::cout << "\nProvider: Step 1 - Create two skeletons" << std::endl;
+    SkeletonContainer<SkeletonMoveSemanticsSkeleton> moved_from_skeleton_container{};
+    moved_from_skeleton_container.CreateSkeleton(kInstanceSpecifierMovedTo, "skeleton_move_semantics");
+    auto moved_from_skeleton = moved_from_skeleton_container.Extract();
+
+    SkeletonContainer<SkeletonMoveSemanticsSkeleton> moved_to_skeleton_container{};
+    moved_to_skeleton_container.CreateSkeleton(kInstanceSpecifierMovedFrom, "skeleton_move_semantics");
+    auto moved_to_skeleton = moved_to_skeleton_container.Extract();
+
+    // Step 2. Move assign skeleton
+    std::cout << "\nProvider: Step 2 - Move assign skeleton" << std::endl;
+    moved_to_skeleton = std::move(moved_from_skeleton);
+
+    // Step 3. Offer skeleton
+    std::cout << "\nProvider: Step 3 - Offer skeleton" << std::endl;
+    auto offer_service_result = moved_to_skeleton.OfferService();
+    if (!offer_service_result.has_value())
+    {
+        FailTest("Provider: OfferService failed: ", offer_service_result.error());
+    }
+
+    // Step 4. Send n values
+    std::cout << "\nProvider: Step 4 - Send " << number_of_samples_to_send_per_offer << " samples" << std::endl;
+    SendSamples(moved_to_skeleton, number_of_samples_to_send_per_offer, 1U);
+
+    // Step 5. Wait for consumer to notify that it received the first n values
+    if (!proxy_done_synchronizer.WaitWithAbort(stop_token))
+    {
+        FailTest("skeleton_move_semantics provider failed: waiting for consumer done was aborted");
+    }
+    proxy_done_synchronizer.Reset();
+
+    // Step 6. Stop offering skeleton
+    std::cout << "\nProvider: Step 6 - Stop offering skeleton" << std::endl;
+    moved_to_skeleton.StopOfferService();
+
+    // Step 7. Offer skeleton again
+    std::cout << "\nProvider: Step 7 - Offer skeleton again" << std::endl;
+    offer_service_result = moved_to_skeleton.OfferService();
+    if (!offer_service_result.has_value())
+    {
+        FailTest("Provider: OfferService failed: ", offer_service_result.error());
+    }
+
+    // Step 8. Send n values
+    std::cout << "\nProvider: Step 8 - Send " << number_of_samples_to_send_per_offer
+              << " samples again after re-offering" << std::endl;
+    SendSamples(moved_to_skeleton, number_of_samples_to_send_per_offer, number_of_samples_to_send_per_offer + 1U);
+
+    // Step 9. Wait for consumer to notify that it received the second n values
+    if (!proxy_done_synchronizer.WaitWithAbort(stop_token))
+    {
+        FailTest("skeleton_move_semantics provider failed: waiting for consumer done was aborted");
+    }
+}
+
+void RunProviderMoveAssignOfferedSkeleton(const score::cpp::stop_token& stop_token,
+                                          const std::size_t number_of_samples_to_send_per_offer,
+                                          ProcessSynchronizer& moved_to_proxy_done_synchronizer_result,
+                                          ProcessSynchronizer& moved_from_proxy_done_synchronizer_result)
+{
+    // Step 1. Create two skeletons
+    std::cout << "\nProvider: Step 1 - Create two skeletons" << std::endl;
+    SkeletonContainer<SkeletonMoveSemanticsSkeleton> moved_from_skeleton_container{};
+    moved_from_skeleton_container.CreateSkeleton(kInstanceSpecifierMovedTo, "skeleton_move_semantics");
+
+    SkeletonContainer<SkeletonMoveSemanticsSkeleton> moved_to_skeleton_container{};
+    moved_to_skeleton_container.CreateSkeleton(kInstanceSpecifierMovedFrom, "skeleton_move_semantics");
+
+    // Step 2. Offer both skeletons
+    std::cout << "\nProvider: Step 2 - Offer both skeletons" << std::endl;
+    moved_from_skeleton_container.OfferService("skeleton_move_semantics");
+    moved_to_skeleton_container.OfferService("skeleton_move_semantics");
+
+    // Step 3. Send n values from both skeletons
+    std::cout << "\nProvider: Step 3 - Send " << number_of_samples_to_send_per_offer << " samples from both skeletons"
+              << std::endl;
+    SendSamples(moved_to_skeleton_container.GetSkeleton(), number_of_samples_to_send_per_offer, 1U);
+    SendSamples(moved_from_skeleton_container.GetSkeleton(), number_of_samples_to_send_per_offer, 1U);
+
+    // Step 4. Wait for both consumers to notify that they received the first n values
+    if (!moved_to_proxy_done_synchronizer_result.WaitWithAbort(stop_token))
+    {
+        FailTest("skeleton_move_semantics provider failed: waiting for moved-to consumer done was aborted");
+    }
+    moved_to_proxy_done_synchronizer_result.Reset();
+    if (!moved_from_proxy_done_synchronizer_result.WaitWithAbort(stop_token))
+    {
+        FailTest("skeleton_move_semantics provider failed: waiting for moved-from consumer done was aborted");
+    }
+    moved_from_proxy_done_synchronizer_result.Reset();
+
+    // Step 5. Move assign skeleton
+    std::cout << "\nProvider: Step 5 - Move assign skeleton" << std::endl;
+    auto moved_from_skeleton = moved_from_skeleton_container.Extract();
+    auto moved_to_skeleton = moved_to_skeleton_container.Extract();
+    moved_to_skeleton = std::move(moved_from_skeleton);
+
+    // Step 6. Send n values from moved-to skeleton
+    std::cout << "\nProvider: Step 6 - Send " << number_of_samples_to_send_per_offer
+              << " samples from moved-to skeleton" << std::endl;
+    SendSamples(moved_to_skeleton, number_of_samples_to_send_per_offer, number_of_samples_to_send_per_offer + 1U);
+
+    // Step 7. Stop offering moved-to skeleton
+    std::cout << "\nProvider: Step 7 - Stop offering moved-to skeleton" << std::endl;
+    moved_to_skeleton.StopOfferService();
+
+    // Step 8. Offer moved-to skeleton again
+    std::cout << "\nProvider: Step 8 - Offer moved-to skeleton again" << std::endl;
+    const auto offer_service_result = moved_to_skeleton.OfferService();
+    if (!offer_service_result.has_value())
+    {
+        FailTest("Provider: OfferService failed: ", offer_service_result.error());
+    }
+
+    // Step 9. Send n values
+    std::cout << "\nProvider: Step 9 - Send " << number_of_samples_to_send_per_offer
+              << " samples again after re-offering" << std::endl;
+    SendSamples(moved_to_skeleton, number_of_samples_to_send_per_offer, 2 * number_of_samples_to_send_per_offer + 1U);
+
+    // Step 10. Wait for moved-to consumer to notify that it received the third n values
+    if (!moved_to_proxy_done_synchronizer_result.WaitWithAbort(stop_token))
+    {
+        FailTest("skeleton_move_semantics provider failed: waiting for moved-to consumer done was aborted");
+    }
+}
+
+}  // namespace
+
+void RunProvider(const SkeletonMoveScenario& scenario,
+                 const std::size_t num_samples_to_send,
+                 const score::cpp::stop_token& stop_token)
+{
+    const auto moved_to_name = filesystem::Path{kInstanceSpecifierMovedTo.ToString()}.Filename().Native();
+    auto moved_to_proxy_done_synchronizer_result =
+        ProcessSynchronizer::Create(kInterprocessNotificationShmPath + std::string{moved_to_name});
+    if (!moved_to_proxy_done_synchronizer_result.has_value())
+    {
+        FailTest("skeleton_move_semantics provider failed: could not create ready synchronizer");
+    }
+
+    switch (scenario)
+    {
+        case SkeletonMoveScenario::kMoveConstructNotOffered:
+        {
+            RunProviderMoveConstructNotOfferedSkeleton(
+                stop_token, num_samples_to_send, moved_to_proxy_done_synchronizer_result.value());
+            break;
+        }
+        case SkeletonMoveScenario::kMoveConstructOffered:
+        {
+            RunProviderMoveConstructOfferedSkeleton(
+                stop_token, num_samples_to_send, moved_to_proxy_done_synchronizer_result.value());
+            break;
+        }
+        case SkeletonMoveScenario::kMoveAssignNotOffered:
+        {
+            RunProviderMoveAssignNotOfferedSkeleton(
+                stop_token, num_samples_to_send, moved_to_proxy_done_synchronizer_result.value());
+            break;
+        }
+        case SkeletonMoveScenario::kMoveAssignOffered:
+        {
+            const auto moved_from_name = filesystem::Path{kInstanceSpecifierMovedFrom.ToString()}.Filename().Native();
+            auto moved_from_proxy_done_synchronizer_result =
+                ProcessSynchronizer::Create(kInterprocessNotificationShmPath + std::string{moved_from_name});
+            if (!moved_from_proxy_done_synchronizer_result.has_value())
+            {
+                FailTest("skeleton_move_semantics provider failed: could not create ready synchronizer");
+            }
+            RunProviderMoveAssignOfferedSkeleton(stop_token,
+                                                 num_samples_to_send,
+                                                 moved_to_proxy_done_synchronizer_result.value(),
+                                                 moved_from_proxy_done_synchronizer_result.value());
+            break;
+        }
+        case SkeletonMoveScenario::kNumberOfScenarios:
+            [[fallthrough]];
+        default:
+            FailTest("skeleton_move_semantics provider failed: unknown scenario");
+    }
+}
+
+}  // namespace score::mw::com::test

--- a/score/mw/com/test/skeleton_move_semantics/provider.cpp
+++ b/score/mw/com/test/skeleton_move_semantics/provider.cpp
@@ -13,8 +13,8 @@
 #include "score/mw/com/test/skeleton_move_semantics/provider.h"
 
 #include "score/mw/com/test/common_test_resources/fail_test.h"
+#include "score/mw/com/test/common_test_resources/skeleton_container.h"
 #include "score/mw/com/test/methods/methods_test_resources/process_synchronizer.h"
-#include "score/mw/com/test/methods/methods_test_resources/skeleton_container.h"
 #include "score/mw/com/test/skeleton_move_semantics/test_event_datatype.h"
 
 #include <cstdint>
@@ -26,11 +26,6 @@ namespace
 {
 
 const std::string kInterprocessNotificationShmPath{"/skeleton_move_semantics_interprocess_notification"};
-
-const InstanceSpecifier kInstanceSpecifierMovedTo =
-    InstanceSpecifier::Create(std::string{"test/skeleton_move_semantics/MoveEventInterfaceMovedTo"}).value();
-const InstanceSpecifier kInstanceSpecifierMovedFrom =
-    InstanceSpecifier::Create(std::string{"test/skeleton_move_semantics/MoveEventInterfaceMovedFrom"}).value();
 
 void SendSamples(SkeletonMoveSemanticsSkeleton& skeleton,
                  const std::size_t number_of_samples_to_send_per_offer,

--- a/score/mw/com/test/skeleton_move_semantics/provider.h
+++ b/score/mw/com/test/skeleton_move_semantics/provider.h
@@ -1,0 +1,29 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_TEST_SKELETON_MOVE_SEMANTICS_PROVIDER_H
+#define SCORE_MW_COM_TEST_SKELETON_MOVE_SEMANTICS_PROVIDER_H
+
+#include "score/mw/com/test/skeleton_move_semantics/test_parameters.h"
+
+#include <score/stop_token.hpp>
+
+namespace score::mw::com::test
+{
+
+void RunProvider(const SkeletonMoveScenario& scenario,
+                 const std::size_t num_samples_to_send,
+                 const score::cpp::stop_token& stop_token);
+
+}  // namespace score::mw::com::test
+
+#endif  // SCORE_MW_COM_TEST_SKELETON_MOVE_SEMANTICS_PROVIDER_H

--- a/score/mw/com/test/skeleton_move_semantics/test_event_datatype.cpp
+++ b/score/mw/com/test/skeleton_move_semantics/test_event_datatype.cpp
@@ -1,0 +1,13 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/test/skeleton_move_semantics/test_event_datatype.h"

--- a/score/mw/com/test/skeleton_move_semantics/test_event_datatype.h
+++ b/score/mw/com/test/skeleton_move_semantics/test_event_datatype.h
@@ -1,0 +1,37 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_TEST_SKELETON_MOVE_SEMANTICS_TEST_EVENT_DATATYPE_H
+#define SCORE_MW_COM_TEST_SKELETON_MOVE_SEMANTICS_TEST_EVENT_DATATYPE_H
+
+#include "score/mw/com/types.h"
+
+#include <cstdint>
+
+namespace score::mw::com::test
+{
+
+template <typename T>
+class SkeletonMoveSemanticsInterface : public T::Base
+{
+  public:
+    using T::Base::Base;
+
+    typename T::template Event<std::uint32_t> moved_event_{*this, "moved_event"};
+};
+
+using SkeletonMoveSemanticsProxy = score::mw::com::AsProxy<SkeletonMoveSemanticsInterface>;
+using SkeletonMoveSemanticsSkeleton = score::mw::com::AsSkeleton<SkeletonMoveSemanticsInterface>;
+
+}  // namespace score::mw::com::test
+
+#endif  // SCORE_MW_COM_TEST_SKELETON_MOVE_SEMANTICS_TEST_EVENT_DATATYPE_H

--- a/score/mw/com/test/skeleton_move_semantics/test_parameters.cpp
+++ b/score/mw/com/test/skeleton_move_semantics/test_parameters.cpp
@@ -36,15 +36,73 @@ CombinedTestConfiguration ReadCommandLineArguments(int argc, const char** argv)
     }
     const auto scenario = static_cast<SkeletonMoveScenario>(scenario_index);
 
-    const auto num_samples_to_send = GetValue<std::size_t>(args, kNumberOfSamplesToSend);
-    if (num_samples_to_send == 0U)
-    {
-        FailTest("Consumer: ", kNumberOfSamplesToSend, " value must be larger than 0.");
-    }
-
     auto service_instance_manifest = GetValue<std::string>(args, kServiceInstanceManifest);
 
-    return {scenario, num_samples_to_send, service_instance_manifest};
+    return {scenario, service_instance_manifest};
+}
+
+std::size_t GetNumberOfSendIterations(const SkeletonMoveScenario scenario)
+{
+    if (scenario == SkeletonMoveScenario::kMoveConstructNotOffered)
+    {
+        // In this scenario, the provider will:
+        //   - Create a skeleton
+        //   - move construct the skeleton
+        //   - offer the service
+        //   - send samples
+        //   - stop offering the service
+        //   - offer the service again
+        //   - send samples again
+        // The receiver therefore expects two send iterations.
+        return 2U;
+    }
+    else if (scenario == SkeletonMoveScenario::kMoveConstructOffered)
+    {
+        // In this scenario, the provider will:
+        //   - Create a skeleton
+        //   - offer the service
+        //   - send samples
+        //   - move construct the skeleton while the service is offered
+        //   - send samples
+        //   - stop offering the service
+        //   - offer the service again
+        //   - send samples again
+        // The receiver therefore expects three send iterations.
+        return 3U;
+    }
+    else if (scenario == SkeletonMoveScenario::kMoveAssignNotOffered)
+    {
+        // In this scenario, the provider will:
+        //   - Create 2 skeletons
+        //   - move assign the skeleton
+        //   - offer the moved-to service
+        //   - send samples
+        //   - stop offering the service
+        //   - offer the service again
+        //   - send samples again
+        // The receiver therefore expects two send iterations.
+        return 2U;
+    }
+    else if (scenario == SkeletonMoveScenario::kMoveAssignOffered)
+    {
+        // In this scenario, the provider will:
+        //   - Create 2 skeletons
+        //   - offer both services
+        //   - send samples in both services
+        //   - move assign the skeleton
+        //   - send samples from moved-to service
+        //   - stop offering the moved-to service
+        //   - offer the moved-to service again
+        //   - send samples again
+        // The receiver connected to the moved-from service expects one send iteration. The receiver connected to
+        // the moved-to service expects three send iterations.
+        return 3U;
+    }
+    else
+    {
+        FailTest("Unknown scenario, cannot determine number of send iterations");
+        return 0U;
+    }
 }
 
 }  // namespace score::mw::com::test

--- a/score/mw/com/test/skeleton_move_semantics/test_parameters.cpp
+++ b/score/mw/com/test/skeleton_move_semantics/test_parameters.cpp
@@ -1,0 +1,50 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/test/skeleton_move_semantics/test_parameters.h"
+
+#include "score/mw/com/test/common_test_resources/command_line_parser.h"
+#include "score/mw/com/test/common_test_resources/fail_test.h"
+
+namespace score::mw::com::test
+{
+
+CombinedTestConfiguration ReadCommandLineArguments(int argc, const char** argv)
+{
+    auto args = ParseCommandLineArguments(
+        argc, argv, {{kScenario, ""}, {kNumberOfSamplesToSend, ""}, {kServiceInstanceManifest, ""}});
+
+    const auto scenario_index = GetValue<std::size_t>(args, kScenario);
+    if (scenario_index >= static_cast<std::size_t>(SkeletonMoveScenario::kNumberOfScenarios))
+    {
+        FailTest("Consumer: ",
+                 kScenario,
+                 " value ",
+                 scenario_index,
+                 " is out of range. Valid values are between 0 and ",
+                 static_cast<std::uint8_t>(SkeletonMoveScenario::kNumberOfScenarios) - 1,
+                 ".");
+    }
+    const auto scenario = static_cast<SkeletonMoveScenario>(scenario_index);
+
+    const auto num_samples_to_send = GetValue<std::size_t>(args, kNumberOfSamplesToSend);
+    if (num_samples_to_send == 0U)
+    {
+        FailTest("Consumer: ", kNumberOfSamplesToSend, " value must be larger than 0.");
+    }
+
+    auto service_instance_manifest = GetValue<std::string>(args, kServiceInstanceManifest);
+
+    return {scenario, num_samples_to_send, service_instance_manifest};
+}
+
+}  // namespace score::mw::com::test

--- a/score/mw/com/test/skeleton_move_semantics/test_parameters.h
+++ b/score/mw/com/test/skeleton_move_semantics/test_parameters.h
@@ -1,0 +1,46 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_TEST_SKELETON_MOVE_SEMANTICS_TEST_PARAMETERS_H
+#define SCORE_MW_COM_TEST_SKELETON_MOVE_SEMANTICS_TEST_PARAMETERS_H
+
+#include <cstdint>
+#include <string>
+
+namespace score::mw::com::test
+{
+
+const std::string kScenario{"scenario"};
+const std::string kNumberOfSamplesToSend{"number-of-samples-to-send"};
+const std::string kServiceInstanceManifest{"service-instance-manifest"};
+
+enum class SkeletonMoveScenario : std::uint8_t
+{
+    kMoveConstructNotOffered,
+    kMoveConstructOffered,
+    kMoveAssignNotOffered,
+    kMoveAssignOffered,
+    kNumberOfScenarios
+};
+
+struct CombinedTestConfiguration
+{
+    SkeletonMoveScenario scenario;
+    std::size_t number_of_samples_to_send_per_offer;
+    std::string service_instance_manifest;
+};
+
+CombinedTestConfiguration ReadCommandLineArguments(int argc, const char** argv);
+
+}  // namespace score::mw::com::test
+
+#endif  // SCORE_MW_COM_TEST_SKELETON_MOVE_SEMANTICS_TEST_PARAMETERS_H

--- a/score/mw/com/test/skeleton_move_semantics/test_parameters.h
+++ b/score/mw/com/test/skeleton_move_semantics/test_parameters.h
@@ -13,6 +13,8 @@
 #ifndef SCORE_MW_COM_TEST_SKELETON_MOVE_SEMANTICS_TEST_PARAMETERS_H
 #define SCORE_MW_COM_TEST_SKELETON_MOVE_SEMANTICS_TEST_PARAMETERS_H
 
+#include "score/mw/com/types.h"
+
 #include <cstdint>
 #include <string>
 
@@ -22,6 +24,13 @@ namespace score::mw::com::test
 const std::string kScenario{"scenario"};
 const std::string kNumberOfSamplesToSend{"number-of-samples-to-send"};
 const std::string kServiceInstanceManifest{"service-instance-manifest"};
+
+constexpr std::size_t kNumberOfSamplesToSendPerOffer{10U};
+
+const InstanceSpecifier kInstanceSpecifierMovedTo =
+    InstanceSpecifier::Create(std::string{"test/skeleton_move_semantics/MoveEventInterfaceMovedTo"}).value();
+const InstanceSpecifier kInstanceSpecifierMovedFrom =
+    InstanceSpecifier::Create(std::string{"test/skeleton_move_semantics/MoveEventInterfaceMovedFrom"}).value();
 
 enum class SkeletonMoveScenario : std::uint8_t
 {
@@ -35,11 +44,16 @@ enum class SkeletonMoveScenario : std::uint8_t
 struct CombinedTestConfiguration
 {
     SkeletonMoveScenario scenario;
-    std::size_t number_of_samples_to_send_per_offer;
     std::string service_instance_manifest;
 };
 
 CombinedTestConfiguration ReadCommandLineArguments(int argc, const char** argv);
+
+/// \brief Determines the number of times the provider will send n samples based on the test scenario.
+///
+/// The number of samples expected to be received by the consumer is equal to number_of_samples_to_send_per_offer *
+/// number_of_send_iterations.
+std::size_t GetNumberOfSendIterations(SkeletonMoveScenario scenario);
 
 }  // namespace score::mw::com::test
 


### PR DESCRIPTION
In the near future, we should implement similar tests for SkeletonFields and SkeletonMethods. We should also implement similar tests on proxy side.