### PR TITLE
fix(codeql): create output dir before database init in 'all' phase

### DIFF
--- a/quality/static_analysis/codeql_lint.py
+++ b/quality/static_analysis/codeql_lint.py
@@ -162,6 +162,9 @@ def main():
         # Use standard Bazel output directory for database
         bazel_info = _get_bazel_info(source_root)
         output_path = args.output_dir or bazel_info.get('output_path')
+        # Ensure the output directory exists before CodeQL tries to create the
+        # database inside it (codeql database init does not create parents).
+        os.makedirs(output_path, exist_ok=True)
         db_loc = os.path.join(output_path, "codeql_database")
 
         create_database(codeql_path, args.config_path, target, source_root, db_loc)


### PR DESCRIPTION
The nightly CodeQL job runs codeql_lint with --output-dir /tmp/codeql-results (default --phase all). The 'all' branch builds the database path inside that directory but never creates it, so 'codeql database init' fails with:

  Cannot create database at /tmp/codeql-results/codeql_database because
  /tmp/codeql-results does not exist.

Create the output directory before database creation, matching the behavior already present in the 'create-database' phase.