### PR TITLE
refactor(mw): resolve variable shadowing and unused parameter warnings

### DIFF
--- a/score/mw/com/impl/generic_proxy.cpp
+++ b/score/mw/com/impl/generic_proxy.cpp
@@ -85,7 +85,7 @@ Result<GenericProxy> GenericProxy::Create(HandleType instance_handle) noexcept
 
 GenericProxy::GenericProxy(std::unique_ptr<ProxyBinding> proxy_binding, HandleType instance_handle)
     : ProxyBase{std::move(proxy_binding), std::move(instance_handle)},
-      events_(std::make_unique<std::map<std::string_view, GenericProxyEvent>>()),
+      generic_events_(std::make_unique<std::map<std::string_view, GenericProxyEvent>>()),
       is_proxy_owner_{true}
 {
 }
@@ -99,7 +99,9 @@ GenericProxy::~GenericProxy() noexcept
 }
 
 GenericProxy::GenericProxy(GenericProxy&& other) noexcept
-    : ProxyBase{std::move(other)}, events_{std::move(other.events_)}, is_proxy_owner_{std::move(other.is_proxy_owner_)}
+    : ProxyBase{std::move(other)},
+      generic_events_{std::move(other.generic_events_)},
+      is_proxy_owner_{std::move(other.is_proxy_owner_)}
 {
 }
 
@@ -112,7 +114,7 @@ GenericProxy& GenericProxy::operator=(GenericProxy&& other) noexcept
             this->Deinitialize();
         }
         ProxyBase::operator=(std::move(other));
-        events_ = std::move(other.events_);
+        generic_events_ = std::move(other.generic_events_);
         is_proxy_owner_ = std::move(other.is_proxy_owner_);
     }
     return *this;
@@ -124,7 +126,7 @@ void GenericProxy::FillEventMap(const std::vector<std::string_view>& event_names
     {
         if (proxy_binding_->IsEventProvided(event_name))
         {
-            const auto emplace_result = events_->emplace(
+            const auto emplace_result = generic_events_->emplace(
                 std::piecewise_construct, std::forward_as_tuple(event_name), std::forward_as_tuple(*this, event_name));
             SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(emplace_result.second,
                                                         "Could not emplace GenericProxyEvent in map.");
@@ -140,7 +142,7 @@ void GenericProxy::FillEventMap(const std::vector<std::string_view>& event_names
 
 GenericProxy::EventMapView GenericProxy::GetEvents() const noexcept
 {
-    return ServiceElementMapViewFactory<GenericProxyEvent>::Create(*events_);
+    return ServiceElementMapViewFactory<GenericProxyEvent>::Create(*generic_events_);
 }
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/generic_proxy.h
+++ b/score/mw/com/impl/generic_proxy.h
@@ -92,7 +92,7 @@ class GenericProxy : public ProxyBase
     /// \details This map needs to be covered in a unique_ptr as it shall not be relocated by a move of the
     /// GenericProxy. This is required as we hand out views to this map (see GetEvents()), which need to be valid
     /// even after the GenericProxy instance has been moved.
-    std::unique_ptr<ServiceElementMapViewFactory<GenericProxyEvent>::map_type> events_;
+    std::unique_ptr<ServiceElementMapViewFactory<GenericProxyEvent>::map_type> generic_events_;
 
     /// Flag which is checked before calling Unsubscribe in the destructor.
     /// Cleared on move so the moved-from instance does not call Unsubscribe.

--- a/score/mw/com/impl/skeleton_event.h
+++ b/score/mw/com/impl/skeleton_event.h
@@ -172,7 +172,7 @@ SkeletonEvent<SampleDataType>::SkeletonEvent(SkeletonBase& skeleton_base,
 }
 
 template <typename SampleDataType>
-SkeletonEvent<SampleDataType>::SkeletonEvent(SkeletonBase& skeleton_base,
+SkeletonEvent<SampleDataType>::SkeletonEvent(SkeletonBase& /*skeleton_base*/,
                                              const std::string_view event_name,
                                              std::unique_ptr<SkeletonEventBinding<EventType>> binding)
     : SkeletonEventBase{event_name, std::move(binding)}, skeleton_event_mock_{nullptr}

--- a/score/mw/com/impl/skeleton_field_test.cpp
+++ b/score/mw/com/impl/skeleton_field_test.cpp
@@ -921,7 +921,7 @@ TEST_F(SkeletonFieldSetHandlerTest, PrepareOfferFailsWhenSetHandlerNotRegistered
 
 TEST_F(SkeletonFieldSetHandlerTest, PrepareOfferSucceedsAfterRegisterSetHandler)
 {
-    const TestSampleType kDummyInitialValue{7U};
+    const TestSampleType kSetHandlerInitialValue{7U};
 
     // Given a skeleton containing a field with a setter enabled
     MySetterSkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
@@ -930,7 +930,7 @@ TEST_F(SkeletonFieldSetHandlerTest, PrepareOfferSucceedsAfterRegisterSetHandler)
     ASSERT_TRUE(unit.my_setter_field_.RegisterSetHandler([](TestSampleType& /*value*/) noexcept {}).has_value());
 
     // Set the initial field value
-    ASSERT_TRUE(unit.my_setter_field_.Update(kDummyInitialValue).has_value());
+    ASSERT_TRUE(unit.my_setter_field_.Update(kSetHandlerInitialValue).has_value());
 
     // When PrepareOffer is called
     const auto result = unit.my_setter_field_.PrepareOffer();
@@ -1146,17 +1146,17 @@ TEST_F(SkeletonFieldSetHandlerTest, IsSetHandlerRegisteredFlagIsSetAfterRegistra
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
-    const TestSampleType kDummyInitialValue{3U};
+    const TestSampleType kLocalInitialValue{3U};
 
     EXPECT_CALL(skeleton_field_binding_mock_, PrepareOffer()).WillOnce(Return(Result<void>{}));
-    EXPECT_CALL(skeleton_field_binding_mock_, Send(kDummyInitialValue, _)).WillOnce(Return(Result<void>{}));
+    EXPECT_CALL(skeleton_field_binding_mock_, Send(kLocalInitialValue, _)).WillOnce(Return(Result<void>{}));
 
     EXPECT_CALL(skeleton_field_set_binding_mock_, RegisterHandler(_)).WillOnce(Return(Result<void>{}));
 
     MySetterSkeleton unit{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
 
     // Before registration PrepareOffer should fail with kSetHandlerNotSet
-    ASSERT_TRUE(unit.my_setter_field_.Update(kDummyInitialValue).has_value());
+    ASSERT_TRUE(unit.my_setter_field_.Update(kLocalInitialValue).has_value());
     {
         // Separate scope: verify failure without handler
         // (We cannot call PrepareOffer twice without a stop-offer in between, so we

--- a/score/mw/com/impl/tracing/skeleton_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/skeleton_tracing_test.cpp
@@ -58,7 +58,7 @@ constexpr std::string_view kFieldName{"DummyField1"};
 class MyDummyField : public SkeletonFieldBase
 {
   public:
-    MyDummyField(SkeletonBase& skeleton_base,
+    MyDummyField(SkeletonBase& /*skeleton_base*/,
                  const std::string_view field_name,
                  std::unique_ptr<SkeletonEventBindingBase> skeleton_event_base)
         : SkeletonFieldBase{field_name, std::make_unique<SkeletonEventBase>(field_name, std::move(skeleton_event_base))}


### PR DESCRIPTION
Fix compiler errors and warnings triggered by strict safety settings (-Werror, -Wshadow-field, -Wunused-parameter).

- Rename 'events_' member in 'GenericProxy' to 'generic_events_' to prevent shadowing 'ProxyBase::events_'.
- Comment out unused 'skeleton_base' constructor parameters in 'SkeletonEvent' and 'MyDummyField' to silence unused variable warnings.
- Rename 'kDummyInitialValue' inside field tests to specific names ('kSetHandlerInitialValue', 'kLocalInitialValue') to improve test readability and avoid naming collisions.