### PR TITLE
mw/com : Add the integration tests for moving skeletonMethod.

### DIFF
--- a/score/mw/com/test/move_semantics/skeleton_method/BUILD
+++ b/score/mw/com/test/move_semantics/skeleton_method/BUILD
@@ -1,0 +1,168 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@score_baselibs//score/language/safecpp:toolchain_features.bzl", "COMPILER_WARNING_FEATURES")
+load("//bazel/tools:json_schema_validator.bzl", "validate_json_schema_test")
+load("//score/mw/com/test:pkg_application.bzl", "pkg_application")
+
+validate_json_schema_test(
+    name = "validate_config_schema",
+    json = "config/mw_com_config.json",
+    schema = "//score/mw/com:config_schema",
+    tags = ["lint"],
+)
+
+cc_library(
+    name = "test_method_datatype",
+    srcs = ["test_method_datatype.cpp"],
+    hdrs = ["test_method_datatype.h"],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        "//score/mw/com",
+    ],
+)
+
+cc_library(
+    name = "test_parameters",
+    srcs = ["test_parameters.cpp"],
+    hdrs = ["test_parameters.h"],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:command_line_parser",
+        "//score/mw/com/test/common_test_resources:fail_test",
+    ],
+)
+
+cc_library(
+    name = "provider",
+    srcs = ["provider.cpp"],
+    hdrs = ["provider.h"],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        ":test_method_datatype",
+        ":test_parameters",
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:fail_test",
+        "//score/mw/com/test/common_test_resources:skeleton_container",
+        "@score_baselibs//score/concurrency:notification",
+        "@score_baselibs//score/language/futurecpp",
+    ],
+)
+
+cc_library(
+    name = "consumer",
+    srcs = ["consumer.cpp"],
+    hdrs = ["consumer.h"],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        ":test_method_datatype",
+        ":test_parameters",
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:fail_test",
+        "//score/mw/com/test/common_test_resources:proxy_container",
+        "@score_baselibs//score/language/futurecpp",
+    ],
+)
+
+cc_binary(
+    name = "main_provider",
+    srcs = ["main_provider.cpp"],
+    data = ["config/mw_com_config.json"],
+    features = COMPILER_WARNING_FEATURES + [
+        "aborts_upon_exception",
+    ],
+    deps = [
+        ":provider",
+        ":test_parameters",
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:assert_handler",
+        "//score/mw/com/test/common_test_resources:fail_test",
+        "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
+    ],
+)
+
+cc_binary(
+    name = "main_consumer",
+    srcs = ["main_consumer.cpp"],
+    data = ["config/mw_com_config.json"],
+    features = COMPILER_WARNING_FEATURES + [
+        "aborts_upon_exception",
+    ],
+    deps = [
+        ":consumer",
+        ":test_parameters",
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:assert_handler",
+        "//score/mw/com/test/common_test_resources:fail_test",
+        "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
+    ],
+)
+
+cc_binary(
+    name = "main_consumer_and_provider",
+    srcs = ["main_consumer_and_provider.cpp"],
+    data = ["config/mw_com_config.json"],
+    features = COMPILER_WARNING_FEATURES + [
+        "aborts_upon_exception",
+    ],
+    deps = [
+        ":consumer",
+        ":provider",
+        ":test_parameters",
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:assert_handler",
+        "//score/mw/com/test/common_test_resources:fail_test",
+        "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
+    ],
+)
+
+pkg_application(
+    name = "main_provider-pkg",
+    app_name = "MainProviderApp",
+    bin = [":main_provider"],
+    etc = [
+        "config/mw_com_config.json",
+        "config/logging.json",
+    ],
+    visibility = [
+        "//score/mw/com/test/move_semantics/skeleton_method:__subpackages__",
+    ],
+)
+
+pkg_application(
+    name = "main_consumer-pkg",
+    app_name = "MainConsumerApp",
+    bin = [":main_consumer"],
+    etc = [
+        "config/mw_com_config.json",
+        "config/logging.json",
+    ],
+    visibility = [
+        "//score/mw/com/test/move_semantics/skeleton_method:__subpackages__",
+    ],
+)
+
+pkg_application(
+    name = "main_consumer_and_provider-pkg",
+    app_name = "MainConsumerAndProviderApp",
+    bin = [":main_consumer_and_provider"],
+    etc = [
+        "config/mw_com_config.json",
+        "config/logging.json",
+    ],
+    visibility = [
+        "//score/mw/com/test/move_semantics/skeleton_method:__subpackages__",
+    ],
+)

--- a/score/mw/com/test/move_semantics/skeleton_method/config/logging.json
+++ b/score/mw/com/test/move_semantics/skeleton_method/config/logging.json
@@ -1,0 +1,7 @@
+{
+  "appId": "SMMS",
+  "appDesc": "skeleton_method_move_semantics",
+  "logLevel": "kDebug",
+  "logLevelThresholdConsole": "kDebug",
+  "logMode": "kRemote|kConsole"
+}

--- a/score/mw/com/test/move_semantics/skeleton_method/config/mw_com_config.json
+++ b/score/mw/com/test/move_semantics/skeleton_method/config/mw_com_config.json
@@ -1,0 +1,102 @@
+{
+  "serviceTypes": [
+    {
+      "serviceTypeName": "/test/move_semantics/skeleton_method/SkeletonMethodMoveInterface",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "bindings": [
+        {
+          "binding": "SHM",
+          "serviceId": 2200,
+          "methods": [
+            {
+              "methodName": "moved_method",
+              "methodId": 1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "serviceInstances": [
+    {
+      "instanceSpecifier": "test/move_semantics/skeleton_method/SkeletonMethodMoveInterfaceMovedTo",
+      "serviceTypeName": "/test/move_semantics/skeleton_method/SkeletonMethodMoveInterface",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "instances": [
+        {
+          "instanceId": 1,
+          "asil-level": "B",
+          "binding": "SHM",
+          "methods": [
+            {
+              "methodName": "moved_method",
+              "queueSize": 1
+            }
+          ],
+          "allowedConsumer": {
+            "QM": [
+              0
+            ],
+            "B": [
+              0
+            ]
+          },
+          "allowedProvider": {
+            "QM": [
+              0
+            ],
+            "B": [
+              0
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "instanceSpecifier": "test/move_semantics/skeleton_method/SkeletonMethodMoveInterfaceMovedFrom",
+      "serviceTypeName": "/test/move_semantics/skeleton_method/SkeletonMethodMoveInterface",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "instances": [
+        {
+          "instanceId": 2,
+          "asil-level": "B",
+          "binding": "SHM",
+          "methods": [
+            {
+              "methodName": "moved_method",
+              "queueSize": 1
+            }
+          ],
+          "allowedConsumer": {
+            "QM": [
+              0
+            ],
+            "B": [
+              0
+            ]
+          },
+          "allowedProvider": {
+            "QM": [
+              0
+            ],
+            "B": [
+              0
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "global": {
+    "asil-level": "B"
+  }
+}

--- a/score/mw/com/test/move_semantics/skeleton_method/consumer.cpp
+++ b/score/mw/com/test/move_semantics/skeleton_method/consumer.cpp
@@ -21,6 +21,7 @@
 
 #include <chrono>
 #include <iostream>
+#include <optional>
 #include <thread>
 
 namespace score::mw::com::test
@@ -28,9 +29,7 @@ namespace score::mw::com::test
 namespace
 {
 
-constexpr auto kDetectionWindow = std::chrono::milliseconds{5000};
-
-constexpr auto kDetectionCallGap = std::chrono::milliseconds{5};
+constexpr auto kDetectionCallGap = std::chrono::milliseconds{2};
 
 std::int32_t CallMethodOrFail(SkeletonMethodMoveProxy& proxy)
 {
@@ -42,21 +41,9 @@ std::int32_t CallMethodOrFail(SkeletonMethodMoveProxy& proxy)
     return *(result.value());
 }
 
-void VerifyResultIsOneOf(std::int32_t actual,
-                         std::int32_t first_expected,
-                         std::int32_t second_expected,
-                         std::size_t call_index)
-{
-    if (actual != first_expected && actual != second_expected)
-    {
-        FailTest(
-            "Consumer: call ", call_index, " expected ", first_expected, " or ", second_expected, " but got ", actual);
-    }
-}
-
 }  // namespace
 
-void RunConsumer(const SkeletonMoveScenario& scenario, const score::cpp::stop_token& stop_token)
+void RunConsumer(const score::cpp::stop_token& stop_token)
 {
     static_cast<void>(stop_token);
 
@@ -71,24 +58,37 @@ void RunConsumer(const SkeletonMoveScenario& scenario, const score::cpp::stop_to
     //         (fuzzy) scenarios the move may already have happened, so any call may return either
     //         handler's result — each call is just checked against the two known-valid results.
     std::cout << "\nConsumer: Step 2 - Loop calling until second handler is detected" << std::endl;
-    const std::int32_t first_expected = GetFirstHandlerExpectedResult(scenario);
-    const std::int32_t second_expected = GetSecondHandlerExpectedResult(scenario);
-    const auto deadline = std::chrono::steady_clock::now() + kDetectionWindow;
     std::size_t call_count = 0U;
-    std::int32_t actual = 0;
-    do
+    std::optional<std::int32_t> actual{};
+    while (!actual.has_value() || actual.value() != kSecondHandlerExpectedResult)
     {
-        if (std::chrono::steady_clock::now() >= deadline)
-        {
-            FailTest("Consumer: timed out waiting to observe the second handler's result");
-        }
         actual = CallMethodOrFail(proxy_moved_to);
-        VerifyResultIsOneOf(actual, first_expected, second_expected, call_count);
         ++call_count;
-        std::this_thread::sleep_for(kDetectionCallGap);
-    } while (actual != second_expected);
 
-    std::cout << "\nConsumer: Step 2 done (" << call_count << " calls, second handler result=" << actual << ")"
+        // If the first handler is still registered, then we continue calling the method.
+        if (actual == kFirstHandlerExpectedResult)
+        {
+            std::this_thread::sleep_for(kDetectionCallGap);
+            continue;
+        }
+
+        // If the second handler has been registered, then we can finish.
+        if (actual == kSecondHandlerExpectedResult)
+        {
+            break;
+        }
+
+        FailTest("Consumer: call ",
+                 call_count,
+                 " expected ",
+                 kFirstHandlerExpectedResult,
+                 " or ",
+                 kSecondHandlerExpectedResult,
+                 " but got ",
+                 actual.value());
+    }
+
+    std::cout << "\nConsumer: Step 2 done (" << call_count << " calls, second handler result=" << actual.value() << ")"
               << std::endl;
 }
 

--- a/score/mw/com/test/move_semantics/skeleton_method/consumer.cpp
+++ b/score/mw/com/test/move_semantics/skeleton_method/consumer.cpp
@@ -17,8 +17,6 @@
 #include "score/mw/com/test/move_semantics/skeleton_method/test_method_datatype.h"
 #include "score/mw/com/test/move_semantics/skeleton_method/test_parameters.h"
 
-#include <score/stop_token.hpp>
-
 #include <chrono>
 #include <iostream>
 #include <optional>
@@ -29,7 +27,7 @@ namespace score::mw::com::test
 namespace
 {
 
-constexpr auto kDetectionCallGap = std::chrono::milliseconds{2};
+constexpr auto kMethodCallInterval = std::chrono::milliseconds{2};
 
 std::int32_t CallMethodOrFail(SkeletonMethodMoveProxy& proxy)
 {
@@ -43,10 +41,8 @@ std::int32_t CallMethodOrFail(SkeletonMethodMoveProxy& proxy)
 
 }  // namespace
 
-void RunConsumer(const score::cpp::stop_token& stop_token)
+void RunConsumer()
 {
-    static_cast<void>(stop_token);
-
     // Step 1. Create proxy for kInstanceSpecifierMovedTo.
     std::cout << "\nConsumer: Step 1 - Create proxy (kMovedTo)" << std::endl;
     ProxyContainer<SkeletonMethodMoveProxy> proxy_moved_to_container{};
@@ -59,21 +55,22 @@ void RunConsumer(const score::cpp::stop_token& stop_token)
     //         handler's result — each call is just checked against the two known-valid results.
     std::cout << "\nConsumer: Step 2 - Loop calling until second handler is detected" << std::endl;
     std::size_t call_count = 0U;
-    std::optional<std::int32_t> actual{};
-    while (!actual.has_value() || actual.value() != kSecondHandlerExpectedResult)
+    std::optional<std::int32_t> actual_method_return_value{};
+    while (!actual_method_return_value.has_value() ||
+           actual_method_return_value.value() != kSecondHandlerExpectedResult)
     {
-        actual = CallMethodOrFail(proxy_moved_to);
+        actual_method_return_value = CallMethodOrFail(proxy_moved_to);
         ++call_count;
 
         // If the first handler is still registered, then we continue calling the method.
-        if (actual == kFirstHandlerExpectedResult)
+        if (actual_method_return_value == kFirstHandlerExpectedResult)
         {
-            std::this_thread::sleep_for(kDetectionCallGap);
+            std::this_thread::sleep_for(kMethodCallInterval);
             continue;
         }
 
         // If the second handler has been registered, then we can finish.
-        if (actual == kSecondHandlerExpectedResult)
+        if (actual_method_return_value == kSecondHandlerExpectedResult)
         {
             break;
         }
@@ -85,11 +82,11 @@ void RunConsumer(const score::cpp::stop_token& stop_token)
                  " or ",
                  kSecondHandlerExpectedResult,
                  " but got ",
-                 actual.value());
+                 actual_method_return_value.value());
     }
 
-    std::cout << "\nConsumer: Step 2 done (" << call_count << " calls, second handler result=" << actual.value() << ")"
-              << std::endl;
+    std::cout << "\nConsumer: Step 2 done (" << call_count
+              << " calls, second handler result=" << actual_method_return_value.value() << ")" << std::endl;
 }
 
 }  // namespace score::mw::com::test

--- a/score/mw/com/test/move_semantics/skeleton_method/consumer.cpp
+++ b/score/mw/com/test/move_semantics/skeleton_method/consumer.cpp
@@ -1,0 +1,95 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/test/move_semantics/skeleton_method/consumer.h"
+
+#include "score/mw/com/test/common_test_resources/fail_test.h"
+#include "score/mw/com/test/common_test_resources/proxy_container.h"
+#include "score/mw/com/test/move_semantics/skeleton_method/test_method_datatype.h"
+#include "score/mw/com/test/move_semantics/skeleton_method/test_parameters.h"
+
+#include <score/stop_token.hpp>
+
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+namespace score::mw::com::test
+{
+namespace
+{
+
+constexpr auto kDetectionWindow = std::chrono::milliseconds{5000};
+
+constexpr auto kDetectionCallGap = std::chrono::milliseconds{5};
+
+std::int32_t CallMethodOrFail(SkeletonMethodMoveProxy& proxy)
+{
+    auto result = proxy.moved_method_(kTestArgA, kTestArgB);
+    if (!result.has_value())
+    {
+        FailTest("Consumer: moved_method_ call failed: ", result.error());
+    }
+    return *(result.value());
+}
+
+void VerifyResultIsOneOf(std::int32_t actual,
+                         std::int32_t first_expected,
+                         std::int32_t second_expected,
+                         std::size_t call_index)
+{
+    if (actual != first_expected && actual != second_expected)
+    {
+        FailTest(
+            "Consumer: call ", call_index, " expected ", first_expected, " or ", second_expected, " but got ", actual);
+    }
+}
+
+}  // namespace
+
+void RunConsumer(const SkeletonMoveScenario& scenario, const score::cpp::stop_token& stop_token)
+{
+    static_cast<void>(stop_token);
+
+    // Step 1. Create proxy for kInstanceSpecifierMovedTo.
+    std::cout << "\nConsumer: Step 1 - Create proxy (kMovedTo)" << std::endl;
+    ProxyContainer<SkeletonMethodMoveProxy> proxy_moved_to_container{};
+    proxy_moved_to_container.CreateProxy(kInstanceSpecifierMovedTo, "skeleton_method_move_semantics");
+    auto& proxy_moved_to = proxy_moved_to_container.GetProxy();
+
+    // Step 2. Keep calling the method until the return value identifies the second handler. For
+    //         "before offered" scenarios the first call is always Handler A. For "after offered"
+    //         (fuzzy) scenarios the move may already have happened, so any call may return either
+    //         handler's result — each call is just checked against the two known-valid results.
+    std::cout << "\nConsumer: Step 2 - Loop calling until second handler is detected" << std::endl;
+    const std::int32_t first_expected = GetFirstHandlerExpectedResult(scenario);
+    const std::int32_t second_expected = GetSecondHandlerExpectedResult(scenario);
+    const auto deadline = std::chrono::steady_clock::now() + kDetectionWindow;
+    std::size_t call_count = 0U;
+    std::int32_t actual = 0;
+    do
+    {
+        if (std::chrono::steady_clock::now() >= deadline)
+        {
+            FailTest("Consumer: timed out waiting to observe the second handler's result");
+        }
+        actual = CallMethodOrFail(proxy_moved_to);
+        VerifyResultIsOneOf(actual, first_expected, second_expected, call_count);
+        ++call_count;
+        std::this_thread::sleep_for(kDetectionCallGap);
+    } while (actual != second_expected);
+
+    std::cout << "\nConsumer: Step 2 done (" << call_count << " calls, second handler result=" << actual << ")"
+              << std::endl;
+}
+
+}  // namespace score::mw::com::test

--- a/score/mw/com/test/move_semantics/skeleton_method/consumer.h
+++ b/score/mw/com/test/move_semantics/skeleton_method/consumer.h
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_TEST_MOVE_SEMANTICS_SKELETON_METHOD_CONSUMER_H
+#define SCORE_MW_COM_TEST_MOVE_SEMANTICS_SKELETON_METHOD_CONSUMER_H
+
+#include "score/mw/com/test/move_semantics/skeleton_method/test_parameters.h"
+
+#include <score/stop_token.hpp>
+
+namespace score::mw::com::test
+{
+
+void RunConsumer(const SkeletonMoveScenario& scenario, const score::cpp::stop_token& stop_token);
+
+}  // namespace score::mw::com::test
+
+#endif  // SCORE_MW_COM_TEST_MOVE_SEMANTICS_SKELETON_METHOD_CONSUMER_H

--- a/score/mw/com/test/move_semantics/skeleton_method/consumer.h
+++ b/score/mw/com/test/move_semantics/skeleton_method/consumer.h
@@ -20,7 +20,7 @@
 namespace score::mw::com::test
 {
 
-void RunConsumer(const SkeletonMoveScenario& scenario, const score::cpp::stop_token& stop_token);
+void RunConsumer(const score::cpp::stop_token& stop_token);
 
 }  // namespace score::mw::com::test
 

--- a/score/mw/com/test/move_semantics/skeleton_method/consumer.h
+++ b/score/mw/com/test/move_semantics/skeleton_method/consumer.h
@@ -15,12 +15,10 @@
 
 #include "score/mw/com/test/move_semantics/skeleton_method/test_parameters.h"
 
-#include <score/stop_token.hpp>
-
 namespace score::mw::com::test
 {
 
-void RunConsumer(const score::cpp::stop_token& stop_token);
+void RunConsumer();
 
 }  // namespace score::mw::com::test
 

--- a/score/mw/com/test/move_semantics/skeleton_method/integration_test/BUILD
+++ b/score/mw/com/test/move_semantics/skeleton_method/integration_test/BUILD
@@ -1,0 +1,95 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
+load("//quality/integration_testing:integration_testing.bzl", "integration_test")
+
+integration_test(
+    name = "move_construct_before_offered_skeleton_same_process_test",
+    srcs = [
+        "move_construct_before_offered_skeleton_same_process_test.py",
+        "test_fixture.py",
+    ],
+    filesystem = "//score/mw/com/test/move_semantics/skeleton_method:main_consumer_and_provider-pkg",
+)
+
+integration_test(
+    name = "move_construct_after_offered_skeleton_same_process_test",
+    srcs = [
+        "move_construct_after_offered_skeleton_same_process_test.py",
+        "test_fixture.py",
+    ],
+    filesystem = "//score/mw/com/test/move_semantics/skeleton_method:main_consumer_and_provider-pkg",
+)
+
+integration_test(
+    name = "move_assign_before_offered_skeleton_same_process_test",
+    srcs = [
+        "move_assign_before_offered_skeleton_same_process_test.py",
+        "test_fixture.py",
+    ],
+    filesystem = "//score/mw/com/test/move_semantics/skeleton_method:main_consumer_and_provider-pkg",
+)
+
+integration_test(
+    name = "move_assign_after_offered_skeleton_same_process_test",
+    srcs = [
+        "move_assign_after_offered_skeleton_same_process_test.py",
+        "test_fixture.py",
+    ],
+    filesystem = "//score/mw/com/test/move_semantics/skeleton_method:main_consumer_and_provider-pkg",
+)
+
+pkg_filegroup(
+    name = "different_processes_filesystem",
+    srcs = [
+        "//score/mw/com/test/move_semantics/skeleton_method:main_consumer-pkg",
+        "//score/mw/com/test/move_semantics/skeleton_method:main_provider-pkg",
+    ],
+)
+
+integration_test(
+    name = "move_construct_before_offered_skeleton_different_process_test",
+    srcs = [
+        "move_construct_before_offered_skeleton_different_process_test.py",
+        "test_fixture.py",
+    ],
+    filesystem = ":different_processes_filesystem",
+)
+
+integration_test(
+    name = "move_construct_after_offered_skeleton_different_process_test",
+    srcs = [
+        "move_construct_after_offered_skeleton_different_process_test.py",
+        "test_fixture.py",
+    ],
+    filesystem = ":different_processes_filesystem",
+)
+
+integration_test(
+    name = "move_assign_before_offered_skeleton_different_process_test",
+    srcs = [
+        "move_assign_before_offered_skeleton_different_process_test.py",
+        "test_fixture.py",
+    ],
+    filesystem = ":different_processes_filesystem",
+)
+
+integration_test(
+    name = "move_assign_after_offered_skeleton_different_process_test",
+    srcs = [
+        "move_assign_after_offered_skeleton_different_process_test.py",
+        "test_fixture.py",
+    ],
+    filesystem = ":different_processes_filesystem",
+)

--- a/score/mw/com/test/move_semantics/skeleton_method/integration_test/move_assign_after_offered_skeleton_different_process_test.py
+++ b/score/mw/com/test/move_semantics/skeleton_method/integration_test/move_assign_after_offered_skeleton_different_process_test.py
@@ -1,0 +1,19 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from test_fixture import consumer, provider, SkeletonMoveScenario
+
+
+def test_move_assign_after_offered_different_process(target):
+    with consumer(target, SkeletonMoveScenario.MOVE_ASSIGN_AFTER_OFFERED):
+        with provider(target, SkeletonMoveScenario.MOVE_ASSIGN_AFTER_OFFERED):
+            pass

--- a/score/mw/com/test/move_semantics/skeleton_method/integration_test/move_assign_after_offered_skeleton_same_process_test.py
+++ b/score/mw/com/test/move_semantics/skeleton_method/integration_test/move_assign_after_offered_skeleton_same_process_test.py
@@ -1,0 +1,18 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from test_fixture import consumer_and_provider, SkeletonMoveScenario
+
+
+def test_move_assign_after_offered_same_process(target):
+    with consumer_and_provider(target, SkeletonMoveScenario.MOVE_ASSIGN_AFTER_OFFERED):
+        pass

--- a/score/mw/com/test/move_semantics/skeleton_method/integration_test/move_assign_before_offered_skeleton_different_process_test.py
+++ b/score/mw/com/test/move_semantics/skeleton_method/integration_test/move_assign_before_offered_skeleton_different_process_test.py
@@ -1,0 +1,19 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from test_fixture import consumer, provider, SkeletonMoveScenario
+
+
+def test_move_assign_before_offered_different_process(target):
+    with consumer(target, SkeletonMoveScenario.MOVE_ASSIGN_BEFORE_OFFERED):
+        with provider(target, SkeletonMoveScenario.MOVE_ASSIGN_BEFORE_OFFERED):
+            pass

--- a/score/mw/com/test/move_semantics/skeleton_method/integration_test/move_assign_before_offered_skeleton_same_process_test.py
+++ b/score/mw/com/test/move_semantics/skeleton_method/integration_test/move_assign_before_offered_skeleton_same_process_test.py
@@ -1,0 +1,18 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from test_fixture import consumer_and_provider, SkeletonMoveScenario
+
+
+def test_move_assign_before_offered_same_process(target):
+    with consumer_and_provider(target, SkeletonMoveScenario.MOVE_ASSIGN_BEFORE_OFFERED):
+        pass

--- a/score/mw/com/test/move_semantics/skeleton_method/integration_test/move_construct_after_offered_skeleton_different_process_test.py
+++ b/score/mw/com/test/move_semantics/skeleton_method/integration_test/move_construct_after_offered_skeleton_different_process_test.py
@@ -1,0 +1,19 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from test_fixture import consumer, provider, SkeletonMoveScenario
+
+
+def test_move_construct_after_offered_different_process(target):
+    with consumer(target, SkeletonMoveScenario.MOVE_CONSTRUCT_AFTER_OFFERED):
+        with provider(target, SkeletonMoveScenario.MOVE_CONSTRUCT_AFTER_OFFERED):
+            pass

--- a/score/mw/com/test/move_semantics/skeleton_method/integration_test/move_construct_after_offered_skeleton_same_process_test.py
+++ b/score/mw/com/test/move_semantics/skeleton_method/integration_test/move_construct_after_offered_skeleton_same_process_test.py
@@ -1,0 +1,18 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from test_fixture import consumer_and_provider, SkeletonMoveScenario
+
+
+def test_move_construct_after_offered_same_process(target):
+    with consumer_and_provider(target, SkeletonMoveScenario.MOVE_CONSTRUCT_AFTER_OFFERED):
+        pass

--- a/score/mw/com/test/move_semantics/skeleton_method/integration_test/move_construct_before_offered_skeleton_different_process_test.py
+++ b/score/mw/com/test/move_semantics/skeleton_method/integration_test/move_construct_before_offered_skeleton_different_process_test.py
@@ -1,0 +1,19 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from test_fixture import consumer, provider, SkeletonMoveScenario
+
+
+def test_move_construct_before_offered_different_process(target):
+    with consumer(target, SkeletonMoveScenario.MOVE_CONSTRUCT_BEFORE_OFFERED):
+        with provider(target, SkeletonMoveScenario.MOVE_CONSTRUCT_BEFORE_OFFERED):
+            pass

--- a/score/mw/com/test/move_semantics/skeleton_method/integration_test/move_construct_before_offered_skeleton_same_process_test.py
+++ b/score/mw/com/test/move_semantics/skeleton_method/integration_test/move_construct_before_offered_skeleton_same_process_test.py
@@ -1,0 +1,18 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from test_fixture import consumer_and_provider, SkeletonMoveScenario
+
+
+def test_move_construct_before_offered_same_process(target):
+    with consumer_and_provider(target, SkeletonMoveScenario.MOVE_CONSTRUCT_BEFORE_OFFERED):
+        pass

--- a/score/mw/com/test/move_semantics/skeleton_method/integration_test/test_fixture.py
+++ b/score/mw/com/test/move_semantics/skeleton_method/integration_test/test_fixture.py
@@ -1,0 +1,41 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from enum import IntEnum
+
+
+class SkeletonMoveScenario(IntEnum):
+    MOVE_CONSTRUCT_BEFORE_OFFERED = 0
+    MOVE_CONSTRUCT_AFTER_OFFERED  = 1
+    MOVE_ASSIGN_BEFORE_OFFERED    = 2
+    MOVE_ASSIGN_AFTER_OFFERED     = 3
+
+
+def consumer_and_provider(target, scenario, **kwargs):
+    args = ["--scenario", str(int(scenario)), "--service-instance-manifest", f"./etc/mw_com_config.json"]
+    return target.wrap_exec(
+        "bin/main_consumer_and_provider", args, cwd="/opt/MainConsumerAndProviderApp", wait_on_exit=True, **kwargs
+    )
+
+
+def consumer(target, scenario, **kwargs):
+    args = ["--scenario", str(int(scenario)), "--service-instance-manifest", f"./etc/mw_com_config.json"]
+    return target.wrap_exec(
+        "bin/main_consumer", args, cwd="/opt/MainConsumerApp", wait_on_exit=True, **kwargs
+    )
+
+
+def provider(target, scenario, **kwargs):
+    args = ["--scenario", str(int(scenario)), "--service-instance-manifest", f"./etc/mw_com_config.json"]
+    return target.wrap_exec(
+        "bin/main_provider", args, cwd="/opt/MainProviderApp", wait_on_exit=True, **kwargs
+    )

--- a/score/mw/com/test/move_semantics/skeleton_method/integration_test/test_fixture.py
+++ b/score/mw/com/test/move_semantics/skeleton_method/integration_test/test_fixture.py
@@ -15,9 +15,9 @@ from enum import IntEnum
 
 class SkeletonMoveScenario(IntEnum):
     MOVE_CONSTRUCT_BEFORE_OFFERED = 0
-    MOVE_CONSTRUCT_AFTER_OFFERED  = 1
-    MOVE_ASSIGN_BEFORE_OFFERED    = 2
-    MOVE_ASSIGN_AFTER_OFFERED     = 3
+    MOVE_CONSTRUCT_AFTER_OFFERED = 1
+    MOVE_ASSIGN_BEFORE_OFFERED = 2
+    MOVE_ASSIGN_AFTER_OFFERED = 3
 
 
 def consumer_and_provider(target, scenario, **kwargs):
@@ -29,13 +29,9 @@ def consumer_and_provider(target, scenario, **kwargs):
 
 def consumer(target, scenario, **kwargs):
     args = ["--scenario", str(int(scenario)), "--service-instance-manifest", f"./etc/mw_com_config.json"]
-    return target.wrap_exec(
-        "bin/main_consumer", args, cwd="/opt/MainConsumerApp", wait_on_exit=True, **kwargs
-    )
+    return target.wrap_exec("bin/main_consumer", args, cwd="/opt/MainConsumerApp", wait_on_exit=True, **kwargs)
 
 
 def provider(target, scenario, **kwargs):
     args = ["--scenario", str(int(scenario)), "--service-instance-manifest", f"./etc/mw_com_config.json"]
-    return target.wrap_exec(
-        "bin/main_provider", args, cwd="/opt/MainProviderApp", wait_on_exit=True, **kwargs
-    )
+    return target.wrap_exec("bin/main_provider", args, cwd="/opt/MainProviderApp", wait_on_exit=True, **kwargs)

--- a/score/mw/com/test/move_semantics/skeleton_method/main_consumer.cpp
+++ b/score/mw/com/test/move_semantics/skeleton_method/main_consumer.cpp
@@ -1,0 +1,42 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/runtime.h"
+
+#include "score/mw/com/test/common_test_resources/assert_handler.h"
+#include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
+#include "score/mw/com/test/move_semantics/skeleton_method/consumer.h"
+#include "score/mw/com/test/move_semantics/skeleton_method/test_parameters.h"
+
+#include <iostream>
+
+int main(int argc, const char** argv)
+{
+    auto test_configuration{score::mw::com::test::ReadCommandLineArguments(argc, argv)};
+
+    score::mw::com::test::SetupAssertHandler();
+    score::mw::com::runtime::InitializeRuntime(argc, argv);
+
+    score::cpp::stop_source stop_source{};
+    const bool sig_term_handler_setup_success = score::mw::com::SetupStopTokenSigTermHandler(stop_source);
+    if (!sig_term_handler_setup_success)
+    {
+        std::cerr << "Unable to set signal handler for SIGINT and/or SIGTERM, cautiously continuing" << std::endl;
+    }
+
+    std::cout << "Starting consumer with scenario " << static_cast<std::size_t>(test_configuration.scenario)
+              << std::endl;
+
+    score::mw::com::test::RunConsumer(test_configuration.scenario, stop_source.get_token());
+
+    return EXIT_SUCCESS;
+}

--- a/score/mw/com/test/move_semantics/skeleton_method/main_consumer.cpp
+++ b/score/mw/com/test/move_semantics/skeleton_method/main_consumer.cpp
@@ -36,7 +36,7 @@ int main(int argc, const char** argv)
     std::cout << "Starting consumer with scenario " << static_cast<std::size_t>(test_configuration.scenario)
               << std::endl;
 
-    score::mw::com::test::RunConsumer(stop_source.get_token());
+    score::mw::com::test::RunConsumer();
 
     return EXIT_SUCCESS;
 }

--- a/score/mw/com/test/move_semantics/skeleton_method/main_consumer.cpp
+++ b/score/mw/com/test/move_semantics/skeleton_method/main_consumer.cpp
@@ -36,7 +36,7 @@ int main(int argc, const char** argv)
     std::cout << "Starting consumer with scenario " << static_cast<std::size_t>(test_configuration.scenario)
               << std::endl;
 
-    score::mw::com::test::RunConsumer(test_configuration.scenario, stop_source.get_token());
+    score::mw::com::test::RunConsumer(stop_source.get_token());
 
     return EXIT_SUCCESS;
 }

--- a/score/mw/com/test/move_semantics/skeleton_method/main_consumer_and_provider.cpp
+++ b/score/mw/com/test/move_semantics/skeleton_method/main_consumer_and_provider.cpp
@@ -1,0 +1,51 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/runtime.h"
+
+#include "score/mw/com/test/common_test_resources/assert_handler.h"
+#include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
+#include "score/mw/com/test/move_semantics/skeleton_method/consumer.h"
+#include "score/mw/com/test/move_semantics/skeleton_method/provider.h"
+#include "score/mw/com/test/move_semantics/skeleton_method/test_parameters.h"
+
+#include <future>
+#include <iostream>
+
+int main(int argc, const char** argv)
+{
+    auto test_configuration{score::mw::com::test::ReadCommandLineArguments(argc, argv)};
+
+    score::mw::com::test::SetupAssertHandler();
+    score::mw::com::runtime::InitializeRuntime(argc, argv);
+
+    score::cpp::stop_source stop_source{};
+    const bool sig_term_handler_setup_success = score::mw::com::SetupStopTokenSigTermHandler(stop_source);
+    if (!sig_term_handler_setup_success)
+    {
+        std::cerr << "Unable to set signal handler for SIGINT and/or SIGTERM, cautiously continuing" << std::endl;
+    }
+
+    std::cout << "Starting consumer and provider with scenario "
+              << static_cast<std::size_t>(test_configuration.scenario) << std::endl;
+
+    auto provider_future =
+        std::async(score::mw::com::test::RunProvider, test_configuration.scenario, stop_source.get_token());
+
+    auto consumer_future =
+        std::async(score::mw::com::test::RunConsumer, test_configuration.scenario, stop_source.get_token());
+
+    provider_future.get();
+    consumer_future.get();
+
+    return EXIT_SUCCESS;
+}

--- a/score/mw/com/test/move_semantics/skeleton_method/main_consumer_and_provider.cpp
+++ b/score/mw/com/test/move_semantics/skeleton_method/main_consumer_and_provider.cpp
@@ -41,8 +41,7 @@ int main(int argc, const char** argv)
     auto provider_future =
         std::async(score::mw::com::test::RunProvider, test_configuration.scenario, stop_source.get_token());
 
-    auto consumer_future =
-        std::async(score::mw::com::test::RunConsumer, test_configuration.scenario, stop_source.get_token());
+    auto consumer_future = std::async(score::mw::com::test::RunConsumer, stop_source.get_token());
 
     provider_future.get();
     consumer_future.get();

--- a/score/mw/com/test/move_semantics/skeleton_method/main_consumer_and_provider.cpp
+++ b/score/mw/com/test/move_semantics/skeleton_method/main_consumer_and_provider.cpp
@@ -41,7 +41,7 @@ int main(int argc, const char** argv)
     auto provider_future =
         std::async(score::mw::com::test::RunProvider, test_configuration.scenario, stop_source.get_token());
 
-    auto consumer_future = std::async(score::mw::com::test::RunConsumer, stop_source.get_token());
+    auto consumer_future = std::async(score::mw::com::test::RunConsumer);
 
     provider_future.get();
     consumer_future.get();

--- a/score/mw/com/test/move_semantics/skeleton_method/main_provider.cpp
+++ b/score/mw/com/test/move_semantics/skeleton_method/main_provider.cpp
@@ -1,0 +1,42 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/runtime.h"
+
+#include "score/mw/com/test/common_test_resources/assert_handler.h"
+#include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
+#include "score/mw/com/test/move_semantics/skeleton_method/provider.h"
+#include "score/mw/com/test/move_semantics/skeleton_method/test_parameters.h"
+
+#include <iostream>
+
+int main(int argc, const char** argv)
+{
+    auto test_configuration{score::mw::com::test::ReadCommandLineArguments(argc, argv)};
+
+    score::mw::com::test::SetupAssertHandler();
+    score::mw::com::runtime::InitializeRuntime(argc, argv);
+
+    score::cpp::stop_source stop_source{};
+    const bool sig_term_handler_setup_success = score::mw::com::SetupStopTokenSigTermHandler(stop_source);
+    if (!sig_term_handler_setup_success)
+    {
+        std::cerr << "Unable to set signal handler for SIGINT and/or SIGTERM, cautiously continuing" << std::endl;
+    }
+
+    std::cout << "Starting provider with scenario " << static_cast<std::size_t>(test_configuration.scenario)
+              << std::endl;
+
+    score::mw::com::test::RunProvider(test_configuration.scenario, stop_source.get_token());
+
+    return EXIT_SUCCESS;
+}

--- a/score/mw/com/test/move_semantics/skeleton_method/provider.cpp
+++ b/score/mw/com/test/move_semantics/skeleton_method/provider.cpp
@@ -86,14 +86,14 @@ void RunProviderMoveConstructBeforeOffered(const score::cpp::stop_token& stop_to
     std::cout << "\nProvider: Step 2 - Move #1: Skeleton B = std::move(Skeleton A)" << std::endl;
     auto skeleton_b = std::move(skeleton_a);
 
-    // Step 3. Register Handler A on Skeleton B. Its body notifies notification_a when called.
+    // Step 3. Register Handler A on Skeleton B. Its body notifies handler_a_called when called.
     std::cout << "\nProvider: Step 3 - Register Handler A (a + b) on Skeleton B" << std::endl;
-    concurrency::Notification notification_a{};
+    concurrency::Notification handler_a_called{};
     RegisterHandlerOrFail(
         skeleton_b.moved_method_,
-        [&notification_a](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
+        [&handler_a_called](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
             result = a + b;
-            notification_a.notify();
+            handler_a_called.notify();
         },
         "Provider: Failed to register Handler A: ");
 
@@ -107,22 +107,22 @@ void RunProviderMoveConstructBeforeOffered(const score::cpp::stop_token& stop_to
 
     // Step 6. Wait until Handler A has been called at least once.
     std::cout << "\nProvider: Step 6 - Wait for Handler A to be called" << std::endl;
-    WaitOrFail(notification_a, stop_token, "Provider: Notification wait (Handler A) timed out");
+    WaitOrFail(handler_a_called, stop_token, "Provider: Notification wait (Handler A) timed out");
 
-    // Step 7. Register Handler B on Skeleton C. Its body notifies notification_b when called.
+    // Step 7. Register Handler B on Skeleton C. Its body notifies handler_b_called when called.
     std::cout << "\nProvider: Step 7 - Register Handler B (a * b) on Skeleton C" << std::endl;
-    concurrency::Notification notification_b{};
+    concurrency::Notification handler_b_called{};
     RegisterHandlerOrFail(
         skeleton_c.moved_method_,
-        [&notification_b](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
+        [&handler_b_called](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
             result = a * b;
-            notification_b.notify();
+            handler_b_called.notify();
         },
         "Provider: Failed to register Handler B: ");
 
     // Step 8. Wait until Handler B has been called at least once before finishing.
     std::cout << "\nProvider: Step 8 - Wait for Handler B to be called" << std::endl;
-    WaitOrFail(notification_b, stop_token, "Provider: Notification wait (Handler B) timed out");
+    WaitOrFail(handler_b_called, stop_token, "Provider: Notification wait (Handler B) timed out");
 
     // Step 9. Return: Skeleton C's destructor calls StopOfferService().
     std::cout << "\nProvider: Step 9 - Finishing" << std::endl;
@@ -136,12 +136,14 @@ void RunProviderMoveConstructAfterOffered(const score::cpp::stop_token& stop_tok
     skeleton_container.CreateSkeleton(kInstanceSpecifierMovedTo, "skeleton_method_move_semantics");
     auto skeleton_a = skeleton_container.Extract();
 
-    // Step 2. Register Handler A on Skeleton A.
+    // Step 2. Register Handler A on Skeleton A. Its body notifies handler_a_called when called.
     std::cout << "\nProvider: Step 2 - Register Handler A (a + b)" << std::endl;
+    concurrency::Notification handler_a_called{};
     RegisterHandlerOrFail(
         skeleton_a.moved_method_,
-        [](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
+        [&handler_a_called](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
             result = a + b;
+            handler_a_called.notify();
         },
         "Provider: Failed to register Handler A: ");
 
@@ -149,31 +151,35 @@ void RunProviderMoveConstructAfterOffered(const score::cpp::stop_token& stop_tok
     std::cout << "\nProvider: Step 3 - Offer Skeleton A" << std::endl;
     OfferSkeletonOrFail(skeleton_a, "Provider: OfferService failed: ");
 
-    // Step 4. Sleep a random duration (0-500ms). Fuzzy Scenario: Move operation is done at random point while
+    // Step 4. Wait until Handler A has been called at least once before proceeding.
+    std::cout << "\nProvider: Step 4 - Wait for Handler A to be called" << std::endl;
+    WaitOrFail(handler_a_called, stop_token, "Provider: Notification wait (Handler A) timed out");
+
+    // Step 5. Sleep a random duration (0-500ms). Fuzzy Scenario: Move operation is done at random point while
     //         the consumer is independently calling the method in a loop.
     SleepRandomDuration();
 
-    // Step 5. Move construct: Skeleton B = std::move(Skeleton A)  [already offered, random timing]
-    std::cout << "\nProvider: Step 5 - Move construct Skeleton B = std::move(Skeleton A)" << std::endl;
+    // Step 6. Move construct: Skeleton B = std::move(Skeleton A)  [already offered, random timing]
+    std::cout << "\nProvider: Step 6 - Move construct Skeleton B = std::move(Skeleton A)" << std::endl;
     auto skeleton_b = std::move(skeleton_a);
 
-    // Step 6. Register Handler B on Skeleton B. Its body notifies notification_b when called.
-    std::cout << "\nProvider: Step 6 - Register Handler B (a * b) on Skeleton B" << std::endl;
-    concurrency::Notification notification_b{};
+    // Step 7. Register Handler B on Skeleton B. Its body notifies handler_b_called when called.
+    std::cout << "\nProvider: Step 7 - Register Handler B (a * b) on Skeleton B" << std::endl;
+    concurrency::Notification handler_b_called{};
     RegisterHandlerOrFail(
         skeleton_b.moved_method_,
-        [&notification_b](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
+        [&handler_b_called](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
             result = a * b;
-            notification_b.notify();
+            handler_b_called.notify();
         },
         "Provider: Failed to register Handler B: ");
 
-    // Step 7. Wait until Handler B has been called at least once before finishing.
-    std::cout << "\nProvider: Step 7 - Wait for Handler B to be called" << std::endl;
-    WaitOrFail(notification_b, stop_token, "Provider: Notification wait (Handler B) timed out");
+    // Step 8. Wait until Handler B has been called at least once before finishing.
+    std::cout << "\nProvider: Step 8 - Wait for Handler B to be called" << std::endl;
+    WaitOrFail(handler_b_called, stop_token, "Provider: Notification wait (Handler B) timed out");
 
-    // Step 8. Return: Skeleton B's destructor calls StopOfferService().
-    std::cout << "\nProvider: Step 8 - Finishing" << std::endl;
+    // Step 9. Return: Skeleton B's destructor calls StopOfferService().
+    std::cout << "\nProvider: Step 9 - Finishing" << std::endl;
 }
 
 void RunProviderMoveAssignBeforeOffered(const score::cpp::stop_token& stop_token)
@@ -192,14 +198,14 @@ void RunProviderMoveAssignBeforeOffered(const score::cpp::stop_token& stop_token
     std::cout << "\nProvider: Step 2 - Move-assign #1: Skeleton B = std::move(Skeleton A)" << std::endl;
     skeleton_b = std::move(skeleton_a);
 
-    // Step 3. Register Handler A on Skeleton B. Its body notifies notification_a when called.
+    // Step 3. Register Handler A on Skeleton B. Its body notifies handler_a_called when called.
     std::cout << "\nProvider: Step 3 - Register Handler A (a + b) on Skeleton B" << std::endl;
-    concurrency::Notification notification_a{};
+    concurrency::Notification handler_a_called{};
     RegisterHandlerOrFail(
         skeleton_b.moved_method_,
-        [&notification_a](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
+        [&handler_a_called](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
             result = a + b;
-            notification_a.notify();
+            handler_a_called.notify();
         },
         "Provider: Failed to register Handler A: ");
 
@@ -219,23 +225,23 @@ void RunProviderMoveAssignBeforeOffered(const score::cpp::stop_token& stop_token
 
     // Step 7. Wait until Handler A has been called at least once.
     std::cout << "\nProvider: Step 7 - Wait for Handler A to be called" << std::endl;
-    WaitOrFail(notification_a, stop_token, "Provider: Notification wait (Handler A) timed out");
+    WaitOrFail(handler_a_called, stop_token, "Provider: Notification wait (Handler A) timed out");
 
     // Step 8. Register Handler C (a * b) on Skeleton C. Its body notifies
-    //         notification_c when called.
+    //         handler_c_called when called.
     std::cout << "\nProvider: Step 8 - Register Handler C (a * b) on Skeleton C" << std::endl;
-    concurrency::Notification notification_c{};
+    concurrency::Notification handler_c_called{};
     RegisterHandlerOrFail(
         skeleton_c.moved_method_,
-        [&notification_c](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
+        [&handler_c_called](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
             result = a * b;
-            notification_c.notify();
+            handler_c_called.notify();
         },
         "Provider: Failed to register Handler C: ");
 
     // Step 9. Wait until Handler C has been called at least once before finishing.
     std::cout << "\nProvider: Step 9 - Wait for Handler C to be called" << std::endl;
-    WaitOrFail(notification_c, stop_token, "Provider: Notification wait (Handler C) timed out");
+    WaitOrFail(handler_c_called, stop_token, "Provider: Notification wait (Handler C) timed out");
 
     // Step 10. Return: Skeleton C's destructor calls StopOfferService().
     std::cout << "\nProvider: Step 10 - Finishing" << std::endl;
@@ -253,12 +259,15 @@ void RunProviderMoveAssignAfterOffered(const score::cpp::stop_token& stop_token)
     skeleton_b_container.CreateSkeleton(kInstanceSpecifierMovedFrom, "skeleton_method_move_semantics");
     auto skeleton_b = skeleton_b_container.Extract();
 
-    // Step 2. Register Handler A on Skeleton A and Register Handler B on Skeleton B.
+    // Step 2. Register Handler A on Skeleton A. Its body notifies notification_a when called.
+    //         Register the placeholder handler on Skeleton B.
     std::cout << "\nProvider: Step 2 - Register Handler A (a + b) on Skeleton A" << std::endl;
+    concurrency::Notification handler_a_called{};
     RegisterHandlerOrFail(
         skeleton_a.moved_method_,
-        [](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
+        [&handler_a_called](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
             result = a + b;
+            handler_a_called.notify();
         },
         "Provider: Failed to register Handler A: ");
     RegisterHandlerOrFail(
@@ -273,31 +282,35 @@ void RunProviderMoveAssignAfterOffered(const score::cpp::stop_token& stop_token)
     OfferSkeletonOrFail(skeleton_a, "Provider: OfferService (Skeleton A) failed: ");
     OfferSkeletonOrFail(skeleton_b, "Provider: OfferService (Skeleton B) failed: ");
 
-    // Step 4. Sleep a random duration (0-500ms).
+    // Step 4. Wait until Handler A has been called at least once before proceeding.
+    std::cout << "\nProvider: Step 4 - Wait for Handler A to be called" << std::endl;
+    WaitOrFail(handler_a_called, stop_token, "Provider: Notification wait (Handler A) timed out");
+
+    // Step 5. Sleep a random duration (0-500ms).
     SleepRandomDuration();
 
-    // Step 5. Move-assign: Skeleton B = std::move(Skeleton A)  [already offered, random timing]
-    std::cout << "\nProvider: Step 5 - Move-assign Skeleton B = std::move(Skeleton A)" << std::endl;
+    // Step 6. Move-assign: Skeleton B = std::move(Skeleton A)  [already offered, random timing]
+    std::cout << "\nProvider: Step 6 - Move-assign Skeleton B = std::move(Skeleton A)" << std::endl;
     skeleton_b = std::move(skeleton_a);
 
-    // Step 6. Register Handler C (a * b) on Skeleton B. Its body notifies
-    //         notification_c when called.
-    std::cout << "\nProvider: Step 6 - Register Handler C (a * b) on Skeleton B" << std::endl;
-    concurrency::Notification notification_c{};
+    // Step 7. Register Handler C (a * b) on Skeleton B. Its body notifies
+    //         handler_c_called when called.
+    std::cout << "\nProvider: Step 7 - Register Handler C (a * b) on Skeleton B" << std::endl;
+    concurrency::Notification handler_c_called{};
     RegisterHandlerOrFail(
         skeleton_b.moved_method_,
-        [&notification_c](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
+        [&handler_c_called](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
             result = a * b;
-            notification_c.notify();
+            handler_c_called.notify();
         },
         "Provider: Failed to register Handler C: ");
 
-    // Step 7. Wait until Handler C has been called at least once before finishing.
-    std::cout << "\nProvider: Step 7 - Wait for Handler C to be called" << std::endl;
-    WaitOrFail(notification_c, stop_token, "Provider: Notification wait (Handler C) timed out");
+    // Step 8. Wait until Handler C has been called at least once before finishing.
+    std::cout << "\nProvider: Step 8 - Wait for Handler C to be called" << std::endl;
+    WaitOrFail(handler_c_called, stop_token, "Provider: Notification wait (Handler C) timed out");
 
-    // Step 8. Return: Skeleton B's destructor calls StopOfferService().
-    std::cout << "\nProvider: Step 8 - Finishing" << std::endl;
+    // Step 9. Return: Skeleton B's destructor calls StopOfferService().
+    std::cout << "\nProvider: Step 9 - Finishing" << std::endl;
 }
 
 }  // namespace

--- a/score/mw/com/test/move_semantics/skeleton_method/provider.cpp
+++ b/score/mw/com/test/move_semantics/skeleton_method/provider.cpp
@@ -1,0 +1,336 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/test/move_semantics/skeleton_method/provider.h"
+
+#include "score/mw/com/test/common_test_resources/fail_test.h"
+#include "score/mw/com/test/common_test_resources/skeleton_container.h"
+#include "score/mw/com/test/move_semantics/skeleton_method/test_method_datatype.h"
+#include "score/mw/com/test/move_semantics/skeleton_method/test_parameters.h"
+
+#include "score/concurrency/notification.h"
+
+#include <score/stop_token.hpp>
+
+#include <chrono>
+#include <iostream>
+#include <random>
+#include <thread>
+#include <utility>
+
+namespace score::mw::com::test
+{
+namespace
+{
+
+constexpr auto kNotificationTimeout = std::chrono::milliseconds{5000};
+
+void SleepRandomDuration()
+{
+    std::random_device rd{};
+    std::mt19937 gen{rd()};
+    std::uniform_int_distribution<std::int64_t> dist{0, kMaxFuzzySleepDuration.count()};
+    const auto delay_ms = std::chrono::milliseconds{dist(gen)};
+    std::cout << "\nProvider: Sleeping " << delay_ms.count() << "ms before move" << std::endl;
+    std::this_thread::sleep_for(delay_ms);
+}
+
+template <typename Method, typename Handler>
+void RegisterHandlerOrFail(Method& method, Handler handler, const char* error_msg)
+{
+    const auto result = method.RegisterHandler(std::move(handler));
+    if (!result.has_value())
+    {
+        FailTest(error_msg, result.error());
+    }
+}
+
+template <typename Skeleton>
+void OfferSkeletonOrFail(Skeleton& skeleton, const char* error_msg)
+{
+    const auto result = skeleton.OfferService();
+    if (!result.has_value())
+    {
+        FailTest(error_msg, result.error());
+    }
+}
+
+void WaitOrFail(concurrency::Notification& notification,
+                const score::cpp::stop_token& stop_token,
+                const char* error_msg)
+{
+    if (!notification.waitForWithAbort(kNotificationTimeout, stop_token))
+    {
+        FailTest(error_msg);
+    }
+}
+
+void RunProviderMoveConstructBeforeOffered(const score::cpp::stop_token& stop_token)
+{
+    // Step 1. Create Skeleton A
+    std::cout << "\nProvider: Step 1 - Create Skeleton A" << std::endl;
+    SkeletonContainer<SkeletonMethodMoveSkeleton> skeleton_container{};
+    skeleton_container.CreateSkeleton(kInstanceSpecifierMovedTo, "skeleton_method_move_semantics");
+    auto skeleton_a = skeleton_container.Extract();
+
+    // Step 2. Move #1: Skeleton B = std::move(Skeleton A)  [before registering any handler]
+    std::cout << "\nProvider: Step 2 - Move #1: Skeleton B = std::move(Skeleton A)" << std::endl;
+    auto skeleton_b = std::move(skeleton_a);
+
+    // Step 3. Register Handler A on Skeleton B. Its body notifies notification_a when called.
+    std::cout << "\nProvider: Step 3 - Register Handler A (a + b) on Skeleton B" << std::endl;
+    concurrency::Notification notification_a{};
+    RegisterHandlerOrFail(
+        skeleton_b.moved_method_,
+        [&notification_a](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
+            result = a + b;
+            notification_a.notify();
+        },
+        "Provider: Failed to register Handler A: ");
+
+    // Step 4. Move #2: Skeleton C = std::move(Skeleton B)  [after registering the handler]
+    std::cout << "\nProvider: Step 4 - Move #2: Skeleton C = std::move(Skeleton B)" << std::endl;
+    auto skeleton_c = std::move(skeleton_b);
+
+    // Step 5. Offer Skeleton C
+    std::cout << "\nProvider: Step 5 - Offer Skeleton C" << std::endl;
+    OfferSkeletonOrFail(skeleton_c, "Provider: OfferService failed: ");
+
+    // Step 6. Wait until Handler A has been called at least once.
+    std::cout << "\nProvider: Step 6 - Wait for Handler A to be called" << std::endl;
+    WaitOrFail(notification_a, stop_token, "Provider: Notification wait (Handler A) timed out");
+
+    // Step 7. Register Handler B on Skeleton C. Its body notifies notification_b when called.
+    std::cout << "\nProvider: Step 7 - Register Handler B (a * b) on Skeleton C" << std::endl;
+    concurrency::Notification notification_b{};
+    RegisterHandlerOrFail(
+        skeleton_c.moved_method_,
+        [&notification_b](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
+            result = a * b;
+            notification_b.notify();
+        },
+        "Provider: Failed to register Handler B: ");
+
+    // Step 8. Wait until Handler B has been called at least once before finishing.
+    std::cout << "\nProvider: Step 8 - Wait for Handler B to be called" << std::endl;
+    WaitOrFail(notification_b, stop_token, "Provider: Notification wait (Handler B) timed out");
+
+    // Step 9. Return: Skeleton C's destructor calls StopOfferService().
+    std::cout << "\nProvider: Step 9 - Finishing" << std::endl;
+}
+
+void RunProviderMoveConstructAfterOffered(const score::cpp::stop_token& stop_token)
+{
+    // Step 1. Create Skeleton A
+    std::cout << "\nProvider: Step 1 - Create Skeleton A" << std::endl;
+    SkeletonContainer<SkeletonMethodMoveSkeleton> skeleton_container{};
+    skeleton_container.CreateSkeleton(kInstanceSpecifierMovedTo, "skeleton_method_move_semantics");
+    auto skeleton_a = skeleton_container.Extract();
+
+    // Step 2. Register Handler A on Skeleton A.
+    std::cout << "\nProvider: Step 2 - Register Handler A (a + b)" << std::endl;
+    RegisterHandlerOrFail(
+        skeleton_a.moved_method_,
+        [](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
+            result = a + b;
+        },
+        "Provider: Failed to register Handler A: ");
+
+    // Step 3. Offer Skeleton A
+    std::cout << "\nProvider: Step 3 - Offer Skeleton A" << std::endl;
+    OfferSkeletonOrFail(skeleton_a, "Provider: OfferService failed: ");
+
+    // Step 4. Sleep a random duration (0-500ms). Fuzzy Scenario: Move operation is done at random point while
+    //         the consumer is independently calling the method in a loop.
+    SleepRandomDuration();
+
+    // Step 5. Move construct: Skeleton B = std::move(Skeleton A)  [already offered, random timing]
+    std::cout << "\nProvider: Step 5 - Move construct Skeleton B = std::move(Skeleton A)" << std::endl;
+    auto skeleton_b = std::move(skeleton_a);
+
+    // Step 6. Register Handler B on Skeleton B. Its body notifies notification_b when called.
+    std::cout << "\nProvider: Step 6 - Register Handler B (a * b) on Skeleton B" << std::endl;
+    concurrency::Notification notification_b{};
+    RegisterHandlerOrFail(
+        skeleton_b.moved_method_,
+        [&notification_b](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
+            result = a * b;
+            notification_b.notify();
+        },
+        "Provider: Failed to register Handler B: ");
+
+    // Step 7. Wait until Handler B has been called at least once before finishing.
+    std::cout << "\nProvider: Step 7 - Wait for Handler B to be called" << std::endl;
+    WaitOrFail(notification_b, stop_token, "Provider: Notification wait (Handler B) timed out");
+
+    // Step 8. Return: Skeleton B's destructor calls StopOfferService().
+    std::cout << "\nProvider: Step 8 - Finishing" << std::endl;
+}
+
+void RunProviderMoveAssignBeforeOffered(const score::cpp::stop_token& stop_token)
+{
+    // Step 1. Create Skeleton A  and Skeleton B.
+    std::cout << "\nProvider: Step 1 - Create Skeleton A and placeholder Skeleton B" << std::endl;
+    SkeletonContainer<SkeletonMethodMoveSkeleton> skeleton_a_container{};
+    skeleton_a_container.CreateSkeleton(kInstanceSpecifierMovedTo, "skeleton_method_move_semantics");
+    auto skeleton_a = skeleton_a_container.Extract();
+
+    SkeletonContainer<SkeletonMethodMoveSkeleton> skeleton_b_container{};
+    skeleton_b_container.CreateSkeleton(kInstanceSpecifierMovedFrom, "skeleton_method_move_semantics");
+    auto skeleton_b = skeleton_b_container.Extract();
+
+    // Step 2. Move-assign #1: Skeleton B = std::move(Skeleton A)  [before registering any handler]
+    std::cout << "\nProvider: Step 2 - Move-assign #1: Skeleton B = std::move(Skeleton A)" << std::endl;
+    skeleton_b = std::move(skeleton_a);
+
+    // Step 3. Register Handler A on Skeleton B. Its body notifies notification_a when called.
+    std::cout << "\nProvider: Step 3 - Register Handler A (a + b) on Skeleton B" << std::endl;
+    concurrency::Notification notification_a{};
+    RegisterHandlerOrFail(
+        skeleton_b.moved_method_,
+        [&notification_a](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
+            result = a + b;
+            notification_a.notify();
+        },
+        "Provider: Failed to register Handler A: ");
+
+    // Step 4. Create Skeleton C, a second placeholder assignment target.
+    std::cout << "\nProvider: Step 4 - Create placeholder Skeleton C" << std::endl;
+    SkeletonContainer<SkeletonMethodMoveSkeleton> skeleton_c_container{};
+    skeleton_c_container.CreateSkeleton(kInstanceSpecifierMovedFrom, "skeleton_method_move_semantics");
+    auto skeleton_c = skeleton_c_container.Extract();
+
+    // Step 5. Move-assign #2: Skeleton C = std::move(Skeleton B)  [after registering the handler]
+    std::cout << "\nProvider: Step 5 - Move-assign #2: Skeleton C = std::move(Skeleton B)" << std::endl;
+    skeleton_c = std::move(skeleton_b);
+
+    // Step 6. Offer Skeleton C
+    std::cout << "\nProvider: Step 6 - Offer Skeleton C" << std::endl;
+    OfferSkeletonOrFail(skeleton_c, "Provider: OfferService failed: ");
+
+    // Step 7. Wait until Handler A has been called at least once.
+    std::cout << "\nProvider: Step 7 - Wait for Handler A to be called" << std::endl;
+    WaitOrFail(notification_a, stop_token, "Provider: Notification wait (Handler A) timed out");
+
+    // Step 8. Register Handler C (a * b) on Skeleton C. Its body notifies
+    //         notification_c when called.
+    std::cout << "\nProvider: Step 8 - Register Handler C (a * b) on Skeleton C" << std::endl;
+    concurrency::Notification notification_c{};
+    RegisterHandlerOrFail(
+        skeleton_c.moved_method_,
+        [&notification_c](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
+            result = a * b;
+            notification_c.notify();
+        },
+        "Provider: Failed to register Handler C: ");
+
+    // Step 9. Wait until Handler C has been called at least once before finishing.
+    std::cout << "\nProvider: Step 9 - Wait for Handler C to be called" << std::endl;
+    WaitOrFail(notification_c, stop_token, "Provider: Notification wait (Handler C) timed out");
+
+    // Step 10. Return: Skeleton C's destructor calls StopOfferService().
+    std::cout << "\nProvider: Step 10 - Finishing" << std::endl;
+}
+
+void RunProviderMoveAssignAfterOffered(const score::cpp::stop_token& stop_token)
+{
+    // Step 1. Create Skeleton A and Skeleton B.
+    std::cout << "\nProvider: Step 1 - Create Skeleton A and placeholder Skeleton B" << std::endl;
+    SkeletonContainer<SkeletonMethodMoveSkeleton> skeleton_a_container{};
+    skeleton_a_container.CreateSkeleton(kInstanceSpecifierMovedTo, "skeleton_method_move_semantics");
+    auto skeleton_a = skeleton_a_container.Extract();
+
+    SkeletonContainer<SkeletonMethodMoveSkeleton> skeleton_b_container{};
+    skeleton_b_container.CreateSkeleton(kInstanceSpecifierMovedFrom, "skeleton_method_move_semantics");
+    auto skeleton_b = skeleton_b_container.Extract();
+
+    // Step 2. Register Handler A on Skeleton A and Register Handler B on Skeleton B.
+    std::cout << "\nProvider: Step 2 - Register Handler A (a + b) on Skeleton A" << std::endl;
+    RegisterHandlerOrFail(
+        skeleton_a.moved_method_,
+        [](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
+            result = a + b;
+        },
+        "Provider: Failed to register Handler A: ");
+    RegisterHandlerOrFail(
+        skeleton_b.moved_method_,
+        [](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
+            result = a - b;
+        },
+        "Provider: Failed to register placeholder handler on Skeleton B: ");
+
+    // Step 3. Offer both skeletons.
+    std::cout << "\nProvider: Step 3 - Offer both skeletons" << std::endl;
+    OfferSkeletonOrFail(skeleton_a, "Provider: OfferService (Skeleton A) failed: ");
+    OfferSkeletonOrFail(skeleton_b, "Provider: OfferService (Skeleton B) failed: ");
+
+    // Step 4. Sleep a random duration (0-500ms).
+    SleepRandomDuration();
+
+    // Step 5. Move-assign: Skeleton B = std::move(Skeleton A)  [already offered, random timing]
+    std::cout << "\nProvider: Step 5 - Move-assign Skeleton B = std::move(Skeleton A)" << std::endl;
+    skeleton_b = std::move(skeleton_a);
+
+    // Step 6. Register Handler C (a * b) on Skeleton B. Its body notifies
+    //         notification_c when called.
+    std::cout << "\nProvider: Step 6 - Register Handler C (a * b) on Skeleton B" << std::endl;
+    concurrency::Notification notification_c{};
+    RegisterHandlerOrFail(
+        skeleton_b.moved_method_,
+        [&notification_c](std::int32_t& result, const std::int32_t& a, const std::int32_t& b) {
+            result = a * b;
+            notification_c.notify();
+        },
+        "Provider: Failed to register Handler C: ");
+
+    // Step 7. Wait until Handler C has been called at least once before finishing.
+    std::cout << "\nProvider: Step 7 - Wait for Handler C to be called" << std::endl;
+    WaitOrFail(notification_c, stop_token, "Provider: Notification wait (Handler C) timed out");
+
+    // Step 8. Return: Skeleton B's destructor calls StopOfferService().
+    std::cout << "\nProvider: Step 8 - Finishing" << std::endl;
+}
+
+}  // namespace
+
+void RunProvider(const SkeletonMoveScenario& scenario, const score::cpp::stop_token& stop_token)
+{
+    switch (scenario)
+    {
+        case SkeletonMoveScenario::kMoveConstructBeforeOffered:
+        {
+            RunProviderMoveConstructBeforeOffered(stop_token);
+            break;
+        }
+        case SkeletonMoveScenario::kMoveConstructAfterOffered:
+        {
+            RunProviderMoveConstructAfterOffered(stop_token);
+            break;
+        }
+        case SkeletonMoveScenario::kMoveAssignBeforeOffered:
+        {
+            RunProviderMoveAssignBeforeOffered(stop_token);
+            break;
+        }
+        case SkeletonMoveScenario::kMoveAssignAfterOffered:
+        {
+            RunProviderMoveAssignAfterOffered(stop_token);
+            break;
+        }
+        case SkeletonMoveScenario::kNumberOfScenarios:
+            [[fallthrough]];
+        default:
+            FailTest("RunProvider: Unknown scenario");
+    }
+}
+
+}  // namespace score::mw::com::test

--- a/score/mw/com/test/move_semantics/skeleton_method/provider.h
+++ b/score/mw/com/test/move_semantics/skeleton_method/provider.h
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_TEST_MOVE_SEMANTICS_SKELETON_METHOD_PROVIDER_H
+#define SCORE_MW_COM_TEST_MOVE_SEMANTICS_SKELETON_METHOD_PROVIDER_H
+
+#include "score/mw/com/test/move_semantics/skeleton_method/test_parameters.h"
+
+#include <score/stop_token.hpp>
+
+namespace score::mw::com::test
+{
+
+void RunProvider(const SkeletonMoveScenario& scenario, const score::cpp::stop_token& stop_token);
+
+}  // namespace score::mw::com::test
+
+#endif  // SCORE_MW_COM_TEST_MOVE_SEMANTICS_SKELETON_METHOD_PROVIDER_H

--- a/score/mw/com/test/move_semantics/skeleton_method/test_method_datatype.cpp
+++ b/score/mw/com/test/move_semantics/skeleton_method/test_method_datatype.cpp
@@ -1,0 +1,13 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/test/move_semantics/skeleton_method/test_method_datatype.h"

--- a/score/mw/com/test/move_semantics/skeleton_method/test_method_datatype.h
+++ b/score/mw/com/test/move_semantics/skeleton_method/test_method_datatype.h
@@ -1,0 +1,37 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_TEST_MOVE_SEMANTICS_SKELETON_METHOD_TEST_METHOD_DATATYPE_H
+#define SCORE_MW_COM_TEST_MOVE_SEMANTICS_SKELETON_METHOD_TEST_METHOD_DATATYPE_H
+
+#include "score/mw/com/types.h"
+
+#include <cstdint>
+
+namespace score::mw::com::test
+{
+
+template <typename T>
+class SkeletonMethodMoveInterface : public T::Base
+{
+  public:
+    using T::Base::Base;
+
+    typename T::template Method<std::int32_t(std::int32_t, std::int32_t)> moved_method_{*this, "moved_method"};
+};
+
+using SkeletonMethodMoveProxy = score::mw::com::AsProxy<SkeletonMethodMoveInterface>;
+using SkeletonMethodMoveSkeleton = score::mw::com::AsSkeleton<SkeletonMethodMoveInterface>;
+
+}  // namespace score::mw::com::test
+
+#endif  // SCORE_MW_COM_TEST_MOVE_SEMANTICS_SKELETON_METHOD_TEST_METHOD_DATATYPE_H

--- a/score/mw/com/test/move_semantics/skeleton_method/test_parameters.cpp
+++ b/score/mw/com/test/move_semantics/skeleton_method/test_parameters.cpp
@@ -1,0 +1,65 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/test/move_semantics/skeleton_method/test_parameters.h"
+
+#include "score/mw/com/test/common_test_resources/command_line_parser.h"
+#include "score/mw/com/test/common_test_resources/fail_test.h"
+
+namespace score::mw::com::test
+{
+
+CombinedTestConfiguration ReadCommandLineArguments(int argc, const char** argv)
+{
+    auto args = ParseCommandLineArguments(argc, argv, {{kScenario, ""}, {kServiceInstanceManifest, ""}});
+
+    const auto scenario_index = GetValue<std::size_t>(args, kScenario);
+    if (scenario_index >= static_cast<std::size_t>(SkeletonMoveScenario::kNumberOfScenarios))
+    {
+        FailTest("skeleton_method_move_semantics: ",
+                 kScenario,
+                 " value ",
+                 scenario_index,
+                 " is out of range. Valid values are between 0 and ",
+                 static_cast<std::uint8_t>(SkeletonMoveScenario::kNumberOfScenarios) - 1,
+                 ".");
+    }
+    const auto scenario = static_cast<SkeletonMoveScenario>(scenario_index);
+
+    auto service_instance_manifest = GetValue<std::string>(args, kServiceInstanceManifest);
+
+    return {scenario, service_instance_manifest};
+}
+
+std::int32_t GetFirstHandlerExpectedResult(const SkeletonMoveScenario scenario)
+{
+    if (scenario >= SkeletonMoveScenario::kNumberOfScenarios)
+    {
+        FailTest("GetFirstHandlerExpectedResult: Unknown scenario");
+        return 0;
+    }
+    // Handler A is always registered first and always computes a + b, for all scenarios.
+    return kTestArgA + kTestArgB;
+}
+
+std::int32_t GetSecondHandlerExpectedResult(const SkeletonMoveScenario scenario)
+{
+    if (scenario >= SkeletonMoveScenario::kNumberOfScenarios)
+    {
+        FailTest("GetSecondHandlerExpectedResult: Unknown scenario");
+        return 0;
+    }
+    // The second handler (Handler B/C) always computes a * b, for all scenarios.
+    return kTestArgA * kTestArgB;
+}
+
+}  // namespace score::mw::com::test

--- a/score/mw/com/test/move_semantics/skeleton_method/test_parameters.cpp
+++ b/score/mw/com/test/move_semantics/skeleton_method/test_parameters.cpp
@@ -40,26 +40,4 @@ CombinedTestConfiguration ReadCommandLineArguments(int argc, const char** argv)
     return {scenario, service_instance_manifest};
 }
 
-std::int32_t GetFirstHandlerExpectedResult(const SkeletonMoveScenario scenario)
-{
-    if (scenario >= SkeletonMoveScenario::kNumberOfScenarios)
-    {
-        FailTest("GetFirstHandlerExpectedResult: Unknown scenario");
-        return 0;
-    }
-    // Handler A is always registered first and always computes a + b, for all scenarios.
-    return kTestArgA + kTestArgB;
-}
-
-std::int32_t GetSecondHandlerExpectedResult(const SkeletonMoveScenario scenario)
-{
-    if (scenario >= SkeletonMoveScenario::kNumberOfScenarios)
-    {
-        FailTest("GetSecondHandlerExpectedResult: Unknown scenario");
-        return 0;
-    }
-    // The second handler (Handler B/C) always computes a * b, for all scenarios.
-    return kTestArgA * kTestArgB;
-}
-
 }  // namespace score::mw::com::test

--- a/score/mw/com/test/move_semantics/skeleton_method/test_parameters.h
+++ b/score/mw/com/test/move_semantics/skeleton_method/test_parameters.h
@@ -1,0 +1,69 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_TEST_MOVE_SEMANTICS_SKELETON_METHOD_TEST_PARAMETERS_H
+#define SCORE_MW_COM_TEST_MOVE_SEMANTICS_SKELETON_METHOD_TEST_PARAMETERS_H
+
+#include "score/mw/com/types.h"
+
+#include <chrono>
+#include <cstdint>
+#include <string>
+
+namespace score::mw::com::test
+{
+
+const std::string kScenario{"scenario"};
+const std::string kServiceInstanceManifest{"service-instance-manifest"};
+
+constexpr std::int32_t kTestArgA{10};
+constexpr std::int32_t kTestArgB{5};
+
+// Upper bound (in milliseconds) for the provider's random pre-move sleep in "after offered" (fuzzy)
+// scenarios.
+constexpr std::chrono::milliseconds kMaxFuzzySleepDuration{500};
+
+const InstanceSpecifier kInstanceSpecifierMovedTo =
+    InstanceSpecifier::Create(std::string{"test/move_semantics/skeleton_method/SkeletonMethodMoveInterfaceMovedTo"})
+        .value();
+const InstanceSpecifier kInstanceSpecifierMovedFrom =
+    InstanceSpecifier::Create(std::string{"test/move_semantics/skeleton_method/SkeletonMethodMoveInterfaceMovedFrom"})
+        .value();
+
+enum class SkeletonMoveScenario : std::uint8_t
+{
+    kMoveConstructBeforeOffered,
+    kMoveConstructAfterOffered,
+    kMoveAssignBeforeOffered,
+    kMoveAssignAfterOffered,
+    kNumberOfScenarios
+};
+
+struct CombinedTestConfiguration
+{
+    SkeletonMoveScenario scenario;
+    std::string service_instance_manifest;
+};
+
+CombinedTestConfiguration ReadCommandLineArguments(int argc, const char** argv);
+
+/// \brief Returns the expected return value of moved_method_(kTestArgA, kTestArgB) for the first,
+///        deterministic call (always resolves to Handler A: a + b = 15).
+std::int32_t GetFirstHandlerExpectedResult(SkeletonMoveScenario scenario);
+
+/// \brief Returns the expected return value once the second handler is registered and called
+///        (Handler B/C: a * b = 50, for all scenarios).
+std::int32_t GetSecondHandlerExpectedResult(SkeletonMoveScenario scenario);
+
+}  // namespace score::mw::com::test
+
+#endif  // SCORE_MW_COM_TEST_MOVE_SEMANTICS_SKELETON_METHOD_TEST_PARAMETERS_H

--- a/score/mw/com/test/move_semantics/skeleton_method/test_parameters.h
+++ b/score/mw/com/test/move_semantics/skeleton_method/test_parameters.h
@@ -32,6 +32,12 @@ constexpr std::int32_t kTestArgB{5};
 // scenarios.
 constexpr std::chrono::milliseconds kMaxFuzzySleepDuration{500};
 
+// Handler A is always registered first and always computes a + b, for all scenarios.
+constexpr std::int32_t kFirstHandlerExpectedResult{kTestArgA + kTestArgB};
+
+// The second handler (Handler B/C) always computes a * b, for all scenarios.
+constexpr std::int32_t kSecondHandlerExpectedResult{kTestArgA * kTestArgB};
+
 const InstanceSpecifier kInstanceSpecifierMovedTo =
     InstanceSpecifier::Create(std::string{"test/move_semantics/skeleton_method/SkeletonMethodMoveInterfaceMovedTo"})
         .value();
@@ -55,14 +61,6 @@ struct CombinedTestConfiguration
 };
 
 CombinedTestConfiguration ReadCommandLineArguments(int argc, const char** argv);
-
-/// \brief Returns the expected return value of moved_method_(kTestArgA, kTestArgB) for the first,
-///        deterministic call (always resolves to Handler A: a + b = 15).
-std::int32_t GetFirstHandlerExpectedResult(SkeletonMoveScenario scenario);
-
-/// \brief Returns the expected return value once the second handler is registered and called
-///        (Handler B/C: a * b = 50, for all scenarios).
-std::int32_t GetSecondHandlerExpectedResult(SkeletonMoveScenario scenario);
 
 }  // namespace score::mw::com::test
 


### PR DESCRIPTION
Adding integration tests that verify a Skeleton (and its SkeletonMethod) can be move-constructed or move-assigned without disrupting method handler registration or invocation.

Issue : #483 