### PR TITLE
Fix public API breakage

### DIFF
--- a/score/mw/com/impl/methods/proxy_method_with_in_args_and_return.h
+++ b/score/mw/com/impl/methods/proxy_method_with_in_args_and_return.h
@@ -58,7 +58,7 @@ class ProxyMethod<ReturnType(ArgTypes...)> final : public ProxyMethodBase
     // ProxyField needs to instantiate ProxyMethod via the private FieldOnlyConstructorEnabler tag.
     // coverity[autosar_cpp14_a11_3_1_violation]
     template <typename, typename...>
-    friend class ProxyField;
+    friend class ProxyFieldImpl;
 
     struct FieldOnlyConstructorEnabler
     {

--- a/score/mw/com/impl/methods/proxy_method_with_return_type.h
+++ b/score/mw/com/impl/methods/proxy_method_with_return_type.h
@@ -53,7 +53,7 @@ class ProxyMethod<ReturnType()> final : public ProxyMethodBase
     // ProxyField needs to instantiate ProxyMethod via the private FieldOnlyConstructorEnabler tag.
     // coverity[autosar_cpp14_a11_3_1_violation]
     template <typename, typename...>
-    friend class ProxyField;
+    friend class ProxyFieldImpl;
 
     struct FieldOnlyConstructorEnabler
     {

--- a/score/mw/com/impl/methods/skeleton_method.h
+++ b/score/mw/com/impl/methods/skeleton_method.h
@@ -54,7 +54,7 @@ class SkeletonMethod<ReturnType(ArgTypes...)> final : public SkeletonMethodBase
 
     template <typename, typename...>
     // coverity[autosar_cpp14_a11_3_1_violation]
-    friend class SkeletonField;
+    friend class SkeletonFieldImpl;
 
     struct FieldOnlyConstructorEnabler
     {

--- a/score/mw/com/impl/proxy_event.h
+++ b/score/mw/com/impl/proxy_event.h
@@ -63,7 +63,7 @@ class ProxyEvent final : public ProxyEventBase
     // shared private APIs which necessitates the use of the friend keyword.
     // coverity[autosar_cpp14_a11_3_1_violation]
     template <typename, typename...>
-    friend class ProxyField;
+    friend class ProxyFieldImpl;
 
     // Empty struct that is used to make the second constructor only accessible to ProxyField (as it is a friend).
     struct FieldOnlyConstructorEnabler

--- a/score/mw/com/impl/proxy_field.h
+++ b/score/mw/com/impl/proxy_field.h
@@ -53,10 +53,10 @@ class ProxyFieldAttorney;
 ///         GetFreeSampleCount(), GetNumNewSamplesAvailable(), SetReceiveHandler(), UnsetReceiveHandler(),
 ///         GetNewSamples().
 template <typename SampleDataType, typename... Tags>
-class ProxyField final : public ProxyFieldBase
+class ProxyFieldImpl : public ProxyFieldBase
 {
 
-    // A ProxyField must enable WithGetter or WithNotifier. A field with only WithSetter (or no tags at all)
+    // A ProxyFieldImpl must enable WithGetter or WithNotifier. A field with only WithSetter (or no tags at all)
     // gives the consumer no way to observe the value it can write, making the field useless.
     static_assert(
         contains_type<WithNotifier, Tags...>::value || contains_type<WithGetter, Tags...>::value,
@@ -85,28 +85,28 @@ class ProxyField final : public ProxyFieldBase
     /// \param get_method_binding Optional mock Get-method binding. If nullptr, no ProxyMethod is built for Get;
     ///        this avoids the ProxyMethod ctor calling ProxyBaseView::MarkServiceElementBindingInvalid() on the
     ///        parent, which would otherwise make AreBindingsValid() return false during proxy construction.
-    ProxyField(ProxyBase& proxy_base,
-               const std::string_view field_name,
-               std::unique_ptr<ProxyEventBinding<FieldType>> event_binding,
-               std::unique_ptr<ProxyMethodBinding> set_method_binding = nullptr,
-               std::unique_ptr<ProxyMethodBinding> get_method_binding = nullptr)
-        : ProxyField{proxy_base,
-                     field_name,
-                     std::make_unique<ProxyEvent<FieldType>>(proxy_base, field_name, std::move(event_binding)),
-                     set_method_binding == nullptr
-                         ? nullptr
-                         : std::make_unique<ProxyMethod<FieldType(FieldType)>>(
-                               proxy_base,
-                               field_name,
-                               std::move(set_method_binding),
-                               typename ProxyMethod<FieldType(FieldType)>::FieldOnlyConstructorEnabler{}),
-                     get_method_binding == nullptr
-                         ? nullptr
-                         : std::make_unique<ProxyMethod<FieldType()>>(
-                               proxy_base,
-                               field_name,
-                               std::move(get_method_binding),
-                               typename ProxyMethod<FieldType()>::FieldOnlyConstructorEnabler{})}
+    ProxyFieldImpl(ProxyBase& proxy_base,
+                   const std::string_view field_name,
+                   std::unique_ptr<ProxyEventBinding<FieldType>> event_binding,
+                   std::unique_ptr<ProxyMethodBinding> set_method_binding = nullptr,
+                   std::unique_ptr<ProxyMethodBinding> get_method_binding = nullptr)
+        : ProxyFieldImpl{proxy_base,
+                         field_name,
+                         std::make_unique<ProxyEvent<FieldType>>(proxy_base, field_name, std::move(event_binding)),
+                         set_method_binding == nullptr
+                             ? nullptr
+                             : std::make_unique<ProxyMethod<FieldType(FieldType)>>(
+                                   proxy_base,
+                                   field_name,
+                                   std::move(set_method_binding),
+                                   typename ProxyMethod<FieldType(FieldType)>::FieldOnlyConstructorEnabler{}),
+                         get_method_binding == nullptr
+                             ? nullptr
+                             : std::make_unique<ProxyMethod<FieldType()>>(
+                                   proxy_base,
+                                   field_name,
+                                   std::move(get_method_binding),
+                                   typename ProxyMethod<FieldType()>::FieldOnlyConstructorEnabler{})}
     {
     }
 
@@ -117,12 +117,12 @@ class ProxyField final : public ProxyFieldBase
     ///          WithNotifier is present.
     /// \param proxy_base Parent proxy that owns this field's registration.
     /// \param field_name Field's name as it appears in the deployment.
-    ProxyField(ProxyBase& proxy_base, const std::string_view field_name)
-        : ProxyField{proxy_base,
-                     field_name,
-                     MakeEventDispatchIfEnabled(proxy_base, field_name),
-                     MakeSetMethodDispatchIfEnabled(proxy_base, field_name),
-                     MakeGetMethodDispatchIfEnabled(proxy_base, field_name)}
+    ProxyFieldImpl(ProxyBase& proxy_base, const std::string_view field_name)
+        : ProxyFieldImpl{proxy_base,
+                         field_name,
+                         MakeEventDispatchIfEnabled(proxy_base, field_name),
+                         MakeSetMethodDispatchIfEnabled(proxy_base, field_name),
+                         MakeGetMethodDispatchIfEnabled(proxy_base, field_name)}
     {
         // Each Make*IfEnabled must have produced a non-null dispatch when the
         // corresponding tag is in the pack.
@@ -140,15 +140,15 @@ class ProxyField final : public ProxyFieldBase
         }
     }
 
-    /// \brief A ProxyField shall not be copyable
-    ProxyField(const ProxyField&) = delete;
-    ProxyField& operator=(const ProxyField&) = delete;
+    /// \brief A ProxyFieldImpl shall not be copyable
+    ProxyFieldImpl(const ProxyFieldImpl&) = delete;
+    ProxyFieldImpl& operator=(const ProxyFieldImpl&) = delete;
 
     /// \brief A ProxyField shall be moveable
-    ProxyField(ProxyField&&) noexcept = default;
-    ProxyField& operator=(ProxyField&&) noexcept = default;
+    ProxyFieldImpl(ProxyFieldImpl&&) noexcept = default;
+    ProxyFieldImpl& operator=(ProxyFieldImpl&&) noexcept = default;
 
-    ~ProxyField() noexcept = default;
+    ~ProxyFieldImpl() noexcept = default;
 
     /**
      * \api
@@ -401,11 +401,11 @@ class ProxyField final : public ProxyFieldBase
         }
     }
 
-    ProxyField(ProxyBase& proxy_base,
-               const std::string_view field_name,
-               std::unique_ptr<ProxyEvent<FieldType>> proxy_event_dispatch,
-               std::unique_ptr<ProxyMethod<FieldType(FieldType)>> proxy_method_set_dispatch,
-               std::unique_ptr<ProxyMethod<FieldType()>> proxy_method_get_dispatch)
+    ProxyFieldImpl(ProxyBase& proxy_base,
+                   const std::string_view field_name,
+                   std::unique_ptr<ProxyEvent<FieldType>> proxy_event_dispatch,
+                   std::unique_ptr<ProxyMethod<FieldType(FieldType)>> proxy_method_set_dispatch,
+                   std::unique_ptr<ProxyMethod<FieldType()>> proxy_method_get_dispatch)
         : ProxyFieldBase{field_name, proxy_event_dispatch.get()},
           proxy_event_dispatch_{std::move(proxy_event_dispatch)},
           proxy_method_set_dispatch_{std::move(proxy_method_set_dispatch)},
@@ -420,9 +420,24 @@ class ProxyField final : public ProxyFieldBase
     std::unique_ptr<ProxyMethod<FieldType(FieldType)>> proxy_method_set_dispatch_;
     std::unique_ptr<ProxyMethod<FieldType()>> proxy_method_get_dispatch_;
 
-    static_assert(std::is_same_v<decltype(proxy_event_dispatch_), std::unique_ptr<ProxyEvent<FieldType>>>,
-                  "proxy_event_dispatch_ needs to be a unique_ptr since we pass a pointer to it to ProxyFieldBase, so "
-                  "we must ensure that it doesn't move when the ProxyField is moved to avoid dangling references. ");
+    static_assert(
+        std::is_same_v<decltype(proxy_event_dispatch_), std::unique_ptr<ProxyEvent<FieldType>>>,
+        "proxy_event_dispatch_ needs to be a unique_ptr since we pass a pointer to it to ProxyFieldBase, so "
+        "we must ensure that it doesn't move when the ProxyFieldImpl is moved to avoid dangling references. ");
+};
+
+template <typename SampleDataType, typename... Tags>
+class ProxyField final : public ProxyFieldImpl<SampleDataType, Tags...>
+{
+    using ProxyFieldImpl<SampleDataType, Tags...>::ProxyFieldImpl;
+};
+
+template <typename SampleDataType>
+class [[deprecated("Implicit deduction  of field semantics is deprecated. Choose at least WithNotifier or WithGetter")]]
+ProxyField<SampleDataType>
+    final : public ProxyFieldImpl<SampleDataType, WithNotifier>
+{
+    using ProxyFieldImpl<SampleDataType, WithNotifier>::ProxyFieldImpl;
 };
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/proxy_field_test.cpp
+++ b/score/mw/com/impl/proxy_field_test.cpp
@@ -309,5 +309,26 @@ TEST(ProxyFieldSetterGatingTest, SetIsAbsentWhenWithSetterTagIsMissing)
     static_assert(!has_set<GetterOnlyField>::value);
 }
 
+TEST(ProxyFieldNotifierGatingTest, OnlyNotifierApiExistsWhenNoTagsArePresent)
+{
+    // Given a ProxyField with the WithNotifier tag
+    // When checking the notifier API
+    // Then all notifier-related members should be present
+    using DefaultField = ProxyField<TestSampleType>;
+    static_assert(has_subscribe<DefaultField>::value);
+    static_assert(has_unsubscribe<DefaultField>::value);
+    static_assert(has_set_subscription_state_change_handler<DefaultField>::value);
+    static_assert(has_unset_subscription_state_change_handler<DefaultField>::value);
+    static_assert(has_get_subscription_state<DefaultField>::value);
+    static_assert(has_get_free_sample_count<DefaultField>::value);
+    static_assert(has_get_num_new_samples_available<DefaultField>::value);
+    static_assert(has_set_receive_handler<DefaultField>::value);
+    static_assert(has_unset_receive_handler<DefaultField>::value);
+    static_assert(has_get_new_samples<DefaultField>::value);
+    static_assert(has_inject_mock<DefaultField>::value);
+    static_assert(!has_get<DefaultField>::value);
+    static_assert(!has_set<DefaultField>::value);
+}
+
 }  // namespace
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/skeleton_event.h
+++ b/score/mw/com/impl/skeleton_event.h
@@ -52,7 +52,7 @@ class SkeletonEvent : public SkeletonEventBase
     // private APIs which necessitates the use of the friend keyword.
     // coverity[autosar_cpp14_a11_3_1_violation]
     template <typename T, typename... Ts>
-    friend class SkeletonField;
+    friend class SkeletonFieldImpl;
 
     // Empty struct that is used to make the second constructor only accessible to SkeletonEvent and SkeletonField (as
     // the latter is a friend).

--- a/score/mw/com/impl/skeleton_field.h
+++ b/score/mw/com/impl/skeleton_field.h
@@ -37,9 +37,9 @@ namespace score::mw::com::impl
 {
 
 template <typename SampleDataType, typename... Tags>
-class SkeletonField : public SkeletonFieldBase
+class SkeletonFieldImpl : public SkeletonFieldBase
 {
-    // SkeletonField must enable WithGetter or WithNotifier. Without one the consumer has no way to
+    // SkeletonFieldImpl must enable WithGetter or WithNotifier. Without one the consumer has no way to
     // observe the value, so the field is useless. WithSetter alone does not count.
     static_assert(
         contains_type<WithNotifier, Tags...>::value || contains_type<WithGetter, Tags...>::value,
@@ -54,14 +54,14 @@ class SkeletonField : public SkeletonFieldBase
     /// \param skeleton_base Parent skeleton that owns this field's registration.
     /// \param field_name Field's name as it appears in the deployment.
     /// \param binding Mock event binding.
-    SkeletonField(SkeletonBase& skeleton_base,
-                  const std::string_view field_name,
-                  std::unique_ptr<SkeletonEventBinding<FieldType>> binding)
-        : SkeletonField{skeleton_base,
-                        field_name,
-                        std::make_unique<SkeletonEvent<FieldType>>(skeleton_base, field_name, std::move(binding)),
-                        nullptr,
-                        nullptr}
+    SkeletonFieldImpl(SkeletonBase& skeleton_base,
+                      const std::string_view field_name,
+                      std::unique_ptr<SkeletonEventBinding<FieldType>> binding)
+        : SkeletonFieldImpl{skeleton_base,
+                            field_name,
+                            std::make_unique<SkeletonEvent<FieldType>>(skeleton_base, field_name, std::move(binding)),
+                            nullptr,
+                            nullptr}
     {
     }
 
@@ -70,12 +70,12 @@ class SkeletonField : public SkeletonFieldBase
     ///          and return nullptr when their corresponding tag is absent.
     /// \param parent Parent skeleton that owns this field's registration.
     /// \param field_name Field's name as it appears in the deployment.
-    SkeletonField(SkeletonBase& parent, const std::string_view field_name)
-        : SkeletonField{parent,
-                        field_name,
-                        MakeSkeletonEvent(parent, field_name),
-                        MakeSetMethodIfEnabled(parent, field_name),
-                        MakeGetMethodIfEnabled(parent, field_name)}
+    SkeletonFieldImpl(SkeletonBase& parent, const std::string_view field_name)
+        : SkeletonFieldImpl{parent,
+                            field_name,
+                            MakeSkeletonEvent(parent, field_name),
+                            MakeSetMethodIfEnabled(parent, field_name),
+                            MakeGetMethodIfEnabled(parent, field_name)}
     {
         // Each Make*IfEnabled must have produced a non-null dispatch when
         // the corresponding tag is in the pack.
@@ -89,13 +89,13 @@ class SkeletonField : public SkeletonFieldBase
         }
     }
 
-    ~SkeletonField() override = default;
+    ~SkeletonFieldImpl() override = default;
 
-    SkeletonField(const SkeletonField&) = delete;
-    SkeletonField& operator=(const SkeletonField&) & = delete;
+    SkeletonFieldImpl(const SkeletonFieldImpl&) = delete;
+    SkeletonFieldImpl& operator=(const SkeletonFieldImpl&) & = delete;
 
-    SkeletonField(SkeletonField&& other) noexcept = default;
-    SkeletonField& operator=(SkeletonField&& other) & noexcept = default;
+    SkeletonFieldImpl(SkeletonFieldImpl&& other) noexcept = default;
+    SkeletonFieldImpl& operator=(SkeletonFieldImpl&& other) & noexcept = default;
 
     /**
      * \api
@@ -255,11 +255,11 @@ class SkeletonField : public SkeletonFieldBase
 
     /// \brief Single private delegating constructor. Both the production and test ctors funnel through here with
     ///        appropriate dispatches (real ones from the Make*IfEnabled helpers, or nullptr).
-    SkeletonField(SkeletonBase& parent,
-                  const std::string_view field_name,
-                  std::unique_ptr<SkeletonEvent<FieldType>> skeleton_event_dispatch,
-                  std::unique_ptr<SkeletonMethod<SetMethodSignature>> skeleton_set_method_dispatch,
-                  std::unique_ptr<SkeletonMethod<GetMethodSignature>> skeleton_get_method_dispatch);
+    SkeletonFieldImpl(SkeletonBase& parent,
+                      const std::string_view field_name,
+                      std::unique_ptr<SkeletonEvent<FieldType>> skeleton_event_dispatch,
+                      std::unique_ptr<SkeletonMethod<SetMethodSignature>> skeleton_set_method_dispatch,
+                      std::unique_ptr<SkeletonMethod<GetMethodSignature>> skeleton_get_method_dispatch);
 
     std::unique_ptr<FieldType> initial_field_value_;
     ISkeletonField<FieldType>* skeleton_field_mock_;
@@ -272,7 +272,7 @@ class SkeletonField : public SkeletonFieldBase
 };
 
 template <typename SampleDataType, typename... Tags>
-SkeletonField<SampleDataType, Tags...>::SkeletonField(
+SkeletonFieldImpl<SampleDataType, Tags...>::SkeletonFieldImpl(
     SkeletonBase& parent,
     const std::string_view field_name,
     std::unique_ptr<SkeletonEvent<FieldType>> skeleton_event_dispatch,
@@ -297,7 +297,7 @@ SkeletonField<SampleDataType, Tags...>::SkeletonField(
 /// callback that will update the field value with sample_value which will be called in the first call to
 /// SkeletonFieldBase::PrepareOffer().
 template <typename SampleDataType, typename... Tags>
-Result<void> SkeletonField<SampleDataType, Tags...>::Update(const FieldType& sample_value) noexcept
+Result<void> SkeletonFieldImpl<SampleDataType, Tags...>::Update(const FieldType& sample_value) noexcept
 {
     if (skeleton_field_mock_ != nullptr)
     {
@@ -315,7 +315,7 @@ Result<void> SkeletonField<SampleDataType, Tags...>::Update(const FieldType& sam
 /// \brief FieldType is previously allocated by middleware and provided by the user to indicate that he is finished
 /// filling the provided pointer with live data. Dispatches to SkeletonEvent::Send()
 template <typename SampleDataType, typename... Tags>
-Result<void> SkeletonField<SampleDataType, Tags...>::Update(SampleAllocateePtr<FieldType> sample) noexcept
+Result<void> SkeletonFieldImpl<SampleDataType, Tags...>::Update(SampleAllocateePtr<FieldType> sample) noexcept
 {
     if (skeleton_field_mock_ != nullptr)
     {
@@ -331,7 +331,7 @@ Result<void> SkeletonField<SampleDataType, Tags...>::Update(SampleAllocateePtr<F
 /// This function cannot be currently called to set the initial value of a field as the shared memory must be first
 /// set up in the Skeleton::PrepareOffer() before the user can obtain / use a SampleAllocateePtr.
 template <typename SampleDataType, typename... Tags>
-Result<SampleAllocateePtr<SampleDataType>> SkeletonField<SampleDataType, Tags...>::Allocate() noexcept
+Result<SampleAllocateePtr<SampleDataType>> SkeletonFieldImpl<SampleDataType, Tags...>::Allocate() noexcept
 {
     if (skeleton_field_mock_ != nullptr)
     {
@@ -354,7 +354,7 @@ template <typename SampleDataType, typename... Tags>
 // namespace, or static function with internal linkage, or private member function shall be used.".
 // False-positive, method is used in the base class in PrepareOffer().
 // coverity[autosar_cpp14_a0_1_3_violation : FALSE]
-Result<void> SkeletonField<SampleDataType, Tags...>::DoDeferredUpdate() noexcept
+Result<void> SkeletonFieldImpl<SampleDataType, Tags...>::DoDeferredUpdate() noexcept
 {
     SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(
         initial_field_value_ != nullptr,
@@ -371,18 +371,32 @@ Result<void> SkeletonField<SampleDataType, Tags...>::DoDeferredUpdate() noexcept
 }
 
 template <typename SampleDataType, typename... Tags>
-Result<void> SkeletonField<SampleDataType, Tags...>::UpdateImpl(const FieldType& sample_value) noexcept
+Result<void> SkeletonFieldImpl<SampleDataType, Tags...>::UpdateImpl(const FieldType& sample_value) noexcept
 {
     return GetTypedEvent()->Send(sample_value);
 }
 
 template <typename SampleDataType, typename... Tags>
-auto SkeletonField<SampleDataType, Tags...>::GetTypedEvent() const noexcept -> SkeletonEvent<SampleDataType>*
+auto SkeletonFieldImpl<SampleDataType, Tags...>::GetTypedEvent() const noexcept -> SkeletonEvent<SampleDataType>*
 {
     auto* const typed_event = dynamic_cast<SkeletonEvent<FieldType>*>(skeleton_event_dispatch_.get());
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(typed_event != nullptr, "Downcast to SkeletonEvent<FieldType> failed!");
     return typed_event;
 }
+
+template <typename SampleDataType, typename... Tags>
+class SkeletonField final : public SkeletonFieldImpl<SampleDataType, Tags...>
+{
+    using SkeletonFieldImpl<SampleDataType, Tags...>::SkeletonFieldImpl;
+};
+
+template <typename SampleDataType>
+class [[deprecated("Implicit deduction of field semantics is deprecated. Choose at least WithNotifier or WithGetter")]]
+SkeletonField<SampleDataType>
+    final : public SkeletonFieldImpl<SampleDataType, WithNotifier>
+{
+    using SkeletonFieldImpl<SampleDataType, WithNotifier>::SkeletonFieldImpl;
+};
 
 }  // namespace score::mw::com::impl
 

--- a/score/mw/com/impl/skeleton_field_test.cpp
+++ b/score/mw/com/impl/skeleton_field_test.cpp
@@ -869,6 +869,14 @@ TEST(SkeletonFieldSetHandlerTypeTraitsTest, RegisterSetHandlerOnlyExistsWhenWith
                   "RegisterSetHandler must be SFINAE-removed on a SkeletonField without WithSetter");
 }
 
+TEST(ProxyFieldNotifierGatingTest, RegisterSetHandlerDoesNotExistWhenNoTagPresent)
+{
+    using DefaultField = SkeletonField<TestSampleType>;
+
+    static_assert(!has_register_set_handler<DefaultField>::value,
+                  "RegisterSetHandler must be SFINAE-removed on a SkeletonField without WithSetter");
+}
+
 using SkeletonFieldSetHandlerTest = SkeletonFieldTestFixture;
 
 TEST_F(SkeletonFieldSetHandlerTest, RegisterSetHandlerForwardsToMethodBinding)


### PR DESCRIPTION
The introduction of getters and setters in fields broke the public API.

This change introduces a facade layer that restores the previous behavior of the public API. Since the breakage was intentional in terms of envisioned API, we still plan to migrate to this new API. Therefore, the fix also introduces a deprecation warning. This makes migration for users simpler.

This commit can be reverted once we enforce the new API.