### PR TITLE
Rust::com FFI Unsafe Optimization

### DIFF
--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi.rs
@@ -256,13 +256,12 @@ pub trait FFIBridge: Send + Sync + Clone + Debug + 'static + Unpin + Default {
     /// `get_event_from_proxy`. `event_type` must match the type used when the handler was set.
     unsafe fn clear_event_receive_handler(&self, proxy_event_ptr: *mut ProxyEventBase);
 
-    /// # Safety
-    /// `callback` must be a valid `FatPtr` referencing a callable compatible with the
-    /// find-service callback signature. `instance_spec` must be a valid `InstanceSpecifier`.
+    /// Starts asynchronous service discovery. The `callback` invariant is encoded in
+    /// `FindServiceCallable, check its `unsafe` constructor for the full contract.
     /// The returned handle must eventually be passed to `stop_find_service`.
-    unsafe fn start_find_service(
+    fn start_find_service(
         &self,
-        callback: &FatPtr,
+        callback: &FindServiceCallable,
         instance_spec: InstanceSpecifier,
     ) -> *mut FindServiceHandle;
 
@@ -300,6 +299,33 @@ pub struct SkeletonBase {
 #[repr(C)]
 pub struct FindServiceHandle {
     dummy: [u8; 0],
+}
+
+/// A type-safe wrapper around a `FatPtr` that has been verified to represent a valid
+/// find-service callback (`FnMut(HandleContainer, NativeFindServiceHandle)`).
+///
+/// Constructing this type is `unsafe`, once constructed, passing it to
+/// `FFIBridge::start_find_service` is safe because the invariant is encoded here.
+pub struct FindServiceCallable {
+    inner: FatPtr,
+}
+
+impl FindServiceCallable {
+    /// Wraps `fat_ptr` in a `FindServiceCallable`.
+    ///
+    /// # Safety
+    /// `fat_ptr` must be a valid, whose underlying closure has the signature
+    /// `FnMut(HandleContainer, NativeFindServiceHandle)` and must remain valid for
+    /// as long as the returned `FindServiceCallable` (and the find-service operation
+    /// registered with it) is alive.
+    pub unsafe fn new(fat_ptr: FatPtr) -> Self {
+        Self { inner: fat_ptr }
+    }
+
+    /// Returns a reference to the inner `FatPtr`.
+    pub fn as_fat_ptr(&self) -> &FatPtr {
+        &self.inner
+    }
 }
 
 /// This struct wraps the raw pointer to FindServiceHandle returned

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
@@ -42,8 +42,13 @@ unsafe extern "C" fn mw_com_impl_call_dyn_ref_fnmut_sample(
     // The caller must ensure the lifetime of the closure outlives this call.
     let callable: &mut dyn FnMut(*mut std::ffi::c_void) = unsafe { std::mem::transmute(*ptr) };
 
-    // Invoke the closure with the void* sample pointer
-    callable(sample_ptr);
+    // Invoke the closure with the void* sample pointer.
+    // catch_unwind prevents a Rust panic from unwinding across the C++ stack boundary.
+    if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| callable(sample_ptr))).is_err() {
+        // LOG the error here, Once logging mechanism is available.
+        // Abort to prevent unwinding across FFI boundary
+        std::process::abort();
+    }
 }
 
 /// Rust closure invocation for C++ callbacks for FindService
@@ -71,11 +76,20 @@ unsafe extern "C" fn mw_com_impl_call_dyn_ref_fnmut_find_service(
     let callable: &mut dyn FnMut(HandleContainer, NativeFindServiceHandle) =
         unsafe { std::mem::transmute(*ptr) };
 
-    // Invoke with correct types
-    callable(
-        HandleContainer::new(service_handles),
-        NativeFindServiceHandle::new(find_service_handle),
-    );
+    // Invoke with correct types.
+    // catch_unwind prevents a Rust panic from unwinding across the C++ stack boundary.
+    if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| {
+        callable(
+            HandleContainer::new(service_handles),
+            NativeFindServiceHandle::new(find_service_handle),
+        )
+    }))
+    .is_err()
+    {
+        // LOG the error here, Once logging mechanism is available.
+        // Abort to prevent unwinding across FFI boundary
+        std::process::abort();
+    }
 }
 
 // FFI declarations for C++ functions implemented in registry_bridge_macro.cpp
@@ -358,6 +372,11 @@ impl FFIBridge for LolaFFIBridge {
     /// event_ptr must point to a valid SkeletonEventBase,
     /// allocatee_ptr must point to valid memory for the allocatee,
     /// and event_type must be a valid UTF-8 string representing the event type.
+    ///
+    /// Note: We cannot use SampleAllocateePtr<T> directly in the FFIBridge trait methods,
+    /// because the underlying extern "C" functions use *mut c_void (C linkage has no generics).
+    /// Type-specific operations are instead delegated to TypeOperationsManager, which resolves
+    /// the concrete type at runtime via the C++ type registry.
     unsafe fn get_allocatee_ptr(
         &self,
         event_ptr: *mut SkeletonEventBase,
@@ -372,7 +391,7 @@ impl FFIBridge for LolaFFIBridge {
     /// Delete allocatee pointer of SampleAllocateePtr<T>
     ///
     /// # Arguments
-    /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
+    /// * `allocatee_ptr` - type erased pointer to SampleAllocateePtr<T>
     /// * `type_ops` - Reference to TypeOperationsManager for the type
     ///
     /// # Safety
@@ -393,7 +412,7 @@ impl FFIBridge for LolaFFIBridge {
     /// Get allocatee data pointer from allocatee of specific type
     ///
     /// # Arguments
-    /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
+    /// * `allocatee_ptr` - type erased pointer to SampleAllocateePtr<T>
     /// * `type_ops` - Reference to TypeOperationsManager for the type
     ///
     /// # Returns
@@ -417,7 +436,7 @@ impl FFIBridge for LolaFFIBridge {
     /// # Arguments
     /// * `event_ptr` - Opaque skeleton event pointer
     /// * `type_ops` - Reference to TypeOperationsManager for the type
-    /// * `allocatee_ptr` - Pointer to SampleAllocateePtr<T>
+    /// * `allocatee_ptr` - type erased pointer to SampleAllocateePtr<T>
     ///
     /// # Returns
     /// True if event was sent successfully, false otherwise
@@ -782,26 +801,22 @@ impl FFIBridge for LolaFFIBridge {
         }
     }
 
-    /// Unsafe wrapper around mw_com_start_find_service
+    /// Wrapper around mw_com_start_find_service
     ///
     /// # Arguments
-    /// * `callback` - FatPtr to callback function to be invoked when services are found
+    /// * `callback` - Valid find-service callable, its invariant is guaranteed by `FindServiceCallable`.
     /// * `instance_spec` - InstanceSpecifier identifying the service instance to find
     ///
     /// # Returns
     /// Opaque handle pointer for the find service operation, or nullptr on failure
-    ///
-    /// # Safety
-    /// callback must be a valid FatPtr referencing a callable compatible with the find service results.
-    /// instance_spec must be a valid InstanceSpecifier for the service to find.
-    unsafe fn start_find_service(
+    fn start_find_service(
         &self,
-        callback: &FatPtr,
+        callback: &FindServiceCallable,
         instance_spec: InstanceSpecifier,
     ) -> *mut FindServiceHandle {
-        // SAFETY: callback and instance_spec are guaranteed to be valid per the caller's contract.
-        // The C++ implementation handles the find service operation and callback invocation safely.
-        unsafe { mw_com_start_find_service(callback, instance_spec.as_native()) }
+        // SAFETY: FindServiceCallable guarantees that the inner FatPtr is a valid callable
+        // compatible with the find-service callback signature.
+        unsafe { mw_com_start_find_service(callback.as_fat_ptr(), instance_spec.as_native()) }
     }
 
     /// Unsafe wrapper around mw_com_stop_find_service

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -71,8 +71,9 @@
 //! This mock back-end is used for unit testing of Lola-Runtime.
 
 use bridge_ffi_rs::{
-    FatPtr, FindServiceHandle, HandleType, InstanceSpecifier, NativeInstanceSpecifier, ProxyBase,
-    ProxyEventBase, SkeletonBase, SkeletonEventBase, TypeOperationsManager,
+    FatPtr, FindServiceCallable, FindServiceHandle, HandleType, InstanceSpecifier,
+    NativeInstanceSpecifier, ProxyBase, ProxyEventBase, SkeletonBase, SkeletonEventBase,
+    TypeOperationsManager,
 };
 use mockall::mock;
 
@@ -182,9 +183,9 @@ mock! {
             proxy_event_ptr: *mut ProxyEventBase,
         );
 
-        unsafe fn start_find_service(
+        fn start_find_service(
             &self,
-            callback: &FatPtr,
+            callback: &FindServiceCallable,
             instance_spec: InstanceSpecifier,
         ) -> *mut FindServiceHandle;
 
@@ -414,13 +415,12 @@ impl bridge_ffi_rs::FFIBridge for SharedMockBridge {
         unsafe { self.locked().clear_event_receive_handler(event_ptr) }
     }
 
-    unsafe fn start_find_service(
+    fn start_find_service(
         &self,
-        callback: &FatPtr,
+        callback: &FindServiceCallable,
         instance_spec: InstanceSpecifier,
     ) -> *mut FindServiceHandle {
-        //Safety: This is just forwarding the call to the inner mock, which is expected to be configured correctly in tests using mockall's expectations.
-        unsafe { self.locked().start_find_service(callback, instance_spec) }
+        self.locked().start_find_service(callback, instance_spec)
     }
 
     unsafe fn stop_find_service(&self, find_service_handle: *mut FindServiceHandle) {

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -960,17 +960,16 @@ where
                 + 'static,
         > = discovery_callback;
 
-        // SAFETY: it is safe to transmute the closure to a FatPtr because it has
-        // the same representation in memory as a FnMut fat pointer
-        let fat_ptr: FatPtr = unsafe { std::mem::transmute(dyn_callback) };
+        // SAFETY: dyn_callback has the signature FnMut(HandleContainer, NativeFindServiceHandle)
+        // which matches the find-service callback contract required by FindServiceCallable.
+        let callable = unsafe { FindServiceCallable::new(std::mem::transmute(dyn_callback)) };
 
         let bridge = self.bridge.clone();
         let find_service_result = instance_specifier_lola.and_then(|spec| {
-            // SAFETY: start_find_service is safe because fat_ptr is valid and
-            // instance specifier is valid. The returned handle is stored
-            // synchronously — before any async polling — guaranteeing
+            // start_find_service is safe: the callback invariant is encoded in FindServiceCallable.
+            // The returned handle is stored synchronously — before any async polling — guaranteeing
             // stop_find_service is always called in Drop.
-            let raw_handle = unsafe { bridge.start_find_service(&fat_ptr, spec) };
+            let raw_handle = bridge.start_find_service(&callable, spec);
             if raw_handle.is_null() {
                 Err(Error::ServiceError(
                     ServiceFailedReason::FailedToStartDiscovery,


### PR DESCRIPTION
* FindServiceCallback optimized
* Updated callback with catch_unwind

https://github.com/eclipse-score/communication/issues/431