### PR TITLE
ci: Use job id as cache name

### DIFF
--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -53,7 +53,7 @@ jobs:
         uses: castler/setup-bazel@cache-optimized
         with:
           bazelisk-cache: true
-          disk-cache: ${{ github.job }}
+          disk-cache: "coverage_report"
           repository-cache: true
           cache-optimized: true
           cache-save: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -24,6 +24,7 @@ on:
 
 permissions:
   contents: read
+  actions: write # Needed to delete old bazel caches
 
 concurrency:
   group: coverage_report-${{ github.event.pull_request.number || github.run_id }}
@@ -52,7 +53,7 @@ jobs:
         uses: castler/setup-bazel@cache-optimized
         with:
           bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}
+          disk-cache: ${{ github.job }}
           repository-cache: true
           cache-optimized: true
           cache-save: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -54,7 +54,7 @@ jobs:
         uses: castler/setup-bazel@cache-optimized
         with:
           bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}
+          disk-cache: ${{ github.job }}
           repository-cache: true
           cache-optimized: true
           cache-save: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -54,7 +54,7 @@ jobs:
         uses: castler/setup-bazel@cache-optimized
         with:
           bazelisk-cache: true
-          disk-cache: ${{ github.job }}
+          disk-cache: "build_docs"
           repository-cache: true
           cache-optimized: true
           cache-save: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/nightly_quality.yml
+++ b/.github/workflows/nightly_quality.yml
@@ -81,7 +81,7 @@ jobs:
         uses: castler/setup-bazel@cache-optimized
         with:
           bazelisk-cache: true
-          disk-cache: ${{ github.job }}
+          disk-cache: "deploy_quality_reports"
           repository-cache: true
           cache-optimized: true
           cache-save: ${{ github.ref == 'refs/heads/main' }}

--- a/.github/workflows/nightly_quality.yml
+++ b/.github/workflows/nightly_quality.yml
@@ -50,6 +50,7 @@ jobs:
     uses: ./.github/workflows/coverage_report.yml
     permissions:
       contents: read
+      actions: write
 
   # --------------------------------------------------------------------
   # Quality job 2: Clang-Tidy
@@ -80,7 +81,7 @@ jobs:
         uses: castler/setup-bazel@cache-optimized
         with:
           bazelisk-cache: true
-          disk-cache: ${{ github.workflow }}
+          disk-cache: ${{ github.job }}
           repository-cache: true
           cache-optimized: true
           cache-save: ${{ github.ref == 'refs/heads/main' }}


### PR DESCRIPTION
At the moment there are three caches named "Nightly Quality Jobs". This is caused by using the workflow_name and calling workflow files in subjobs.

With workflow_call the job name should be a better fit for the cache name. An alternative would also be to follow the pattern proposed here: https://github.com/eclipse-score/cicd-actions/tree/main/setup-bazel-cache#usage

https://docs.github.com/en/actions/reference/workflows-and-actions/contexts#github-context