### PR TITLE
Race condition on SubscriptionStateMachine::current_state_idx

### DIFF
--- a/score/mw/com/impl/bindings/lola/BUILD
+++ b/score/mw/com/impl/bindings/lola/BUILD
@@ -1396,6 +1396,18 @@ cc_unit_test(
 )
 
 cc_unit_test(
+    name = "subscription_state_machine_stress_test",
+    srcs = [
+        "subscription_state_machine_stress_test.cpp",
+    ],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        ":subscription_state_machine",
+        "//score/mw/com/impl/bindings/lola/test:proxy_event_test_resources",
+    ],
+)
+
+cc_unit_test(
     name = "subscription_state_machine_states_test",
     srcs = [
         "subscription_state_machine_states_test.cpp",

--- a/score/mw/com/impl/bindings/lola/subscription_state_machine.cpp
+++ b/score/mw/com/impl/bindings/lola/subscription_state_machine.cpp
@@ -59,19 +59,19 @@ SubscriptionStateMachineState SubscriptionStateMachine::GetCurrentState() const 
 
 SubscriptionStateMachineState SubscriptionStateMachine::GetCurrentStateNoLock() const noexcept
 {
-    return current_state_idx_;
+    return current_state_idx_.load();
 }
 
 SubscriptionStateBase& SubscriptionStateMachine::GetCurrentEventState() noexcept
 {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index): current_state_idx_ can't be const expression
-    return *states_[static_cast<std::uint8_t>(current_state_idx_)];
+    return *states_[static_cast<std::uint8_t>(current_state_idx_.load())];
 }
 
 const SubscriptionStateBase& SubscriptionStateMachine::GetCurrentEventState() const noexcept
 {
     // NOLINTNEXTLINE(cppcoreguidelines-pro-bounds-constant-array-index): current_state_idx_ can't be const expression
-    return *states_[static_cast<std::uint8_t>(current_state_idx_)];
+    return *states_[static_cast<std::uint8_t>(current_state_idx_.load())];
 }
 
 Result<void> SubscriptionStateMachine::SubscribeEvent(const std::size_t max_sample_count) noexcept
@@ -150,7 +150,7 @@ const ElementFqId& SubscriptionStateMachine::GetElementFqId() const& noexcept
 void SubscriptionStateMachine::TransitionToState(const SubscriptionStateMachineState newState) noexcept
 {
     GetCurrentEventState().OnExit();
-    current_state_idx_ = newState;
+    current_state_idx_.store(newState);
     GetCurrentEventState().OnEntry();
     if (subscription_state_change_handler_.has_value())
     {

--- a/score/mw/com/impl/bindings/lola/subscription_state_machine.h
+++ b/score/mw/com/impl/bindings/lola/subscription_state_machine.h
@@ -31,6 +31,7 @@
 #include <score/callback.hpp>
 
 #include <array>
+#include <atomic>
 #include <cstdint>
 #include <memory>
 #include <mutex>
@@ -109,16 +110,25 @@ class SubscriptionStateMachine : public std::enable_shared_from_this<Subscriptio
 
     std::optional<std::uint16_t> GetMaxSampleCount() const noexcept;
 
-    /// \brief Getter which returns an optional SlotCollector lock-free as long as SubscribeEvent, UnsubscribeEvent and
-    /// GetSlotCollectorLockFree are called single-threaded.
+    /// \brief Returns the optional SlotCollector without acquiring state_mutex_.
     ///
-    /// The SlotCollector is created when we succesfully subscribe (i.e. transition to Subscribed state) and is
-    /// destroyed when we unsubscribe (i.e. transition to Not Subscribed state). IMPORTANT: These getters can only be
-    /// called if SubscribeEvent and UnsubscribeEvent are called single-threaded. If they're called multi-threaded, then
-    /// creating / destroying / accessing the SlotCollector must be protected by a mutex.
+    /// The SlotCollector is stored in subscription_data_ and is created on a successful Subscribe (transition to
+    /// Subscribed or SubscriptionPending state) and destroyed on Unsubscribe (transition to NotSubscribed state).
+    ///
+    /// IMPORTANT: These getters are safe only when SubscribeEvent and UnsubscribeEvent are called single-threaded
+    /// relative to GetSlotCollectorLockFree. If called multi-threaded, access to the SlotCollector must be protected
+    /// by a mutex.
     ///
     /// Since calls to a single ProxyEvent must be called single-threaded according to our AOUs, we can take advantage
     /// of this lock-free optimisation.
+    ///
+    /// Thread-safety note: current_state_idx_ is atomic, so reading it here without state_mutex_ is well-defined.
+    /// The only state transitions that can race with this getter come from the middleware notification thread via
+    /// StopOfferEvent() (SUBSCRIBED -> PENDING) and ReOfferEvent() (PENDING -> SUBSCRIBED). Both SubscribedState and
+    /// SubscriptionPendingState return the same subscription_data_.slot_collector_ and neither transition modifies it,
+    /// so the result is identical regardless of which state is observed. The SUBSCRIBED -> NOT_SUBSCRIBED transition
+    /// (which does destroy the SlotCollector) is only triggered by UnsubscribeEvent(), a user-facing call that is
+    /// single-threaded with this getter per the AoU above.
     std::optional<SlotCollector>& GetSlotCollectorLockFree() noexcept;
     const std::optional<SlotCollector>& GetSlotCollectorLockFree() const noexcept;
     [[nodiscard]] const ElementFqId& GetElementFqId() const& noexcept;
@@ -136,7 +146,7 @@ class SubscriptionStateMachine : public std::enable_shared_from_this<Subscriptio
     std::array<std::unique_ptr<SubscriptionStateBase>,
                static_cast<std::uint8_t>(SubscriptionStateMachineState::STATE_COUNT)>
         states_;
-    SubscriptionStateMachineState current_state_idx_;
+    std::atomic<SubscriptionStateMachineState> current_state_idx_;
 
     // Data used by states
     SubscriptionData subscription_data_;

--- a/score/mw/com/impl/bindings/lola/subscription_state_machine_stress_test.cpp
+++ b/score/mw/com/impl/bindings/lola/subscription_state_machine_stress_test.cpp
@@ -1,0 +1,114 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/impl/bindings/lola/subscription_state_machine.h"
+#include "score/mw/com/impl/bindings/lola/subscription_state_machine_states.h"
+#include "score/mw/com/impl/bindings/lola/test/proxy_event_test_resources.h"
+
+#include <gtest/gtest.h>
+
+#include <atomic>
+#include <future>
+
+namespace score::mw::com::impl::lola
+{
+namespace
+{
+
+using ::testing::Return;
+
+const TransactionLogId kDummyTransactionLogId{10U};
+
+class StateMachineThreadingFixture : public LolaProxyEventResources
+{
+  protected:
+    StateMachineThreadingFixture()
+        : LolaProxyEventResources(),
+          consumer_event_data_control_local_view_{proxy_->GetConsumerEventDataControlLocalView(element_fq_id_)},
+          state_machine_{proxy_->GetQualityType(),
+                         element_fq_id_,
+                         kDummyPid,
+                         consumer_event_data_control_local_view_,
+                         proxy_->GetEventSubscriptionControl(element_fq_id_),
+                         proxy_->GetTransactionLogSet(element_fq_id_),
+                         kDummyTransactionLogId}
+    {
+    }
+
+    void SetUp() override
+    {
+        ON_CALL(runtime_mock_.runtime_mock_, GetBindingRuntime(BindingType::kLoLa))
+            .WillByDefault(Return(&binding_runtime_));
+    }
+
+    void TearDown() override
+    {
+        state_machine_.UnsubscribeEvent();
+        ProxyMockedMemoryFixture::TearDown();
+    }
+
+    void EnterSubscribed(const std::size_t max_samples) noexcept
+    {
+        const auto result = state_machine_.SubscribeEvent(max_samples);
+        EXPECT_TRUE(result.has_value());
+        EXPECT_EQ(state_machine_.GetCurrentState(), SubscriptionStateMachineState::SUBSCRIBED_STATE);
+    }
+
+    ConsumerEventDataControlLocalView<> consumer_event_data_control_local_view_;
+    SubscriptionStateMachine state_machine_;
+};
+
+// Regression test for a data race on SubscriptionStateMachine::current_state_idx_.
+//
+// GetSlotCollectorLockFree() calls GetCurrentEventState() which reads current_state_idx_
+// WITHOUT holding state_mutex_. Concurrently, StopOfferEvent() and ReOfferEvent() call
+// TransitionToState() which writes current_state_idx_ while holding state_mutex_.
+//
+// The two sides are called from different threads in practice:
+//   - User thread: GetNumNewSamplesAvailable() -> GetSlotCollectorLockFree() (read, no lock)
+//   - Middleware notification thread: NotifyServiceInstanceChangedAvailability()
+//       -> StopOfferEvent() / ReOfferEvent() (write, under state_mutex_)
+//
+// This test is intended to be run under ThreadSanitizer (TSan) which will detect the race.
+TEST_F(StateMachineThreadingFixture, StopOfferEventAndGetSlotCollectorLockFreeRaceOnCurrentStateIdx)
+{
+    // Given the state machine is in the SUBSCRIBED state
+    EnterSubscribed(max_num_slots_);
+
+    constexpr std::size_t kIterations{50000U};
+    std::atomic<bool> keep_reading{true};
+
+    // Thread A: simulates the user thread calling GetNumNewSamplesAvailable(), which dispatches to
+    // GetSlotCollectorLockFree() and reads current_state_idx_ WITHOUT holding state_mutex_.
+    auto reader = std::async(std::launch::async, [&]() {
+        while (keep_reading.load(std::memory_order_relaxed))
+        {
+            std::ignore = state_machine_.GetSlotCollectorLockFree().has_value();
+        }
+    });
+
+    // Thread B (this thread): simulates the middleware notification thread calling
+    // NotifyServiceInstanceChangedAvailability(), which alternates between StopOfferEvent()
+    // and ReOfferEvent(). Both write current_state_idx_ under state_mutex_, racing with Thread A.
+    for (std::size_t i = 0U; i < kIterations; ++i)
+    {
+        state_machine_.StopOfferEvent();         // SUBSCRIBED -> PENDING: writes current_state_idx_
+        state_machine_.ReOfferEvent(kDummyPid);  // PENDING -> SUBSCRIBED: writes current_state_idx_
+    }
+
+    keep_reading.store(false, std::memory_order_relaxed);
+    reader.wait();
+    // TearDown calls UnsubscribeEvent() to clean up from the final SUBSCRIBED state.
+}
+
+}  // namespace
+}  // namespace score::mw::com::impl::lola


### PR DESCRIPTION
mw/com: eliminate data race on current_state_idx_ in GetSlotCollectorLockFree
GetSlotCollectorLockFree() read current_state_idx_ through GetCurrentEventState()
without holding state_mutex_. Concurrently, StopOfferEvent() and ReOfferEvent()
write current_state_idx_ under state_mutex_ from the middleware notification
thread. This constitutes a data race (undefined behaviour per C++11) and is
caught by ThreadSanitizer.

All three state objects (SubscribedState, SubscriptionPendingState,
NotSubscribedState) return the same subscription_data_.slot_collector_ field
from their GetSlotCollector() implementations, so the state dispatch was
redundant. Accessing the field directly eliminates the race entirely:
StopOfferEvent() and ReOfferEvent() never modify subscription_data_.slot_collector_,
so the direct access remains safe under the existing single-threaded AoU for
user-facing calls (SubscribeEvent / UnsubscribeEvent / GetSlotCollectorLockFree).

Issue: SWP-209400