### PR TITLE
Fix condition for cancel-in-progress

### DIFF
--- a/.github/workflows/address_undefined_behavior_leak_sanitizer.yml
+++ b/.github/workflows/address_undefined_behavior_leak_sanitizer.yml
@@ -26,7 +26,7 @@ on:
   workflow_call:
 concurrency:
   group: address_undefined_behavior_leak_sanitizer-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request'}}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 env:
   ANDROID_HOME: ""
   ANDROID_SDK_ROOT: ""

--- a/.github/workflows/build_and_test_host.yml
+++ b/.github/workflows/build_and_test_host.yml
@@ -31,7 +31,7 @@ on:
         default: true
 concurrency:
   group: build_and_test_host-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request'}}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 env:
   ANDROID_HOME: ""
   ANDROID_SDK_ROOT: ""

--- a/.github/workflows/build_and_test_qnx.yml
+++ b/.github/workflows/build_and_test_qnx.yml
@@ -33,7 +33,7 @@ on:
 
 concurrency:
   group: build_and_test_qnx-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request_target'}}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 env:
   LICENSE_DIR: "/opt/score_qnx/license"

--- a/.github/workflows/clang_tidy.yml
+++ b/.github/workflows/clang_tidy.yml
@@ -53,7 +53,7 @@ permissions:
 
 concurrency:
   group: clang-tidy-pr-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: true
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 
 env:
   ANDROID_HOME: ""

--- a/.github/workflows/coverage_report.yml
+++ b/.github/workflows/coverage_report.yml
@@ -28,7 +28,7 @@ permissions:
 
 concurrency:
   group: coverage_report-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request'}}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 env:
   ANDROID_HOME: ""
   ANDROID_SDK_ROOT: ""

--- a/.github/workflows/thread_sanitizer.yml
+++ b/.github/workflows/thread_sanitizer.yml
@@ -25,7 +25,7 @@ on:
   workflow_call:
 concurrency:
   group: thread_sanitizer-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ github.event_name == 'pull_request'}}
+  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
 env:
   ANDROID_HOME: ""
   ANDROID_SDK_ROOT: ""


### PR DESCRIPTION
GitHub CI evaluates cacnel-in-progress based on information known at queuing of the job.

For whatever reason github.event_name is not reliably included in this information.

Hence, the evaluation always results in false.

We switch to a different solution with equal result: https://github.com/orgs/community/discussions/69704#discussioncomment-11974661