### PR TITLE
refactor: clean up shadowed and unused identifiers across com impl/tests

### DIFF
--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance.cpp
@@ -311,7 +311,7 @@ message_passing::MessageCallback MessagePassingServiceInstance::CreateSendMessag
     // (e.g. an issue with message passing itself). Any recoverable errors are sent back to the client in the reply
     // message and handled there.
     auto received_send_message_with_reply_callback =
-        [message_callback_with_reply_scoped_function = std::move(message_callback_with_reply_scoped_function)](
+        [scoped_callback = std::move(message_callback_with_reply_scoped_function)](
             score::message_passing::IServerConnection& connection,
             score::cpp::span<const std::uint8_t> message) noexcept -> score::cpp::expected_blank<score::os::Error> {
         const auto client_identity = connection.GetClientIdentity();
@@ -319,10 +319,8 @@ message_passing::MessageCallback MessagePassingServiceInstance::CreateSendMessag
         const auto client_uid = client_identity.uid;
 
         SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(
-            message_callback_with_reply_scoped_function != nullptr,
-            "Message callback with reply callable was not properly constructed");
-        auto function_invocation_result =
-            std::invoke(*message_callback_with_reply_scoped_function, client_uid, client_pid, message);
+            scoped_callback != nullptr, "Message callback with reply callable was not properly constructed");
+        auto function_invocation_result = std::invoke(*scoped_callback, client_uid, client_pid, message);
         if (!(function_invocation_result.has_value()))
         {
             score::mw::log::LogError("lola")

--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance_methods_test.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance_methods_test.cpp
@@ -770,7 +770,7 @@ TEST_F(MessagePassingServiceInstanceHandleMessageWithReplyTest, RepliesWithError
 
     // When a MessageWithReply message is received which is empty
     std::vector<std::uint8_t> empty_message(0U);
-    const auto result = received_send_message_with_reply_callback_(
+    std::ignore = received_send_message_with_reply_callback_(
         server_connection_mock_, score::cpp::span<std::uint8_t>{empty_message.data(), empty_message.size()});
 }
 
@@ -805,7 +805,7 @@ TEST_F(MessagePassingServiceInstanceHandleMessageWithReplyTest, RepliesWithError
     // When a MessageWithReply message is received of unexpected type
     std::vector<std::uint8_t> payload_with_unexpected_type(sizeof(MethodCallUnserializedPayload) + 2U);
     payload_with_unexpected_type[0] = 20U;
-    const auto result = received_send_message_with_reply_callback_(
+    std::ignore = received_send_message_with_reply_callback_(
         server_connection_mock_,
         score::cpp::span<std::uint8_t>{payload_with_unexpected_type.data(), payload_with_unexpected_type.size()});
 }

--- a/score/mw/com/impl/bindings/lola/provider_event_data_control_local_view_test.cpp
+++ b/score/mw/com/impl/bindings/lola/provider_event_data_control_local_view_test.cpp
@@ -39,7 +39,6 @@ using ::testing::_;
 using ::testing::Return;
 
 constexpr std::size_t kMaxSlots{5U};
-constexpr std::size_t kMaxSubscribers{5U};
 
 constexpr auto kSlotIsInWriting = std::numeric_limits<EventSlotStatus::SubscriberCount>::max();
 

--- a/score/mw/com/impl/bindings/lola/sample_allocatee_ptr_test.cpp
+++ b/score/mw/com/impl/bindings/lola/sample_allocatee_ptr_test.cpp
@@ -33,7 +33,6 @@ struct DummyStruct
 };
 
 constexpr std::size_t kMaxSlots{5U};
-constexpr std::size_t kMaxSubscribers{5U};
 
 class SampleAllocateePtrFixture : public ::testing::Test
 {

--- a/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client_sequence_test.cpp
+++ b/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client_sequence_test.cpp
@@ -97,7 +97,7 @@ TEST_F(ServiceDiscoveryClientFixture, CorrectlyAssociatesSubsearchWithCorrectDir
     FindServiceHandle expected_handle{make_FindServiceHandle(1U)};
     const auto start_find_service_result = service_discovery_client_->StartFindService(
         expected_handle,
-        [&find_service_handler, destructor_notifier = std::move(destructor_notifier)](
+        [&find_service_handler, moved_notifier = std::move(destructor_notifier)](
             ServiceHandleContainer<HandleType> containers, FindServiceHandle handle) noexcept {
             find_service_handler.AsStdFunction()(containers, handle);
         },
@@ -150,7 +150,7 @@ TEST_F(ServiceDiscoveryClientFixture, DoesNotCallHandlerIfFindServiceIsStoppedBu
     FindServiceHandle expected_handle{make_FindServiceHandle(1U)};
     const auto start_find_service_result = service_discovery_client_->StartFindService(
         expected_handle,
-        [&find_service_handler, destructor_notifier = std::move(destructor_notifier)](
+        [&find_service_handler, moved_notifier = std::move(destructor_notifier)](
             ServiceHandleContainer<HandleType> containers, FindServiceHandle handle) noexcept {
             find_service_handler.AsStdFunction()(containers, handle);
         },

--- a/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client_stop_find_service_test.cpp
+++ b/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client_stop_find_service_test.cpp
@@ -116,7 +116,7 @@ TEST_F(ServiceDiscoveryClientStopFindServiceFixture, DoesNotCallHandlerIfFindSer
     WhichContainsAServiceDiscoveryClient().WithAnActiveStartFindService(
         kConfigStoreQm1.GetInstanceIdentifier(),
         expected_handle,
-        [&handler_called, destructor_notifier = std::move(destructor_notifier)](auto, auto) noexcept {
+        [&handler_called, moved_notifier = std::move(destructor_notifier)](auto, auto) noexcept {
             handler_called = true;
         });
 
@@ -144,7 +144,7 @@ TEST_F(ServiceDiscoveryClientStopFindServiceFixture, DoesNotCallHandlerIfFindSer
     WhichContainsAServiceDiscoveryClient().WithAnActiveStartFindService(
         kConfigStoreFindAny.GetInstanceIdentifier(),
         expected_handle,
-        [&handler_called, destructor_notifier = std::move(destructor_notifier)](auto, auto) noexcept {
+        [&handler_called, moved_notifier = std::move(destructor_notifier)](auto, auto) noexcept {
             handler_called = true;
         });
 

--- a/score/mw/com/impl/bindings/lola/skeleton_method_handling_test.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_method_handling_test.cpp
@@ -468,7 +468,7 @@ TEST_F(SkeletonPrepareOfferFixture, PrepareOfferWillNotCallUnregisterSubscribedM
         }));
 
     // When calling PrepareOffer
-    const auto result = PrepareOffer();
+    std::ignore = PrepareOffer();
 
     // Then UnregisterOnServiceMethodSubscribedHandler was not called during PrepareOffer
     EXPECT_FALSE(*unregister_called);

--- a/score/mw/com/impl/bindings/lola/transaction_log_set_test.cpp
+++ b/score/mw/com/impl/bindings/lola/transaction_log_set_test.cpp
@@ -637,8 +637,7 @@ TEST_F(TransactionLogSetRegisterFixture, RegisterUnregisterMultipleTransactionLo
     // again.
     for (std::size_t thread_idx = 0; thread_idx < thread_count; ++thread_idx)
     {
-        threads.emplace_back([this,
-                              &unit,
+        threads.emplace_back([&unit,
                               thread_number = TransactionLogIndex(thread_idx + 1U),
                               &consumer_event_data_control_locals,
                               thread_idx]() noexcept {

--- a/score/mw/com/impl/generic_proxy.cpp
+++ b/score/mw/com/impl/generic_proxy.cpp
@@ -85,7 +85,7 @@ Result<GenericProxy> GenericProxy::Create(HandleType instance_handle) noexcept
 
 GenericProxy::GenericProxy(std::unique_ptr<ProxyBinding> proxy_binding, HandleType instance_handle)
     : ProxyBase{std::move(proxy_binding), std::move(instance_handle)},
-      events_(std::make_unique<std::map<std::string_view, GenericProxyEvent>>()),
+      generic_events_(std::make_unique<std::map<std::string_view, GenericProxyEvent>>()),
       is_proxy_owner_{true}
 {
 }
@@ -99,7 +99,9 @@ GenericProxy::~GenericProxy() noexcept
 }
 
 GenericProxy::GenericProxy(GenericProxy&& other) noexcept
-    : ProxyBase{std::move(other)}, events_{std::move(other.events_)}, is_proxy_owner_{std::move(other.is_proxy_owner_)}
+    : ProxyBase{std::move(other)},
+      generic_events_{std::move(other.generic_events_)},
+      is_proxy_owner_{std::move(other.is_proxy_owner_)}
 {
 }
 
@@ -112,7 +114,7 @@ GenericProxy& GenericProxy::operator=(GenericProxy&& other) noexcept
             this->Deinitialize();
         }
         ProxyBase::operator=(std::move(other));
-        events_ = std::move(other.events_);
+        generic_events_ = std::move(other.generic_events_);
         is_proxy_owner_ = std::move(other.is_proxy_owner_);
     }
     return *this;
@@ -124,7 +126,7 @@ void GenericProxy::FillEventMap(const std::vector<std::string_view>& event_names
     {
         if (proxy_binding_->IsEventProvided(event_name))
         {
-            const auto emplace_result = events_->emplace(
+            const auto emplace_result = generic_events_->emplace(
                 std::piecewise_construct, std::forward_as_tuple(event_name), std::forward_as_tuple(*this, event_name));
             SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(emplace_result.second,
                                                         "Could not emplace GenericProxyEvent in map.");
@@ -140,7 +142,7 @@ void GenericProxy::FillEventMap(const std::vector<std::string_view>& event_names
 
 GenericProxy::EventMapView GenericProxy::GetEvents() const noexcept
 {
-    return ServiceElementMapViewFactory<GenericProxyEvent>::Create(*events_);
+    return ServiceElementMapViewFactory<GenericProxyEvent>::Create(*generic_events_);
 }
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/generic_proxy.h
+++ b/score/mw/com/impl/generic_proxy.h
@@ -92,7 +92,7 @@ class GenericProxy : public ProxyBase
     /// \details This map needs to be covered in a unique_ptr as it shall not be relocated by a move of the
     /// GenericProxy. This is required as we hand out views to this map (see GetEvents()), which need to be valid
     /// even after the GenericProxy instance has been moved.
-    std::unique_ptr<ServiceElementMapViewFactory<GenericProxyEvent>::map_type> events_;
+    std::unique_ptr<ServiceElementMapViewFactory<GenericProxyEvent>::map_type> generic_events_;
 
     /// Flag which is checked before calling Unsubscribe in the destructor.
     /// Cleared on move so the moved-from instance does not call Unsubscribe.

--- a/score/mw/com/impl/methods/skeleton_method.h
+++ b/score/mw/com/impl/methods/skeleton_method.h
@@ -170,9 +170,8 @@ Result<void> SkeletonMethod<ReturnType(ArgTypes...)>::RegisterHandler(Callable&&
     };
 
     SkeletonMethodBinding::TypeErasedHandler type_erased_callable =
-        [callable_invoker = std::move(callable_invoker)](
-            std::optional<score::cpp::span<std::byte>> type_erased_in_args,
-            std::optional<score::cpp::span<std::byte>> type_erased_return) {
+        [invoker = std::move(callable_invoker)](std::optional<score::cpp::span<std::byte>> type_erased_in_args,
+                                                std::optional<score::cpp::span<std::byte>> type_erased_return) {
             using InArgPtrTuple = std::tuple<ArgTypes*...>;
             InArgPtrTuple typed_in_arg_ptrs{};
 
@@ -192,12 +191,12 @@ Result<void> SkeletonMethod<ReturnType(ArgTypes...)>::RegisterHandler(Callable&&
                 SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
                     type_erased_return.has_value(),
                     "ReturnType is non void. Thus, type_erased_result needs to have a value!");
-                ReturnType res = std::apply(callable_invoker, std::forward<InArgPtrTuple>(typed_in_arg_ptrs));
+                ReturnType res = std::apply(invoker, std::forward<InArgPtrTuple>(typed_in_arg_ptrs));
                 SerializeArgs<ReturnType>(type_erased_return.value(), res);
             }
             else
             {
-                std::apply(callable_invoker, std::forward<InArgPtrTuple>(typed_in_arg_ptrs));
+                std::apply(invoker, std::forward<InArgPtrTuple>(typed_in_arg_ptrs));
             }
         };
 

--- a/score/mw/com/impl/proxy_event.h
+++ b/score/mw/com/impl/proxy_event.h
@@ -223,8 +223,8 @@ Result<std::size_t> ProxyEvent<SampleType>::GetNewSamples(F&& receiver, std::siz
     if (proxy_event_mock_ != nullptr)
     {
         typename IProxyEvent<SampleType>::Callback mock_callback =
-            [receiver = std::forward<F>(receiver)](SamplePtr<SampleType> sample_ptr) noexcept {
-                receiver(std::move(sample_ptr));
+            [fwd_receiver = std::forward<F>(receiver)](SamplePtr<SampleType> sample_ptr) noexcept {
+                fwd_receiver(std::move(sample_ptr));
             };
         return proxy_event_mock_->GetNewSamples(std::move(mock_callback), max_num_samples);
     }

--- a/score/mw/com/impl/proxy_event_base.cpp
+++ b/score/mw/com/impl/proxy_event_base.cpp
@@ -161,8 +161,8 @@ void ProxyEventBase::Unsubscribe() noexcept
         return;
     }
 
-    utils::ScopeExit clear_subscribed_flag_on_exit{[&is_subscribed_flag_ = is_subscribed_flag_] {
-        is_subscribed_flag_.Clear();
+    utils::ScopeExit clear_subscribed_flag_on_exit{[&subscribed_flag_ref = is_subscribed_flag_] {
+        subscribed_flag_ref.Clear();
     }};
 
     if (proxy_event_base_mock_ != nullptr)
@@ -257,9 +257,9 @@ Result<void> ProxyEventBase::SetReceiveHandler(EventReceiveHandler handler) noex
     // Package the tracing handler, which already encapsulates the user provided EventReceiveHandler into another
     // move-only function, which adds the aspect of updating the thread local state is_in_receive_handler_context
     // correctly.
-    auto extended_tracing_handler = [handler = std::move(tracing_handler)]() noexcept {
+    auto extended_tracing_handler = [tracing_handler_fn = std::move(tracing_handler)]() noexcept {
         is_in_receive_handler_context = true;
-        handler();
+        tracing_handler_fn();
         is_in_receive_handler_context = false;
     };
 

--- a/score/mw/com/impl/skeleton_field.h
+++ b/score/mw/com/impl/skeleton_field.h
@@ -152,9 +152,9 @@ class SkeletonField : public SkeletonFieldBase
                       "The argument initially holds the proxy-requested value and may be modified in-place.");
 
         auto wrapped_callback =
-            [this, set_handler = std::forward<CallableType>(set_handler)](FieldType& new_value) -> FieldType {
+            [this, fwd_set_handler = std::forward<CallableType>(set_handler)](FieldType& new_value) -> FieldType {
             // Allow user to validate/modify the value in-place
-            set_handler(new_value);
+            fwd_set_handler(new_value);
 
             // Store the (possibly modified) value as the latest field value
             auto update_result = this->Update(new_value);

--- a/score/mw/com/impl/skeleton_field_base_test.cpp
+++ b/score/mw/com/impl/skeleton_field_base_test.cpp
@@ -64,7 +64,7 @@ class MyDummyField : public SkeletonFieldBase
     {
     }
 
-    void UpdateSkeletonReference(SkeletonBase& skeleton_base) noexcept override {}
+    void UpdateSkeletonReference(SkeletonBase& /*skeleton_base*/) noexcept override {}
 
     StrictMock<mock_binding::SkeletonEventBase>* GetMockEventBinding() noexcept
     {
@@ -97,7 +97,7 @@ class MyDummyField : public SkeletonFieldBase
 class MyDummyFieldFailingDeferredUpdate final : public MyDummyField
 {
   public:
-    void UpdateSkeletonReference(SkeletonBase& skeleton_base) noexcept override {}
+    void UpdateSkeletonReference(SkeletonBase& /*skeleton_base*/) noexcept override {}
 
     Result<void> DoDeferredUpdate() noexcept override
     {

--- a/score/mw/com/impl/skeleton_field_test.cpp
+++ b/score/mw/com/impl/skeleton_field_test.cpp
@@ -939,7 +939,7 @@ TEST_F(SkeletonFieldSetHandlerTest, PrepareOfferFailsWhenSetHandlerNotRegistered
 
 TEST_F(SkeletonFieldSetHandlerTest, PrepareOfferSucceedsAfterRegisterSetHandler)
 {
-    const TestSampleType kDummyInitialValue{7U};
+    const TestSampleType kSetHandlerInitialValue{7U};
 
     // Given a skeleton containing a field with a setter enabled
     MySetterSkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
@@ -948,7 +948,7 @@ TEST_F(SkeletonFieldSetHandlerTest, PrepareOfferSucceedsAfterRegisterSetHandler)
     ASSERT_TRUE(unit.my_setter_field_.RegisterSetHandler([](TestSampleType& /*value*/) noexcept {}).has_value());
 
     // Set the initial field value
-    ASSERT_TRUE(unit.my_setter_field_.Update(kDummyInitialValue).has_value());
+    ASSERT_TRUE(unit.my_setter_field_.Update(kSetHandlerInitialValue).has_value());
 
     // When PrepareOffer is called
     const auto result = unit.my_setter_field_.PrepareOffer();
@@ -1164,17 +1164,17 @@ TEST_F(SkeletonFieldSetHandlerTest, IsSetHandlerRegisteredFlagIsSetAfterRegistra
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
-    const TestSampleType kDummyInitialValue{3U};
+    const TestSampleType kLocalInitialValue{3U};
 
     EXPECT_CALL(skeleton_field_binding_mock_, PrepareOffer()).WillOnce(Return(Result<void>{}));
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _)).WillOnce(Return(Result<void>{}));
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(kLocalInitialValue, _)).WillOnce(Return(Result<void>{}));
 
     EXPECT_CALL(skeleton_field_set_binding_mock_, RegisterHandler(_)).WillOnce(Return(Result<void>{}));
 
     MySetterSkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
 
     // Before registration PrepareOffer should fail with kSetHandlerNotSet
-    ASSERT_TRUE(unit.my_setter_field_.Update(kDummyInitialValue).has_value());
+    ASSERT_TRUE(unit.my_setter_field_.Update(kLocalInitialValue).has_value());
     {
         // Separate scope: verify failure without handler
         // (We cannot call PrepareOffer twice without a stop-offer in between, so we

--- a/score/mw/com/impl/tracing/proxy_event_tracing.cpp
+++ b/score/mw/com/impl/tracing/proxy_event_tracing.cpp
@@ -422,9 +422,9 @@ score::cpp::callback<void(void), 128U> CreateTracingReceiveHandler(
     if (proxy_event_tracing_data.enable_call_receive_handler)
     {
         score::cpp::callback<void(void), 128U> tracing_receive_handler =
-            [&proxy_event_tracing_data, &proxy_event_binding_base, handler = std::move(handler)]() noexcept {
+            [&proxy_event_tracing_data, &proxy_event_binding_base, fwd_handler = std::move(handler)]() noexcept {
                 TraceCallReceiveHandler(proxy_event_tracing_data, proxy_event_binding_base);
-                handler();
+                fwd_handler();
             };
         return tracing_receive_handler;
     }

--- a/score/mw/com/impl/tracing/proxy_event_tracing.h
+++ b/score/mw/com/impl/tracing/proxy_event_tracing.h
@@ -77,14 +77,14 @@ auto CreateTracingGetNewSamplesCallback(ProxyEventTracingData& proxy_event_traci
             // via: (1) std::move if the value is an rvalue reference, (2) std::forward if the value is forwarding
             // reference. std::forward is already used here.
             // coverity[autosar_cpp14_a18_9_2_violation : FALSE]
-            [&proxy_event_tracing_data, &proxy_event_binding_base, receiver = std::forward<ReceiverType>(receiver)](
+            [&proxy_event_tracing_data, &proxy_event_binding_base, fwd_receiver = std::forward<ReceiverType>(receiver)](
                 SamplePtr<SampleType> sample_ptr, ITracingRuntime::TracePointDataId trace_point_data_id) noexcept {
                 TraceCallGetNewSamplesCallback(proxy_event_tracing_data, proxy_event_binding_base, trace_point_data_id);
                 // Suppress "AUTOSAR C++14 A18-9-2", The rule states: "Forwarding values to other functions shall be
                 // done via: (1) std::move if the value is an rvalue reference, (2) std::forward if the value is
                 // forwarding reference. std::move is already used here.
                 // coverity[autosar_cpp14_a18_9_2_violation : FALSE]
-                receiver(std::move(sample_ptr));
+                fwd_receiver(std::move(sample_ptr));
             };
         return tracing_receiver;
     }
@@ -95,13 +95,13 @@ auto CreateTracingGetNewSamplesCallback(ProxyEventTracingData& proxy_event_traci
             // via: (1) std::move if the value is an rvalue reference, (2) std::forward if the value is forwarding
             // reference. std::forward is already used here.
             // coverity[autosar_cpp14_a18_9_2_violation : FALSE]
-            [receiver = std::forward<ReceiverType>(receiver)](SamplePtr<SampleType> sample_ptr,
-                                                              ITracingRuntime::TracePointDataId) noexcept {
+            [fwd_receiver = std::forward<ReceiverType>(receiver)](SamplePtr<SampleType> sample_ptr,
+                                                                  ITracingRuntime::TracePointDataId) noexcept {
                 // Suppress "AUTOSAR C++14 A18-9-2", The rule states: "Forwarding values to other functions shall be
                 // done via: (1) std::move if the value is an rvalue reference, (2) std::forward if the value is
                 // forwarding reference. std::move is already used here.
                 // coverity[autosar_cpp14_a18_9_2_violation : FALSE]
-                receiver(std::move(sample_ptr));
+                fwd_receiver(std::move(sample_ptr));
             };
         return tracing_receiver;
     }
@@ -116,15 +116,15 @@ typename GenericProxyEventBinding::Callback CreateTracingGenericGetNewSamplesCal
     // via: (1) std::move if the value is an rvalue reference, (2) std::forward if the value is forwarding
     // reference. std::forward is already used here.
     // coverity[autosar_cpp14_a18_9_2_violation : FALSE]
-    typename GenericProxyEventBinding::Callback tracing_receiver = [receiver = std::forward<ReceiverType>(receiver)](
-                                                                       SamplePtr<void> sample_ptr,
-                                                                       ITracingRuntime::TracePointDataId) noexcept {
-        // Suppress "AUTOSAR C++14 A18-9-2", The rule states: "Forwarding values to other functions shall be done
-        // via: (1) std::move if the value is an rvalue reference, (2) std::forward if the value is forwarding
-        // reference. std::move is already used here.
-        // coverity[autosar_cpp14_a18_9_2_violation : FALSE]
-        receiver(std::move(sample_ptr));
-    };
+    typename GenericProxyEventBinding::Callback tracing_receiver =
+        [fwd_receiver = std::forward<ReceiverType>(receiver)](SamplePtr<void> sample_ptr,
+                                                              ITracingRuntime::TracePointDataId) noexcept {
+            // Suppress "AUTOSAR C++14 A18-9-2", The rule states: "Forwarding values to other functions shall be done
+            // via: (1) std::move if the value is an rvalue reference, (2) std::forward if the value is forwarding
+            // reference. std::move is already used here.
+            // coverity[autosar_cpp14_a18_9_2_violation : FALSE]
+            fwd_receiver(std::move(sample_ptr));
+        };
     return tracing_receiver;
 }
 

--- a/score/mw/com/impl/tracing/skeleton_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/skeleton_tracing_test.cpp
@@ -67,7 +67,7 @@ class MyDummyField : public SkeletonFieldBase
     {
     }
 
-    void UpdateSkeletonReference(SkeletonBase& skeleton_base) noexcept override {}
+    void UpdateSkeletonReference(SkeletonBase& /*skeleton_base*/) noexcept override {}
 
     bool IsInitialValueSaved() const noexcept override
     {

--- a/score/mw/com/impl/tracing/type_erased_sample_ptr.h
+++ b/score/mw/com/impl/tracing/type_erased_sample_ptr.h
@@ -23,8 +23,8 @@ class TypeErasedSamplePtr
   public:
     template <typename SamplePtrType>
     explicit TypeErasedSamplePtr(SamplePtrType sample_ptr)
-        : type_erased_sample_ptr_{[sample_ptr = std::move(sample_ptr)]() {
-              static_cast<void>(sample_ptr);
+        : type_erased_sample_ptr_{[moved_sample_ptr = std::move(sample_ptr)]() {
+              static_cast<void>(moved_sample_ptr);
           }}
     {
     }

--- a/score/mw/com/test/methods/non_trivial_constructors/consumer.cpp
+++ b/score/mw/com/test/methods/non_trivial_constructors/consumer.cpp
@@ -36,8 +36,7 @@ const InstanceSpecifier kInstanceSpecifier =
 
 void CallMethodWithInArgsAndReturn(NonTrivialConstructorProxy& proxy, const std::string& failure_message_prefix)
 {
-    auto call_result =
-        [&proxy, &failure_message_prefix]() -> score::Result<impl::MethodReturnTypePtr<NonTriviallyConstructibleType>> {
+    auto call_result = [&proxy]() -> score::Result<impl::MethodReturnTypePtr<NonTriviallyConstructibleType>> {
         std::cout << "\n=== Test: with_in_args_and_return (zero-copy) ===" << std::endl;
         auto allocated_args_result = proxy.with_in_args_and_return.Allocate();
         if (!allocated_args_result.has_value())
@@ -66,7 +65,7 @@ void CallMethodWithInArgsAndReturn(NonTrivialConstructorProxy& proxy, const std:
 
 void CallMethodWithInArgsOnly(NonTrivialConstructorProxy& proxy, const std::string& failure_message_prefix)
 {
-    auto call_result = [&proxy, &failure_message_prefix]() -> Result<void> {
+    auto call_result = [&proxy]() -> Result<void> {
         std::cout << "\n=== Test: with_in_args_only (zero-copy) ===" << std::endl;
         auto allocated_args_result = proxy.with_in_args_only.Allocate();
         if (!allocated_args_result.has_value())

--- a/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/consumer.cpp
+++ b/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/consumer.cpp
@@ -36,9 +36,6 @@ constexpr auto kInstanceSpecifierString{"partial_restart/small_but_great"};
 const auto kInstanceSpecifier =
     score::mw::com::InstanceSpecifier::Create(std::string{kInstanceSpecifierString}).value();
 const std::chrono::seconds kMaxHandleNotificationWaitTime{15U};
-// uid 1312, 1313 is reserved for use. See broken_link_cf/display/ipnext/User+Management
-const uid_t kUidFirstConsumer{1312};
-const uid_t kUidSecondConsumer{1313};
 
 bool StartFindServiceAndWait(const std::string& tag,
                              HandleNotificationData& handle_notification_data,


### PR DESCRIPTION
-rename shadowing lambda captures and local variables for clarity -replace unused result bindings with std::ignore in tests -remove unused constants and lambda captures
-rename GenericProxy events map member to generic_events -silence unused parameter warnings in test overrides -keep behavior unchanged while improving static-analysis compliance