### PR TITLE
mw/com: Remove updating of service element in ProxyBase

### DIFF
--- a/score/mw/com/impl/BUILD
+++ b/score/mw/com/impl/BUILD
@@ -317,6 +317,7 @@ cc_library(
         "//score/mw/com:__subpackages__",
     ],
     deps = [
+        ":enable_reference_to_moveable_from_this",
         ":proxy_event_base",
         "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/result",
@@ -457,6 +458,7 @@ cc_library(
         ":find_service_handler",
         ":proxy_event_base",
         ":proxy_field_base",
+        ":reference_to_moveable",
         ":runtime",
         "//score/mw/com/impl/methods:proxy_method_base",
         "//score/mw/com/impl/plumbing",
@@ -479,6 +481,7 @@ cc_library(
         "//score/mw/com/impl/rust:__pkg__",
     ],
     deps = [
+        ":enable_reference_to_moveable_from_this",
         ":error",
         ":flag_owner",
         ":proxy_binding",

--- a/score/mw/com/impl/generic_proxy_event.cpp
+++ b/score/mw/com/impl/generic_proxy_event.cpp
@@ -20,8 +20,7 @@ namespace score::mw::com::impl
 {
 
 GenericProxyEvent::GenericProxyEvent(ProxyBase& base, const std::string_view event_name)
-    : ProxyEventBase{base,
-                     event_name,
+    : ProxyEventBase{event_name,
                      ProxyBaseView{base}.GetBinding(),
                      GenericProxyEventBindingFactory::Create(base, event_name)}
 {
@@ -36,7 +35,7 @@ GenericProxyEvent::GenericProxyEvent(ProxyBase& base, const std::string_view eve
 GenericProxyEvent::GenericProxyEvent(ProxyBase& base,
                                      const std::string_view event_name,
                                      std::unique_ptr<GenericProxyEventBinding> proxy_binding)
-    : ProxyEventBase{base, event_name, ProxyBaseView{base}.GetBinding(), std::move(proxy_binding)}
+    : ProxyEventBase{event_name, ProxyBaseView{base}.GetBinding(), std::move(proxy_binding)}
 {
     ProxyBaseView proxy_base_view{base};
     if (!binding_base_)

--- a/score/mw/com/impl/methods/BUILD
+++ b/score/mw/com/impl/methods/BUILD
@@ -39,6 +39,7 @@ cc_library(
     ],
     deps = [
         ":proxy_method_binding",
+        "//score/mw/com/impl:enable_reference_to_moveable_from_this",
         "//score/mw/com/impl:method_type",
         "@score_baselibs//score/containers:dynamic_array",
         "@score_baselibs//score/memory:data_type_size_info",

--- a/score/mw/com/impl/methods/proxy_method_base.h
+++ b/score/mw/com/impl/methods/proxy_method_base.h
@@ -14,6 +14,7 @@
 #ifndef SCORE_MW_COM_IMPL_METHODS_PROXY_METHOD_BASE_H
 #define SCORE_MW_COM_IMPL_METHODS_PROXY_METHOD_BASE_H
 
+#include "score/mw/com/impl/enable_reference_to_moveable_from_this.h"
 #include "score/mw/com/impl/method_type.h"
 #include "score/mw/com/impl/methods/proxy_method_binding.h"
 
@@ -26,16 +27,13 @@
 namespace score::mw::com::impl
 {
 
-class ProxyBase;
-
-class ProxyMethodBase
+class ProxyMethodBase : public EnableReferenceToMoveableFromThis<ProxyMethodBase>
 {
   public:
-    ProxyMethodBase(ProxyBase& proxy_base,
-                    std::string_view method_name,
+    ProxyMethodBase(std::string_view method_name,
                     std::unique_ptr<ProxyMethodBinding> proxy_method_binding,
                     MethodType method_type = MethodType::kMethod) noexcept
-        : proxy_base_{proxy_base},
+        : EnableReferenceToMoveableFromThis<ProxyMethodBase>(),
           method_name_{method_name},
           method_type_{method_type},
           is_return_type_ptr_active_{kCallQueueSize, false},
@@ -50,11 +48,6 @@ class ProxyMethodBase
     ProxyMethodBase(ProxyMethodBase&&) noexcept = default;
     ProxyMethodBase& operator=(ProxyMethodBase&&) noexcept = default;
     virtual ~ProxyMethodBase() = default;
-
-    void UpdateProxyReference(ProxyBase& proxy_base) noexcept
-    {
-        proxy_base_ = proxy_base;
-    }
 
     /// \brief Default initializes each method InArg and Return value (if they exist)
     ///
@@ -71,8 +64,6 @@ class ProxyMethodBase
     /// \brief Size of the call-queue is currently fixed to 1! As soon as we are going to support larger call-queues,
     /// the call-queue-size shall be taken from configuration and handed over to ProxyMethod ctor.
     static constexpr containers::DynamicArray<int>::size_type kCallQueueSize = 1U;
-
-    std::reference_wrapper<ProxyBase> proxy_base_;
 
     std::string_view method_name_;
     MethodType method_type_;

--- a/score/mw/com/impl/methods/proxy_method_test.cpp
+++ b/score/mw/com/impl/methods/proxy_method_test.cpp
@@ -98,7 +98,7 @@ class ProxyMethodTestFixture : public ::testing::Test
         auto moved_method = methods.find(kMethodName);
 
         EXPECT_NE(moved_method, methods.end());
-        return &moved_method->second.get();
+        return &moved_method->second.get().Get();
     }
 
     alignas(8) std::array<std::byte, 1024> method_in_args_buffer_{};

--- a/score/mw/com/impl/methods/proxy_method_with_in_args.h
+++ b/score/mw/com/impl/methods/proxy_method_with_in_args.h
@@ -63,11 +63,11 @@ class ProxyMethod<void(ArgTypes...)> final : public ProxyMethodBase
     ProxyMethod(ProxyBase& proxy_base,
                 std::string_view method_name,
                 std::unique_ptr<ProxyMethodBinding> proxy_method_binding) noexcept
-        : ProxyMethodBase(proxy_base, method_name, std::move(proxy_method_binding), MethodType::kMethod),
+        : ProxyMethodBase(method_name, std::move(proxy_method_binding), MethodType::kMethod),
           are_in_arg_ptrs_active_(kCallQueueSize)
     {
         auto proxy_base_view = ProxyBaseView{proxy_base};
-        proxy_base_view.RegisterMethod(method_name_, *this);
+        proxy_base_view.RegisterMethod(method_name_, GetReferenceToMoveable());
         if (binding_ == nullptr)
         {
             proxy_base_view.MarkServiceElementBindingInvalid();
@@ -82,8 +82,8 @@ class ProxyMethod<void(ArgTypes...)> final : public ProxyMethodBase
     ProxyMethod& operator=(const ProxyMethod&) = delete;
 
     /// \brief A ProxyMethod shall be moveable.
-    ProxyMethod(ProxyMethod&&) noexcept;
-    ProxyMethod& operator=(ProxyMethod&&) noexcept;
+    ProxyMethod(ProxyMethod&&) noexcept = default;
+    ProxyMethod& operator=(ProxyMethod&&) noexcept = default;
 
     Result<void> InitializeInArgsAndReturnValues() override;
 
@@ -124,30 +124,6 @@ class ProxyMethod<void(ArgTypes...)> final : public ProxyMethodBase
     /// pointer passed to the zero-copy call-operator is active.
     containers::DynamicArray<std::array<bool, sizeof...(ArgTypes)>> are_in_arg_ptrs_active_;
 };
-
-template <typename... ArgTypes>
-ProxyMethod<void(ArgTypes...)>::ProxyMethod(ProxyMethod&& other) noexcept
-    : ProxyMethodBase(std::move(other)), are_in_arg_ptrs_active_{std::move(other.are_in_arg_ptrs_active_)}
-{
-    // Since the address of this method has changed, we need update the address stored in the parent proxy.
-    ProxyBaseView proxy_base_view{proxy_base_.get()};
-    proxy_base_view.UpdateMethod(method_name_, *this);
-}
-
-template <typename... ArgTypes>
-auto ProxyMethod<void(ArgTypes...)>::operator=(ProxyMethod&& other) noexcept -> ProxyMethod<void(ArgTypes...)>&
-{
-    if (this != &other)
-    {
-        ProxyMethodBase::operator=(std::move(other));
-        are_in_arg_ptrs_active_ = std::move(other.are_in_arg_ptrs_active_);
-
-        // Since the address of this method has changed, we need update the address stored in the parent proxy.
-        ProxyBaseView proxy_base_view{proxy_base_.get()};
-        proxy_base_view.UpdateMethod(method_name_, *this);
-    }
-    return *this;
-}
 
 template <typename... ArgTypes>
 score::Result<void> ProxyMethod<void(ArgTypes...)>::operator()(const ArgTypes&... args)

--- a/score/mw/com/impl/methods/proxy_method_with_in_args_and_return.h
+++ b/score/mw/com/impl/methods/proxy_method_with_in_args_and_return.h
@@ -67,7 +67,6 @@ class ProxyMethod<ReturnType(ArgTypes...)> final : public ProxyMethodBase
   public:
     ProxyMethod(ProxyBase& proxy_base, std::string_view method_name) noexcept
         : ProxyMethodBase(
-              proxy_base,
               method_name,
               ProxyMethodBindingFactory<ReturnType(ArgTypes...)>::Create(proxy_base.GetHandle(),
                                                                          ProxyBaseView{proxy_base}.GetBinding(),
@@ -77,7 +76,7 @@ class ProxyMethod<ReturnType(ArgTypes...)> final : public ProxyMethodBase
           are_in_arg_ptrs_active_(kCallQueueSize)
     {
         auto proxy_base_view = ProxyBaseView{proxy_base};
-        proxy_base_view.RegisterMethod(method_name_, *this);
+        proxy_base_view.RegisterMethod(method_name_, GetReferenceToMoveable());
         if (binding_ == nullptr)
         {
             proxy_base_view.MarkServiceElementBindingInvalid();
@@ -88,11 +87,11 @@ class ProxyMethod<ReturnType(ArgTypes...)> final : public ProxyMethodBase
     ProxyMethod(ProxyBase& proxy_base,
                 std::string_view method_name,
                 std::unique_ptr<ProxyMethodBinding> proxy_method_binding) noexcept
-        : ProxyMethodBase(proxy_base, method_name, std::move(proxy_method_binding), MethodType::kMethod),
+        : ProxyMethodBase(method_name, std::move(proxy_method_binding), MethodType::kMethod),
           are_in_arg_ptrs_active_(kCallQueueSize)
     {
         auto proxy_base_view = ProxyBaseView{proxy_base};
-        proxy_base_view.RegisterMethod(method_name_, *this);
+        proxy_base_view.RegisterMethod(method_name_, GetReferenceToMoveable());
         if (binding_ == nullptr)
         {
             proxy_base_view.MarkServiceElementBindingInvalid();
@@ -104,7 +103,7 @@ class ProxyMethod<ReturnType(ArgTypes...)> final : public ProxyMethodBase
                 std::string_view method_name,
                 std::unique_ptr<ProxyMethodBinding> proxy_method_binding,
                 FieldOnlyConstructorEnabler) noexcept
-        : ProxyMethodBase(proxy_base, method_name, std::move(proxy_method_binding), MethodType::kSet),
+        : ProxyMethodBase(method_name, std::move(proxy_method_binding), MethodType::kSet),
           are_in_arg_ptrs_active_(kCallQueueSize)
     {
         auto proxy_base_view = ProxyBaseView{proxy_base};
@@ -122,8 +121,8 @@ class ProxyMethod<ReturnType(ArgTypes...)> final : public ProxyMethodBase
     ProxyMethod& operator=(const ProxyMethod&) = delete;
 
     /// \brief A ProxyMethod shall be moveable.
-    ProxyMethod(ProxyMethod&&) noexcept;
-    ProxyMethod& operator=(ProxyMethod&&) noexcept;
+    ProxyMethod(ProxyMethod&&) noexcept = default;
+    ProxyMethod& operator=(ProxyMethod&&) noexcept = default;
 
     Result<void> InitializeInArgsAndReturnValues() override;
 
@@ -167,31 +166,6 @@ class ProxyMethod<ReturnType(ArgTypes...)> final : public ProxyMethodBase
     /// pointer passed to the zero-copy call-operator is active.
     containers::DynamicArray<std::array<bool, sizeof...(ArgTypes)>> are_in_arg_ptrs_active_;
 };
-
-template <typename ReturnType, typename... ArgTypes>
-ProxyMethod<ReturnType(ArgTypes...)>::ProxyMethod(ProxyMethod&& other) noexcept
-    : ProxyMethodBase(std::move(other)), are_in_arg_ptrs_active_{std::move(other.are_in_arg_ptrs_active_)}
-{
-    // Since the address of this method has changed, we need update the address stored in the parent proxy.
-    ProxyBaseView proxy_base_view{proxy_base_.get()};
-    proxy_base_view.UpdateMethod(method_name_, *this);
-}
-
-template <typename ReturnType, typename... ArgTypes>
-auto ProxyMethod<ReturnType(ArgTypes...)>::operator=(ProxyMethod&& other) noexcept
-    -> ProxyMethod<ReturnType(ArgTypes...)>&
-{
-    if (this != &other)
-    {
-        ProxyMethodBase::operator=(std::move(other));
-        are_in_arg_ptrs_active_ = std::move(other.are_in_arg_ptrs_active_);
-
-        // Since the address of this method has changed, we need update the address stored in the parent proxy
-        ProxyBaseView proxy_base_view{proxy_base_.get()};
-        proxy_base_view.UpdateMethod(method_name_, *this);
-    }
-    return *this;
-}
 
 template <typename ReturnType, typename... ArgTypes>
 score::Result<MethodReturnTypePtr<ReturnType>> ProxyMethod<ReturnType(ArgTypes...)>::operator()(const ArgTypes&... args)

--- a/score/mw/com/impl/methods/proxy_method_with_return_type.h
+++ b/score/mw/com/impl/methods/proxy_method_with_return_type.h
@@ -61,8 +61,7 @@ class ProxyMethod<ReturnType()> final : public ProxyMethodBase
 
   public:
     ProxyMethod(ProxyBase& proxy_base, std::string_view method_name) noexcept
-        : ProxyMethodBase(proxy_base,
-                          method_name,
+        : ProxyMethodBase(method_name,
                           ProxyMethodBindingFactory<ReturnType()>::Create(proxy_base.GetHandle(),
                                                                           ProxyBaseView{proxy_base}.GetBinding(),
                                                                           method_name,
@@ -70,7 +69,7 @@ class ProxyMethod<ReturnType()> final : public ProxyMethodBase
                           MethodType::kMethod)
     {
         auto proxy_base_view = ProxyBaseView{proxy_base};
-        proxy_base_view.RegisterMethod(method_name_, *this);
+        proxy_base_view.RegisterMethod(method_name_, GetReferenceToMoveable());
         if (binding_ == nullptr)
         {
             proxy_base_view.MarkServiceElementBindingInvalid();
@@ -81,10 +80,10 @@ class ProxyMethod<ReturnType()> final : public ProxyMethodBase
     ProxyMethod(ProxyBase& proxy_base,
                 std::string_view method_name,
                 std::unique_ptr<ProxyMethodBinding> proxy_method_binding) noexcept
-        : ProxyMethodBase(proxy_base, method_name, std::move(proxy_method_binding), MethodType::kMethod)
+        : ProxyMethodBase(method_name, std::move(proxy_method_binding), MethodType::kMethod)
     {
         auto proxy_base_view = ProxyBaseView{proxy_base};
-        proxy_base_view.RegisterMethod(method_name_, *this);
+        proxy_base_view.RegisterMethod(method_name_, GetReferenceToMoveable());
         if (binding_ == nullptr)
         {
             proxy_base_view.MarkServiceElementBindingInvalid();
@@ -96,7 +95,7 @@ class ProxyMethod<ReturnType()> final : public ProxyMethodBase
                 std::string_view method_name,
                 std::unique_ptr<ProxyMethodBinding> proxy_method_binding,
                 FieldOnlyConstructorEnabler) noexcept
-        : ProxyMethodBase(proxy_base, method_name, std::move(proxy_method_binding), MethodType::kGet)
+        : ProxyMethodBase(method_name, std::move(proxy_method_binding), MethodType::kGet)
     {
         auto proxy_base_view = ProxyBaseView{proxy_base};
         if (binding_ == nullptr)
@@ -113,8 +112,8 @@ class ProxyMethod<ReturnType()> final : public ProxyMethodBase
     ProxyMethod& operator=(const ProxyMethod&) = delete;
 
     /// \brief A ProxyMethod shall be moveable.
-    ProxyMethod(ProxyMethod&&) noexcept;
-    ProxyMethod& operator=(ProxyMethod&&) noexcept;
+    ProxyMethod(ProxyMethod&&) noexcept = default;
+    ProxyMethod& operator=(ProxyMethod&&) noexcept = default;
 
     Result<void> InitializeInArgsAndReturnValues() override;
 
@@ -133,28 +132,6 @@ class ProxyMethod<ReturnType()> final : public ProxyMethodBase
     static constexpr std::optional<memory::DataTypeSizeInfo> type_erased_return_type_ =
         CreateDataTypeSizeInfoFromTypes<ReturnType>();
 };
-
-template <typename ReturnType>
-ProxyMethod<ReturnType()>::ProxyMethod(ProxyMethod&& other) noexcept : ProxyMethodBase(std::move(other))
-{
-    // Since the address of this method has changed, we need update the address stored in the parent proxy.
-    ProxyBaseView proxy_base_view{proxy_base_.get()};
-    proxy_base_view.UpdateMethod(method_name_, *this);
-}
-
-template <typename ReturnType>
-auto ProxyMethod<ReturnType()>::operator=(ProxyMethod&& other) noexcept -> ProxyMethod<ReturnType()>&
-{
-    if (this != &other)
-    {
-        ProxyMethodBase::operator=(std::move(other));
-
-        // Since the address of this method has changed, we need update the address stored in the parent proxy.
-        ProxyBaseView proxy_base_view{proxy_base_.get()};
-        proxy_base_view.UpdateMethod(method_name_, *this);
-    }
-    return *this;
-}
 
 template <typename ReturnType>
 score::Result<MethodReturnTypePtr<ReturnType>> ProxyMethod<ReturnType()>::operator()()

--- a/score/mw/com/impl/methods/proxy_method_without_in_args_or_return.cpp
+++ b/score/mw/com/impl/methods/proxy_method_without_in_args_or_return.cpp
@@ -14,26 +14,6 @@
 
 namespace score::mw::com::impl
 {
-ProxyMethod<void()>::ProxyMethod(ProxyMethod&& other) noexcept : ProxyMethodBase(std::move(other))
-{
-    // Since the address of this method has changed, we need update the address stored in the parent proxy.
-    ProxyBaseView proxy_base_view{proxy_base_.get()};
-    proxy_base_view.UpdateMethod(method_name_, *this);
-}
-
-auto ProxyMethod<void()>::operator=(ProxyMethod&& other) noexcept -> ProxyMethod<void()>&
-{
-    if (this != &other)
-    {
-        ProxyMethodBase::operator=(std::move(other));
-
-        // Since the address of this method has changed, we need update the address stored in the parent proxy.
-        ProxyBaseView proxy_base_view{proxy_base_.get()};
-        proxy_base_view.UpdateMethod(method_name_, *this);
-    }
-    return *this;
-}
-
 score::Result<void> ProxyMethod<void()>::operator()()
 {
     auto queue_position = detail::DetermineNextAvailableQueueSlot(is_return_type_ptr_active_);

--- a/score/mw/com/impl/methods/proxy_method_without_in_args_or_return.h
+++ b/score/mw/com/impl/methods/proxy_method_without_in_args_or_return.h
@@ -45,8 +45,7 @@ class ProxyMethod<void()> final : public ProxyMethodBase
 
   public:
     ProxyMethod(ProxyBase& proxy_base, std::string_view method_name) noexcept
-        : ProxyMethodBase(proxy_base,
-                          method_name,
+        : ProxyMethodBase(method_name,
                           ProxyMethodBindingFactory<void()>::Create(proxy_base.GetHandle(),
                                                                     ProxyBaseView{proxy_base}.GetBinding(),
                                                                     method_name,
@@ -54,7 +53,7 @@ class ProxyMethod<void()> final : public ProxyMethodBase
                           MethodType::kMethod)
     {
         auto proxy_base_view = ProxyBaseView{proxy_base};
-        proxy_base_view.RegisterMethod(method_name_, *this);
+        proxy_base_view.RegisterMethod(method_name_, GetReferenceToMoveable());
         if (binding_ == nullptr)
         {
             proxy_base_view.MarkServiceElementBindingInvalid();
@@ -65,10 +64,10 @@ class ProxyMethod<void()> final : public ProxyMethodBase
     ProxyMethod(ProxyBase& proxy_base,
                 std::string_view method_name,
                 std::unique_ptr<ProxyMethodBinding> proxy_method_binding) noexcept
-        : ProxyMethodBase(proxy_base, method_name, std::move(proxy_method_binding), MethodType::kMethod)
+        : ProxyMethodBase(method_name, std::move(proxy_method_binding), MethodType::kMethod)
     {
         auto proxy_base_view = ProxyBaseView{proxy_base};
-        proxy_base_view.RegisterMethod(method_name_, *this);
+        proxy_base_view.RegisterMethod(method_name_, GetReferenceToMoveable());
         if (binding_ == nullptr)
         {
             proxy_base_view.MarkServiceElementBindingInvalid();
@@ -83,8 +82,8 @@ class ProxyMethod<void()> final : public ProxyMethodBase
     ProxyMethod& operator=(const ProxyMethod&) = delete;
 
     /// \brief A ProxyMethod shall be moveable.
-    ProxyMethod(ProxyMethod&&) noexcept;
-    ProxyMethod& operator=(ProxyMethod&&) noexcept;
+    ProxyMethod(ProxyMethod&&) noexcept = default;
+    ProxyMethod& operator=(ProxyMethod&&) noexcept = default;
 
     Result<void> InitializeInArgsAndReturnValues() override
     {

--- a/score/mw/com/impl/proxy_base.cpp
+++ b/score/mw/com/impl/proxy_base.cpp
@@ -16,6 +16,7 @@
 #include "score/mw/com/impl/methods/proxy_method_base.h"
 #include "score/mw/com/impl/proxy_event_base.h"
 #include "score/mw/com/impl/proxy_field_base.h"
+#include "score/mw/com/impl/reference_to_moveable.h"
 #include "score/mw/com/impl/runtime.h"
 
 #include <score/assert.hpp>
@@ -36,65 +37,6 @@ ProxyBase::ProxyBase(std::unique_ptr<ProxyBinding> proxy_binding, HandleType han
       fields_{},
       methods_{}
 {
-}
-
-ProxyBase::ProxyBase(ProxyBase&& other) noexcept
-    : proxy_binding_(std::move(other.proxy_binding_)),
-      handle_(std::move(other.handle_)),
-      are_service_element_bindings_valid_(other.are_service_element_bindings_valid_),
-      events_(std::move(other.events_)),
-      fields_(std::move(other.fields_)),
-      methods_(std::move(other.methods_))
-{
-    // Since the address of this proxy has changed, we need update the address stored in each of the events, fields
-    // and methods belonging to the proxy.
-    for (auto& event : events_)
-    {
-        event.second.get().UpdateProxyReference(*this);
-    }
-
-    for (auto& field : fields_)
-    {
-        field.second.get().UpdateProxyReference(*this);
-    }
-
-    for (auto& method : methods_)
-    {
-        method.second.get().UpdateProxyReference(*this);
-    }
-}
-
-ProxyBase& ProxyBase::operator=(ProxyBase&& other) noexcept
-{
-    if (this == &other)
-    {
-        return *this;
-    }
-
-    proxy_binding_ = std::move(other.proxy_binding_);
-    handle_ = std::move(other.handle_);
-    are_service_element_bindings_valid_ = other.are_service_element_bindings_valid_;
-    events_ = std::move(other.events_);
-    fields_ = std::move(other.fields_);
-    methods_ = std::move(other.methods_);
-
-    // Since the address of this proxy has changed, we need update the address stored in each of the events, fields
-    // and methods belonging to the proxy.
-    for (auto& event : events_)
-    {
-        event.second.get().UpdateProxyReference(*this);
-    }
-
-    for (auto& field : fields_)
-    {
-        field.second.get().UpdateProxyReference(*this);
-    }
-
-    for (auto& method : methods_)
-    {
-        method.second.get().UpdateProxyReference(*this);
-    }
-    return *this;
 }
 
 const HandleType& ProxyBase::GetHandle() const& noexcept
@@ -169,7 +111,7 @@ Result<void> ProxyBase::SetupMethods()
 
     for (auto& method_key_value_pair : methods_)
     {
-        auto& method = method_key_value_pair.second.get();
+        auto& method = method_key_value_pair.second.get().Get();
         const auto method_init_result = method.InitializeInArgsAndReturnValues();
         if (!method_init_result.has_value())
         {
@@ -187,11 +129,11 @@ void ProxyBase::Deinitialize()
     }
     for (auto& event : events_)
     {
-        event.second.get().Unsubscribe();
+        event.second.get().Get().Unsubscribe();
     }
     for (auto& field : fields_)
     {
-        ProxyFieldBaseView{field.second.get()}.Unsubscribe();
+        ProxyFieldBaseView{field.second.get().Get()}.Unsubscribe();
     }
     if (proxy_binding_ != nullptr)
     {
@@ -216,68 +158,29 @@ void ProxyBaseView::MarkServiceElementBindingInvalid() noexcept
     proxy_base_.are_service_element_bindings_valid_ = false;
 }
 
-void ProxyBaseView::RegisterEvent(const std::string_view event_name, ProxyEventBase& event)
+void ProxyBaseView::RegisterEvent(const std::string_view event_name,
+                                  ReferenceToMoveable<ProxyEventBase>::Reference& event)
 {
-    const auto result = proxy_base_.events_.emplace(event_name, event);
+    const auto result = proxy_base_.events_.emplace(event_name, std::ref(event));
     const bool was_event_inserted = result.second;
     SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(was_event_inserted, "Event cannot be registered as it already exists.");
 }
 
-void ProxyBaseView::RegisterField(const std::string_view field_name, ProxyFieldBase& field)
+void ProxyBaseView::RegisterField(const std::string_view field_name,
+                                  ReferenceToMoveable<ProxyFieldBase>::Reference& field)
 {
-    const auto result = proxy_base_.fields_.emplace(field_name, field);
+    const auto result = proxy_base_.fields_.emplace(field_name, std::ref(field));
     const bool was_field_inserted = result.second;
     SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(was_field_inserted, "Field cannot be registered as it already exists.");
 }
 
-void ProxyBaseView::RegisterMethod(const std::string_view method_name, ProxyMethodBase& method)
+void ProxyBaseView::RegisterMethod(const std::string_view method_name,
+                                   ReferenceToMoveable<ProxyMethodBase>::Reference& method)
 {
-    const auto result = proxy_base_.methods_.emplace(method_name, method);
+    const auto result = proxy_base_.methods_.emplace(method_name, std::ref(method));
     const bool was_method_inserted = result.second;
     SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(was_method_inserted, "Method cannot be registered as it already exists.");
 }
-
-void ProxyBaseView::UpdateEvent(const std::string_view event_name, ProxyEventBase& event)
-{
-    auto event_it = proxy_base_.events_.find(event_name);
-    if (event_it == proxy_base_.events_.cend())
-    {
-        score::mw::log::LogFatal("lola") << "ProxyBaseView::UpdateEvent failed to update, because the requested event "
-                                         << event_name << " doesn't exist!";
-
-        SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(false);
-    }
-
-    event_it->second = event;
-}
-
-void ProxyBaseView::UpdateField(const std::string_view field_name, ProxyFieldBase& field)
-{
-    auto field_it = proxy_base_.fields_.find(field_name);
-    if (field_it == proxy_base_.fields_.cend())
-    {
-        score::mw::log::LogFatal("lola") << "ProxyBaseView::UpdateField failed to update, because the requested field "
-                                         << field_name << " doesn't exist";
-        SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(false);
-    }
-
-    field_it->second = field;
-}
-
-void ProxyBaseView::UpdateMethod(const std::string_view method_name, ProxyMethodBase& method)
-{
-    auto method_it = proxy_base_.methods_.find(method_name);
-    if (method_it == proxy_base_.methods_.cend())
-    {
-        score::mw::log::LogFatal("lola")
-            << "ProxyBaseView::UpdateMethod failed to update, because the requested method " << method_name
-            << " doesn't exist";
-        SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(false);
-    }
-
-    method_it->second = method;
-}
-
 bool ProxyBaseView::AreBindingsValid() const
 {
     return proxy_base_.AreBindingsValid();

--- a/score/mw/com/impl/proxy_base.h
+++ b/score/mw/com/impl/proxy_base.h
@@ -19,6 +19,7 @@
 #include "score/mw/com/impl/instance_identifier.h"
 #include "score/mw/com/impl/instance_specifier.h"
 #include "score/mw/com/impl/proxy_binding.h"
+#include "score/mw/com/impl/reference_to_moveable.h"
 
 #include "score/result/result.h"
 
@@ -117,9 +118,12 @@ class ProxyBase
     const HandleType& GetHandle() const& noexcept;
 
   protected:
-    using ProxyEvents = std::map<std::string_view, std::reference_wrapper<ProxyEventBase>>;
-    using ProxyFields = std::map<std::string_view, std::reference_wrapper<ProxyFieldBase>>;
-    using ProxyMethods = std::map<std::string_view, std::reference_wrapper<ProxyMethodBase>>;
+    using ProxyEvents =
+        std::map<std::string_view, std::reference_wrapper<ReferenceToMoveable<ProxyEventBase>::Reference>>;
+    using ProxyFields =
+        std::map<std::string_view, std::reference_wrapper<ReferenceToMoveable<ProxyFieldBase>::Reference>>;
+    using ProxyMethods =
+        std::map<std::string_view, std::reference_wrapper<ReferenceToMoveable<ProxyMethodBase>::Reference>>;
 
     /// \brief A Proxy shall not be copyable
     /// \requirement SWS_CM_00136
@@ -128,8 +132,8 @@ class ProxyBase
 
     /// \brief A Proxy shall be movable
     /// \requirement SWS_CM_00137
-    ProxyBase(ProxyBase&& other) noexcept;
-    ProxyBase& operator=(ProxyBase&& other) noexcept;
+    ProxyBase(ProxyBase&& other) noexcept = default;
+    ProxyBase& operator=(ProxyBase&& other) noexcept = default;
 
     /// \brief Deinitialize all events and fields and tears down binding-level state.
     ///  Must only be invoked from the wrapper class destructor (ProxyWrapperClass / GenericProxy).
@@ -177,18 +181,11 @@ class ProxyBaseView final
 
     void MarkServiceElementBindingInvalid() noexcept;
 
-    void RegisterEvent(const std::string_view event_name, ProxyEventBase& event);
+    void RegisterEvent(const std::string_view event_name, ReferenceToMoveable<ProxyEventBase>::Reference& event);
 
-    void RegisterField(const std::string_view field_name, ProxyFieldBase& field);
+    void RegisterField(const std::string_view field_name, ReferenceToMoveable<ProxyFieldBase>::Reference& field);
 
-    void RegisterMethod(const std::string_view method_name, ProxyMethodBase& method);
-
-    void UpdateEvent(const std::string_view event_name, ProxyEventBase& event);
-
-    void UpdateField(const std::string_view field_name, ProxyFieldBase& field);
-
-    void UpdateMethod(const std::string_view method_name, ProxyMethodBase& method);
-
+    void RegisterMethod(const std::string_view method_name, ReferenceToMoveable<ProxyMethodBase>::Reference& method);
     bool AreBindingsValid() const;
 
   private:

--- a/score/mw/com/impl/proxy_base_test.cpp
+++ b/score/mw/com/impl/proxy_base_test.cpp
@@ -597,28 +597,20 @@ class ProxyBaseServiceElementReferencesFixture : public ::testing::Test
     mock_binding::Proxy proxy_binding_mock_{};
     MyProxy proxy_{std::make_unique<mock_binding::ProxyFacade>(proxy_binding_mock_), handle_};
 
-    ProxyEventBase event_0_{proxy_,
-                            event_name_0_,
-                            &proxy_binding_mock_,
-                            std::make_unique<mock_binding::ProxyEventBase>()};
-    ProxyEventBase event_1_{proxy_,
-                            event_name_1_,
-                            &proxy_binding_mock_,
-                            std::make_unique<mock_binding::ProxyEventBase>()};
+    ProxyEventBase event_0_{event_name_0_, &proxy_binding_mock_, std::make_unique<mock_binding::ProxyEventBase>()};
+    ProxyEventBase event_1_{event_name_1_, &proxy_binding_mock_, std::make_unique<mock_binding::ProxyEventBase>()};
 
-    ProxyEventBase field_event_dispatch_0_{proxy_,
-                                           field_name_0_,
+    ProxyEventBase field_event_dispatch_0_{field_name_0_,
                                            &proxy_binding_mock_,
                                            std::make_unique<mock_binding::ProxyEventBase>()};
-    ProxyEventBase field_event_dispatch_1_{proxy_,
-                                           field_name_1_,
+    ProxyEventBase field_event_dispatch_1_{field_name_1_,
                                            &proxy_binding_mock_,
                                            std::make_unique<mock_binding::ProxyEventBase>()};
-    ProxyFieldBase field_0_{proxy_, field_name_0_, &field_event_dispatch_0_};
-    ProxyFieldBase field_1_{proxy_, field_name_1_, &field_event_dispatch_1_};
+    ProxyFieldBase field_0_{field_name_0_, &field_event_dispatch_0_};
+    ProxyFieldBase field_1_{field_name_1_, &field_event_dispatch_1_};
 
-    DummyProxyMethod method_0_{proxy_, method_name_0_, std::make_unique<mock_binding::ProxyMethod>()};
-    DummyProxyMethod method_1_{proxy_, method_name_1_, std::make_unique<mock_binding::ProxyMethod>()};
+    DummyProxyMethod method_0_{method_name_0_, std::make_unique<mock_binding::ProxyMethod>()};
+    DummyProxyMethod method_1_{method_name_1_, std::make_unique<mock_binding::ProxyMethod>()};
 };
 
 TEST_F(ProxyBaseServiceElementReferencesFixture, RegisteringServiceElementStoresReferenceInMap)
@@ -626,28 +618,28 @@ TEST_F(ProxyBaseServiceElementReferencesFixture, RegisteringServiceElementStores
     // Given a valid MyProxy object
 
     // When registering 2 Events, Fields and Methods
-    ProxyBaseView{proxy_}.RegisterEvent(event_name_0_, event_0_);
-    ProxyBaseView{proxy_}.RegisterEvent(event_name_1_, event_1_);
-    ProxyBaseView{proxy_}.RegisterField(field_name_0_, field_0_);
-    ProxyBaseView{proxy_}.RegisterField(field_name_1_, field_1_);
-    ProxyBaseView{proxy_}.RegisterMethod(method_name_0_, method_0_);
-    ProxyBaseView{proxy_}.RegisterMethod(method_name_1_, method_1_);
+    ProxyBaseView{proxy_}.RegisterEvent(event_name_0_, event_0_.GetReferenceToMoveable());
+    ProxyBaseView{proxy_}.RegisterEvent(event_name_1_, event_1_.GetReferenceToMoveable());
+    ProxyBaseView{proxy_}.RegisterField(field_name_0_, field_0_.GetReferenceToMoveable());
+    ProxyBaseView{proxy_}.RegisterField(field_name_1_, field_1_.GetReferenceToMoveable());
+    ProxyBaseView{proxy_}.RegisterMethod(method_name_0_, method_0_.GetReferenceToMoveable());
+    ProxyBaseView{proxy_}.RegisterMethod(method_name_1_, method_1_.GetReferenceToMoveable());
 
     // Then the proxy's reference maps should contain references to the registered elements
     const auto& events = proxy_.GetEvents();
     EXPECT_EQ(events.size(), 2U);
-    EXPECT_EQ(&events.at(event_name_0_).get(), &event_0_);
-    EXPECT_EQ(&events.at(event_name_1_).get(), &event_1_);
+    EXPECT_EQ(&events.at(event_name_0_).get().Get(), &event_0_);
+    EXPECT_EQ(&events.at(event_name_1_).get().Get(), &event_1_);
 
     const auto& fields = proxy_.GetFields();
     EXPECT_EQ(fields.size(), 2U);
-    EXPECT_EQ(&fields.at(field_name_0_).get(), &field_0_);
-    EXPECT_EQ(&fields.at(field_name_1_).get(), &field_1_);
+    EXPECT_EQ(&fields.at(field_name_0_).get().Get(), &field_0_);
+    EXPECT_EQ(&fields.at(field_name_1_).get().Get(), &field_1_);
 
     const auto& methods = proxy_.GetMethods();
     EXPECT_EQ(methods.size(), 2U);
-    EXPECT_EQ(&methods.at(method_name_0_).get(), &method_0_);
-    EXPECT_EQ(&methods.at(method_name_1_).get(), &method_1_);
+    EXPECT_EQ(&methods.at(method_name_0_).get().Get(), &method_0_);
+    EXPECT_EQ(&methods.at(method_name_1_).get().Get(), &method_1_);
 }
 
 TEST_F(ProxyBaseServiceElementReferencesFixture, MoveConstructingUpdatesReferencesToServiceElements)
@@ -659,12 +651,12 @@ TEST_F(ProxyBaseServiceElementReferencesFixture, MoveConstructingUpdatesReferenc
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Given a valid MyProxy object on which 2 Events, Fields and Methods were registered
-    ProxyBaseView{proxy_}.RegisterEvent(event_name_0_, event_0_);
-    ProxyBaseView{proxy_}.RegisterEvent(event_name_1_, event_1_);
-    ProxyBaseView{proxy_}.RegisterField(field_name_0_, field_0_);
-    ProxyBaseView{proxy_}.RegisterField(field_name_1_, field_1_);
-    ProxyBaseView{proxy_}.RegisterMethod(method_name_0_, method_0_);
-    ProxyBaseView{proxy_}.RegisterMethod(method_name_1_, method_1_);
+    ProxyBaseView{proxy_}.RegisterEvent(event_name_0_, event_0_.GetReferenceToMoveable());
+    ProxyBaseView{proxy_}.RegisterEvent(event_name_1_, event_1_.GetReferenceToMoveable());
+    ProxyBaseView{proxy_}.RegisterField(field_name_0_, field_0_.GetReferenceToMoveable());
+    ProxyBaseView{proxy_}.RegisterField(field_name_1_, field_1_.GetReferenceToMoveable());
+    ProxyBaseView{proxy_}.RegisterMethod(method_name_0_, method_0_.GetReferenceToMoveable());
+    ProxyBaseView{proxy_}.RegisterMethod(method_name_1_, method_1_.GetReferenceToMoveable());
 
     // When move constructing a new MyProxy object
     MyProxy moved_to_proxy{std::move(proxy_)};
@@ -672,18 +664,18 @@ TEST_F(ProxyBaseServiceElementReferencesFixture, MoveConstructingUpdatesReferenc
     // Then the moved-to proxy's reference maps should still contain references to the registered elements
     const auto& events = moved_to_proxy.GetEvents();
     ASSERT_EQ(events.size(), 2U);
-    EXPECT_EQ(&events.at(event_name_0_).get(), &event_0_);
-    EXPECT_EQ(&events.at(event_name_1_).get(), &event_1_);
+    EXPECT_EQ(&events.at(event_name_0_).get().Get(), &event_0_);
+    EXPECT_EQ(&events.at(event_name_1_).get().Get(), &event_1_);
 
     const auto& fields = moved_to_proxy.GetFields();
     ASSERT_EQ(fields.size(), 2U);
-    EXPECT_EQ(&fields.at(field_name_0_).get(), &field_0_);
-    EXPECT_EQ(&fields.at(field_name_1_).get(), &field_1_);
+    EXPECT_EQ(&fields.at(field_name_0_).get().Get(), &field_0_);
+    EXPECT_EQ(&fields.at(field_name_1_).get().Get(), &field_1_);
 
     const auto& methods = moved_to_proxy.GetMethods();
     EXPECT_EQ(methods.size(), 2U);
-    EXPECT_EQ(&methods.at(method_name_0_).get(), &method_0_);
-    EXPECT_EQ(&methods.at(method_name_1_).get(), &method_1_);
+    EXPECT_EQ(&methods.at(method_name_0_).get().Get(), &method_0_);
+    EXPECT_EQ(&methods.at(method_name_1_).get().Get(), &method_1_);
 }
 
 TEST_F(ProxyBaseServiceElementReferencesFixture, MoveAssigningUpdatesReferencesToServiceElements)
@@ -700,26 +692,25 @@ TEST_F(ProxyBaseServiceElementReferencesFixture, MoveAssigningUpdatesReferencesT
     mock_binding::Proxy proxy_binding_mock{};
 
     // Given a valid MyProxy object on which 2 Events, Fields and Methods were registered
-    ProxyBaseView{proxy_}.RegisterEvent(event_name_0_, event_0_);
-    ProxyBaseView{proxy_}.RegisterField(field_name_0_, field_0_);
-    ProxyBaseView{proxy_}.RegisterMethod(method_name_0_, method_0_);
-    ProxyBaseView{proxy_}.RegisterEvent(event_name_1_, event_1_);
-    ProxyBaseView{proxy_}.RegisterField(field_name_1_, field_1_);
-    ProxyBaseView{proxy_}.RegisterMethod(method_name_1_, method_1_);
+    ProxyBaseView{proxy_}.RegisterEvent(event_name_0_, event_0_.GetReferenceToMoveable());
+    ProxyBaseView{proxy_}.RegisterField(field_name_0_, field_0_.GetReferenceToMoveable());
+    ProxyBaseView{proxy_}.RegisterMethod(method_name_0_, method_0_.GetReferenceToMoveable());
+    ProxyBaseView{proxy_}.RegisterEvent(event_name_1_, event_1_.GetReferenceToMoveable());
+    ProxyBaseView{proxy_}.RegisterField(field_name_1_, field_1_.GetReferenceToMoveable());
+    ProxyBaseView{proxy_}.RegisterMethod(method_name_1_, method_1_.GetReferenceToMoveable());
 
     // and given a second valid MyProxy object
     MyProxy proxy_2{std::make_unique<mock_binding::ProxyFacade>(proxy_binding_mock), handle_};
 
     // and given that an Event, Field and Method were registered on the second proxy
-    ProxyEventBase event{
-        proxy_2, other_event_name, &proxy_binding_mock, std::make_unique<mock_binding::ProxyEventBase>()};
+    ProxyEventBase event{other_event_name, &proxy_binding_mock, std::make_unique<mock_binding::ProxyEventBase>()};
     ProxyEventBase field_event_dispatch{
-        proxy_2, other_field_name, &proxy_binding_mock, std::make_unique<mock_binding::ProxyEventBase>()};
-    ProxyFieldBase field{proxy_2, other_field_name, &field_event_dispatch};
-    DummyProxyMethod method{proxy_2, other_method_name, std::make_unique<mock_binding::ProxyMethod>()};
-    ProxyBaseView{proxy_2}.RegisterEvent(other_event_name, event);
-    ProxyBaseView{proxy_2}.RegisterField(other_field_name, field);
-    ProxyBaseView{proxy_2}.RegisterMethod(other_method_name, method);
+        other_field_name, &proxy_binding_mock, std::make_unique<mock_binding::ProxyEventBase>()};
+    ProxyFieldBase field{other_field_name, &field_event_dispatch};
+    DummyProxyMethod method{other_method_name, std::make_unique<mock_binding::ProxyMethod>()};
+    ProxyBaseView{proxy_2}.RegisterEvent(other_event_name, event.GetReferenceToMoveable());
+    ProxyBaseView{proxy_2}.RegisterField(other_field_name, field.GetReferenceToMoveable());
+    ProxyBaseView{proxy_2}.RegisterMethod(other_method_name, method.GetReferenceToMoveable());
 
     // When move assigning the first MyProxy object to the second
     proxy_2 = std::move(proxy_);
@@ -727,18 +718,18 @@ TEST_F(ProxyBaseServiceElementReferencesFixture, MoveAssigningUpdatesReferencesT
     // Then the second proxy's reference maps should contain references to the first proxy's registered elements
     const auto& events = proxy_2.GetEvents();
     ASSERT_EQ(events.size(), 2U);
-    EXPECT_EQ(&events.at(event_name_0_).get(), &event_0_);
-    EXPECT_EQ(&events.at(event_name_1_).get(), &event_1_);
+    EXPECT_EQ(&events.at(event_name_0_).get().Get(), &event_0_);
+    EXPECT_EQ(&events.at(event_name_1_).get().Get(), &event_1_);
 
     const auto& fields = proxy_2.GetFields();
     ASSERT_EQ(fields.size(), 2U);
-    EXPECT_EQ(&fields.at(field_name_0_).get(), &field_0_);
-    EXPECT_EQ(&fields.at(field_name_1_).get(), &field_1_);
+    EXPECT_EQ(&fields.at(field_name_0_).get().Get(), &field_0_);
+    EXPECT_EQ(&fields.at(field_name_1_).get().Get(), &field_1_);
 
     const auto& methods = proxy_2.GetMethods();
     EXPECT_EQ(methods.size(), 2U);
-    EXPECT_EQ(&methods.at(method_name_0_).get(), &method_0_);
-    EXPECT_EQ(&methods.at(method_name_1_).get(), &method_1_);
+    EXPECT_EQ(&methods.at(method_name_0_).get().Get(), &method_0_);
+    EXPECT_EQ(&methods.at(method_name_1_).get().Get(), &method_1_);
 }
 
 TEST_F(ProxyBaseServiceElementReferencesFixture, MoveAssigningToItselfDoesNotDoAnything)
@@ -756,76 +747,4 @@ TEST_F(ProxyBaseServiceElementReferencesFixture, MoveAssigningToItselfDoesNotDoA
     // be taken without crash.
 }
 
-TEST_F(ProxyBaseServiceElementReferencesFixture, UpdateEventUpdatesCorrectly)
-{
-    // Given a proxy with a registered event
-    ProxyBaseView{proxy_}.RegisterEvent(event_name_0_, event_0_);
-
-    // When we update the event with a new event value
-    ProxyBaseView{proxy_}.UpdateEvent(event_name_0_, event_1_);
-
-    // Then we expect the proxy to contain the new event under the old name
-    auto& updated_event = proxy_.GetEvents().find(event_name_0_)->second.get();
-
-    EXPECT_EQ(&updated_event, &event_1_);
-    EXPECT_NE(&updated_event, &event_0_);
-}
-
-TEST_F(ProxyBaseServiceElementReferencesFixture, UpdateEventTerminatesOnFailiure)
-{
-    // Given a proxy with a registered event
-    ProxyBaseView{proxy_}.RegisterEvent(event_name_0_, event_0_);
-
-    // When we try to update the event but use a wrong name, then the program terminates
-    SCORE_LANGUAGE_FUTURECPP_EXPECT_CONTRACT_VIOLATED(ProxyBaseView{proxy_}.UpdateEvent("wrong_event_name", event_0_));
-}
-
-TEST_F(ProxyBaseServiceElementReferencesFixture, UpdateFieldUpdatesCorrectly)
-{
-    // Given a proxy with a registered field
-    ProxyBaseView{proxy_}.RegisterField(field_name_0_, field_0_);
-
-    // When we update the field with a new field value
-    ProxyBaseView{proxy_}.UpdateField(field_name_0_, field_1_);
-
-    // Then we expect the proxy to contain the new field under the old name
-    auto& updated_field = proxy_.GetFields().find(field_name_0_)->second.get();
-
-    EXPECT_EQ(&updated_field, &field_1_);
-    EXPECT_NE(&updated_field, &field_0_);
-}
-
-TEST_F(ProxyBaseServiceElementReferencesFixture, UpdateFieldTerminatesOnFailiure)
-{
-    // Given a proxy with a registered event
-    ProxyBaseView{proxy_}.RegisterField(field_name_0_, field_0_);
-
-    // When we try to update the even but use a wrong name, then the program terminates
-    SCORE_LANGUAGE_FUTURECPP_EXPECT_CONTRACT_VIOLATED(ProxyBaseView{proxy_}.UpdateField("wrong_field_name", field_0_));
-}
-
-TEST_F(ProxyBaseServiceElementReferencesFixture, UpdateMethodUpdatesCorrectly)
-{
-    // Given a proxy with a registered method
-    ProxyBaseView{proxy_}.RegisterMethod(method_name_0_, method_0_);
-
-    // When we update the method with a new method value
-    ProxyBaseView{proxy_}.UpdateMethod(method_name_0_, method_1_);
-
-    // Then we expect the proxy to contain the new method under the old name
-    auto& updated_method = proxy_.GetMethods().find(method_name_0_)->second.get();
-
-    EXPECT_EQ(&updated_method, &method_1_);
-    EXPECT_NE(&updated_method, &method_0_);
-}
-
-TEST_F(ProxyBaseServiceElementReferencesFixture, UpdateMethodTerminatesOnFailiure)
-{
-    // Given a proxy with a registered event
-    ProxyBaseView{proxy_}.RegisterMethod(method_name_0_, method_0_);
-
-    // When we try to update the even but use a wrong name, then the program terminates
-    SCORE_LANGUAGE_FUTURECPP_EXPECT_CONTRACT_VIOLATED(
-        ProxyBaseView{proxy_}.UpdateMethod("wrong_method_name", method_0_));
-}
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/proxy_event.h
+++ b/score/mw/com/impl/proxy_event.h
@@ -105,8 +105,8 @@ class ProxyEvent final : public ProxyEventBase
     ProxyEvent& operator=(const ProxyEvent&) & = delete;
 
     /// \brief A ProxyEvent shall be movable
-    ProxyEvent(ProxyEvent&& other) noexcept;
-    ProxyEvent& operator=(ProxyEvent&& other) & noexcept;
+    ProxyEvent(ProxyEvent&& other) noexcept = default;
+    ProxyEvent& operator=(ProxyEvent&& other) noexcept = default;
 
     ~ProxyEvent() override = default;
 
@@ -145,7 +145,7 @@ template <typename SampleType>
 ProxyEvent<SampleType>::ProxyEvent(ProxyBase& base,
                                    const std::string_view event_name,
                                    std::unique_ptr<ProxyEventBinding<SampleType>> proxy_event_binding)
-    : ProxyEventBase{base, event_name, ProxyBaseView{base}.GetBinding(), std::move(proxy_event_binding)},
+    : ProxyEventBase{event_name, ProxyBaseView{base}.GetBinding(), std::move(proxy_event_binding)},
       proxy_event_mock_{nullptr}
 {
     ProxyBaseView proxy_base_view{base};
@@ -163,7 +163,7 @@ ProxyEvent<SampleType>::ProxyEvent(ProxyBase& base, const std::string_view event
     if (GetTypedEventBinding() != nullptr)
     {
         ProxyBaseView proxy_base_view{base};
-        proxy_base_view.RegisterEvent(event_name, *this);
+        proxy_base_view.RegisterEvent(event_name, GetReferenceToMoveable());
         const auto& instance_identifier = proxy_base_view.GetAssociatedHandleType().GetInstanceIdentifier();
         tracing_data_ = tracing::GenerateProxyTracingStructFromEventConfig(instance_identifier, event_name);
     }
@@ -185,35 +185,6 @@ ProxyEvent<SampleType>::ProxyEvent(ProxyBase& base,
         const auto& instance_identifier = proxy_base_view.GetAssociatedHandleType().GetInstanceIdentifier();
         tracing_data_ = tracing::GenerateProxyTracingStructFromFieldConfig(instance_identifier, event_name);
     }
-}
-
-template <typename SampleType>
-ProxyEvent<SampleType>::ProxyEvent(ProxyEvent&& other) noexcept
-    : ProxyEventBase(std::move(static_cast<ProxyEventBase&&>(other))),
-      proxy_event_mock_{std::move(other.proxy_event_mock_)}
-{
-    // Since the address of this event has changed, we need update the address stored in the parent proxy.
-    ProxyBaseView proxy_base_view{proxy_base_.get()};
-    proxy_base_view.UpdateEvent(event_name_, *this);
-}
-
-template <typename SampleType>
-// Suppress "AUTOSAR C++14 A6-2-1" rule violation. The rule states "Move and copy assignment operators shall either move
-// or respectively copy base classes and data members of a class, without any side effects."
-// Rationale: The parent proxy stores a reference to the ProxyEvent. The address that is pointed to must be
-// updated when the ProxyEvent is moved. Therefore, side effects are required.
-// coverity[autosar_cpp14_a6_2_1_violation]
-auto ProxyEvent<SampleType>::operator=(ProxyEvent&& other) & noexcept -> ProxyEvent<SampleType>&
-{
-    if (this != &other)
-    {
-        ProxyEventBase::operator=(std::move(static_cast<ProxyEventBase&&>(other)));
-        proxy_event_mock_ = std::move(other.proxy_event_mock_);
-        // Since the address of this event has changed, we need update the address stored in the parent proxy.
-        ProxyBaseView proxy_base_view{proxy_base_.get()};
-        proxy_base_view.UpdateEvent(event_name_, *this);
-    }
-    return *this;
 }
 
 template <typename SampleType>

--- a/score/mw/com/impl/proxy_event_base.cpp
+++ b/score/mw/com/impl/proxy_event_base.cpp
@@ -77,12 +77,12 @@ class EventBindingRegistrationGuard final
 // in multiple translation units without violating the One Definition Rule."
 // This is false positive. Function is declared only once.
 // coverity[autosar_cpp14_a3_1_1_violation]
-ProxyEventBase::ProxyEventBase(ProxyBase& proxy_base,
-                               std::string_view event_name,
+
+ProxyEventBase::ProxyEventBase(std::string_view event_name,
                                ProxyBinding* proxy_binding_ptr,
                                std::unique_ptr<ProxyEventBindingBase> proxy_event_binding) noexcept
-    : binding_base_{std::move(proxy_event_binding)},
-      proxy_base_(proxy_base),
+    : EnableReferenceToMoveableFromThis<ProxyEventBase>(),
+      binding_base_{std::move(proxy_event_binding)},
       event_name_{event_name},
       tracker_{std::make_unique<SampleReferenceTracker>()},
       tracing_data_{},

--- a/score/mw/com/impl/proxy_event_base.h
+++ b/score/mw/com/impl/proxy_event_base.h
@@ -14,6 +14,7 @@
 #ifndef SCORE_MW_COM_IMPL_PROXY_EVENT_BASE_H
 #define SCORE_MW_COM_IMPL_PROXY_EVENT_BASE_H
 
+#include "score/mw/com/impl/enable_reference_to_moveable_from_this.h"
 #include "score/mw/com/impl/event_receive_handler.h"
 #include "score/mw/com/impl/flag_owner.h"
 #include "score/mw/com/impl/proxy_binding.h"
@@ -35,14 +36,13 @@ namespace score::mw::com::impl
 {
 
 class EventBindingRegistrationGuard;
-class ProxyBase;
 
 /// \brief This is the user-visible class of an event that is part of a proxy. It contains ProxyEvent functionality that
 /// is agnostic of the data type that is transferred by the event.
 ///
 /// The class itself is a concrete type. However, it delegates all actions to an implementation
 /// that is provided by the binding the proxy is operating on.
-class ProxyEventBase
+class ProxyEventBase : public EnableReferenceToMoveableFromThis<ProxyEventBase>
 {
     // Suppress "AUTOSAR C++14 A11-3-1", The rule declares: "Friend declarations shall not be used".
     // Design dessision: The "*Attorney" class is a helper, which sets the internal state of this class accessing
@@ -52,16 +52,11 @@ class ProxyEventBase
 
   public:
     /// \brief Constructs a ProxyEventBase with the given proxy event binding.
-    /// \param proxy_base The parent proxy of this event. ProxyEventBase just stores a reference to it and allows the
-    /// update of this reference in case the ProxyBase is moved. For this a simple forward declaration of ProxyBase is
-    /// sufficient and needed to avoid cyclic dependencies. Subclasses of ProxyEventBase need to include the full
-    /// definition of ProxyBase, which is not a problem, since it doesn't provoke cyclic dependencies.
     /// \param proxy_binding_ptr Pointer to the ProxyBinding of the parent ProxyBase. Needed to register the
     /// proxy_event_binding at the proxy_binding.
     /// \param proxy_event_binding The binding that shall be associated with this proxy event.
     /// \param event_name Event name of the event.
-    ProxyEventBase(ProxyBase& proxy_base,
-                   std::string_view event_name,
+    ProxyEventBase(std::string_view event_name,
                    ProxyBinding* proxy_binding_ptr,
                    std::unique_ptr<ProxyEventBindingBase> proxy_event_binding) noexcept;
 
@@ -70,27 +65,10 @@ class ProxyEventBase
     ProxyEventBase& operator=(const ProxyEventBase&) = delete;
 
     /// \brief A ProxyEventBase shall be moveable
-    // Suppress "AUTOSAR C++14 M3-2-2": "The One Definition Rule shall not be violated.";
-    // "AUTOSAR C++14 M3-2-4": "An identifier with external linkage shall have exactly one definition".
-    // All these findings are false-positives.
-    // Suppress "AUTOSAR C++14 A12-8-6": "Copy and move constructors and copy assignment and move assignment operators
-    // shall be declared protected or defined “=delete” in base class". Movable constructors cannot be protected, it
-    // cannot be tested if not public.
-    // coverity[autosar_cpp14_a12_8_6_violation]
-    // coverity[autosar_cpp14_m3_2_2_violation]
-    // coverity[autosar_cpp14_m3_2_4_violation]
     ProxyEventBase(ProxyEventBase&&) noexcept;
-    // coverity[autosar_cpp14_a12_8_6_violation]
-    // coverity[autosar_cpp14_m3_2_2_violation]
-    // coverity[autosar_cpp14_m3_2_4_violation]
     ProxyEventBase& operator=(ProxyEventBase&&) noexcept;
 
     virtual ~ProxyEventBase() noexcept;
-
-    void UpdateProxyReference(ProxyBase& proxy_base) noexcept
-    {
-        proxy_base_ = proxy_base;
-    }
 
     /**
      * \api
@@ -203,8 +181,6 @@ class ProxyEventBase
     // GenericProxyEvent.
     // coverity[autosar_cpp14_m11_0_1_violation]
     std::unique_ptr<ProxyEventBindingBase> binding_base_;
-    // coverity[autosar_cpp14_m11_0_1_violation]
-    std::reference_wrapper<ProxyBase> proxy_base_;
     // coverity[autosar_cpp14_m11_0_1_violation]
     std::string_view event_name_;
     // coverity[autosar_cpp14_m11_0_1_violation]

--- a/score/mw/com/impl/proxy_event_base_test.cpp
+++ b/score/mw/com/impl/proxy_event_base_test.cpp
@@ -1069,12 +1069,9 @@ TEST(ProxyEventBaseTest, MoveConstructingProxyEventDoesNotCrash)
     auto mock_proxy_event_binding_ptr = std::make_unique<StrictMock<mock_binding::ProxyEventBase>>();
     auto& mock_proxy_event_binding = *mock_proxy_event_binding_ptr;
 
-    DummyProxy empty_proxy(std::make_unique<mock_binding::Proxy>(),
-                           make_HandleType(make_InstanceIdentifier(kEmptyInstanceDeployment, kEmptyTypeDeployment)));
-
     // Given a Service Element, that is connected to a mock binding
-    ProxyEventBase dummy_event{
-        empty_proxy, kEventName, ProxyBaseView{empty_proxy}.GetBinding(), std::move(mock_proxy_event_binding_ptr)};
+    mock_binding::Proxy proxy_binding{};
+    ProxyEventBase dummy_event{kEventName, &proxy_binding, std::move(mock_proxy_event_binding_ptr)};
 
     // And a new Service Element is created with the move constructor
     ProxyEventBase dummy_event_2{std::move(dummy_event)};
@@ -1095,18 +1092,14 @@ TEST(ProxyEventBaseTest, MoveAssigningProxyEventDoesNotCrash)
     auto mock_proxy_event_binding_ptr = std::make_unique<StrictMock<mock_binding::ProxyEventBase>>();
     auto& mock_proxy_event_binding = *mock_proxy_event_binding_ptr;
 
-    DummyProxy empty_proxy(std::make_unique<mock_binding::Proxy>(),
-                           make_HandleType(make_InstanceIdentifier(kEmptyInstanceDeployment, kEmptyTypeDeployment)));
-
     // Given a Service Element, that is connected to a mock binding
-    ProxyEventBase dummy_event{
-        empty_proxy, kEventName, ProxyBaseView{empty_proxy}.GetBinding(), std::move(mock_proxy_event_binding_ptr)};
+    mock_binding::Proxy proxy_binding{};
+    ProxyEventBase dummy_event{kEventName, &proxy_binding, std::move(mock_proxy_event_binding_ptr)};
 
     // And a new Service Element is created and move assigned
-    ProxyEventBase dummy_event_2{empty_proxy,
-                                 kEventName2,
-                                 ProxyBaseView{empty_proxy}.GetBinding(),
-                                 std::make_unique<StrictMock<mock_binding::ProxyEventBase>>()};
+    mock_binding::Proxy proxy_binding2{};
+    ProxyEventBase dummy_event_2{
+        kEventName2, &proxy_binding2, std::make_unique<StrictMock<mock_binding::ProxyEventBase>>()};
     dummy_event_2 = std::move(dummy_event);
 
     // Expect that Subscribe is called on the binding only once
@@ -1125,12 +1118,9 @@ TEST(ProxyEventBaseTest, SetSubscriptionStateChangeHandlerWorks)
     auto mock_proxy_event_binding_ptr = std::make_unique<StrictMock<mock_binding::ProxyEventBase>>();
     auto& mock_proxy_event_binding = *mock_proxy_event_binding_ptr;
 
-    DummyProxy empty_proxy(std::make_unique<mock_binding::Proxy>(),
-                           make_HandleType(make_InstanceIdentifier(kEmptyInstanceDeployment, kEmptyTypeDeployment)));
-
     // Given a Service Element, that is connected to a mock binding
-    ProxyEventBase dummy_event{
-        empty_proxy, kEventName, ProxyBaseView{empty_proxy}.GetBinding(), std::move(mock_proxy_event_binding_ptr)};
+    mock_binding::Proxy proxy_binding{};
+    ProxyEventBase dummy_event{kEventName, &proxy_binding, std::move(mock_proxy_event_binding_ptr)};
 
     // Expect that SetSubscriptionStateChangeHandler is called
     EXPECT_CALL(mock_proxy_event_binding, SetSubscriptionStateChangeHandler).WillOnce(Return(score::Result<void>{}));
@@ -1147,12 +1137,9 @@ TEST(ProxyEventBaseTest, UnsetSubscriptionStateChangeHandlerWorks)
     auto mock_proxy_event_binding_ptr = std::make_unique<StrictMock<mock_binding::ProxyEventBase>>();
     auto& mock_proxy_event_binding = *mock_proxy_event_binding_ptr;
 
-    DummyProxy empty_proxy(std::make_unique<mock_binding::Proxy>(),
-                           make_HandleType(make_InstanceIdentifier(kEmptyInstanceDeployment, kEmptyTypeDeployment)));
-
     // Given a Service Element, that is connected to a mock binding
-    ProxyEventBase dummy_event{
-        empty_proxy, kEventName, ProxyBaseView{empty_proxy}.GetBinding(), std::move(mock_proxy_event_binding_ptr)};
+    mock_binding::Proxy proxy_binding{};
+    ProxyEventBase dummy_event{kEventName, &proxy_binding, std::move(mock_proxy_event_binding_ptr)};
 
     // Expect that UnsetSubscriptionStateChangeHandler is called
     EXPECT_CALL(mock_proxy_event_binding, UnsetSubscriptionStateChangeHandler).WillOnce(Return(score::Result<void>{}));

--- a/score/mw/com/impl/proxy_event_test.cpp
+++ b/score/mw/com/impl/proxy_event_test.cpp
@@ -560,8 +560,8 @@ TEST_F(ProxyEventMoveAssignmentTest, MoveAssignmentTransfersBindingFromSourceToD
 
     // Given two registered ProxyEvents, each with their own binding mock
     ProxyEventType second_event{empty_proxy_, kEventName2, std::move(second_binding_facade)};
-    ProxyBaseView{empty_proxy_}.RegisterEvent(kEventName, proxy_event_);
-    ProxyBaseView{empty_proxy_}.RegisterEvent(kEventName2, second_event);
+    ProxyBaseView{empty_proxy_}.RegisterEvent(kEventName, proxy_event_.GetReferenceToMoveable());
+    ProxyBaseView{empty_proxy_}.RegisterEvent(kEventName2, second_event.GetReferenceToMoveable());
 
     constexpr std::size_t max_sample_count{7U};
     EXPECT_CALL(second_binding_mock, GetSubscriptionState()).WillOnce(Return(SubscriptionState::kNotSubscribed));

--- a/score/mw/com/impl/proxy_field.h
+++ b/score/mw/com/impl/proxy_field.h
@@ -145,8 +145,8 @@ class ProxyField final : public ProxyFieldBase
     ProxyField& operator=(const ProxyField&) = delete;
 
     /// \brief A ProxyField shall be moveable
-    ProxyField(ProxyField&&) noexcept;
-    ProxyField& operator=(ProxyField&&) & noexcept;
+    ProxyField(ProxyField&&) noexcept = default;
+    ProxyField& operator=(ProxyField&&) noexcept = default;
 
     ~ProxyField() noexcept = default;
 
@@ -406,13 +406,13 @@ class ProxyField final : public ProxyFieldBase
                std::unique_ptr<ProxyEvent<FieldType>> proxy_event_dispatch,
                std::unique_ptr<ProxyMethod<FieldType(FieldType)>> proxy_method_set_dispatch,
                std::unique_ptr<ProxyMethod<FieldType()>> proxy_method_get_dispatch)
-        : ProxyFieldBase{proxy_base, field_name, proxy_event_dispatch.get()},
+        : ProxyFieldBase{field_name, proxy_event_dispatch.get()},
           proxy_event_dispatch_{std::move(proxy_event_dispatch)},
           proxy_method_set_dispatch_{std::move(proxy_method_set_dispatch)},
           proxy_method_get_dispatch_{std::move(proxy_method_get_dispatch)}
     {
         ProxyBaseView proxy_base_view{proxy_base};
-        proxy_base_view.RegisterField(field_name, *this);
+        proxy_base_view.RegisterField(field_name, GetReferenceToMoveable());
     }
 
     std::unique_ptr<ProxyEvent<FieldType>> proxy_event_dispatch_;
@@ -424,39 +424,6 @@ class ProxyField final : public ProxyFieldBase
                   "proxy_event_dispatch_ needs to be a unique_ptr since we pass a pointer to it to ProxyFieldBase, so "
                   "we must ensure that it doesn't move when the ProxyField is moved to avoid dangling references. ");
 };
-
-template <typename SampleDataType, typename... Tags>
-ProxyField<SampleDataType, Tags...>::ProxyField(ProxyField&& other) noexcept
-    : ProxyFieldBase(std::move(static_cast<ProxyFieldBase&&>(other))),
-      proxy_event_dispatch_(std::move(other.proxy_event_dispatch_)),
-      proxy_method_set_dispatch_(std::move(other.proxy_method_set_dispatch_)),
-      proxy_method_get_dispatch_(std::move(other.proxy_method_get_dispatch_))
-{
-    ProxyBaseView proxy_base_view{proxy_base_.get()};
-    proxy_base_view.UpdateField(field_name_, *this);
-}
-
-template <typename SampleDataType, typename... Tags>
-// Suppress "AUTOSAR C++14 A6-2-1" rule violation. The rule states "Move and copy assignment operators shall either move
-// or respectively copy base classes and data members of a class, without any side effects."
-// Rationale: The parent proxy stores a reference to the ProxyEvent. The address that is pointed to must be
-// updated when the ProxyField is moved. Therefore, side effects are required.
-// coverity[autosar_cpp14_a6_2_1_violation]
-auto ProxyField<SampleDataType, Tags...>::operator=(ProxyField&& other) & noexcept
-    -> ProxyField<SampleDataType, Tags...>&
-{
-    if (this != &other)
-    {
-        ProxyFieldBase::operator=(std::move(other));
-
-        ProxyBaseView proxy_base_view{proxy_base_.get()};
-        proxy_base_view.UpdateField(field_name_, *this);
-        proxy_event_dispatch_ = std::move(other.proxy_event_dispatch_);
-        proxy_method_set_dispatch_ = std::move(other.proxy_method_set_dispatch_);
-        proxy_method_get_dispatch_ = std::move(other.proxy_method_get_dispatch_);
-    }
-    return *this;
-}
 
 }  // namespace score::mw::com::impl
 

--- a/score/mw/com/impl/proxy_field_base.h
+++ b/score/mw/com/impl/proxy_field_base.h
@@ -13,6 +13,7 @@
 #ifndef SCORE_MW_COM_IMPL_PROXY_FIELD_BASE_H
 #define SCORE_MW_COM_IMPL_PROXY_FIELD_BASE_H
 
+#include "score/mw/com/impl/enable_reference_to_moveable_from_this.h"
 #include "score/mw/com/impl/proxy_event_base.h"
 
 #include "score/result/result.h"
@@ -20,17 +21,15 @@
 #include <score/assert.hpp>
 
 #include <cstddef>
-#include <functional>
 #include <string_view>
 #include <utility>
 
 namespace score::mw::com::impl
 {
 
-class ProxyBase;
 class ProxyFieldBaseView;
 
-class ProxyFieldBase
+class ProxyFieldBase : public EnableReferenceToMoveableFromThis<ProxyFieldBase>
 {
     // Suppress "AUTOSAR C++14 A11-3-1", The rule states: "Friend declarations shall not be used".
     // Design decision. This class provides a view to the private members of this class.
@@ -39,8 +38,10 @@ class ProxyFieldBase
 
   public:
     /// \param proxy_event_base_dispatch May be nullptr when the field's tag pack does not include WithNotifier.
-    ProxyFieldBase(ProxyBase& proxy_base, std::string_view field_name, ProxyEventBase* proxy_event_base_dispatch)
-        : proxy_base_{proxy_base}, proxy_event_base_dispatch_{proxy_event_base_dispatch}, field_name_{field_name}
+    ProxyFieldBase(std::string_view field_name, ProxyEventBase* proxy_event_base_dispatch)
+        : EnableReferenceToMoveableFromThis<ProxyFieldBase>(),
+          proxy_event_base_dispatch_{proxy_event_base_dispatch},
+          field_name_{field_name}
     {
     }
 
@@ -53,11 +54,6 @@ class ProxyFieldBase
     ProxyFieldBase& operator=(ProxyFieldBase&&) noexcept = default;
 
     virtual ~ProxyFieldBase() noexcept = default;
-
-    void UpdateProxyReference(ProxyBase& proxy_base) noexcept
-    {
-        proxy_base_ = proxy_base;
-    }
 
     /**
      * \name Tag-gated interface
@@ -125,7 +121,6 @@ class ProxyFieldBase
     }
     /// \}
 
-    std::reference_wrapper<ProxyBase> proxy_base_;
     ProxyEventBase* proxy_event_base_dispatch_;
     std::string_view field_name_;
 };


### PR DESCRIPTION
Previously, each service element had to store a reference to the parent ProxyBase so that it could update the reference to itself in the ProxyBase when the service element was moved. This meant that both ProxyBase and the service elements had to store references to each other. Keeping these references in a valid state during moving was complex and error prone.

Each service element now inherits from EnableReferenceToMoveableFromThis which stores a ReferenceToMoveableOwner element which is updated when the service element moves. The ProxyBase stores a ReferenceToMoveable::Reference to each service element, instead of a regular reference which is now always valid, regardless of moving of the ProxyBase or service elements.

Depends-on: https://github.com/eclipse-score/communication/pull/572