### PR TITLE
migrate mw/com to result nodiscard.

### DIFF
--- a/score/mw/com/example/ipc_bridge/sample_sender_receiver.cpp
+++ b/score/mw/com/example/ipc_bridge/sample_sender_receiver.cpp
@@ -539,7 +539,7 @@ int EventSenderReceiver::RunAsGenericSkeleton(const score::mw::com::InstanceSpec
 
         {
             std::lock_guard lock{event_sending_mutex_};
-            event.Send(std::move(sample));
+            score::cpp::ignore = event.Send(std::move(sample));
             event_published_ = true;
         }
         std::this_thread::sleep_for(cycle_time);

--- a/score/mw/com/impl/bindings/lola/service_discovery/flag_file_test.cpp
+++ b/score/mw/com/impl/bindings/lola/service_discovery/flag_file_test.cpp
@@ -329,7 +329,7 @@ TEST_F(FlagFileDeathTest, GivenFileRemoveFailWhenMakeThenWillDie)
 
     // When Make is called
     // Then the program terminates
-    EXPECT_DEATH(FlagFile::Make(kEnrichedInstanceIdentifier2, disambiguator_, filesystem_), ".*");
+    EXPECT_DEATH(score::cpp::ignore = FlagFile::Make(kEnrichedInstanceIdentifier2, disambiguator_, filesystem_), ".*");
 }
 
 TEST_F(FlagFileTest, CreatePathReturnsValidPathWhenDirectoryAlreadyExists)

--- a/score/mw/com/impl/bindings/lola/skeleton_event_test.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_event_test.cpp
@@ -144,7 +144,7 @@ TEST_F(SkeletonEventAllocateFixture, AllocateReturnsUniquePointersForMultipleCal
 
     // Given an offered event
     InitialiseSkeletonEvent(fake_element_fq_id_, fake_event_name_, max_samples_, max_subscribers_, enforce_max_samples);
-    skeleton_event_->PrepareOffer();
+    score::cpp::ignore = skeleton_event_->PrepareOffer();
 
     // When allocating multiple samples without sending them
     std::vector<impl::SampleAllocateePtr<test::TestSampleType>> allocated_pointers;

--- a/score/mw/com/impl/instance_identifier_test.cpp
+++ b/score/mw/com/impl/instance_identifier_test.cpp
@@ -347,7 +347,7 @@ TEST_F(InstanceIdentifierDeathTest, DeathOnCreationWithDuplicateServiceIdentifie
     // When creating a second InstanceIdentifier with the same ServiceIdentifierType
     // Then the program terminates
     std::string second_serialized_string_form_copy{serialized_string_form};
-    EXPECT_DEATH(InstanceIdentifier::Create(std::move(second_serialized_string_form_copy)), ".*");
+    EXPECT_DEATH(score::cpp::ignore = InstanceIdentifier::Create(std::move(second_serialized_string_form_copy)), ".*");
 }
 
 TEST_F(InstanceIdentifierDeathTest, CreatingFromSerializedObjectWithMismatchedSerializationVersionTerminates)
@@ -365,7 +365,7 @@ TEST_F(InstanceIdentifierDeathTest, CreatingFromSerializedObjectWithMismatchedSe
     std::string serialized_string_form = writer.ToBuffer(serialized_unit).value();
 
     // Then: Verify creation of identifier with mismatched serialization version causes program termination
-    EXPECT_DEATH(InstanceIdentifier::Create(std::move(serialized_string_form)), ".*");
+    EXPECT_DEATH(score::cpp::ignore = InstanceIdentifier::Create(std::move(serialized_string_form)), ".*");
 }
 
 TEST_F(InstanceIdentifierDeathTest, DeathOnCreationWithDuplicateInstanceSpecifier)
@@ -379,7 +379,7 @@ TEST_F(InstanceIdentifierDeathTest, DeathOnCreationWithDuplicateInstanceSpecifie
 
     // When: Creating a second instance identifier with the same instance specifier
     // Then: The program terminates
-    EXPECT_DEATH(InstanceIdentifier::Create(std::move(serialized_form_service2)), ".*");
+    EXPECT_DEATH(score::cpp::ignore = InstanceIdentifier::Create(std::move(serialized_form_service2)), ".*");
 }
 
 TEST_F(InstanceIdentifierFixture, HashInstanceIdentifierComparesEqual)


### PR DESCRIPTION
Migrated baselibs result to nodiscard and modified mw/com to ensure all return values are either utilized appropriately or explicitly discarded.