### PR TITLE
mw/com: Undo change which breaks binding independence of factories 

### DIFF
--- a/score/mw/com/impl/generic_proxy_event.cpp
+++ b/score/mw/com/impl/generic_proxy_event.cpp
@@ -23,7 +23,7 @@ GenericProxyEvent::GenericProxyEvent(ProxyBase& base, const std::string_view eve
     : ProxyEventBase{base,
                      event_name,
                      ProxyBaseView{base}.GetBinding(),
-                     GenericProxyEventBindingFactory::Create(base, event_name)}
+                     GenericProxyEventBindingFactory::Create(base, event_name, ServiceElementType::EVENT)}
 {
     ProxyBaseView proxy_base_view{base};
     if (!binding_base_)

--- a/score/mw/com/impl/generic_proxy_test.cpp
+++ b/score/mw/com/impl/generic_proxy_test.cpp
@@ -175,7 +175,7 @@ class GenericProxyFixture : public ::testing::Test
         // This ideally would be an ON_CALL as we want Create to create a mock binding and return it by default.
         // However, we get a "unknown file: Failure" while running the test in that case. Changing it to an EXPECT_CALL
         // solves the problem.
-        EXPECT_CALL(generic_proxy_event_binding_guard_.factory_mock_, Create(_, _))
+        EXPECT_CALL(generic_proxy_event_binding_guard_.factory_mock_, Create(_, _, _))
             .Times(AnyNumber())
             .WillRepeatedly([]() {
                 return std::make_unique<mock_binding::GenericProxyEvent>();
@@ -287,7 +287,8 @@ TEST_F(GenericProxyFixture, CreatingGenericProxyWithNoGenericProxyEventBindingRe
     // Given a handle created from valid instance and type deployments
     // and that the Create call on the ProxyEventBindingFactory returns a nullptr.
     CreateAHandle({kEventName1, kEventName2, kEventName3});
-    EXPECT_CALL(generic_proxy_event_binding_guard_.factory_mock_, Create(_, std::string_view{kEventName1}))
+    EXPECT_CALL(generic_proxy_event_binding_guard_.factory_mock_,
+                Create(_, std::string_view{kEventName1}, ServiceElementType::EVENT))
         .WillRepeatedly(Return(ByMove(nullptr)));
 
     // When creating a GenericProxy
@@ -313,11 +314,14 @@ TEST_F(GenericProxyFixture, GenericProxyWillCreateEventBindingsSpecifiedInHandle
     CreateAHandle({kEventName1, kEventName2, kEventName3});
 
     // Then bindings are created for the provided events
-    EXPECT_CALL(generic_proxy_event_binding_guard_.factory_mock_, Create(_, std::string_view{kEventName1}))
+    EXPECT_CALL(generic_proxy_event_binding_guard_.factory_mock_,
+                Create(_, std::string_view{kEventName1}, ServiceElementType::EVENT))
         .WillOnce(Return(ByMove(std::make_unique<mock_binding::GenericProxyEvent>())));
-    EXPECT_CALL(generic_proxy_event_binding_guard_.factory_mock_, Create(_, std::string_view{kEventName2}))
+    EXPECT_CALL(generic_proxy_event_binding_guard_.factory_mock_,
+                Create(_, std::string_view{kEventName2}, ServiceElementType::EVENT))
         .WillOnce(Return(ByMove(std::make_unique<mock_binding::GenericProxyEvent>())));
-    EXPECT_CALL(generic_proxy_event_binding_guard_.factory_mock_, Create(_, std::string_view{kEventName3}))
+    EXPECT_CALL(generic_proxy_event_binding_guard_.factory_mock_,
+                Create(_, std::string_view{kEventName3}, ServiceElementType::EVENT))
         .WillOnce(Return(ByMove(std::make_unique<mock_binding::GenericProxyEvent>())));
 
     // When constructing the generic proxy from the handle
@@ -366,10 +370,14 @@ TEST_F(GenericProxyFixture, GenericProxyWillOnlyCreateEventBindingsForEventsProv
     ON_CALL(*proxy_binding_mock_, IsEventProvided(std::string_view{kEventName3})).WillByDefault(Return(true));
 
     // Then bindings are only created for the provided events
-    EXPECT_CALL(generic_proxy_event_binding_guard_.factory_mock_, Create(_, std::string_view{kEventName1}))
+    EXPECT_CALL(generic_proxy_event_binding_guard_.factory_mock_,
+                Create(_, std::string_view{kEventName1}, ServiceElementType::EVENT))
         .WillOnce(Return(ByMove(std::make_unique<mock_binding::GenericProxyEvent>())));
-    EXPECT_CALL(generic_proxy_event_binding_guard_.factory_mock_, Create(_, std::string_view{kEventName2})).Times(0);
-    EXPECT_CALL(generic_proxy_event_binding_guard_.factory_mock_, Create(_, std::string_view{kEventName3}))
+    EXPECT_CALL(generic_proxy_event_binding_guard_.factory_mock_,
+                Create(_, std::string_view{kEventName2}, ServiceElementType::EVENT))
+        .Times(0);
+    EXPECT_CALL(generic_proxy_event_binding_guard_.factory_mock_,
+                Create(_, std::string_view{kEventName3}, ServiceElementType::EVENT))
         .WillOnce(Return(ByMove(std::make_unique<mock_binding::GenericProxyEvent>())));
 
     // When constructing the generic proxy

--- a/score/mw/com/impl/plumbing/BUILD
+++ b/score/mw/com/impl/plumbing/BUILD
@@ -265,15 +265,19 @@ cc_library(
     srcs = ["lola_proxy_element_building_blocks.cpp"],
     hdrs = ["lola_proxy_element_building_blocks.h"],
     features = COMPILER_WARNING_FEATURES,
+    implementation_deps = [
+        "@score_baselibs//score/language/futurecpp",
+        "@score_baselibs//score/mw/log",
+    ],
     tags = ["FFI"],
     visibility = [
         "//score/mw/com/impl/plumbing:__subpackages__",
     ],
     deps = [
-        "//score/mw/com/impl:proxy_base",
+        "//score/mw/com/impl:handle_type",
+        "//score/mw/com/impl:service_element_type",
         "//score/mw/com/impl/bindings/lola",
         "//score/mw/com/impl/configuration",
-        "@score_baselibs//score/language/futurecpp",
     ],
 )
 
@@ -304,6 +308,7 @@ cc_library(
     deps = [
         ":i_proxy_field_binding_factory",
         ":lola_proxy_element_building_blocks",
+        ":proxy_event_binding_factory",
         ":proxy_method_binding_factory",
         "//score/mw/com/impl:method_type",
         "@score_baselibs//score/language/futurecpp",

--- a/score/mw/com/impl/plumbing/i_proxy_event_binding_factory.h
+++ b/score/mw/com/impl/plumbing/i_proxy_event_binding_factory.h
@@ -14,8 +14,6 @@
 #define SCORE_MW_COM_IMPL_PLUMBING_I_PROXY_EVENT_BINDING_FACTORY_H
 
 #include "score/mw/com/impl/generic_proxy_event_binding.h"
-#include "score/mw/com/impl/handle_type.h"
-#include "score/mw/com/impl/instance_identifier.h"
 #include "score/mw/com/impl/proxy_base.h"
 #include "score/mw/com/impl/proxy_event_binding.h"
 
@@ -45,7 +43,9 @@ class IProxyEventBindingFactory
     /// \param handle The handle containing the binding information.
     /// \param event_name The binding unspecific name of the event inside the proxy denoted by handle.
     /// \return An instance of ProxyEventBinding or nullptr in case of an error.
-    virtual auto Create(ProxyBase& parent, const std::string_view event_name) noexcept
+    virtual auto Create(ProxyBase& parent,
+                        const std::string_view event_name,
+                        const ServiceElementType service_element_type) noexcept
         -> std::unique_ptr<ProxyEventBinding<SampleType>> = 0;
 };
 
@@ -67,8 +67,10 @@ class IGenericProxyEventBindingFactory
     /// \param handle The handle containing the binding information.
     /// \param event_name The binding unspecific name of the event inside the proxy denoted by handle.
     /// \return An instance of ProxyEventBinding or nullptr in case of an error.
-    virtual std::unique_ptr<GenericProxyEventBinding> Create(ProxyBase& parent,
-                                                             const std::string_view event_name) noexcept = 0;
+    virtual std::unique_ptr<GenericProxyEventBinding> Create(
+        ProxyBase& parent,
+        const std::string_view event_name,
+        const ServiceElementType service_element_type) noexcept = 0;
 };
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/lola_proxy_element_building_blocks.cpp
+++ b/score/mw/com/impl/plumbing/lola_proxy_element_building_blocks.cpp
@@ -12,8 +12,6 @@
  ********************************************************************************/
 #include "score/mw/com/impl/plumbing/lola_proxy_element_building_blocks.h"
 
-#include "score/mw/com/impl/configuration/binding_service_type_deployment.h"
-#include "score/mw/com/impl/configuration/lola_service_type_deployment.h"
 #include "score/mw/log/logging.h"
 
 #include <score/assert.hpp>
@@ -26,76 +24,38 @@
 namespace score::mw::com::impl
 {
 
-namespace
+lola::ElementFqId GetElementFqId(const HandleType& handle,
+                                 const LolaServiceTypeDeployment& lola_type_deployment,
+                                 const std::string_view service_element_name,
+                                 const ServiceElementType element_type)
 {
-
-std::optional<LoLaProxyElementBuildingBlocks> LookupForLola(const HandleType& handle,
-                                                            ProxyBinding* parent_binding,
-                                                            const LolaServiceTypeDeployment& lola_type_deployment,
-                                                            const std::string_view name,
-                                                            const ServiceElementType element_type) noexcept
-{
-    auto* const lola_parent = dynamic_cast<lola::Proxy*>(parent_binding);
-    if (lola_parent == nullptr)
-    {
-        return std::nullopt;
-    }
-
     const auto instance_id = handle.GetInstanceId();
     const auto* const lola_instance_id = std::get_if<LolaServiceInstanceId>(&(instance_id.binding_info_));
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(lola_instance_id != nullptr,
                                                 "ServiceInstanceId does not contain lola binding.");
 
-    const std::string name_str{name};
-    LolaServiceElementId element_id{};
-    switch (element_type)
-    {
-        case ServiceElementType::EVENT:
-            element_id = GetServiceElementId<ServiceElementType::EVENT>(lola_type_deployment, name_str);
-            break;
-        case ServiceElementType::FIELD:
-            element_id = GetServiceElementId<ServiceElementType::FIELD>(lola_type_deployment, name_str);
-            break;
-        case ServiceElementType::METHOD:
-            element_id = GetServiceElementId<ServiceElementType::METHOD>(lola_type_deployment, name_str);
-            break;
-        case ServiceElementType::INVALID:
-        default:
-            score::mw::log::LogFatal("lola") << "LookupLolaProxyElement called with invalid ServiceElementType.";
-            SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
-                false, "LookupLolaProxyElement called with invalid ServiceElementType.");
-            return std::nullopt;
-    }
+    const std::string service_element_name_str{service_element_name};
+    const LolaServiceElementId element_id{[element_type, &lola_type_deployment, &service_element_name_str]() {
+        switch (element_type)
+        {
+            case ServiceElementType::EVENT:
+                return GetServiceElementId<ServiceElementType::EVENT>(lola_type_deployment, service_element_name_str);
+                break;
+            case ServiceElementType::FIELD:
+                return GetServiceElementId<ServiceElementType::FIELD>(lola_type_deployment, service_element_name_str);
+                break;
+            case ServiceElementType::METHOD:
+                return GetServiceElementId<ServiceElementType::METHOD>(lola_type_deployment, service_element_name_str);
+                break;
+            case ServiceElementType::INVALID:
+            default:
+                score::mw::log::LogFatal("lola") << "LookupLolaProxyElement called with invalid ServiceElementType.";
+                SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+                    false, "LookupLolaProxyElement called with invalid ServiceElementType.");
+        }
+    }()};
 
-    const lola::ElementFqId element_fq_id{
-        lola_type_deployment.service_id_, element_id, lola_instance_id->GetId(), element_type};
-
-    return LoLaProxyElementBuildingBlocks{*lola_parent, lola_instance_id->GetId(), element_fq_id};
-}
-
-}  // namespace
-
-// Suppress "AUTOSAR C++14 A15-5-3" rule finding. std::visit may throw std::bad_variant_access only
-// if the variant is valueless_by_exception, which cannot happen here because we do not throw
-// exceptions during construction of the alternatives.
-// coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-std::optional<LoLaProxyElementBuildingBlocks> LookupLolaProxyElement(const HandleType& handle,
-                                                                     ProxyBinding* parent_binding,
-                                                                     const std::string_view service_element_name,
-                                                                     const ServiceElementType element_type) noexcept
-{
-    const auto& type_deployment = handle.GetServiceTypeDeployment();
-
-    auto visitor = score::cpp::overload(
-        [&handle, parent_binding, service_element_name, element_type](
-            const LolaServiceTypeDeployment& lola_deployment) {
-            return LookupForLola(handle, parent_binding, lola_deployment, service_element_name, element_type);
-        },
-        [](const score::cpp::blank&) noexcept -> std::optional<LoLaProxyElementBuildingBlocks> {
-            return std::nullopt;
-        });
-
-    return std::visit(visitor, type_deployment.binding_info_);
+    return {lola_type_deployment.service_id_, element_id, lola_instance_id->GetId(), element_type};
 }
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/lola_proxy_element_building_blocks.h
+++ b/score/mw/com/impl/plumbing/lola_proxy_element_building_blocks.h
@@ -14,49 +14,19 @@
 #define SCORE_MW_COM_IMPL_PLUMBING_LOLA_PROXY_ELEMENT_BUILDING_BLOCKS_H
 
 #include "score/mw/com/impl/bindings/lola/element_fq_id.h"
-#include "score/mw/com/impl/bindings/lola/proxy.h"
-#include "score/mw/com/impl/configuration/lola_service_element_id.h"
-#include "score/mw/com/impl/configuration/lola_service_instance_deployment.h"
+#include "score/mw/com/impl/configuration/lola_service_type_deployment.h"
 #include "score/mw/com/impl/handle_type.h"
-#include "score/mw/com/impl/proxy_base.h"
-#include "score/mw/com/impl/proxy_binding.h"
 #include "score/mw/com/impl/service_element_type.h"
 
-#include <optional>
 #include <string_view>
 
 namespace score::mw::com::impl
 {
 
-/// \brief Result of resolving a named service element against the lola deployment on the proxy side.
-/// \details Carries everything a binding constructor needs that comes from deployment/handle lookup.
-///          This is intentionally agnostic to what kind of binding is being built (event, field notifier,
-///          method); the construction step lives with the caller.
-struct LoLaProxyElementBuildingBlocks
-{
-    lola::Proxy& parent;
-    LolaServiceInstanceId::InstanceId instance_id;
-    lola::ElementFqId element_fq_id;
-};
-
-/// \brief Validate the parent is a lola proxy and resolve the element name against the lola deployment contained in the
-/// given handle.
-/// \return The lookup data on success, std::nullopt for non-lola bindings or a missing parent binding.
-/// \note Fatally asserts on a malformed instance id or an element name that is not present in the
-///       deployment, matching the previous behaviour of the per-factory inlined lookups.
-std::optional<LoLaProxyElementBuildingBlocks> LookupLolaProxyElement(const HandleType& handle,
-                                                                     ProxyBinding* parent_binding,
-                                                                     std::string_view service_element_name,
-                                                                     ServiceElementType element_type) noexcept;
-
-/// \brief Convenience overload that pulls the handle and binding out of a ProxyBase reference.
-inline std::optional<LoLaProxyElementBuildingBlocks> LookupLolaProxyElement(ProxyBase& parent,
-                                                                            std::string_view service_element_name,
-                                                                            ServiceElementType element_type) noexcept
-{
-    return LookupLolaProxyElement(
-        parent.GetHandle(), ProxyBaseView{parent}.GetBinding(), service_element_name, element_type);
-}
+lola::ElementFqId GetElementFqId(const HandleType& handle,
+                                 const LolaServiceTypeDeployment& lola_type_deployment,
+                                 const std::string_view service_element_name,
+                                 const ServiceElementType element_type);
 
 }  // namespace score::mw::com::impl
 

--- a/score/mw/com/impl/plumbing/proxy_event_binding_factory.h
+++ b/score/mw/com/impl/plumbing/proxy_event_binding_factory.h
@@ -34,9 +34,11 @@ class ProxyEventBindingFactory final
 {
   public:
     /// \brief See documentation in IProxyEventBindingFactory.
-    static std::unique_ptr<ProxyEventBinding<SampleType>> Create(ProxyBase& parent, std::string_view event_name)
+    static std::unique_ptr<ProxyEventBinding<SampleType>> Create(ProxyBase& parent,
+                                                                 std::string_view event_name,
+                                                                 const ServiceElementType service_element_type)
     {
-        return instance().Create(parent, event_name);
+        return instance().Create(parent, event_name, service_element_type);
     }
 
     /// \brief Inject a mock IProxyEventBindingFactory. If a mock is injected, then all calls on
@@ -57,9 +59,11 @@ class GenericProxyEventBindingFactory final
 {
   public:
     /// \brief See documentation in IGenericProxyEventBindingFactory.
-    static std::unique_ptr<GenericProxyEventBinding> Create(ProxyBase& parent, std::string_view event_name)
+    static std::unique_ptr<GenericProxyEventBinding> Create(ProxyBase& parent,
+                                                            std::string_view event_name,
+                                                            const ServiceElementType service_element_type)
     {
-        return instance().Create(parent, event_name);
+        return instance().Create(parent, event_name, service_element_type);
     }
 
     /// \brief Inject a mock IGenericProxyEventBindingFactory. If a mock is injected, then all calls on

--- a/score/mw/com/impl/plumbing/proxy_event_binding_factory_impl.cpp
+++ b/score/mw/com/impl/plumbing/proxy_event_binding_factory_impl.cpp
@@ -33,17 +33,35 @@ namespace score::mw::com::impl
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
 std::unique_ptr<GenericProxyEventBinding> GenericProxyEventBindingFactoryImpl::Create(
     ProxyBase& parent,
-    const std::string_view event_name) noexcept
+    const std::string_view event_name,
+    const ServiceElementType service_element_type) noexcept
 {
-    const auto lookup = LookupLolaProxyElement(parent, event_name, ServiceElementType::EVENT);
-    if (!lookup.has_value())
-    {
-        score::mw::log::LogError("lola")
-            << "GenericProxyEvent binding could not be created for event" << event_name
-            << "because the parent proxy binding is not a lola binding or the element could not be resolved.";
-        return nullptr;
-    }
-    return std::make_unique<lola::GenericProxyEvent>(lookup->parent, lookup->element_fq_id, event_name);
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(service_element_type == ServiceElementType::EVENT ||
+                                              service_element_type == ServiceElementType::FIELD);
+
+    using ReturnType = std::unique_ptr<lola::GenericProxyEvent>;
+    auto deployment_info_visitor = score::cpp::overload(
+        [&parent, event_name, service_element_type](
+            const LolaServiceTypeDeployment& lola_type_deployment) -> ReturnType {
+            auto* const lola_proxy = dynamic_cast<lola::Proxy*>(ProxyBaseView{parent}.GetBinding());
+            if (lola_proxy == nullptr)
+            {
+                score::mw::log::LogError("lola") << "Generic proxy event binding could not be created for" << event_name
+                                                 << "because the parent proxy binding is not a lola binding.";
+                return nullptr;
+            }
+
+            const auto element_fq_id =
+                GetElementFqId(parent.GetHandle(), lola_type_deployment, std::string{event_name}, service_element_type);
+            return std::make_unique<lola::GenericProxyEvent>(*lola_proxy, element_fq_id, event_name);
+        },
+        [](const score::cpp::blank&) noexcept -> ReturnType {
+            return nullptr;
+        });
+
+    const HandleType& handle = parent.GetHandle();
+    const auto& type_deployment = handle.GetServiceTypeDeployment();
+    return std::visit(deployment_info_visitor, type_deployment.binding_info_);
 }
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/proxy_event_binding_factory_impl.h
+++ b/score/mw/com/impl/plumbing/proxy_event_binding_factory_impl.h
@@ -29,6 +29,51 @@
 
 namespace score::mw::com::impl
 {
+namespace detail
+{
+
+template <typename ProxyServiceElementBinding, typename ProxyServiceElement, ServiceElementType element_type>
+std::unique_ptr<ProxyServiceElementBinding> CreateProxyEvent(ProxyBase& parent,
+                                                             const std::string_view service_element_name) noexcept
+{
+    using ReturnType = std::unique_ptr<ProxyServiceElementBinding>;
+
+    const HandleType& handle = parent.GetHandle();
+    const auto& type_deployment = handle.GetServiceTypeDeployment();
+
+    auto deployment_info_visitor = score::cpp::overload(
+        [&parent, &handle, service_element_name](const LolaServiceTypeDeployment& lola_type_deployment) -> ReturnType {
+            auto* const lola_parent = dynamic_cast<lola::Proxy*>(ProxyBaseView{parent}.GetBinding());
+            if (lola_parent == nullptr)
+            {
+                score::mw::log::LogError("lola") << "Proxy service element could not be created because parent proxy "
+                                                    "binding is a nullptr.";
+                return nullptr;
+            }
+
+            const auto instance_id = handle.GetInstanceId();
+            const auto* const lola_service_instance_id =
+                std::get_if<LolaServiceInstanceId>(&(instance_id.binding_info_));
+            SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(lola_service_instance_id != nullptr,
+                                                        "ServiceInstanceId does not contain lola binding.");
+
+            const auto lola_service_element_id =
+                GetServiceElementId<element_type>(lola_type_deployment, std::string{service_element_name});
+            const lola::ElementFqId element_fq_id{lola_type_deployment.service_id_,
+                                                  lola_service_element_id,
+                                                  lola_service_instance_id->GetId(),
+                                                  element_type};
+            return std::make_unique<ProxyServiceElement>(*lola_parent, element_fq_id, service_element_name);
+        },
+        [](const score::cpp::blank&) noexcept -> ReturnType {
+            return nullptr;
+        });
+
+    // coverity[autosar_cpp14_a15_5_3_violation]
+    return std::visit(deployment_info_visitor, type_deployment.binding_info_);
+}
+
+}  // namespace detail
 
 /// \brief Factory class that dispatches calls to the appropriate binding based on binding information in the
 /// deployment configuration.
@@ -41,8 +86,10 @@ class ProxyEventBindingFactoryImpl : public IProxyEventBindingFactory<SampleType
     /// \param handle The handle containing the binding information.
     /// \param event_name The binding unspecific name of the event inside the proxy denoted by handle.
     /// \return An instance of ProxyEventBinding or nullptr in case of an error.
-    std::unique_ptr<ProxyEventBinding<SampleType>> Create(ProxyBase& parent,
-                                                          const std::string_view event_name) noexcept override;
+    std::unique_ptr<ProxyEventBinding<SampleType>> Create(
+        ProxyBase& parent,
+        const std::string_view event_name,
+        const ServiceElementType service_element_type) noexcept override;
 };
 
 /// \brief Factory class that dispatches calls to the appropriate binding based on binding information in the
@@ -55,31 +102,43 @@ class GenericProxyEventBindingFactoryImpl : public IGenericProxyEventBindingFact
     /// \param event_name The binding unspecific name of the event inside the proxy denoted by handle.
     /// \return An instance of ProxyEventBinding or nullptr in case of an error.
     std::unique_ptr<GenericProxyEventBinding> Create(ProxyBase& parent,
-                                                     const std::string_view event_name) noexcept override;
+                                                     const std::string_view event_name,
+                                                     const ServiceElementType service_element_type) noexcept override;
 };
 
 template <typename SampleType>
-// Suppress "AUTOSAR C++14 A15-5-3" rule finding. This rule states: "The std::terminate() function shall
-// not be called implicitly.". std::visit Throws std::bad_variant_access if
-// as-variant(vars_i).valueless_by_exception() is true for any variant vars_i in vars. The variant may only become
-// valueless if an exception is thrown during different stages. Since we don't throw exceptions, it's not possible
-// that the variant can return true from valueless_by_exception and therefore not possible that std::visit throws
-// an exception.
-// This suppression should be removed after fixing [Ticket-173043](broken_link_j/Ticket-173043)
-// coverity[autosar_cpp14_a15_5_3_violation : FALSE]
 inline std::unique_ptr<ProxyEventBinding<SampleType>> ProxyEventBindingFactoryImpl<SampleType>::Create(
     ProxyBase& parent,
-    const std::string_view event_name) noexcept
+    const std::string_view event_of_field_name,
+    const ServiceElementType service_element_type) noexcept
 {
-    const auto lookup = LookupLolaProxyElement(parent, event_name, ServiceElementType::EVENT);
-    if (!lookup.has_value())
-    {
-        score::mw::log::LogError("lola")
-            << "ProxyEvent binding could not be created for event" << event_name
-            << "because the parent proxy binding is not a lola binding or the element could not be resolved.";
-        return nullptr;
-    }
-    return std::make_unique<lola::ProxyEvent<SampleType>>(lookup->parent, lookup->element_fq_id, event_name);
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(service_element_type == ServiceElementType::EVENT ||
+                                              service_element_type == ServiceElementType::FIELD);
+
+    using ReturnType = std::unique_ptr<ProxyEventBinding<SampleType>>;
+    auto deployment_info_visitor = score::cpp::overload(
+        [&parent, event_of_field_name, service_element_type](
+            const LolaServiceTypeDeployment& lola_type_deployment) -> ReturnType {
+            auto* const lola_proxy = dynamic_cast<lola::Proxy*>(ProxyBaseView{parent}.GetBinding());
+            if (lola_proxy == nullptr)
+            {
+                score::mw::log::LogError("lola")
+                    << "Proxy event binding could not be created for" << event_of_field_name
+                    << "because the parent proxy binding is not a lola binding.";
+                return nullptr;
+            }
+
+            const auto element_fq_id = GetElementFqId(
+                parent.GetHandle(), lola_type_deployment, std::string{event_of_field_name}, service_element_type);
+            return std::make_unique<lola::ProxyEvent<SampleType>>(*lola_proxy, element_fq_id, event_of_field_name);
+        },
+        [](const score::cpp::blank&) noexcept -> ReturnType {
+            return nullptr;
+        });
+
+    const HandleType& handle = parent.GetHandle();
+    const auto& type_deployment = handle.GetServiceTypeDeployment();
+    return std::visit(deployment_info_visitor, type_deployment.binding_info_);
 }
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/proxy_event_binding_factory_mock.h
+++ b/score/mw/com/impl/plumbing/proxy_event_binding_factory_mock.h
@@ -26,7 +26,7 @@ class ProxyEventBindingFactoryMock : public IProxyEventBindingFactory<SampleType
   public:
     MOCK_METHOD(std::unique_ptr<ProxyEventBinding<SampleType>>,
                 Create,
-                (ProxyBase&, const std::string_view event_name),
+                (ProxyBase&, const std::string_view event_name, const ServiceElementType service_element_type),
                 (noexcept, override));
 };
 
@@ -35,7 +35,7 @@ class GenericProxyEventBindingFactoryMock : public IGenericProxyEventBindingFact
   public:
     MOCK_METHOD(std::unique_ptr<GenericProxyEventBinding>,
                 Create,
-                (ProxyBase&, const std::string_view event_name),
+                (ProxyBase&, const std::string_view event_name, const ServiceElementType service_element_type),
                 (noexcept, override));
 };
 

--- a/score/mw/com/impl/plumbing/proxy_event_field_binding_factory_test.cpp
+++ b/score/mw/com/impl/plumbing/proxy_event_field_binding_factory_test.cpp
@@ -131,11 +131,13 @@ class ProxyServiceElementBindingFactoryParamaterisedFixture : public lola::Proxy
         switch (service_element_type_)
         {
             case ServiceElementTypes::PROXY_EVENT:
-                return ProxyEventBindingFactory<TestSampleType>::Create(*proxy_base_, kDummyEventName);
+                return ProxyEventBindingFactory<TestSampleType>::Create(
+                    *proxy_base_, kDummyEventName, ServiceElementType::EVENT);
             case ServiceElementTypes::PROXY_FIELD:
                 return ProxyFieldBindingFactory<TestSampleType>::CreateEventBinding(*proxy_base_, kDummyFieldName);
             case ServiceElementTypes::GENERIC_PROXY_EVENT:
-                return GenericProxyEventBindingFactory::Create(*proxy_base_, kDummyGenericProxyEventName);
+                return GenericProxyEventBindingFactory::Create(
+                    *proxy_base_, kDummyGenericProxyEventName, ServiceElementType::EVENT);
             default:
                 // This should never be reached since we assert the value of element_type_ in service_element_type_()
                 std::terminate();

--- a/score/mw/com/impl/plumbing/proxy_field_binding_factory_impl.h
+++ b/score/mw/com/impl/plumbing/proxy_field_binding_factory_impl.h
@@ -18,6 +18,7 @@
 #include "score/mw/com/impl/method_type.h"
 #include "score/mw/com/impl/plumbing/i_proxy_field_binding_factory.h"
 #include "score/mw/com/impl/plumbing/lola_proxy_element_building_blocks.h"
+#include "score/mw/com/impl/plumbing/proxy_event_binding_factory.h"
 #include "score/mw/com/impl/plumbing/proxy_method_binding_factory.h"
 #include "score/mw/com/impl/proxy_base.h"
 #include "score/mw/com/impl/proxy_event_binding.h"
@@ -66,15 +67,7 @@ inline std::unique_ptr<ProxyEventBinding<SampleType>> ProxyFieldBindingFactoryIm
     ProxyBase& parent,
     const std::string_view field_name) noexcept
 {
-    const auto lookup = LookupLolaProxyElement(parent, field_name, ServiceElementType::FIELD);
-    if (!lookup.has_value())
-    {
-        score::mw::log::LogError("lola")
-            << "ProxyField event binding could not be created for field" << field_name
-            << "because the parent proxy binding is not a lola binding or the element could not be resolved.";
-        return nullptr;
-    }
-    return std::make_unique<lola::ProxyEvent<SampleType>>(lookup->parent, lookup->element_fq_id, field_name);
+    return ProxyEventBindingFactory<SampleType>::Create(parent, field_name, ServiceElementType::FIELD);
 }
 
 template <typename SampleType>

--- a/score/mw/com/impl/plumbing/proxy_method_binding_factory_impl.cpp
+++ b/score/mw/com/impl/plumbing/proxy_method_binding_factory_impl.cpp
@@ -18,6 +18,8 @@
 
 namespace score::mw::com::impl
 {
+namespace detail
+{
 
 LolaMethodInstanceDeployment::QueueSize GetQueueSize(HandleType parent_handle,
                                                      const std::string& method_name_str,
@@ -52,4 +54,7 @@ LolaMethodInstanceDeployment::QueueSize GetQueueSize(HandleType parent_handle,
     }
     return lola_method_instance_deployment.queue_size_.value();
 }
+
+}  // namespace detail
+
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/proxy_method_binding_factory_impl.h
+++ b/score/mw/com/impl/plumbing/proxy_method_binding_factory_impl.h
@@ -97,35 +97,47 @@ std::unique_ptr<ProxyMethodBinding> ProxyMethodBindingFactoryImpl<ReturnType(Arg
     const std::string_view method_name,
     MethodType method_type) noexcept
 {
-    // When method_type is Get or Set, method_name holds a field name, not a method name. A field
-    // only has one id at the lola level, so the Get and the Set of the same field both resolve to
-    // the same element id here. The Get-vs-Set split is added further down when we pair the id
-    // with method_type to build the UniqueMethodIdentifier.
-    const auto element_type = ((method_type == MethodType::kGet) || (method_type == MethodType::kSet))
-                                  ? ServiceElementType::FIELD
-                                  : ServiceElementType::METHOD;
+    auto method_name_str = std::string{method_name};
 
-    const auto lookup = LookupLolaProxyElement(parent_handle, parent_binding, method_name, element_type);
-    if (!lookup.has_value())
-    {
-        score::mw::log::LogError("lola")
-            << "Proxy Method binding could not be created for" << method_name
-            << "because the parent proxy binding is not a lola binding or the element could not be resolved.";
-        return nullptr;
-    }
+    using LambdaReturnType = std::unique_ptr<ProxyMethodBinding>;
 
-    const auto method_name_str = std::string{method_name};
-    const lola::TypeErasedCallQueue::TypeErasedElementInfo type_erased_element_info =
-        GetTypeErasedElementInfo<ReturnType, ArgTypes...>(parent_handle, method_name_str, method_type);
+    auto deployment_info_visitor = score::cpp::overload(
+        [&parent_handle, parent_binding, &method_name_str, method_type](
+            const LolaServiceTypeDeployment& lola_type_deployment) -> LambdaReturnType {
+            auto* const lola_proxy = dynamic_cast<lola::Proxy*>(parent_binding);
+            if (lola_proxy == nullptr)
+            {
+                score::mw::log::LogError("lola") << "Proxy Method binding could not be created for" << method_name_str
+                                                 << "because the parent proxy binding is not a lola binding.";
+                return nullptr;
+            }
 
-    // Pairing the id with method_type is what keeps Get and Set separate from here on. They share
-    // the same id, but the pair (id, method_type) is different, so the two end up in separate
-    // entries of the proxy_methods_ / skeleton_methods_ maps in the binding layer.
-    const lola::ProxyMethodInstanceIdentifier proxy_method_instance_identifier{
-        lookup->parent.GetProxyInstanceIdentifier(), {lookup->element_fq_id.element_id_, method_type}};
+            // When method_type is Get or Set, method_name holds a field name, not a method name. A field
+            // only has one id at the lola level, so the Get and the Set of the same field both resolve to
+            // the same element id here. The Get-vs-Set split is added further down when we pair the id
+            // with method_type to build the UniqueMethodIdentifier.
+            const auto service_element_type = ((method_type == MethodType::kGet) || (method_type == MethodType::kSet))
+                                                  ? ServiceElementType::FIELD
+                                                  : ServiceElementType::METHOD;
 
-    return std::make_unique<lola::ProxyMethod>(
-        lookup->parent, proxy_method_instance_identifier, type_erased_element_info);
+            const auto element_fq_id =
+                GetElementFqId(parent_handle, lola_type_deployment, method_name_str, service_element_type);
+
+            lola::TypeErasedCallQueue::TypeErasedElementInfo type_erased_element_info =
+                GetTypeErasedElementInfo<ReturnType, ArgTypes...>(parent_handle, method_name_str, method_type);
+
+            lola::ProxyMethodInstanceIdentifier proxy_method_instance_identifier{
+                lola_proxy->GetProxyInstanceIdentifier(), {element_fq_id.element_id_, method_type}};
+
+            return std::make_unique<lola::ProxyMethod>(
+                *lola_proxy, proxy_method_instance_identifier, type_erased_element_info);
+        },
+        [](const score::cpp::blank&) noexcept -> LambdaReturnType {
+            return nullptr;
+        });
+
+    const auto& type_deployment = parent_handle.GetServiceTypeDeployment();
+    return std::visit(deployment_info_visitor, type_deployment.binding_info_);
 }
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/proxy_method_binding_factory_impl.h
+++ b/score/mw/com/impl/plumbing/proxy_method_binding_factory_impl.h
@@ -37,36 +37,12 @@
 
 namespace score::mw::com::impl
 {
-
-template <typename Signature>
-class ProxyMethodBindingFactoryImpl : IProxyMethodBindingFactory
+namespace detail
 {
-    static_assert(sizeof(Signature) == 0,
-                  "ProxyMethodBindingFactory can only be instantiated with a function signature, e.g., "
-                  "ProxyMethodBindingFactory<void(int, double)>. "
-                  "You tried to use an unsupported signature type.");
-};
 
 LolaMethodInstanceDeployment::QueueSize GetQueueSize(HandleType parent_handle,
                                                      const std::string& method_name_str,
                                                      MethodType method_type);
-
-/// \brief Factory class that dispatches calls to the appropriate binding based on binding information in the
-/// deployment configuration.
-template <typename ReturnType, typename... ArgTypes>
-class ProxyMethodBindingFactoryImpl<ReturnType(ArgTypes...)> : public IProxyMethodBindingFactory
-{
-  public:
-    /// Creates instances of the binding specific implementations for a proxy method with a particular data type.
-    /// \tparam SampleType Type of the data that is exchanges
-    /// \param handle The handle containing the binding information.
-    /// \param method_name The binding unspecific name of the method inside the proxy denoted by handle.
-    /// \return An instance of ProxyMethodBinding or nullptr in case of an error.
-    std::unique_ptr<ProxyMethodBinding> Create(HandleType parent_handle,
-                                               ProxyBinding* parent_binding,
-                                               const std::string_view method_name,
-                                               MethodType method_type) noexcept override;
-};
 
 template <typename ReturnType, typename... ArgTypes>
 lola::TypeErasedCallQueue::TypeErasedElementInfo GetTypeErasedElementInfo(HandleType parent_handle,
@@ -89,6 +65,34 @@ lola::TypeErasedCallQueue::TypeErasedElementInfo GetTypeErasedElementInfo(Handle
 
     return lola::TypeErasedCallQueue::TypeErasedElementInfo{in_arg_type_info, return_type_info, queue_size};
 }
+
+}  // namespace detail
+
+template <typename Signature>
+class ProxyMethodBindingFactoryImpl : IProxyMethodBindingFactory
+{
+    static_assert(sizeof(Signature) == 0,
+                  "ProxyMethodBindingFactory can only be instantiated with a function signature, e.g., "
+                  "ProxyMethodBindingFactory<void(int, double)>. "
+                  "You tried to use an unsupported signature type.");
+};
+
+/// \brief Factory class that dispatches calls to the appropriate binding based on binding information in the
+/// deployment configuration.
+template <typename ReturnType, typename... ArgTypes>
+class ProxyMethodBindingFactoryImpl<ReturnType(ArgTypes...)> : public IProxyMethodBindingFactory
+{
+  public:
+    /// Creates instances of the binding specific implementations for a proxy method with a particular data type.
+    /// \tparam SampleType Type of the data that is exchanges
+    /// \param handle The handle containing the binding information.
+    /// \param method_name The binding unspecific name of the method inside the proxy denoted by handle.
+    /// \return An instance of ProxyMethodBinding or nullptr in case of an error.
+    std::unique_ptr<ProxyMethodBinding> Create(HandleType parent_handle,
+                                               ProxyBinding* parent_binding,
+                                               const std::string_view method_name,
+                                               MethodType method_type) noexcept override;
+};
 
 template <typename ReturnType, typename... ArgTypes>
 std::unique_ptr<ProxyMethodBinding> ProxyMethodBindingFactoryImpl<ReturnType(ArgTypes...)>::Create(
@@ -124,7 +128,7 @@ std::unique_ptr<ProxyMethodBinding> ProxyMethodBindingFactoryImpl<ReturnType(Arg
                 GetElementFqId(parent_handle, lola_type_deployment, method_name_str, service_element_type);
 
             lola::TypeErasedCallQueue::TypeErasedElementInfo type_erased_element_info =
-                GetTypeErasedElementInfo<ReturnType, ArgTypes...>(parent_handle, method_name_str, method_type);
+                detail::GetTypeErasedElementInfo<ReturnType, ArgTypes...>(parent_handle, method_name_str, method_type);
 
             lola::ProxyMethodInstanceIdentifier proxy_method_instance_identifier{
                 lola_proxy->GetProxyInstanceIdentifier(), {element_fq_id.element_id_, method_type}};

--- a/score/mw/com/impl/plumbing/proxy_method_binding_factory_test.cpp
+++ b/score/mw/com/impl/plumbing/proxy_method_binding_factory_test.cpp
@@ -186,7 +186,7 @@ TYPED_TEST(ProxyMethodFactoryTypedFixture, GetQueueSizeReturnsValueForMethodInLo
     const auto handle = this->GetValidLoLaHandle();
 
     // when GetQueueSize is called with a method name that exists in the lola deployment
-    auto queue_size = GetQueueSize(handle, kDummyMethodName, MethodType::kMethod);
+    auto queue_size = detail::GetQueueSize(handle, kDummyMethodName, MethodType::kMethod);
 
     // Then the correct que_size is returned and no crush occures
     ASSERT_EQ(queue_size, kQueueSize);
@@ -199,7 +199,7 @@ TYPED_TEST(ProxyMethodFactoryTypedFixture, GetQueueSizeReturnsOneForFieldGetMeth
 
     // When GetQueueSize is called with MethodType::kGet, the method_name argument is not consulted
     // because field Get/Set are synchronous and fixed at queue size 1.
-    auto queue_size = GetQueueSize(handle, "AnyFieldName", MethodType::kGet);
+    auto queue_size = detail::GetQueueSize(handle, "AnyFieldName", MethodType::kGet);
 
     ASSERT_EQ(queue_size, 1U);
 }
@@ -210,7 +210,7 @@ TYPED_TEST(ProxyMethodFactoryTypedFixture, GetQueueSizeReturnsOneForFieldSetMeth
     const auto handle = this->GetValidLoLaHandle();
 
     // Same as above for MethodType::kSet.
-    auto queue_size = GetQueueSize(handle, "AnyFieldName", MethodType::kSet);
+    auto queue_size = detail::GetQueueSize(handle, "AnyFieldName", MethodType::kSet);
 
     ASSERT_EQ(queue_size, 1U);
 }
@@ -224,8 +224,8 @@ TYPED_TEST(ProxyMethodFactoryTypedFixture, GetQueueSizeTerminatesForMethodNotInL
     auto wrong_name = "ThisMethodDoesNotExist";
 
     // Then the program terminates
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_CONTRACT_VIOLATED(score::cpp::ignore =
-                                                          GetQueueSize(handle, wrong_name, MethodType::kMethod));
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_CONTRACT_VIOLATED(
+        score::cpp::ignore = detail::GetQueueSize(handle, wrong_name, MethodType::kMethod));
 }
 
 TYPED_TEST(ProxyMethodFactoryTypedFixture, GetQueueSizeTerminatesForMethodInLolaDeploymentWithoutQueueSize)
@@ -236,8 +236,8 @@ TYPED_TEST(ProxyMethodFactoryTypedFixture, GetQueueSizeTerminatesForMethodInLola
 
     // when GetQueueSize is called with the method name with empty QueueSize
     // Then the program terminates
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_CONTRACT_VIOLATED(score::cpp::ignore =
-                                                          GetQueueSize(handle, kDummyMethodName, MethodType::kMethod));
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_CONTRACT_VIOLATED(
+        score::cpp::ignore = detail::GetQueueSize(handle, kDummyMethodName, MethodType::kMethod));
 }
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/proxy_event.h
+++ b/score/mw/com/impl/proxy_event.h
@@ -158,7 +158,9 @@ ProxyEvent<SampleType>::ProxyEvent(ProxyBase& base,
 
 template <typename SampleType>
 ProxyEvent<SampleType>::ProxyEvent(ProxyBase& base, const std::string_view event_name)
-    : ProxyEvent{base, event_name, ProxyEventBindingFactory<SampleType>::Create(base, event_name)}
+    : ProxyEvent{base,
+                 event_name,
+                 ProxyEventBindingFactory<SampleType>::Create(base, event_name, ServiceElementType::EVENT)}
 {
     if (GetTypedEventBinding() != nullptr)
     {

--- a/score/mw/com/impl/tracing/test/proxy_event_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/test/proxy_event_tracing_test.cpp
@@ -119,7 +119,7 @@ class ProxyEventTracingFixture : public ::testing::Test
     {
         auto proxy_event_binding_mock_ptr = std::make_unique<mock_binding::ProxyEvent<TestSampleType>>();
         mock_proxy_event_binding_ = proxy_event_binding_mock_ptr.get();
-        EXPECT_CALL(factory_mock_guard.factory_mock_, Create(_, kServiceElementName))
+        EXPECT_CALL(factory_mock_guard.factory_mock_, Create(_, kServiceElementName, ServiceElementType::EVENT))
             .WillOnce(Return(ByMove(std::move(proxy_event_binding_mock_ptr))));
     }
 

--- a/score/mw/com/impl/traits_test.cpp
+++ b/score/mw/com/impl/traits_test.cpp
@@ -122,7 +122,7 @@ class ProxyCreationFixture : public ::testing::Test
             .WillByDefault(Return(ByMove(std::move(proxy_binding_mock_ptr))));
 
         // By default the Create call on the ProxyEventBindingFactory returns valid bindings.
-        ON_CALL(proxy_event_binding_factory_mock_guard_.factory_mock_, Create(_, kEventName))
+        ON_CALL(proxy_event_binding_factory_mock_guard_.factory_mock_, Create(_, kEventName, ServiceElementType::EVENT))
             .WillByDefault(Return(ByMove(std::move(proxy_event_binding_mock_ptr))));
 
         // By default the Create call on the ProxyFieldBindingFactory returns valid bindings.
@@ -207,7 +207,7 @@ TEST_F(GeneratedProxyCreationTestFixture, ReturnGeneratedProxyWhenSuccessfullyCr
     // Expecting that valid bindings are created for the Proxy, ProxyEvent and ProxyField
     EXPECT_CALL(proxy_binding_factory_mock_guard_.factory_mock_, Create(handle_))
         .WillRepeatedly(Return(ByMove(std::move(proxy_binding_mock_ptr))));
-    EXPECT_CALL(proxy_event_binding_factory_mock_guard_.factory_mock_, Create(_, kEventName))
+    EXPECT_CALL(proxy_event_binding_factory_mock_guard_.factory_mock_, Create(_, kEventName, ServiceElementType::EVENT))
         .WillRepeatedly(Return(ByMove(std::move(proxy_event_binding_mock_ptr))));
     EXPECT_CALL(proxy_field_binding_factory_mock_guard_.factory_mock_, CreateEventBinding(_, kFieldName))
         .WillRepeatedly(Return(ByMove(std::move(proxy_field_binding_mock_ptr))));
@@ -253,7 +253,7 @@ TEST_F(GeneratedProxyCreationTestFixture, ReturnErrorWhenCreatingProxyWithNoProx
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     // Expecting that the Create call on the ProxyEventBindingFactory returns an invalid binding for the event.
-    EXPECT_CALL(proxy_event_binding_factory_mock_guard_.factory_mock_, Create(_, kEventName))
+    EXPECT_CALL(proxy_event_binding_factory_mock_guard_.factory_mock_, Create(_, kEventName, ServiceElementType::EVENT))
         .WillOnce(Return(ByMove(nullptr)));
 
     // When creating a MyProxy


### PR DESCRIPTION
This commit undoes most of the changes to the binding factories added in
https://github.com/eclipse-score/communication/commit/5804ab699490b062877296599826211a30075f0e. This change removed the
variant handling in the factory create functions which are needed to
support different bindings in mw/com.

It also adds ServiceElementType to ProxyEventBindingFactory::Create so
that it can be reused by ProxyFieldBindingFactory.