### PR TITLE
ci: Add actions: write permissions to jobs using castler/setup-bazel

### DIFF
--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -49,6 +49,7 @@ on:
 
 permissions:
   contents: read
+  actions: write # Needed to delete old bazel caches
 
 concurrency:
   group: clang-tidy-pr-${{ github.event.pull_request.number || github.run_id }}

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -32,7 +32,7 @@ permissions:
   contents: write  # needed for uploading release assets
   pages: write
   id-token: write
-  actions: read    # needed to download artifacts from the nightly workflow_run
+  actions: write    # needed to download artifacts from the nightly workflow_run and delete old bazel caches
 
 concurrency:
   group: "pages"


### PR DESCRIPTION
These jobs have old caches lingering around, which they cannot delete. With the write permission the old cashes will be taken care of.