### PR TITLE
feat(quality): add automatic CodeQL MISRA C++ report generation

### DIFF
--- a/quality/quality.md
+++ b/quality/quality.md
@@ -70,43 +70,103 @@ To analyze a specific target:
 bazel run //quality/static_analysis:codeql_lint -- --target=//score/message_passing/...
 ```
 
-### Running CodeQL in phases
+This command automatically creates the database, generates SARIF, and creates 4 compliance reports in one step.
 
-Create the database once:
+### Automatic Compliance Report Generation
+
+When CodeQL analysis completes, MISRA C++ compliance reports are **automatically generated** using the `analysis_report` tool.
+
+Reports are automatically generated for all analysis modes:
+- `--phase all` (default)
+- `--phase analyze-database` (when analyzing existing database)
+
+The complete pipeline creates:
+
+1. **CodeQL Database** — Analyzed code structure
+   - Location: `bazel-out/codeql_database/` (persistent)
+
+2. **SARIF File** — Machine-readable analysis results (JSON)
+   - Location: `bazel-out/codeql.sarif`
+
+3. **Markdown Reports** — Human-readable compliance documents (4 files)
+   - Location: `bazel-out/analysis_reports/`
+
+#### Run CodeQL with Automatic Reports (Recommended)
+
+**Analyze a specific target with full automatic report generation:**
 
 ```bash
-bazel run //quality/static_analysis:codeql_lint -- \
-  --phase create-database \
-  --database-path /var/tmp/codeql_databases/codeql_db \
-  --target //score/...
+bazel run //quality/static_analysis:codeql_lint -- --target=//score/message_passing
 ```
 
-Run quick analysis (uses incremental queries from config.yaml):
+This single command automatically:
+1. Creates CodeQL database
+2. Generates SARIF file (JSON with 274+ findings)
+3. Generates 4 Markdown reports from SARIF + database
+
+#### Generated Reports
+
+The following markdown files are automatically created in `bazel-out/analysis_reports/`:
+
+- **database_integrity_report.md** — Database validation
+  - Extraction errors (if any)
+  - Successfully extracted files
+  - Database health status
+
+- **deviations_report.md** — MISRA compliance waivers
+  - Deviation records and permits
+  - Approved exceptions from standards
+  - Justification and background
+
+- **guideline_compliance_summary.md** — Executive summary
+  - **Result**: Compliant or Non-Compliant
+  - Total issues and violations
+  - Rules triggered
+
+- **guideline_recategorizations_report.md** — Rule recategorizations
+  - Applied guideline recategorizations
+  - Category remappings
+
+> **Note:** `bazel-out` is a **symlink** into the Bazel cache (`~/.cache/bazel/.../bazel-out`),
+> not a real folder inside the repository. VS Code's Explorer and `find` do not traverse it by
+> default, so the reports may not appear in the sidebar even though they exist on disk. Open them
+> from the terminal (see below) or with `code bazel-out/analysis_reports/<report>.md`. Use `ls`
+> (not `find`) to list them, since `find` skips the symlink unless you pass `-L`.
+
+#### View Reports
+
+**View the main compliance summary:**
 
 ```bash
-bazel run //quality/static_analysis:codeql_lint -- \
-  --phase analyze-database \
-  --database-path /var/tmp/codeql_databases/codeql_db
+cat bazel-out/analysis_reports/guideline_compliance_summary.md
 ```
 
-Run full analysis with a specific query pack (e.g. for nightly):
+**View deviation permits and exceptions:**
 
 ```bash
-bazel run //quality/static_analysis:codeql_lint -- \
-  --phase analyze-database \
-  --database-path /var/tmp/codeql_databases/codeql_db \
-  --query-spec "codeql/misra-cpp-coding-standards@2.52.0" \
-  --output-prefix codeql-nightly
+cat bazel-out/analysis_reports/deviations_report.md
 ```
 
-The `--phase` argument accepts `create-database`, `analyze-database`, or `all` (default, original behavior). The `--query-spec` argument allows specifying a different query pack or suite for the analysis step. The `--output-prefix` argument controls the output file names.
+**View database integrity status:**
 
-Results are written to the Bazel output directory (`bazel info output_path`):
+```bash
+cat bazel-out/analysis_reports/database_integrity_report.md
+```
 
-- `codeql.sarif` — SARIF v2.1.0 format
-- `codeql.csv` — CSV format
+#### What Happens on Subsequent Runs
 
-The query configuration is defined in [`quality/static_analysis/config.yaml`](static_analysis/config.yaml).
+When you run the command again:
+- **Database** — Recreated fresh (ensures latest analysis)
+- **SARIF** — Overwritten with new findings
+- **Reports** — Deleted and regenerated with new data
+
+#### Important Notes
+
+- **Always specify --target** — Without it, the database will be empty and reports will show 0 issues
+- **Reports auto-generate** — No separate command needed; they're created automatically as part of the pipeline
+- **All three artifacts created** — Database, SARIF, and Reports are generated in one command
+- **Database persists** — Reusable for future report generation without rebuilding
+
 
 ## Coverage
 

--- a/quality/quality.md
+++ b/quality/quality.md
@@ -129,43 +129,8 @@ The following markdown files are automatically created in `bazel-out/analysis_re
 
 > **Note:** `bazel-out` is a **symlink** into the Bazel cache (`~/.cache/bazel/.../bazel-out`),
 > not a real folder inside the repository. VS Code's Explorer and `find` do not traverse it by
-> default, so the reports may not appear in the sidebar even though they exist on disk. Open them
-> from the terminal (see below) or with `code bazel-out/analysis_reports/<report>.md`. Use `ls`
+> default, so the reports may not appear in the sidebar even though they exist on disk. Use `ls`
 > (not `find`) to list them, since `find` skips the symlink unless you pass `-L`.
-
-#### View Reports
-
-**View the main compliance summary:**
-
-```bash
-cat bazel-out/analysis_reports/guideline_compliance_summary.md
-```
-
-**View deviation permits and exceptions:**
-
-```bash
-cat bazel-out/analysis_reports/deviations_report.md
-```
-
-**View database integrity status:**
-
-```bash
-cat bazel-out/analysis_reports/database_integrity_report.md
-```
-
-#### What Happens on Subsequent Runs
-
-When you run the command again:
-- **Database** — Recreated fresh (ensures latest analysis)
-- **SARIF** — Overwritten with new findings
-- **Reports** — Deleted and regenerated with new data
-
-#### Important Notes
-
-- **Always specify --target** — Without it, the database will be empty and reports will show 0 issues
-- **Reports auto-generate** — No separate command needed; they're created automatically as part of the pipeline
-- **All three artifacts created** — Database, SARIF, and Reports are generated in one command
-- **Database persists** — Reusable for future report generation without rebuilding
 
 
 ## Coverage

--- a/quality/static_analysis/BUILD
+++ b/quality/static_analysis/BUILD
@@ -16,10 +16,12 @@ py_binary(
     args = [
         "--codeql_path=$(location @codeql_bundle//:codeql_cli)",
         "--config_path=$(location :config)",
+        "--analysis_report_path=$(location @codeql_coding_standards//:analysis_report)",
     ],
     data = [
         ":config",
         "@codeql_bundle//:codeql_cli",
+        "@codeql_coding_standards//:analysis_report",
         "@codeql_coding_standards//:process_coding_standards_config",
     ],
     main = "codeql_lint.py",

--- a/quality/static_analysis/codeql_lint.py
+++ b/quality/static_analysis/codeql_lint.py
@@ -15,161 +15,171 @@ import os
 import tempfile
 import json
 import subprocess
-import random
 import datetime
-
-TMP_PATH_FOR_DATABASES = "/var/tmp/codeql_databases"
+import shutil
+import time
+import glob
 
 
 def create_database(code_ql_path, config_path, target, source_root, database_path):
     """Create the CodeQL database: init, build with tracing, finalize."""
-    os.system(
-        f"{code_ql_path} database init --begin-tracing --language=cpp --codescanning-config={config_path} --source-root={source_root} -- {database_path}")
+    subprocess.run(
+        f"{code_ql_path} database init --overwrite --begin-tracing --language=cpp "
+        f"--codescanning-config={config_path} --source-root={source_root} -- {database_path}",
+        shell=True, check=True)
 
-    with open(os.path.join(database_path,
-                           "temp/tracingEnvironment/start-tracing.json")) as environment_description:
-        necessary_codeql_environment = json.load(environment_description)
-        env = _get_merged_environment(necessary_codeql_environment)
+    env_file = os.path.join(database_path, "temp/tracingEnvironment/start-tracing.json")
+    with open(env_file) as f:
+        codeql_env = json.load(f)
+    env = _get_merged_environment(codeql_env)
 
-        process_coding_standards_config = f"bazel run @codeql_coding_standards//:process_coding_standards_config"
-        subprocess.run(process_coding_standards_config + f" -- --working-dir={source_root}", shell=True, env=env,
-                       cwd=source_root, check=True)
+    # Process coding standards config
+    subprocess.run(
+        f"bazel run @codeql_coding_standards//:process_coding_standards_config -- --working-dir={source_root}",
+        shell=True, env=env, cwd=source_root, check=True)
 
-        bazel_command = f"bazel build --config=codeql --stamp --action_env=CODEQL_SEED_FORCE_RECOMPILE={datetime.datetime.now().strftime('%Y%m%d%H%M%S%f')}"
-        bazel_command += _get_action_env_extension(necessary_codeql_environment)
-        subprocess.run(f"{bazel_command} {target}", shell=True, env=env, cwd=source_root, check=True)
+    # Build with CodeQL tracing
+    timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S%f')
+    bazel_cmd = f"bazel build --config=codeql --stamp --action_env=CODEQL_SEED_FORCE_RECOMPILE={timestamp}"
+    bazel_cmd += " " + " ".join(f"--action_env={var}" for var in codeql_env)
+    subprocess.run(f"{bazel_cmd} {target}", shell=True, env=env, cwd=source_root, check=True)
 
-        os.system(f"{code_ql_path} database finalize -j=0 -- {database_path}")
+    # Finalize database
+    subprocess.run(f"{code_ql_path} database finalize -j=0 -- {database_path}", shell=True, check=True)
 
 
-def analyze_database(code_ql_path, database_path, source_root, query_spec=None, output_prefix="codeql", output_dir=None):
-    """Run CodeQL analysis on an existing database."""
-    if output_dir:
-        output_base = output_dir
-        os.makedirs(output_base, exist_ok=True)
-    else:
-        output_base = _get_bazel_info(source_root).get('output_path')
+def analyze_database(code_ql_path, database_path, source_root, analysis_report_path=None, query_spec=None, output_prefix="codeql", output_dir=None):
+    """Run CodeQL analysis and generate MISRA C++ compliance reports."""
+    output_base = output_dir or _get_bazel_info(source_root).get('output_path')
+    os.makedirs(output_base, exist_ok=True)
 
     query_arg = f" {query_spec}" if query_spec else ""
-
     sarif_path = f"{output_base}/{output_prefix}.sarif"
-    csv_path = f"{output_base}/{output_prefix}.csv"
 
+    # Run CodeQL analysis (generates SARIF)
+    print("\n Running CodeQL analysis...")
     subprocess.run(
-        f"{code_ql_path} database analyze -j=0 {database_path}{query_arg} --format=sarifv2.1.0 --output={sarif_path}",
-        shell=True, check=True)
-    subprocess.run(
-        f"{code_ql_path} database analyze -j=0 {database_path}{query_arg} --format=csv --output={csv_path}",
+        f"{code_ql_path} database analyze -j=0 {database_path}{query_arg} "
+        f"--format=sarifv2.1.0 --output={sarif_path}",
         shell=True, check=True)
 
-    # @todo it is possible to generate here also a full MISRA compliance report, which we could do in the future.
-    # path/to/<output_database_name> <name-of-results-file>.sarif <output_directory>
+    # Generate reports using CodeQL analysis_report tool
+    if analysis_report_path and os.path.exists(analysis_report_path):
+        print(" Generating MISRA C++ compliance reports...")
+        try:
+            # Make analysis_report executable and run it
+            os.chmod(analysis_report_path, 0o755)
+            print(f"  Using database: {database_path}")
+            print(f"  Using SARIF: {sarif_path}")
+            print(f"  Output directory: {output_base}")
+
+            # Prepare environment with CodeQL binary path
+            env = os.environ.copy()
+            # codeql_cli is a symlink to the actual codeql binary
+            # Resolve the symlink to get the real directory
+            try:
+                real_codeql_path = os.path.realpath(code_ql_path)
+                codeql_bin_dir = os.path.dirname(real_codeql_path)
+            except:
+                codeql_bin_dir = os.path.dirname(os.path.abspath(code_ql_path))
+
+            # Prepend codeql directory to PATH
+            env["PATH"] = f"{codeql_bin_dir}:{env.get('PATH', '')}"
+
+            # analysis_report expects positional args: database-dir sarif-file output-dir
+            reports_output_dir = os.path.join(output_base, "analysis_reports")
+
+            # Remove existing reports directory if it exists
+            if os.path.exists(reports_output_dir):
+                shutil.rmtree(reports_output_dir)
+
+            result = subprocess.run(
+                [analysis_report_path,
+                 database_path,
+                 sarif_path,
+                 reports_output_dir],
+                capture_output=True, text=True, env=env)
+
+            # Check if reports were generated even if there was an error
+            # (analysis_report writes files before failing on some post-processing)
+            if os.path.exists(reports_output_dir):
+                report_files = glob.glob(os.path.join(reports_output_dir, "*"))
+                if report_files:
+                    print(f"✓ Reports generated successfully")
+                    print(f"\n  Generated Report Files:")
+                    for f in sorted(report_files):
+                        file_size = os.path.getsize(f) / 1024  # KB
+                        print(f"    ✓ {os.path.basename(f)} ({file_size:.1f} KB)")
+                else:
+                    # If no files, raise the error
+                    result.check_returncode()
+            else:
+                result.check_returncode()
+        except subprocess.CalledProcessError as e:
+            print(f"⚠️  Report generation warning: {e.stderr if e.stderr else e}")
+    else:
+        print(" Report generation skipped (analysis_report tool not available)")
 
 
 def main():
-    parser = argparse.ArgumentParser(
-        description="Run CodeQL linting operations"
-    )
-    parser.add_argument(
-        "--codeql_path",
-        help="Path to the CodeQL binary"
-    )
-    parser.add_argument(
-        "--config_path"
-    )
-    parser.add_argument(
-        "--target",
-        nargs="+",
-        help="Bazel target pattern(s) to build during tracing. Multiple targets can be supplied."
-    )
-    parser.add_argument(
-        "--phase",
-        choices=["create-database", "analyze-database", "all"],
-        default="all",
-        help="Phase to run: create-database, analyze-database, or all (default)"
-    )
-    parser.add_argument(
-        "--database-path",
-        help="Path to store/load the CodeQL database. "
-             "Required for create-database and analyze-database phases."
-    )
-    parser.add_argument(
-        "--query-spec",
-        help="Query pack/suite spec for codeql database analyze "
-             "(e.g. codeql/misra-cpp-coding-standards@2.52.0). "
-             "If omitted, uses defaults from codescanning config."
-    )
-    parser.add_argument(
-        "--output-prefix",
-        default="codeql",
-        help="Prefix for output file names (default: codeql)"
-    )
-    parser.add_argument(
-        "--output-dir",
-        help="Directory for output files. If omitted, uses bazel info output_path."
-    )
+    parser = argparse.ArgumentParser(description="Run CodeQL linting operations")
+    parser.add_argument("--codeql_path", help="Path to CodeQL binary")
+    parser.add_argument("--config_path", help="CodeQL config file")
+    parser.add_argument("--analysis_report_path", help="Path to analysis_report binary")
+    parser.add_argument("--target", nargs="+", help="Bazel targets to build")
+    parser.add_argument("--phase", choices=["create-database", "analyze-database", "all"],
+                       default="all", help="Execution phase")
+    parser.add_argument("--database-path", help="CodeQL database path")
+    parser.add_argument("--query-spec", help="CodeQL query spec")
+    parser.add_argument("--output-prefix", default="codeql", help="Output prefix")
+    parser.add_argument("--output-dir", help="Output directory")
 
     args = parser.parse_args()
-    code_ql_path = args.codeql_path
-    config_path = args.config_path
     target = " ".join(args.target) if args.target else ""
     source_root = os.environ["BUILD_WORKING_DIRECTORY"]
 
+    # Make codeql_path absolute
+    codeql_path = os.path.abspath(args.codeql_path) if args.codeql_path else None
+
     if args.phase == "create-database":
-        database_path = args.database_path
-        os.makedirs(os.path.dirname(database_path), exist_ok=True)
-        create_database(code_ql_path, config_path, target, source_root, database_path)
+        os.makedirs(os.path.dirname(args.database_path), exist_ok=True)
+        create_database(codeql_path, args.config_path, target, source_root, args.database_path)
 
     elif args.phase == "analyze-database":
-        database_path = args.database_path
-        analyze_database(code_ql_path, database_path, source_root,
-                         query_spec=args.query_spec, output_prefix=args.output_prefix,
-                         output_dir=args.output_dir)
+        analyze_database(codeql_path, args.database_path, source_root,
+                        analysis_report_path=args.analysis_report_path,
+                        query_spec=args.query_spec, output_prefix=args.output_prefix,
+                        output_dir=args.output_dir)
 
-    elif args.phase == "all":
-        os.makedirs(TMP_PATH_FOR_DATABASES, exist_ok=True)
-        with tempfile.TemporaryDirectory(dir=TMP_PATH_FOR_DATABASES) as database_location:
-            create_database(code_ql_path, config_path, target, source_root, database_location)
-            analyze_database(code_ql_path, database_location, source_root,
-                             query_spec=args.query_spec, output_prefix=args.output_prefix,
-                             output_dir=args.output_dir)
+    else:  # all
+        # Use standard Bazel output directory for database
+        bazel_info = _get_bazel_info(source_root)
+        output_path = args.output_dir or bazel_info.get('output_path')
+        db_loc = os.path.join(output_path, "codeql_database")
 
-
-def _get_action_env_extension(necessary_codeql_environment):
-    action_env_extension = ""
-    for env_var in necessary_codeql_environment:
-        action_env_extension += f" --action_env={env_var}"
-    return action_env_extension
+        create_database(codeql_path, args.config_path, target, source_root, db_loc)
+        analyze_database(codeql_path, db_loc, source_root,
+                       analysis_report_path=args.analysis_report_path,
+                       query_spec=args.query_spec, output_prefix=args.output_prefix,
+                       output_dir=args.output_dir)
+        print(f"  Use this database for future report generation")
 
 
-def _get_merged_environment(necessary_codeql_environment):
+def _get_merged_environment(codeql_env):
     env = os.environ.copy()
-    for env_var in necessary_codeql_environment:
-        if env_var in env:
-            env[env_var] = f"{necessary_codeql_environment[env_var]}:{env[env_var]}"
-        else:
-            env[env_var] = necessary_codeql_environment[env_var]
+    for var in codeql_env:
+        env[var] = f"{codeql_env[var]}:{env.get(var, '')}" if var in env else codeql_env[var]
     return env
 
 
 def _get_bazel_info(source_root):
-    result = subprocess.run(
-        "bazel info",
-        shell=True,
-        cwd=source_root,
-        capture_output=True,
-        text=True,
-        check=True
-    )
-
-    # Parse the output into a dictionary
-    bazel_info = {}
-    for line in result.stdout.strip().split('\n'):
-        if ':' in line:
-            key, value = line.split(':', 1)
-            bazel_info[key.strip()] = value.strip()
-    return bazel_info
+    result = subprocess.run("bazel info", shell=True, cwd=source_root,
+                          capture_output=True, text=True, check=True)
+    return {line.split(':', 1)[0].strip(): line.split(':', 1)[1].strip()
+            for line in result.stdout.strip().split('\n') if ':' in line}
 
 
 if __name__ == "__main__":
     main()
+
+

--- a/quality/static_analysis/codeql_lint.py
+++ b/quality/static_analysis/codeql_lint.py
@@ -41,7 +41,7 @@ def create_database(code_ql_path, config_path, target, source_root, database_pat
     # Build with CodeQL tracing
     timestamp = datetime.datetime.now().strftime('%Y%m%d%H%M%S%f')
     bazel_cmd = f"bazel build --config=codeql --stamp --action_env=CODEQL_SEED_FORCE_RECOMPILE={timestamp}"
-    bazel_cmd += " " + " ".join(f"--action_env={var}" for var in codeql_env)
+    bazel_cmd += _get_action_env_extension(codeql_env)
     subprocess.run(f"{bazel_cmd} {target}", shell=True, env=env, cwd=source_root, check=True)
 
     # Finalize database
@@ -55,12 +55,19 @@ def analyze_database(code_ql_path, database_path, source_root, analysis_report_p
 
     query_arg = f" {query_spec}" if query_spec else ""
     sarif_path = f"{output_base}/{output_prefix}.sarif"
+    csv_path = f"{output_base}/{output_prefix}.csv"
 
     # Run CodeQL analysis (generates SARIF)
     print("\n Running CodeQL analysis...")
     subprocess.run(
         f"{code_ql_path} database analyze -j=0 {database_path}{query_arg} "
         f"--format=sarifv2.1.0 --output={sarif_path}",
+        shell=True, check=True)
+
+    # Generate CSV results
+    subprocess.run(
+        f"{code_ql_path} database analyze -j=0 {database_path}{query_arg} "
+        f"--format=csv --output={csv_path}",
         shell=True, check=True)
 
     # Generate reports using CodeQL analysis_report tool
@@ -165,6 +172,13 @@ def main():
         print(f"  Use this database for future report generation")
 
 
+def _get_action_env_extension(codeql_env):
+    action_env_extension = ""
+    for env_var in codeql_env:
+        action_env_extension += f" --action_env={env_var}"
+    return action_env_extension
+
+
 def _get_merged_environment(codeql_env):
     env = os.environ.copy()
     for var in codeql_env:
@@ -173,10 +187,22 @@ def _get_merged_environment(codeql_env):
 
 
 def _get_bazel_info(source_root):
-    result = subprocess.run("bazel info", shell=True, cwd=source_root,
-                          capture_output=True, text=True, check=True)
-    return {line.split(':', 1)[0].strip(): line.split(':', 1)[1].strip()
-            for line in result.stdout.strip().split('\n') if ':' in line}
+    result = subprocess.run(
+        "bazel info",
+        shell=True,
+        cwd=source_root,
+        capture_output=True,
+        text=True,
+        check=True
+    )
+
+    # Parse the output into a dictionary
+    bazel_info = {}
+    for line in result.stdout.strip().split('\n'):
+        if ':' in line:
+            key, value = line.split(':', 1)
+            bazel_info[key.strip()] = value.strip()
+    return bazel_info
 
 
 if __name__ == "__main__":

--- a/third_party/codeql/codeql_coding_standards.BUILD
+++ b/third_party/codeql/codeql_coding_standards.BUILD
@@ -21,7 +21,16 @@ py_binary(
 
 py_binary(
     name = "analysis_report",
-    srcs = ["scripts/reports/analysis_report.py"],
+    srcs = ["scripts/reports/analysis_report.py",
+            "scripts/reports/diagnostics.py" ,
+            "scripts/reports/deviations.py",
+            "scripts/reports/error.py",
+            "scripts/reports/codeqlvalidation.py",
+            "scripts/reports/utils.py",
+            "scripts/shared/codeql.py",
+            "scripts/reports/guideline_recategorizations.py"],
+    data = ["supported_codeql_configs.json"] + glob(["cpp/**"]),
     deps = [requirement("pyyaml")],
+    imports = ["scripts/reports","scripts/shared"],
     visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
## What this PR does
Adds automatic generation of MISRA C++ compliance reports when CodeQL runs.
Before, CodeQL only produced raw SARIF/CSV results. Now a single command
also creates 4 human-readable markdown reports.

## How it works
Running:

    bazel run //quality/static_analysis:codeql_lint -- --target=//...

automatically:
1. Creates the CodeQL database
2. Generates SARIF and CSV results
3. Generates 4 markdown compliance reports

## Reports generated
- database_integrity_report.md — database health and extracted files
- deviations_report.md — approved MISRA waivers
- guideline_compliance_summary.md — overall Compliant / Non-Compliant result
- guideline_recategorizations_report.md — rule recategorizations

## Files changed
- quality/static_analysis/codeql_lint.py — report generation + persistent database
- quality/static_analysis/BUILD — wires in the analysis_report tool
- third_party/codeql/codeql_coding_standards.BUILD — exposes analysis_report
- quality/quality.md — updated docs

