### PR TITLE
Mark destructor as noexcept

### DIFF
--- a/score/mw/com/impl/service_discovery.cpp
+++ b/score/mw/com/impl/service_discovery.cpp
@@ -45,7 +45,7 @@ ServiceDiscovery::ServiceDiscovery(score::mw::com::impl::IRuntime& runtime)
 {
 }
 
-ServiceDiscovery::~ServiceDiscovery()
+ServiceDiscovery::~ServiceDiscovery() noexcept
 {
     const auto copy_of_handles = handle_to_instances_;
     for (const auto& handle : copy_of_handles)

--- a/score/mw/com/impl/service_discovery.h
+++ b/score/mw/com/impl/service_discovery.h
@@ -42,7 +42,7 @@ class ServiceDiscovery final : public IServiceDiscovery
     ServiceDiscovery& operator=(const ServiceDiscovery&) noexcept = delete;
     ServiceDiscovery(ServiceDiscovery&&) noexcept = delete;
     ServiceDiscovery& operator=(ServiceDiscovery&&) noexcept = delete;
-    ~ServiceDiscovery() override;
+    ~ServiceDiscovery() noexcept override;
 
     [[nodiscard]] Result<void> OfferService(InstanceIdentifier) noexcept override;
     [[nodiscard]] Result<void> StopOfferService(InstanceIdentifier) noexcept override;


### PR DESCRIPTION
We mark the destructor as no except for the following reasons:
- Destructor is considered exception-unfriendly, and this is one of the few places that noexcept is justified. This is required by MISRA:c++2023 18.4.1. In the rule one can also see the explanation in the rationale section.
- No code inside the destructor is expected to throw. StopFindService is already marked noexcept.
- In case that it would throw, we do not have anyway guarantees on availability. If at some point the code could throw, then hitting the noexcept boundary it would terminate. This is not a safety issue because we do not have availability requirements for safety.