### PR TITLE
UpdateSkeletonReference():  Added SkeletonBase as a friend class and switch visibility of "UpdateSkeletonReference" to private.

### DIFF
--- a/score/mw/com/design/ipc_tracing/structural_event_field_extensions.puml
+++ b/score/mw/com/design/ipc_tracing/structural_event_field_extensions.puml
@@ -27,7 +27,7 @@ class "score::mw::com::impl::SkeletonEventBase" {
   +SkeletonEventBase(std::unique_ptr<SkeletonEventBindingBase> binding)
   +PrepareOffer(): score::Result<void>
   +PrepareStopOffer(): void
-  +UpdateSkeletonReference(SkeletonBase& base_skeleton): void
+  -UpdateSkeletonReference(SkeletonBase& base_skeleton): void
   -binding_: std::unique_ptr<SkeletonEventBindingBase>
   -tracing_data_: SkeletonEventTracing
 }

--- a/score/mw/com/design/skeleton_proxy/skeleton_binding_model.puml
+++ b/score/mw/com/design/skeleton_proxy/skeleton_binding_model.puml
@@ -91,7 +91,7 @@ abstract class "score::mw::com::impl::SkeletonFieldBase" as SkeletonFieldBase {
     +SkeletonFieldBase(SkeletonBase&, std::string_view field_name, std::unique_ptr<impl::SkeletonEventBase>)
     +PrepareOffer(): Result<void>
     +PrepareStopOffer(): void
-    +UpdateSkeletonReference(SkeletonBase& base_skeleton): void
+    -UpdateSkeletonReference(SkeletonBase& base_skeleton): void
 
     -IsInitialValueSaved(): bool = 0
     -DoDeferredUpdate(): Result<void> = 0

--- a/score/mw/com/design/skeleton_proxy/skeleton_proxy_binding_model.puml
+++ b/score/mw/com/design/skeleton_proxy/skeleton_proxy_binding_model.puml
@@ -92,7 +92,7 @@ class "score::mw::com::impl::SkeletonFieldBase" as ScoreMwComImplSkeletonFieldBa
   +SkeletonFieldBase(SkeletonBase&, std::string_view field_name, std::unique_ptr<impl::SkeletonEventBase>)
   +PrepareOffer(): Result<void>
   +PrepareStopOffer(): void
-  +UpdateSkeletonReference(SkeletonBase& base_skeleton): void
+  -UpdateSkeletonReference(SkeletonBase& base_skeleton): void
   --
   #skeleton_event_dispatch_ : std::unique_ptr<impl::SkeletonEventBase>
   #skeleton_base_ : std::reference_wrapper<SkeletonBase>

--- a/score/mw/com/impl/methods/skeleton_method.h
+++ b/score/mw/com/impl/methods/skeleton_method.h
@@ -111,6 +111,7 @@ class SkeletonMethod<ReturnType(ArgTypes...)> final : public SkeletonMethodBase
     template <typename Callable>
     Result<void> RegisterHandler(Callable&& callback);
 
+  private:
     void UpdateSkeletonReference(SkeletonBase& skeleton_base) noexcept;
 };
 

--- a/score/mw/com/impl/methods/skeleton_method_base.h
+++ b/score/mw/com/impl/methods/skeleton_method_base.h
@@ -27,6 +27,9 @@ class SkeletonMethodBaseView;
 // forward declaration to avoid cyclical dependencies
 class SkeletonBase;
 
+// Test helper - provides access to private methods for testing
+class SkeletonMethodBaseTestHelper;
+
 class SkeletonMethodBase
 {
     // Suppress "AUTOSAR C++14 A11-3-1", The rule states: "Friend declarations shall not be used".
@@ -34,6 +37,8 @@ class SkeletonMethodBase
     // module.
     // coverity[autosar_cpp14_a11_3_1_violation]
     friend SkeletonMethodBaseView;
+    friend SkeletonBase;
+    friend class SkeletonMethodBaseTestHelper;
 
   public:
     SkeletonMethodBase(SkeletonBase& skeleton_base,
@@ -55,6 +60,7 @@ class SkeletonMethodBase
     SkeletonMethodBase(SkeletonMethodBase&&) noexcept = default;
     SkeletonMethodBase& operator=(SkeletonMethodBase&&) & noexcept = default;
 
+  private:
     void UpdateSkeletonReference(SkeletonBase& skeleton_base) noexcept;
 
   protected:

--- a/score/mw/com/impl/methods/skeleton_method_base_test.cpp
+++ b/score/mw/com/impl/methods/skeleton_method_base_test.cpp
@@ -26,6 +26,16 @@
 namespace score::mw::com::impl
 {
 
+// Test helper to access private UpdateSkeletonReference method
+class SkeletonMethodBaseTestHelper
+{
+  public:
+    static void UpdateSkeletonReference(SkeletonMethodBase& method, SkeletonBase& skeleton_base)
+    {
+        method.UpdateSkeletonReference(skeleton_base);
+    }
+};
+
 namespace
 {
 using ::testing::_;
@@ -80,7 +90,7 @@ TEST(SkeletonMethodBase, UpdateSkeletonReferenceUpdatesTheReference)
     EXPECT_EQ(std::addressof(kEmptySkeleton1), std::addressof(skeleton_method->GetSkeletonReference().get()));
 
     // When UpdateSkeletonReference is called with a reference to a new Skeleton base class
-    skeleton_method->UpdateSkeletonReference(kEmptySkeleton2);
+    SkeletonMethodBaseTestHelper::UpdateSkeletonReference(*skeleton_method, kEmptySkeleton2);
 
     // Then the reference in the skeleton method is updated correctly
     EXPECT_EQ(std::addressof(kEmptySkeleton2), std::addressof(skeleton_method->GetSkeletonReference().get()));


### PR DESCRIPTION
https://github.com/eclipse-score/communication/issues/486