### PR TITLE
mw/com: Add PRIVATE support for semi dynamic data types

### DIFF
--- a/score/mw/com/impl/bindings/lola/proxy.cpp
+++ b/score/mw/com/impl/bindings/lola/proxy.cpp
@@ -600,7 +600,7 @@ bool Proxy::IsEventProvided(const std::string_view event_name) const noexcept
     return event_exists;
 }
 
-score::Result<void> Proxy::SetupMethods()
+score::Result<void> Proxy::SetupMethods(const std::size_t additional_shm_size_bytes)
 {
     auto enabled_method_data = GetMethodIdAndQueueSizeForEnabledMethods();
 
@@ -672,7 +672,7 @@ score::Result<void> Proxy::SetupMethods()
     }
 
     const auto type_erased_element_infos = GetTypeErasedElementInfoForEnabledMethods(enabled_method_data);
-    const auto required_shm_size = CalculateRequiredShmSize(type_erased_element_infos);
+    const auto required_shm_size = CalculateRequiredShmSize(type_erased_element_infos) + additional_shm_size_bytes;
 
     const auto skeleton_shm_permissions = GetSkeletonShmPermissions();
     method_shm_resource_ = memory::shared::SharedMemoryFactory::Create(

--- a/score/mw/com/impl/bindings/lola/proxy.h
+++ b/score/mw/com/impl/bindings/lola/proxy.h
@@ -167,7 +167,16 @@ class Proxy : public ProxyBinding
     /// \return True if the event name exists, otherwise, false
     bool IsEventProvided(const std::string_view event_name) const noexcept override;
 
-    score::Result<void> SetupMethods() override;
+    /// \brief Sets up the shared memory for all the methods of the proxy, notifies the skeleton to open the shared
+    /// memory and perform any setup on skeleton side.
+    ///
+    /// After creating the shared memory, the proxy sends a blocking message which waits for a reply via message passing
+    /// to the skeleton. The skeleton will then open the shared memory and perform any setup on its side. The proxy will
+    /// then wait for an acknowledgement from the skeleton that it has completed its setup.
+    ///
+    /// \return result which contains an error if setup on the proxy or skeleton side failed or if the message passing
+    /// communication with the skeleton failed.
+    score::Result<void> SetupMethods(const std::size_t additional_shm_size_bytes = 0) override;
 
     QualityType GetQualityType() const noexcept;
 
@@ -191,6 +200,14 @@ class Proxy : public ProxyBinding
     /// \brief Clears event and method registration state and marks the proxy ready for destruction.
     /// \note Idempotent: calling it more than once is safe.
     void FinalizeDeinitialize() override;
+
+    memory::shared::ManagedMemoryResource& GetMethodMemoryResource() noexcept
+    {
+        SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(
+            method_shm_resource_ != nullptr,
+            "Proxy::GetControlMemoryResource: Methods managed memory resource pointer is null");
+        return *method_shm_resource_;
+    }
 
   private:
     static std::atomic<ProxyInstanceIdentifier::ProxyInstanceCounter> current_proxy_instance_counter_;

--- a/score/mw/com/impl/bindings/mock_binding/proxy.h
+++ b/score/mw/com/impl/bindings/mock_binding/proxy.h
@@ -17,6 +17,7 @@
 
 #include "score/result/result.h"
 #include <gmock/gmock.h>
+#include <cstddef>
 
 namespace score::mw::com::impl::mock_binding
 {
@@ -29,7 +30,7 @@ class Proxy : public ProxyBinding
     ~Proxy() override = default;
 
     MOCK_METHOD(bool, IsEventProvided, (const std::string_view), (const, noexcept, override));
-    MOCK_METHOD(Result<void>, SetupMethods, (), (override));
+    MOCK_METHOD(Result<void>, SetupMethods, (std::size_t), (override));
     MOCK_METHOD(void, PrepareDeinitialize, (), (override));
     MOCK_METHOD(void, FinalizeDeinitialize, (), (override));
 };
@@ -45,9 +46,9 @@ class ProxyFacade : public ProxyBinding
         return proxy_.IsEventProvided(event_name);
     }
 
-    Result<void> SetupMethods() override
+    Result<void> SetupMethods(std::size_t additional_shm_size_bytes) override
     {
-        return proxy_.SetupMethods();
+        return proxy_.SetupMethods(additional_shm_size_bytes);
     }
 
     void PrepareDeinitialize() override

--- a/score/mw/com/impl/methods/proxy_method.h
+++ b/score/mw/com/impl/methods/proxy_method.h
@@ -13,9 +13,11 @@
 #ifndef SCORE_MW_COM_IMPL_METHODS_PROXY_METHOD_H
 #define SCORE_MW_COM_IMPL_METHODS_PROXY_METHOD_H
 
+#include "score/mw/com/impl/bindings/lola/proxy.h"
 #include "score/mw/com/impl/com_error.h"
 #include "score/mw/com/impl/methods/method_signature_element_ptr.h"
 #include "score/mw/com/impl/methods/proxy_method_binding.h"
+#include "score/mw/com/impl/proxy_binding.h"
 #include "score/mw/com/impl/util/type_erased_storage.h"
 
 #include "score/containers/dynamic_array.h"
@@ -146,12 +148,39 @@ score::Result<std::tuple<impl::MethodInArgPtr<ArgTypes>...>> AllocateImpl(
         std::move(method_in_arg_ptr_tuple));
 }
 
+template <typename T>
+void InitializeArg(void* arg_pointer, ProxyBinding& proxy_binding)
+{
+    if constexpr (std::is_constructible_v<T, const memory::shared::PolymorphicOffsetPtrAllocator<T>&>)
+    {
+        // Temporary workaround to support using types which dynamically allocate memory at runtime (SWP-269486). These
+        // types must take a memory::shared::PolymorphicOffsetPtrAllocator<T> as the only argument in their constructor.
+        // We need to propagate the shared memory resource from the lola binding to the constructor of the type so that
+        // the dynamic memory allocation can be done in shared memory. This is a temporary workaround and is not public.
+        auto* const lola_proxy_binding = dynamic_cast<lola::Proxy*>(&proxy_binding);
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(lola_proxy_binding != nullptr,
+                                                    "ProxyBinding must be of type lola::Proxy, since ArgType is "
+                                                    "constructible with a PolymorphicOffsetPtrAllocator");
+        auto& methods_memory_resource = lola_proxy_binding->GetMethodMemoryResource();
+        memory::shared::PolymorphicOffsetPtrAllocator<T> allocator{methods_memory_resource};
+        score::cpp::ignore = new (arg_pointer) T{allocator};
+    }
+    else
+    {
+        score::cpp::ignore = new (arg_pointer) T{};
+    }
+}
+
 /// \brief Initializes all InArgs by calling the default constructor for each argument.
 ///
 /// This step is important to avoid undefined behaviour (interpreting uninitialized memory) and also to ensure that any
 /// non-trivially constructible types are properly initialized.
+///
+/// \param proxy_binding proxy binding is handed over for an interim solution for support of "semi dynamic" in-arg
+/// data-types. In case the data-type is using a PolymorphicOffsetPtrAllocator, we extract the corresponding
+/// memory_resource from the proxy_binding (SWP-269486).
 template <typename... ArgTypes>
-Result<void> InitializeInArgs(ProxyMethodBinding& binding, const std::size_t queue_size)
+Result<void> InitializeInArgs(ProxyBinding& proxy_binding, ProxyMethodBinding& binding, const std::size_t queue_size)
 {
     for (std::size_t queue_index = 0U; queue_index < queue_size; ++queue_index)
     {
@@ -165,8 +194,8 @@ Result<void> InitializeInArgs(ProxyMethodBinding& binding, const std::size_t que
         // std::apply takes a callable and a tuple. It calls the callable with the arguments from the unpacked tuple.
         // E.g. In this case, it will call the lambda, fn, with: `fn(get<0>(args), get<1>(args), ..., get<n>(args))`
         std::apply(
-            [](typename std::add_pointer<ArgTypes>::type... arg_pointers) {
-                ((score::cpp::ignore = new (arg_pointers) ArgTypes{}), ...);
+            [&proxy_binding](std::add_pointer_t<ArgTypes>... arg_pointers) {
+                (InitializeArg<ArgTypes>(arg_pointers, proxy_binding), ...);
             },
             deserialized_arg_pointers);
     }
@@ -178,7 +207,9 @@ Result<void> InitializeInArgs(ProxyMethodBinding& binding, const std::size_t que
 /// This step is important to avoid undefined behaviour (interpreting uninitialized memory) and also to ensure that any
 /// non-trivially constructible types are properly initialized.
 template <typename ReturnType>
-Result<void> InitializeReturnValue(ProxyMethodBinding& binding, const std::size_t queue_size)
+Result<void> InitializeReturnValue(ProxyBinding& proxy_binding,
+                                   ProxyMethodBinding& binding,
+                                   const std::size_t queue_size)
 {
     for (std::size_t queue_index = 0U; queue_index < queue_size; ++queue_index)
     {
@@ -187,7 +218,7 @@ Result<void> InitializeReturnValue(ProxyMethodBinding& binding, const std::size_
         {
             return Unexpected(allocated_return_value_storage.error());
         }
-        score::cpp::ignore = new (allocated_return_value_storage->data()) ReturnType{};
+        InitializeArg<ReturnType>(allocated_return_value_storage->data(), proxy_binding);
     }
     return {};
 }

--- a/score/mw/com/impl/methods/proxy_method_base.h
+++ b/score/mw/com/impl/methods/proxy_method_base.h
@@ -27,6 +27,8 @@
 namespace score::mw::com::impl
 {
 
+class ProxyBinding;
+
 class ProxyMethodBase : public EnableReferenceToMoveableFromThis<ProxyMethodBase>
 {
   public:
@@ -58,7 +60,7 @@ class ProxyMethodBase : public EnableReferenceToMoveableFromThis<ProxyMethodBase
     /// reinitialized on every method call. This potentially would have performance benefits but more importantly this
     /// allows us to support "semi-dynamic" types in which a type dynamically allocates once on construction and the
     /// constructor is then never called again.
-    virtual Result<void> InitializeInArgsAndReturnValues() = 0;
+    virtual Result<void> InitializeInArgsAndReturnValues(ProxyBinding& proxy_binding) = 0;
 
   protected:
     /// \brief Size of the call-queue is currently fixed to 1! As soon as we are going to support larger call-queues,

--- a/score/mw/com/impl/methods/proxy_method_test.cpp
+++ b/score/mw/com/impl/methods/proxy_method_test.cpp
@@ -101,6 +101,11 @@ class ProxyMethodTestFixture : public ::testing::Test
         return &moved_method->second.get().Get();
     }
 
+    ProxyBinding& GetProxyBinding()
+    {
+        return *ProxyBaseView{proxy_base_}.GetBinding();
+    }
+
     alignas(8) std::array<std::byte, 1024> method_in_args_buffer_{};
     alignas(8) std::array<std::byte, 1024> method_return_type_buffer_{};
     ConfigurationStore config_store_{InstanceSpecifier::Create(std::string{"/my_dummy_instance_specifier"}).value(),
@@ -829,7 +834,7 @@ TEST_F(ProxyMethodWithNonTrivialConstructibleInArgsAndReturnFixture, InitializeI
     this->GivenAValidProxyMethod();
 
     // When calling InitializeInArgsAndReturnValues
-    const auto result = this->unit_->InitializeInArgsAndReturnValues();
+    const auto result = this->unit_->InitializeInArgsAndReturnValues(this->GetProxyBinding());
 
     // Then a valid result is returned
     EXPECT_TRUE(result.has_value());
@@ -858,7 +863,7 @@ TEST_F(ProxyMethodWithNonTrivialConstructibleInArgsAndReturnFixture,
         .WillOnce(Return(MakeUnexpected(ComErrc::kBindingFailure)));
 
     // When calling InitializeInArgsAndReturnValues
-    const auto result = this->unit_->InitializeInArgsAndReturnValues();
+    const auto result = this->unit_->InitializeInArgsAndReturnValues(this->GetProxyBinding());
 
     // Then an error is returned
     ASSERT_FALSE(result.has_value());
@@ -875,7 +880,7 @@ TEST_F(ProxyMethodWithNonTrivialConstructibleInArgsAndReturnFixture,
         .WillOnce(Return(MakeUnexpected(ComErrc::kBindingFailure)));
 
     // When calling InitializeInArgsAndReturnValues
-    const auto result = this->unit_->InitializeInArgsAndReturnValues();
+    const auto result = this->unit_->InitializeInArgsAndReturnValues(this->GetProxyBinding());
 
     // Then an error is returned
     ASSERT_FALSE(result.has_value());
@@ -888,7 +893,7 @@ TEST_F(ProxyMethodWithNonTrivialConstructibleInArgsAndReturnFixture,
     this->GivenAValidProxyMethod();
 
     // When calling InitializeInArgsAndReturnValues
-    this->unit_->InitializeInArgsAndReturnValues();
+    this->unit_->InitializeInArgsAndReturnValues(this->GetProxyBinding());
 
     // Then the zero copy call operator returns a pointer pointing to an initialized object (i.e. the non-trivial
     // default constructor was called, initializing value to NonTriviallyConstructibleType::kInitialValue
@@ -910,7 +915,7 @@ TEST_F(ProxyMethodWithNonTrivialConstructibleInArgsAndReturnFixture,
     this->GivenAValidProxyMethod();
 
     // When calling InitializeInArgsAndReturnValues
-    this->unit_->InitializeInArgsAndReturnValues();
+    this->unit_->InitializeInArgsAndReturnValues(this->GetProxyBinding());
 
     // Then the copy call operator returns a pointer pointing to an initialized object (i.e. the non-trivial
     // default constructor was called, initializing value to NonTriviallyConstructibleType::kInitialValue
@@ -926,7 +931,7 @@ TEST_F(ProxyMethodWithNonTrivialConstructibleInArgsOnlyFixture, InitializeInArgs
     this->GivenAValidProxyMethod();
 
     // When calling InitializeInArgsAndReturnValues
-    this->unit_->InitializeInArgsAndReturnValues();
+    this->unit_->InitializeInArgsAndReturnValues(this->GetProxyBinding());
 
     // Then Allocate returns a pointer pointing to an initialized object (i.e. the non-trivial default constructor was
     // called, initializing value to NonTriviallyConstructibleType::kInitialValue
@@ -952,7 +957,7 @@ TEST_F(ProxyMethodWithNonTrivialConstructibleInArgsOnlyFixture,
         .WillOnce(Return(MakeUnexpected(ComErrc::kBindingFailure)));
 
     // When calling InitializeInArgsAndReturnValues
-    const auto result = this->unit_->InitializeInArgsAndReturnValues();
+    const auto result = this->unit_->InitializeInArgsAndReturnValues(this->GetProxyBinding());
 
     // Then an error is returned
     ASSERT_FALSE(result.has_value());
@@ -965,7 +970,7 @@ TEST_F(ProxyMethodWithNonTrivialConstructibleReturnOnlyFixture,
     this->GivenAValidProxyMethod();
 
     // When calling InitializeInArgsAndReturnValues
-    this->unit_->InitializeInArgsAndReturnValues();
+    this->unit_->InitializeInArgsAndReturnValues(this->GetProxyBinding());
 
     // Then the copy call operator returns a pointer pointing to an initialized object (i.e. the non-trivial
     // default constructor was called, initializing value to NonTriviallyConstructibleType::kInitialValue
@@ -986,7 +991,7 @@ TEST_F(ProxyMethodWithNonTrivialConstructibleReturnOnlyFixture,
         .WillOnce(Return(MakeUnexpected(ComErrc::kBindingFailure)));
 
     // When calling InitializeInArgsAndReturnValues
-    const auto result = this->unit_->InitializeInArgsAndReturnValues();
+    const auto result = this->unit_->InitializeInArgsAndReturnValues(this->GetProxyBinding());
 
     // Then an error is returned
     ASSERT_FALSE(result.has_value());

--- a/score/mw/com/impl/methods/proxy_method_with_in_args.h
+++ b/score/mw/com/impl/methods/proxy_method_with_in_args.h
@@ -85,7 +85,7 @@ class ProxyMethod<void(ArgTypes...)> final : public ProxyMethodBase
     ProxyMethod(ProxyMethod&&) noexcept = default;
     ProxyMethod& operator=(ProxyMethod&&) noexcept = default;
 
-    Result<void> InitializeInArgsAndReturnValues() override;
+    Result<void> InitializeInArgsAndReturnValues(ProxyBinding& proxy_binding) override;
 
     /// \brief Allocates the necessary storage for the argument values and the return value of a method call.
     /// \return On success, a tuple of MethodInArgPtr for each argument type is returned. On failure, an error code is
@@ -158,10 +158,10 @@ score::Result<void> ProxyMethod<void(ArgTypes...)>::operator()(MethodInArgPtr<Ar
 }
 
 template <typename... ArgTypes>
-Result<void> ProxyMethod<void(ArgTypes...)>::InitializeInArgsAndReturnValues()
+Result<void> ProxyMethod<void(ArgTypes...)>::InitializeInArgsAndReturnValues(ProxyBinding& proxy_binding)
 {
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(binding_ != nullptr);
-    const auto init_in_args_result = detail::InitializeInArgs<ArgTypes...>(*binding_, kCallQueueSize);
+    const auto init_in_args_result = detail::InitializeInArgs<ArgTypes...>(proxy_binding, *binding_, kCallQueueSize);
     if (!init_in_args_result.has_value())
     {
         return Unexpected(init_in_args_result.error());

--- a/score/mw/com/impl/methods/proxy_method_with_in_args_and_return.h
+++ b/score/mw/com/impl/methods/proxy_method_with_in_args_and_return.h
@@ -20,6 +20,7 @@
 #include "score/mw/com/impl/methods/proxy_method_binding.h"
 #include "score/mw/com/impl/plumbing/proxy_method_binding_factory.h"
 #include "score/mw/com/impl/proxy_base.h"
+#include "score/mw/com/impl/proxy_binding.h"
 #include "score/mw/com/impl/util/type_erased_storage.h"
 
 #include "score/containers/dynamic_array.h"
@@ -124,7 +125,7 @@ class ProxyMethod<ReturnType(ArgTypes...)> final : public ProxyMethodBase
     ProxyMethod(ProxyMethod&&) noexcept = default;
     ProxyMethod& operator=(ProxyMethod&&) noexcept = default;
 
-    Result<void> InitializeInArgsAndReturnValues() override;
+    Result<void> InitializeInArgsAndReturnValues(ProxyBinding& proxy_binding) override;
 
     /// \brief Allocates the necessary storage for the argument values and the return value of a method call.
     /// \return On success, a tuple of MethodInArgPtr for each argument type is returned. On failure, an error code is
@@ -221,16 +222,16 @@ score::Result<MethodReturnTypePtr<ReturnType>> ProxyMethod<ReturnType(ArgTypes..
 }
 
 template <typename ReturnType, typename... ArgTypes>
-Result<void> ProxyMethod<ReturnType(ArgTypes...)>::InitializeInArgsAndReturnValues()
+Result<void> ProxyMethod<ReturnType(ArgTypes...)>::InitializeInArgsAndReturnValues(ProxyBinding& proxy_binding)
 {
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(binding_ != nullptr);
-    const auto init_in_args_result = detail::InitializeInArgs<ArgTypes...>(*binding_, kCallQueueSize);
+    const auto init_in_args_result = detail::InitializeInArgs<ArgTypes...>(proxy_binding, *binding_, kCallQueueSize);
     if (!init_in_args_result.has_value())
     {
         return Unexpected(init_in_args_result.error());
     }
 
-    const auto init_return_result = detail::InitializeReturnValue<ReturnType>(*binding_, kCallQueueSize);
+    const auto init_return_result = detail::InitializeReturnValue<ReturnType>(proxy_binding, *binding_, kCallQueueSize);
     if (!init_return_result.has_value())
     {
         return Unexpected(init_return_result.error());

--- a/score/mw/com/impl/methods/proxy_method_with_return_type.h
+++ b/score/mw/com/impl/methods/proxy_method_with_return_type.h
@@ -115,7 +115,7 @@ class ProxyMethod<ReturnType()> final : public ProxyMethodBase
     ProxyMethod(ProxyMethod&&) noexcept = default;
     ProxyMethod& operator=(ProxyMethod&&) noexcept = default;
 
-    Result<void> InitializeInArgsAndReturnValues() override;
+    Result<void> InitializeInArgsAndReturnValues(ProxyBinding& proxy_binding) override;
 
     /// \brief This is the call-operator of ProxyMethod with no arguments for a non-void ReturnType.
     score::Result<MethodReturnTypePtr<ReturnType>> operator()();
@@ -172,10 +172,10 @@ score::Result<MethodReturnTypePtr<ReturnType>> ProxyMethod<ReturnType()>::operat
 }
 
 template <typename ReturnType>
-Result<void> ProxyMethod<ReturnType()>::InitializeInArgsAndReturnValues()
+Result<void> ProxyMethod<ReturnType()>::InitializeInArgsAndReturnValues(ProxyBinding& proxy_binding)
 {
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(binding_ != nullptr);
-    const auto init_return_result = detail::InitializeReturnValue<ReturnType>(*binding_, kCallQueueSize);
+    const auto init_return_result = detail::InitializeReturnValue<ReturnType>(proxy_binding, *binding_, kCallQueueSize);
     if (!init_return_result.has_value())
     {
         return Unexpected(init_return_result.error());

--- a/score/mw/com/impl/methods/proxy_method_without_in_args_or_return.h
+++ b/score/mw/com/impl/methods/proxy_method_without_in_args_or_return.h
@@ -85,7 +85,7 @@ class ProxyMethod<void()> final : public ProxyMethodBase
     ProxyMethod(ProxyMethod&&) noexcept = default;
     ProxyMethod& operator=(ProxyMethod&&) noexcept = default;
 
-    Result<void> InitializeInArgsAndReturnValues() override
+    Result<void> InitializeInArgsAndReturnValues(ProxyBinding&) override
     {
         return {};
     }

--- a/score/mw/com/impl/proxy_base.cpp
+++ b/score/mw/com/impl/proxy_base.cpp
@@ -101,9 +101,9 @@ score::Result<void> ProxyBase::StopFindService(const FindServiceHandle handle) n
     return stop_find_service_result;
 }
 
-Result<void> ProxyBase::SetupMethods()
+Result<void> ProxyBase::SetupMethods(const std::size_t additional_shm_size_bytes)
 {
-    const auto result = proxy_binding_->SetupMethods();
+    const auto result = proxy_binding_->SetupMethods(additional_shm_size_bytes);
     if (!result.has_value())
     {
         return MakeUnexpected<void>(result.error());
@@ -112,7 +112,7 @@ Result<void> ProxyBase::SetupMethods()
     for (auto& method_key_value_pair : methods_)
     {
         auto& method = method_key_value_pair.second.get().Get();
-        const auto method_init_result = method.InitializeInArgsAndReturnValues();
+        const auto method_init_result = method.InitializeInArgsAndReturnValues(*proxy_binding_);
         if (!method_init_result.has_value())
         {
             return MakeUnexpected<void>(method_init_result.error());

--- a/score/mw/com/impl/proxy_base.h
+++ b/score/mw/com/impl/proxy_base.h
@@ -146,7 +146,18 @@ class ProxyBase
         return is_proxy_binding_valid && are_service_element_bindings_valid_;
     }
 
-    Result<void> SetupMethods();
+    /// \brief Dispatches to the binding for any binding specific setup and then initializes all method InArgs and
+    /// Return values.
+    ///
+    /// The initialization of the InArgs and Return values is done on the binding independent level since the binding
+    /// level is type erased. The values are initialized once on startup and then reused (i.e. we never re-initialize
+    /// the values when calling a method).
+    ///
+    /// \param additional_shm_size_bytes Additional shared memory size in bytes to be allocated for methods in addition
+    /// to the size calculated for the size of the method in args and return values. This is a temporary workaround
+    /// added to allow using types which dynamically allocate memory once at runtime. This is not currently public and
+    /// should not be used by user applications. (SWP-269486)
+    Result<void> SetupMethods(std::size_t additional_shm_size_bytes);
 
     // Suppress "AUTOSAR C++14 M11-0-1" rule findings. This rule states: "Member data in non-POD class types shall
     // be private.". We need these data elements to exchange this information between the ProxyBase and the

--- a/score/mw/com/impl/proxy_base_test.cpp
+++ b/score/mw/com/impl/proxy_base_test.cpp
@@ -563,7 +563,7 @@ class DummyProxyMethod : public ProxyMethodBase
 {
   public:
     using ProxyMethodBase::ProxyMethodBase;
-    Result<void> InitializeInArgsAndReturnValues() override
+    Result<void> InitializeInArgsAndReturnValues(ProxyBinding&) override
     {
         return {};
     }

--- a/score/mw/com/impl/proxy_binding.h
+++ b/score/mw/com/impl/proxy_binding.h
@@ -17,6 +17,7 @@
 
 #include "score/result/result.h"
 
+#include <cstddef>
 #include <string_view>
 #include <vector>
 
@@ -54,7 +55,13 @@ class ProxyBinding
     /// \return True if the event name exists, otherwise, false
     virtual bool IsEventProvided(const std::string_view event_name) const noexcept = 0;
 
-    virtual Result<void> SetupMethods() = 0;
+    /// \brief Performs any binding specific setup required.
+    ///
+    /// \param additional_shm_size_bytes Additional shared memory size in bytes to be allocated for methods in addition
+    /// to the size calculated for the size of the method in args and return values. This is a temporary workaround
+    /// added to allow using types which dynamically allocate memory once at runtime. This is not currently public and
+    /// should not be used by user applications. (SWP-269486)
+    virtual Result<void> SetupMethods(std::size_t additional_shm_size_bytes) = 0;
 
     /// \brief Contains all cleanup logic for the binding that needs to be executed before any of the service elements
     /// are deinitialized (Called by ProxyBase::Deinitialize).

--- a/score/mw/com/impl/proxy_binding_test.cpp
+++ b/score/mw/com/impl/proxy_binding_test.cpp
@@ -14,6 +14,7 @@
 
 #include <gtest/gtest.h>
 
+#include <cstddef>
 #include <string_view>
 #include <type_traits>
 
@@ -29,7 +30,7 @@ class MyProxy final : public ProxyBinding
     {
         return true;
     }
-    Result<void> SetupMethods() override
+    Result<void> SetupMethods(std::size_t) override
     {
         return {};
     }

--- a/score/mw/com/impl/traits.h
+++ b/score/mw/com/impl/traits.h
@@ -39,6 +39,7 @@
 
 #include <score/utility.hpp>
 
+#include <cstddef>
 #include <exception>
 #include <optional>
 #include <queue>
@@ -86,6 +87,9 @@ class SkeletonWrapperClassTestView;
 
 template <typename T>
 class ProxyWrapperClassTestView;
+
+template <typename T>
+class ProxyWithSemiDynamicMethodFactory;
 
 /// The main idea of these traits are to ease the interface creation for a user. It reduces the necessary generated code
 /// to a bare minimum.
@@ -322,6 +326,8 @@ class ProxyWrapperClass : public Interface<Trait>
     // coverity[autosar_cpp14_a11_3_1_violation]
     friend class ProxyWrapperClassTestView<ProxyWrapperClass>;
 
+    friend class ProxyWithSemiDynamicMethodFactory<ProxyWrapperClass>;
+
   public:
     /// \api
     /// \brief Create a proxy instance from a service handle.
@@ -331,31 +337,7 @@ class ProxyWrapperClass : public Interface<Trait>
     /// \return On success, returns a ProxyWrapperClass instance. On failure, returns an error code.
     static Result<ProxyWrapperClass> Create(const HandleType instance_handle) noexcept
     {
-        if (creation_results_.has_value())
-        {
-            return detail::ExtractCreationResultFrom(instance_handle, creation_results_.value());
-        }
-
-        auto proxy_binding = ProxyBindingFactory::Create(instance_handle);
-
-        ProxyWrapperClass proxy_wrapper(instance_handle, std::move(proxy_binding));
-
-        if (!proxy_wrapper.AreBindingsValid())
-        {
-            ::score::mw::log::LogError("lola")
-                << "Could not create ProxyWrapperClass as Proxy binding or service element "
-                   "bindings could not be created.";
-            return MakeUnexpected(ComErrc::kBindingFailure);
-        }
-
-        const auto setup_methods_result = proxy_wrapper.SetupMethods();
-        if (!(setup_methods_result.has_value()))
-        {
-            ::score::mw::log::LogError("lola") << "Could not setup methods on Proxy side";
-            return MakeUnexpected(ComErrc::kBindingFailure);
-        }
-
-        return proxy_wrapper;
+        return Create(instance_handle, 0U);
     }
 
     ~ProxyWrapperClass()
@@ -391,6 +373,40 @@ class ProxyWrapperClass : public Interface<Trait>
     }
 
   private:
+    /// \brief Create a proxy instance from a service handle with additional shared memory size for methods.
+    ///
+    /// This is a temporary workaround added to allow using types which dynamically allocate memory once at runtime.
+    /// This is not currently public and should not be used by user applications. (SWP-269486). Can be accessed with
+    /// ProxyWithSemiDynamicMethodFactory::Create.
+    static Result<ProxyWrapperClass> Create(const HandleType instance_handle,
+                                            std::size_t additional_shm_size_bytes) noexcept
+    {
+        if (creation_results_.has_value())
+        {
+            return detail::ExtractCreationResultFrom(instance_handle, creation_results_.value());
+        }
+
+        auto proxy_binding = ProxyBindingFactory::Create(instance_handle);
+
+        ProxyWrapperClass proxy_wrapper(instance_handle, std::move(proxy_binding));
+
+        if (!proxy_wrapper.AreBindingsValid())
+        {
+            ::score::mw::log::LogError("lola")
+                << "Could not create ProxyWrapperClass as Proxy binding or service element "
+                   "bindings could not be created.";
+            return MakeUnexpected(ComErrc::kBindingFailure);
+        }
+
+        const auto setup_methods_result = proxy_wrapper.SetupMethods(additional_shm_size_bytes);
+        if (!(setup_methods_result.has_value()))
+        {
+            ::score::mw::log::LogError("lola") << "Could not setup methods on Proxy side";
+            return MakeUnexpected(ComErrc::kBindingFailure);
+        }
+
+        return proxy_wrapper;
+    }
     /// \brief Constructs ProxyWrapperClass
     explicit ProxyWrapperClass(HandleType instance_handle, std::unique_ptr<ProxyBinding> proxy_binding)
         : Interface<Trait>{std::move(proxy_binding), std::move(instance_handle)}, is_proxy_owner_{true}
@@ -431,6 +447,22 @@ using AsProxy = ProxyWrapperClass<T, ProxyTrait>;
 /// \brief Interpret an interface that follows our traits as skeleton (see description above)
 template <template <class> class T>
 using AsSkeleton = SkeletonWrapperClass<T, SkeletonTrait>;
+
+/// \brief Factory class to create a proxy with semi-dynamic methods for use _ONLY_ in the context of (SWP-269486).
+///
+/// This is a temporary workaround added to allow using types which dynamically allocate memory once at runtime.
+/// This is not currently public and should not be used by user applications. (SWP-269486). We make no guarantees about
+/// the stability of this API and it may be removed in future versions so should not be used. The aou
+/// "NoApisFromImplementationNamespace" disallows using this API.
+template <typename T>
+class ProxyWithSemiDynamicMethodFactory
+{
+  public:
+    static Result<T> Create(const HandleType instance_handle, std::size_t additional_shm_size_bytes) noexcept
+    {
+        return T::Create(instance_handle, additional_shm_size_bytes);
+    }
+};
 
 }  // namespace score::mw::com::impl
 

--- a/score/mw/com/impl/traits_test.cpp
+++ b/score/mw/com/impl/traits_test.cpp
@@ -140,7 +140,7 @@ class ProxyCreationFixture : public ::testing::Test
             .WillByDefault(Return(ByMove(std::move(proxy_method_binding_mock_ptr))));
 
         // By default that the proxy_binding can successfully call SetupMethods
-        ON_CALL(proxy_binding_mock_, SetupMethods()).WillByDefault(Return(score::Result<void>{}));
+        ON_CALL(proxy_binding_mock_, SetupMethods(_)).WillByDefault(Return(score::Result<void>{}));
 
         // By default the runtime configuration resolves instance identifiers
         resolved_instance_identifiers_.push_back(identifier_with_valid_binding_);
@@ -304,7 +304,7 @@ TEST_F(GeneratedProxyCreationTestFixture, ReturnErrorWhenCreatingProxyWithNoProx
 TEST_F(GeneratedProxyCreationTestFixture, ReturnErrorWhenCreatingProxyProxyBindingCanNotSuccessfullySetUpMethods)
 {
     // Expecting that the Create call on the ProxyMethodBindingFactory returns an invalid binding for the method.
-    EXPECT_CALL(proxy_binding_mock_, SetupMethods()).WillOnce(Return(MakeUnexpected(ComErrc::kBindingFailure)));
+    EXPECT_CALL(proxy_binding_mock_, SetupMethods(_)).WillOnce(Return(MakeUnexpected(ComErrc::kBindingFailure)));
 
     // When constructing a proxy with a handle
     const auto unit = MyProxy::Create(std::move(handle_));

--- a/score/mw/com/test/methods/semi_dynamic_methods/BUILD
+++ b/score/mw/com/test/methods/semi_dynamic_methods/BUILD
@@ -1,0 +1,175 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library", "cc_test")
+load("@score_baselibs//score/language/safecpp:toolchain_features.bzl", "COMPILER_WARNING_FEATURES")
+load("//bazel/tools:json_schema_validator.bzl", "validate_json_schema_test")
+load("//quality/unit_testing:unit_testing.bzl", "cc_unit_test")
+load("//score/mw/com/test:pkg_application.bzl", "pkg_application")
+
+validate_json_schema_test(
+    name = "validate_config_schema",
+    json = "config/mw_com_config.json",
+    schema = "//score/mw/com:config_schema",
+    tags = ["lint"],
+)
+
+cc_library(
+    name = "runtime_sized_array",
+    srcs = ["runtime_sized_array.cpp"],
+    hdrs = ["runtime_sized_array.h"],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        "@score_baselibs//score/language/futurecpp",
+    ],
+)
+
+cc_library(
+    name = "semi_dynamic_method_datatype",
+    srcs = ["semi_dynamic_method_datatype.cpp"],
+    hdrs = ["semi_dynamic_method_datatype.h"],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        ":runtime_sized_array",
+        "//score/mw/com",
+    ],
+)
+
+cc_library(
+    name = "consumer",
+    srcs = ["consumer.cpp"],
+    hdrs = ["consumer.h"],
+    data = ["config/mw_com_config.json"],
+    features = COMPILER_WARNING_FEATURES,
+    implementation_deps = [
+        ":semi_dynamic_method_datatype",
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:fail_test",
+        "//score/mw/com/test/methods/methods_test_resources:process_synchronizer",
+    ],
+)
+
+cc_library(
+    name = "provider",
+    srcs = ["provider.cpp"],
+    hdrs = ["provider.h"],
+    data = ["config/mw_com_config.json"],
+    features = COMPILER_WARNING_FEATURES,
+    implementation_deps = [
+        ":semi_dynamic_method_datatype",
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:fail_test",
+        "//score/mw/com/test/common_test_resources:skeleton_container",
+        "//score/mw/com/test/methods/methods_test_resources:process_synchronizer",
+    ],
+    deps = [
+        "@score_baselibs//score/language/futurecpp",
+    ],
+)
+
+pkg_application(
+    name = "main_provider-pkg",
+    app_name = "MainProviderApp",
+    bin = [":main_provider"],
+    etc = [
+        "config/mw_com_config.json",
+        "config/logging.json",
+    ],
+    visibility = [
+        "//score/mw/com/test/methods/semi_dynamic_methods:__subpackages__",
+    ],
+)
+
+cc_binary(
+    name = "main_provider",
+    srcs = ["main_provider.cpp"],
+    data = ["config/mw_com_config.json"],
+    features = COMPILER_WARNING_FEATURES + [
+        "aborts_upon_exception",
+    ],
+    deps = [
+        ":provider",
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:assert_handler",
+        "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
+    ],
+)
+
+cc_binary(
+    name = "main_consumer",
+    srcs = ["main_consumer.cpp"],
+    data = ["config/mw_com_config.json"],
+    features = COMPILER_WARNING_FEATURES + [
+        "aborts_upon_exception",
+    ],
+    deps = [
+        ":consumer",
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:assert_handler",
+    ],
+)
+
+cc_binary(
+    name = "main_consumer_and_provider",
+    srcs = ["main_consumer_and_provider.cpp"],
+    data = ["config/mw_com_config.json"],
+    features = COMPILER_WARNING_FEATURES + [
+        "aborts_upon_exception",
+    ],
+    deps = [
+        ":consumer",
+        ":provider",
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:assert_handler",
+        "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
+    ],
+)
+
+pkg_application(
+    name = "main_consumer-pkg",
+    app_name = "MainConsumerApp",
+    bin = [":main_consumer"],
+    etc = [
+        "config/mw_com_config.json",
+        "config/logging.json",
+    ],
+    visibility = [
+        "//score/mw/com/test/methods/semi_dynamic_methods:__subpackages__",
+    ],
+)
+
+pkg_application(
+    name = "main_consumer_and_provider-pkg",
+    app_name = "MainConsumerAndProviderApp",
+    bin = [":main_consumer_and_provider"],
+    etc = [
+        "config/mw_com_config.json",
+        "config/logging.json",
+    ],
+    visibility = [
+        "//score/mw/com/test/methods/semi_dynamic_methods:__subpackages__",
+    ],
+)
+
+cc_unit_test(
+    name = "runtime_sized_array_test",
+    srcs = ["runtime_sized_array_test.cpp"],
+    features = COMPILER_WARNING_FEATURES + [
+        # These tests catch exceptions instead of using gtest EXPECT_DEATH so we disable aborts_upon_exception.
+        "-aborts_upon_exception",
+    ],
+    deps = [
+        ":runtime_sized_array",
+        "@score_baselibs//score/language/futurecpp:futurecpp_test_support",
+    ],
+)

--- a/score/mw/com/test/methods/semi_dynamic_methods/config/logging.json
+++ b/score/mw/com/test/methods/semi_dynamic_methods/config/logging.json
@@ -1,0 +1,7 @@
+{
+  "appId": "MSDM",
+  "appDesc": "semi_dynamic_methods",
+  "logLevel": "kDebug",
+  "logLevelThresholdConsole": "kDebug",
+  "logMode": "kRemote|kConsole"
+}

--- a/score/mw/com/test/methods/semi_dynamic_methods/config/mw_com_config.json
+++ b/score/mw/com/test/methods/semi_dynamic_methods/config/mw_com_config.json
@@ -1,0 +1,65 @@
+{
+  "serviceTypes": [
+    {
+      "serviceTypeName": "/test/methods/semi_dynamic_methods/TestMethods",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "bindings": [
+        {
+          "binding": "SHM",
+          "serviceId": 1000,
+          "methods": [
+            {
+              "methodName": "with_in_args_and_return",
+              "methodId": 1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "serviceInstances": [
+    {
+      "instanceSpecifier": "test/methods/semi_dynamic_methods/TestMethods",
+      "serviceTypeName": "/test/methods/semi_dynamic_methods/TestMethods",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "instances": [
+        {
+          "instanceId": 1,
+          "asil-level": "QM",
+          "binding": "SHM",
+          "methods": [
+            {
+              "methodName": "with_in_args_and_return",
+              "queueSize": 1
+            }
+          ],
+          "allowedConsumer": {
+            "QM": [
+              0
+            ],
+            "B": [
+              0
+            ]
+          },
+          "allowedProvider": {
+            "QM": [
+              0
+            ],
+            "B": [
+              0
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "global": {
+    "asil-level": "QM"
+  }
+}

--- a/score/mw/com/test/methods/semi_dynamic_methods/consumer.cpp
+++ b/score/mw/com/test/methods/semi_dynamic_methods/consumer.cpp
@@ -1,0 +1,239 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/test/methods/semi_dynamic_methods/consumer.h"
+
+#include "score/mw/com/test/common_test_resources/fail_test.h"
+#include "score/mw/com/test/methods/methods_test_resources/process_synchronizer.h"
+#include "score/mw/com/test/methods/semi_dynamic_methods/runtime_sized_array.h"
+#include "score/mw/com/test/methods/semi_dynamic_methods/semi_dynamic_method_datatype.h"
+#include "score/mw/com/types.h"
+
+#include <score/stop_token.hpp>
+
+#include <unistd.h>
+#include <cstdlib>
+#include <iostream>
+
+namespace score::mw::com::test
+{
+namespace
+{
+
+using ArrayValueType = SemiDynamicMethodProxy::ArrayValueType;
+
+const std::string kInterprocessNotificationShmPath{"/semi_dynamic_methods_test_interprocess_notification"};
+
+const InstanceSpecifier kInstanceSpecifier =
+    InstanceSpecifier::Create(std::string{"test/methods/semi_dynamic_methods/TestMethods"}).value();
+
+constexpr std::size_t kNumberOfRuntimeSizedArrayElements = 10U;
+constexpr std::size_t kNumberOfMethodCalls = 10U;
+
+// Additional required shared memory is the number of elements in the runtime sized array multiplied by the size of each
+// element (ArrayValueType). The factor of 2 is because we allocate once for the in arg and once for the return value.
+constexpr std::size_t kAdditionalShmSizeBytes = 2 * kNumberOfRuntimeSizedArrayElements * sizeof(ArrayValueType);
+
+template <typename SemiDynamicProxy>
+class SemiDynamicProxyContainer
+{
+  public:
+    void CreateProxy(InstanceSpecifier instance_specifier,
+                     std::size_t additional_shm_size_bytes,
+                     const std::string& failure_message_prefix);
+
+    SemiDynamicProxy& GetProxy()
+    {
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(proxy_.has_value(),
+                                                    "Proxy was not successfully created! Cannot get it!");
+        return *proxy_;
+    }
+
+  private:
+    std::optional<typename SemiDynamicProxy::HandleType> handle_{};
+    std::mutex proxy_creation_mutex_{};
+    std::condition_variable proxy_creation_condition_variable_{};
+
+    std::optional<SemiDynamicProxy> proxy_{};
+};
+
+template <typename Proxy>
+void SemiDynamicProxyContainer<Proxy>::CreateProxy(InstanceSpecifier instance_specifier,
+                                                   std::size_t additional_shm_size_bytes,
+                                                   const std::string& failure_message_prefix)
+{
+    bool callback_called{false};
+    auto find_service_callback = [this, &callback_called](auto service_handle_container,
+                                                          auto find_service_handle) mutable noexcept {
+        std::cout << "Consumer: find service handler called" << std::endl;
+        std::lock_guard lock{proxy_creation_mutex_};
+        if (service_handle_container.size() != 1)
+        {
+            std::cerr << "Consumer: service handle container should contain 1 handle but contains: "
+                      << service_handle_container.size() << std::endl;
+            callback_called = true;
+            proxy_creation_condition_variable_.notify_all();
+            return;
+        }
+        score::cpp::ignore = handle_.emplace(service_handle_container[0]);
+        score::cpp::ignore = Proxy::StopFindService(find_service_handle);
+        callback_called = true;
+        proxy_creation_condition_variable_.notify_all();
+    };
+
+    auto start_find_service_result = Proxy::StartFindService(find_service_callback, instance_specifier);
+    if (!start_find_service_result.has_value())
+    {
+        FailTest(failure_message_prefix, " Consumer: StartFindService() failed: ", start_find_service_result.error());
+    }
+    std::cout << "Consumer: StartFindService called" << std::endl;
+
+    // Wait for the find service handler to be called (with timeout to prevent indefinite blocking)
+    constexpr auto kServiceDiscoveryTimeout = std::chrono::seconds(10);
+    std::unique_lock proxy_creation_lock{proxy_creation_mutex_};
+    const bool service_found =
+        proxy_creation_condition_variable_.wait_for(proxy_creation_lock, kServiceDiscoveryTimeout, [&callback_called] {
+            return callback_called;
+        });
+    if (!service_found || !handle_.has_value())
+    {
+        FailTest(failure_message_prefix, " Consumer: StartFindService() failed to get handle");
+    }
+
+    auto proxy_result = impl::ProxyWithSemiDynamicMethodFactory<Proxy>::Create(*handle_, additional_shm_size_bytes);
+    proxy_creation_lock.unlock();
+    if (!proxy_result.has_value())
+    {
+        FailTest(failure_message_prefix, " Consumer: Unable to construct proxy: ", proxy_result.error());
+    }
+    score::cpp::ignore = proxy_.emplace(std::move(proxy_result).value());
+
+    std::cout << "Consumer: Proxy created successfully" << std::endl;
+}
+
+void CallMethodZeroCopyWithDynamicDataTypeReserve(SemiDynamicMethodProxy& proxy)
+{
+    auto allocated_args_result = proxy.with_in_args_and_return.Allocate();
+    if (!allocated_args_result.has_value())
+    {
+        FailTest("Consumer: Could not allocate method args: ", allocated_args_result.error());
+    }
+    auto allocated_args = std::move(allocated_args_result).value();
+    auto& [runtime_sized_array_in_arg_ptr] = allocated_args;
+
+    runtime_sized_array_in_arg_ptr->ReserveOnce(kNumberOfRuntimeSizedArrayElements);
+    for (std::size_t i = 0U; i < kNumberOfRuntimeSizedArrayElements; ++i)
+    {
+        runtime_sized_array_in_arg_ptr->emplace_back(static_cast<ArrayValueType>(i));
+    }
+
+    auto method_return_result = proxy.with_in_args_and_return(std::move(runtime_sized_array_in_arg_ptr));
+    if (!(method_return_result.has_value()))
+    {
+        FailTest("Consumer: zero-copy call failed: ", method_return_result.error());
+    }
+    const auto& actual_return_value = *(method_return_result.value());
+    for (std::size_t i = 0U; i < kNumberOfRuntimeSizedArrayElements; ++i)
+    {
+        const auto expected_value = static_cast<ArrayValueType>(i * 2U);
+        if (actual_return_value.at(i) != expected_value)
+        {
+            FailTest("Consumer: zero-copy expected ",
+                     static_cast<int>(expected_value),
+                     " but got ",
+                     static_cast<int>(actual_return_value.at(i)));
+        }
+    }
+}
+
+void CallMethodZeroCopyWithoutDynamicDataTypeReserve(SemiDynamicMethodProxy& proxy, const std::size_t iteration)
+{
+    auto allocated_args_result = proxy.with_in_args_and_return.Allocate();
+    if (!allocated_args_result.has_value())
+    {
+        FailTest("Consumer: Could not allocate method args: ", allocated_args_result.error());
+    }
+    auto allocated_args = std::move(allocated_args_result).value();
+    auto& [runtime_sized_array_in_arg_ptr] = allocated_args;
+
+    // The in arg was already reserved in the previous call, so we can just fill it with new values without reserving
+    // again.
+    for (std::size_t i = 0U; i < kNumberOfRuntimeSizedArrayElements; ++i)
+    {
+        runtime_sized_array_in_arg_ptr->at(i) = static_cast<std::uint32_t>(i * iteration);
+    }
+
+    auto method_return_result = proxy.with_in_args_and_return(std::move(runtime_sized_array_in_arg_ptr));
+    if (!(method_return_result.has_value()))
+    {
+        FailTest("Consumer: zero-copy call failed: ", method_return_result.error());
+    }
+    const auto& actual_return_value = *(method_return_result.value());
+    for (std::size_t i = 0U; i < kNumberOfRuntimeSizedArrayElements; ++i)
+    {
+        const auto expected_value = static_cast<ArrayValueType>(i * 2U * iteration);
+        if (actual_return_value.at(i) != expected_value)
+        {
+            FailTest("Consumer: zero-copy expected ",
+                     static_cast<int>(expected_value),
+                     " but got ",
+                     static_cast<int>(actual_return_value.at(i)));
+        }
+        std::cout << "Consumer: zero-copy returned correct result for iteration " << iteration << ": "
+                  << static_cast<int>(actual_return_value.at(i)) << std::endl;
+    }
+}
+
+}  // namespace
+
+void run_consumer()
+{
+    auto process_synchronizer_result = ProcessSynchronizer::Create(kInterprocessNotificationShmPath);
+    if (!(process_synchronizer_result.has_value()))
+    {
+        FailTest("Methods semi_dynamic_methods_test consumer failed: Could not create ProcessSynchronizer");
+    }
+
+    // Set an exit function to notify the provider in case of failure in calls to FailTest, so that it does not wait
+    // indefinitely for the consumer to finish. Will also be called when the guard goes out of scope at the end of this
+    // function.
+    ExitFunctionGuard process_synchronizer_guard{[&process_synchronizer_result]() {
+        process_synchronizer_result->Notify();
+    }};
+
+    SemiDynamicProxyContainer<SemiDynamicMethodProxy> proxy_container{};
+
+    // Step 1. Find service and create proxy
+    std::cout << "\nConsumer: Step 1 - Find service and create proxy" << std::endl;
+    proxy_container.CreateProxy(kInstanceSpecifier, kAdditionalShmSizeBytes, "semi_dynamic_methods_test");
+    auto& proxy = proxy_container.GetProxy();
+
+    // Step 2. Call zero copy method - cannot use copy api since RuntimeSizedArray is not copyable
+    std::cout << "\nConsumer: Step 2 - Call zero copy method" << std::endl;
+    CallMethodZeroCopyWithDynamicDataTypeReserve(proxy);
+
+    // Step 3. Call zero copy method again (should not reallocate - if it does, it will crash since the memory resource
+    // will not have any available memory)
+    static_assert(kNumberOfMethodCalls > 1,
+                  "kNumberOfMethodCalls must be greater than 1 so that the method is re-called");
+    for (auto i = 0U; i < kNumberOfMethodCalls - 1U; ++i)
+    {
+        std::cout << "Consumer: Step 3 - Call zero copy method again, iteration " << i << std::endl;
+        CallMethodZeroCopyWithoutDynamicDataTypeReserve(proxy, i);
+    }
+
+    // Step 4. Notify provider that consumer is done
+    std::cout << "\nConsumer: Step 4 - Notify provider that consumer is done" << std::endl;
+    process_synchronizer_result->Notify();
+}
+
+}  // namespace score::mw::com::test

--- a/score/mw/com/test/methods/semi_dynamic_methods/consumer.h
+++ b/score/mw/com/test/methods/semi_dynamic_methods/consumer.h
@@ -1,0 +1,23 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_TEST_METHODS_SEMI_DYNAMIC_METHODS_CONSUMER_H
+#define SCORE_MW_COM_TEST_METHODS_SEMI_DYNAMIC_METHODS_CONSUMER_H
+
+namespace score::mw::com::test
+{
+
+void run_consumer();
+
+}  // namespace score::mw::com::test
+
+#endif  // SCORE_MW_COM_TEST_METHODS_SEMI_DYNAMIC_METHODS_CONSUMER_H

--- a/score/mw/com/test/methods/semi_dynamic_methods/integration_test/BUILD
+++ b/score/mw/com/test/methods/semi_dynamic_methods/integration_test/BUILD
@@ -1,0 +1,35 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
+load("//quality/integration_testing:integration_testing.bzl", "integration_test")
+
+integration_test(
+    name = "semi_dynamic_methods_same_process_test",
+    srcs = ["semi_dynamic_methods_same_process_test.py"],
+    filesystem = "//score/mw/com/test/methods/semi_dynamic_methods:main_consumer_and_provider-pkg",
+)
+
+pkg_filegroup(
+    name = "different_processes_filesystem",
+    srcs = [
+        "//score/mw/com/test/methods/semi_dynamic_methods:main_consumer-pkg",
+        "//score/mw/com/test/methods/semi_dynamic_methods:main_provider-pkg",
+    ],
+)
+
+integration_test(
+    name = "semi_dynamic_methods_different_processes_test",
+    srcs = ["semi_dynamic_methods_different_processes_test.py"],
+    filesystem = ":different_processes_filesystem",
+)

--- a/score/mw/com/test/methods/semi_dynamic_methods/integration_test/semi_dynamic_methods_different_processes_test.py
+++ b/score/mw/com/test/methods/semi_dynamic_methods/integration_test/semi_dynamic_methods_different_processes_test.py
@@ -1,0 +1,31 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+
+def provider(target, **kwargs):
+    args = []
+    return target.wrap_exec("bin/main_provider", args, cwd="/opt/MainProviderApp", wait_on_exit=True, **kwargs)
+
+
+def consumer(target, **kwargs):
+    args = []
+    return target.wrap_exec("bin/main_consumer", args, cwd="/opt/MainConsumerApp", wait_on_exit=True, **kwargs)
+
+
+def test_semi_dynamic_methods_different_processes_test(target):
+    """Test semi-dynamic methods with provider and consumer in different processes.
+
+    The provider process offers the service and the consumer process connects to it.
+    """
+    with provider(target), consumer(target):
+        pass

--- a/score/mw/com/test/methods/semi_dynamic_methods/integration_test/semi_dynamic_methods_same_process_test.py
+++ b/score/mw/com/test/methods/semi_dynamic_methods/integration_test/semi_dynamic_methods_same_process_test.py
@@ -1,0 +1,29 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+
+def consumer_and_provider(target, **kwargs):
+    args = []
+    return target.wrap_exec(
+        "bin/main_consumer_and_provider", args, cwd="/opt/MainConsumerAndProviderApp", wait_on_exit=True, **kwargs
+    )
+
+
+def test_semi_dynamic_methods_same_process_test(target):
+    """Test semi-dynamic methods with provider and consumer in the same process.
+
+    The test starts a single process with two threads. The first thread creates a Skeleton
+    instance while the second thread creates a Proxy subscribing to that service.
+    """
+    with consumer_and_provider(target):
+        pass

--- a/score/mw/com/test/methods/semi_dynamic_methods/main_consumer.cpp
+++ b/score/mw/com/test/methods/semi_dynamic_methods/main_consumer.cpp
@@ -1,0 +1,23 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/runtime.h"
+#include "score/mw/com/test/common_test_resources/assert_handler.h"
+#include "score/mw/com/test/methods/semi_dynamic_methods/consumer.h"
+
+int main(int argc, const char** argv)
+{
+    score::mw::com::test::SetupAssertHandler();
+    score::mw::com::runtime::InitializeRuntime(argc, argv);
+    score::mw::com::test::run_consumer();
+    return EXIT_SUCCESS;
+}

--- a/score/mw/com/test/methods/semi_dynamic_methods/main_consumer_and_provider.cpp
+++ b/score/mw/com/test/methods/semi_dynamic_methods/main_consumer_and_provider.cpp
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/runtime.h"
+
+#include "score/mw/com/test/common_test_resources/assert_handler.h"
+#include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
+#include "score/mw/com/test/methods/semi_dynamic_methods/consumer.h"
+#include "score/mw/com/test/methods/semi_dynamic_methods/provider.h"
+
+#include <cstdlib>
+#include <future>
+#include <iostream>
+
+int main(int argc, const char** argv)
+{
+    score::mw::com::test::SetupAssertHandler();
+    score::mw::com::runtime::InitializeRuntime(argc, argv);
+
+    score::cpp::stop_source stop_source{};
+    const bool sig_term_handler_setup_success = score::mw::com::SetupStopTokenSigTermHandler(stop_source);
+    if (!sig_term_handler_setup_success)
+    {
+        std::cerr << "Unable to set signal handler for SIGINT and/or SIGTERM, cautiously continuing\n";
+    }
+
+    auto provider_future = std::async(score::mw::com::test::run_provider, stop_source.get_token());
+    auto consumer_future = std::async(score::mw::com::test::run_consumer);
+
+    provider_future.get();
+    consumer_future.get();
+
+    std::cout << "BasicAcceptanceSameProcessTest: Provider and Consumer completed successfully" << std::endl;
+
+    return EXIT_SUCCESS;
+}

--- a/score/mw/com/test/methods/semi_dynamic_methods/main_provider.cpp
+++ b/score/mw/com/test/methods/semi_dynamic_methods/main_provider.cpp
@@ -1,0 +1,34 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/runtime.h"
+#include "score/mw/com/test/common_test_resources/assert_handler.h"
+#include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
+#include "score/mw/com/test/methods/semi_dynamic_methods/provider.h"
+
+#include <score/stop_token.hpp>
+
+int main(int argc, const char** argv)
+{
+    score::mw::com::test::SetupAssertHandler();
+    score::mw::com::runtime::InitializeRuntime(argc, argv);
+
+    score::cpp::stop_source stop_source{};
+    const bool sig_term_handler_setup_success = score::mw::com::SetupStopTokenSigTermHandler(stop_source);
+    if (!sig_term_handler_setup_success)
+    {
+        std::cerr << "Unable to set signal handler for SIGINT and/or SIGTERM, cautiously continuing\n";
+    }
+
+    score::mw::com::test::run_provider(stop_source.get_token());
+    return EXIT_SUCCESS;
+}

--- a/score/mw/com/test/methods/semi_dynamic_methods/provider.cpp
+++ b/score/mw/com/test/methods/semi_dynamic_methods/provider.cpp
@@ -1,0 +1,102 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/test/methods/semi_dynamic_methods/provider.h"
+
+#include "score/mw/com/test/common_test_resources/fail_test.h"
+#include "score/mw/com/test/common_test_resources/skeleton_container.h"
+#include "score/mw/com/test/methods/methods_test_resources/process_synchronizer.h"
+#include "score/mw/com/test/methods/semi_dynamic_methods/runtime_sized_array.h"
+#include "score/mw/com/test/methods/semi_dynamic_methods/semi_dynamic_method_datatype.h"
+#include "score/mw/com/types.h"
+
+#include "score/result/result.h"
+
+#include <score/stop_token.hpp>
+
+#include <cstdint>
+#include <cstdlib>
+#include <iostream>
+
+namespace score::mw::com::test
+{
+namespace
+{
+
+const std::string kInterprocessNotificationShmPath{"/semi_dynamic_methods_test_interprocess_notification"};
+
+const InstanceSpecifier kInstanceSpecifier =
+    InstanceSpecifier::Create(std::string{"test/methods/semi_dynamic_methods/TestMethods"}).value();
+
+}  // namespace
+
+void run_provider(const score::cpp::stop_token& stop_token)
+{
+    SkeletonContainer<SemiDynamicMethodSkeleton> skeleton_container{};
+    auto process_synchronizer_result = ProcessSynchronizer::Create(kInterprocessNotificationShmPath);
+    if (!(process_synchronizer_result.has_value()))
+    {
+        FailTest("Methods semi_dynamic_methods_test provider failed: Could not create ProcessSynchronizer");
+    }
+
+    // Step 1. Create skeleton
+    std::cout << "\nProvider: Step 1 - Create skeleton" << std::endl;
+    skeleton_container.CreateSkeleton(kInstanceSpecifier, "semi_dynamic_methods_test");
+    auto& skeleton = skeleton_container.GetSkeleton();
+
+    // Step 2. Register method handler
+    std::cout << "\nProvider: Step 2 - Register method handler" << std::endl;
+    auto handler_with_in_args_and_return = [](SemiDynamicMethodSkeleton::SemiDynamicArray& return_value,
+                                              const SemiDynamicMethodSkeleton::SemiDynamicArray& in_arg) {
+        const auto in_arg_size = in_arg.size();
+        // Reserve the return_value capacity only if it is currently zero (i.e. the first time the method is called).
+        // All subsequent calls will reuse the already allocated capacity of the return_value.
+        if (return_value.capacity() == 0U)
+        {
+            return_value.ReserveOnce(in_arg_size);
+            for (std::size_t i = 0; i < in_arg_size; ++i)
+            {
+                return_value.emplace_back(in_arg.at(i) * 2U);
+            }
+        }
+        else
+        {
+            for (std::size_t i = 0; i < in_arg_size; ++i)
+            {
+                return_value.at(i) = in_arg.at(i) * 2U;
+            }
+        }
+    };
+    const auto register_result =
+        skeleton.with_in_args_and_return.RegisterHandler(std::move(handler_with_in_args_and_return));
+    if (!register_result)
+    {
+        FailTest("Provider: Failed to register with_in_args_and_return handler");
+    }
+
+    // Step 3. Offer service
+    std::cout << "\nProvider: Step 3 - Offer Service" << std::endl;
+    skeleton_container.OfferService("semi_dynamic_methods_test");
+
+    // Step 4. Wait for proxy test to finish
+    std::cout << "\nProvider: Step 4 - Wait for proxy to finish" << std::endl;
+    if (!process_synchronizer_result->WaitWithAbort(stop_token))
+    {
+        FailTest(
+            "Methods semi_dynamic_methods_test provider failed: WaitForProxyTestToFinish was stopped by "
+            "stop_token instead of notification");
+    }
+
+    std::cout << "Provider: Shutting down" << std::endl;
+}
+
+}  // namespace score::mw::com::test

--- a/score/mw/com/test/methods/semi_dynamic_methods/provider.h
+++ b/score/mw/com/test/methods/semi_dynamic_methods/provider.h
@@ -1,0 +1,25 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_TEST_METHODS_SEMI_DYNAMIC_METHODS_PROVIDER_H
+#define SCORE_MW_COM_TEST_METHODS_SEMI_DYNAMIC_METHODS_PROVIDER_H
+
+#include <score/stop_token.hpp>
+
+namespace score::mw::com::test
+{
+
+void run_provider(const score::cpp::stop_token& stop_token);
+
+}  // namespace score::mw::com::test
+
+#endif  // SCORE_MW_COM_TEST_METHODS_SEMI_DYNAMIC_METHODS_PROVIDER_H

--- a/score/mw/com/test/methods/semi_dynamic_methods/runtime_sized_array.cpp
+++ b/score/mw/com/test/methods/semi_dynamic_methods/runtime_sized_array.cpp
@@ -1,0 +1,13 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/test/methods/semi_dynamic_methods/runtime_sized_array.h"

--- a/score/mw/com/test/methods/semi_dynamic_methods/runtime_sized_array.h
+++ b/score/mw/com/test/methods/semi_dynamic_methods/runtime_sized_array.h
@@ -1,0 +1,155 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_TEST_METHODS_RUNTIME_SIZED_ARRAY_H
+#define SCORE_MW_COM_TEST_METHODS_RUNTIME_SIZED_ARRAY_H
+
+#include <score/assert.hpp>
+
+#include <memory>
+#include <type_traits>
+
+namespace score::mw::com::test
+{
+namespace detail
+{
+
+template <class T>
+constexpr T* to_address(T* p)
+{
+    static_assert(!std::is_function_v<T>);
+    return p;
+}
+
+template <class T>
+constexpr auto to_address(const T& p)
+{
+    return to_address(p.operator->());
+}
+
+}  // namespace detail
+
+template <typename ElementType, typename Allocator = std::allocator<ElementType>>
+class RuntimeSizedArray
+{
+  public:
+    using value_type = ElementType;
+    using reference = ElementType&;
+    using const_reference = const ElementType&;
+    using iterator = ElementType*;
+    using const_iterator = const ElementType*;
+    using difference_type =
+        typename std::pointer_traits<typename std::allocator_traits<Allocator>::pointer>::difference_type;
+    using size_type = std::size_t;
+
+    explicit RuntimeSizedArray(const Allocator& alloc) : alloc_{std::move(alloc)} {}
+
+    ~RuntimeSizedArray();
+
+    RuntimeSizedArray(const RuntimeSizedArray&) = delete;
+    RuntimeSizedArray& operator=(const RuntimeSizedArray&) = delete;
+    RuntimeSizedArray(RuntimeSizedArray&&) = delete;
+    RuntimeSizedArray& operator=(RuntimeSizedArray&&) = delete;
+
+    void ReserveOnce(size_type new_capacity);
+
+    template <typename... Args>
+    auto emplace_back(Args&&... args) -> ElementType&;
+
+    ElementType& at(const size_type index);
+    const ElementType& at(const size_type index) const;
+
+    size_type size() const noexcept
+    {
+        return size_;
+    }
+
+    size_type capacity() const noexcept
+    {
+        return capacity_;
+    }
+
+    const value_type* data() const
+    {
+        return data_;
+    }
+
+  private:
+    using pointer = typename std::allocator_traits<Allocator>::pointer;
+
+    pointer allocate_array(size_type number_of_elements, Allocator& allocator);
+
+    typename std::allocator_traits<Allocator>::pointer data_{nullptr};
+    Allocator alloc_;
+    size_type size_{0U};
+    size_type capacity_{0U};
+};
+
+template <typename ElementType, typename Allocator>
+RuntimeSizedArray<ElementType, Allocator>::~RuntimeSizedArray()
+{
+    if (data_ != nullptr)
+    {
+        std::allocator_traits<Allocator>::deallocate(alloc_, data_, capacity_);
+    }
+}
+
+template <typename ElementType, typename Allocator>
+auto RuntimeSizedArray<ElementType, Allocator>::allocate_array(size_type number_of_elements, Allocator& allocator)
+    -> pointer
+{
+    auto storage = std::allocator_traits<Allocator>::allocate(allocator, number_of_elements);
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(nullptr != storage, "no memory allocated");
+    return storage;
+}
+
+template <typename ElementType, typename Allocator>
+void RuntimeSizedArray<ElementType, Allocator>::ReserveOnce(const size_type new_capacity)
+{
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(new_capacity > 0, "new_capacity must be > 0");
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(capacity_ == 0, "ReserveOnce() can only be called once");
+    data_ = allocate_array(new_capacity, alloc_);
+    capacity_ = new_capacity;
+}
+
+template <typename ElementType, typename Allocator>
+template <typename... Args>
+auto RuntimeSizedArray<ElementType, Allocator>::emplace_back(Args&&... args) -> ElementType&
+{
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(
+        size_ < capacity_,
+        "Capacity of vector set in constructor has already been reached. Cannot emplace another element.");
+
+    auto* current_storage_pointer = detail::to_address(data_);
+    std::advance(current_storage_pointer, static_cast<difference_type>(size_));
+    std::allocator_traits<Allocator>::construct(alloc_, current_storage_pointer, std::forward<Args>(args)...);
+    size_ += 1U;
+    return *current_storage_pointer;
+}
+
+template <typename ElementType, typename Allocator>
+inline ElementType& RuntimeSizedArray<ElementType, Allocator>::at(const size_type index)
+{
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(index < size_, "index out of bounds");
+    return *(std::next(data_, static_cast<difference_type>(index)));
+}
+
+template <typename ElementType, typename Allocator>
+inline const ElementType& RuntimeSizedArray<ElementType, Allocator>::at(const size_type index) const
+{
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(index < size_, "index out of bounds");
+    return *(std::next(data_, static_cast<difference_type>(index)));
+}
+
+}  // namespace score::mw::com::test
+
+#endif  // SCORE_MW_COM_TEST_METHODS_RUNTIME_SIZED_ARRAY_H

--- a/score/mw/com/test/methods/semi_dynamic_methods/runtime_sized_array_test.cpp
+++ b/score/mw/com/test/methods/semi_dynamic_methods/runtime_sized_array_test.cpp
@@ -1,0 +1,92 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "score/mw/com/test/methods/semi_dynamic_methods/runtime_sized_array.h"
+
+#include <score/assert_support.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <type_traits>
+
+namespace
+{
+
+TEST(RuntimeSizedArrayTest, DefaultConstructorInitializesSizeAndCapacityToZero)
+{
+    // When default constructing a RuntimeSizedArray
+    score::mw::com::test::RuntimeSizedArray<std::int32_t> array{std::allocator<std::int32_t>{}};
+
+    // Then the size and capacity should both be zero
+    EXPECT_EQ(array.size(), 0U);
+    EXPECT_EQ(array.capacity(), 0U);
+}
+
+TEST(RuntimeSizedArrayTest, ReserveOnceSetsCapacityWithoutChangingSize)
+{
+    // Given a RuntimeSizedArray with default constructor
+    score::mw::com::test::RuntimeSizedArray<std::int32_t> array{std::allocator<std::int32_t>{}};
+
+    // When reserving a capacity of 5
+    array.ReserveOnce(5U);
+
+    // Then the capacity should be 5 and size should still be zero
+    EXPECT_EQ(array.capacity(), 5U);
+    EXPECT_EQ(array.size(), 0U);
+}
+
+TEST(RuntimeSizedArrayTest, CallingReserveTwiceTerminates)
+{
+    // Given a RuntimeSizedArray with default constructor
+    score::mw::com::test::RuntimeSizedArray<std::int32_t> array{std::allocator<std::int32_t>{}};
+
+    // and given that ReserveOnce has been called once
+    array.ReserveOnce(5U);
+
+    // When calling ReserveOnce again
+    // Then the program should terminate
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_CONTRACT_VIOLATED(array.ReserveOnce(10U));
+}
+
+TEST(RuntimeSizedArrayTest, EmplaceBackIncreasesSize)
+{
+    // Given a RuntimeSizedArray with reserved capacity
+    score::mw::com::test::RuntimeSizedArray<std::int32_t> array{std::allocator<std::int32_t>{}};
+    array.ReserveOnce(3U);
+
+    // When emplacing back an element
+    array.emplace_back(42);
+
+    // Then the size should increase to 1 and the capacity should remain 3
+    EXPECT_EQ(array.size(), 1U);
+    EXPECT_EQ(array.capacity(), 3U);
+    EXPECT_EQ(array.at(0), 42);
+}
+
+TEST(RuntimeSizedArrayTest, EmplaceBackBeyondCapacityTerminates)
+{
+    // Given a RuntimeSizedArray with reserved capacity of 2
+    score::mw::com::test::RuntimeSizedArray<std::int32_t> array{std::allocator<std::int32_t>{}};
+    array.ReserveOnce(2U);
+
+    // and given that two elements have been emplaced
+    array.emplace_back(1);
+    array.emplace_back(2);
+
+    // When trying to emplace back a third element
+    // Then the program should terminate
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_CONTRACT_VIOLATED(array.emplace_back(3));
+}
+
+}  // namespace

--- a/score/mw/com/test/methods/semi_dynamic_methods/semi_dynamic_method_datatype.cpp
+++ b/score/mw/com/test/methods/semi_dynamic_methods/semi_dynamic_method_datatype.cpp
@@ -1,0 +1,13 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/test/methods/semi_dynamic_methods/semi_dynamic_method_datatype.h"

--- a/score/mw/com/test/methods/semi_dynamic_methods/semi_dynamic_method_datatype.h
+++ b/score/mw/com/test/methods/semi_dynamic_methods/semi_dynamic_method_datatype.h
@@ -1,0 +1,44 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_TEST_METHODS_SEMI_DYNAMIC_METHODS_TEST_METHOD_DATATYPE_H
+#define SCORE_MW_COM_TEST_METHODS_SEMI_DYNAMIC_METHODS_TEST_METHOD_DATATYPE_H
+
+#include "score/mw/com/types.h"
+
+#include "score/mw/com/test/methods/semi_dynamic_methods/runtime_sized_array.h"
+
+#include <cstdint>
+
+namespace score::mw::com::test
+{
+
+template <typename T>
+class SemiDynamicMethodInterface : public T::Base
+{
+  public:
+    using T::Base::Base;
+
+    using ArrayValueType = std::uint32_t;
+    using SemiDynamicArray =
+        RuntimeSizedArray<ArrayValueType, memory::shared::PolymorphicOffsetPtrAllocator<ArrayValueType>>;
+
+    typename T::template Method<SemiDynamicArray(SemiDynamicArray)> with_in_args_and_return{*this,
+                                                                                            "with_in_args_and_return"};
+};
+
+using SemiDynamicMethodProxy = score::mw::com::AsProxy<SemiDynamicMethodInterface>;
+using SemiDynamicMethodSkeleton = score::mw::com::AsSkeleton<SemiDynamicMethodInterface>;
+
+}  // namespace score::mw::com::test
+
+#endif  // SCORE_MW_COM_TEST_METHODS_SEMI_DYNAMIC_METHODS_TEST_METHOD_DATATYPE_H


### PR DESCRIPTION
Adds support for dynamic types which allocate once at runtime. An
additional size in bytes can be passed to a private proxy Create
function which increases the amount of shared memory allocated for
methods. An application can then create a data type which guarantees to
not allocate more than the provided value.

An example test application is created
mw/com/test/methods/semi_dynamic_methods.

This should only be used in the context of SWP-269486. Any other usage
of this is a violation of our AOU: NoApisFromImplementationNamespace