### PR TITLE
mw::com: mark the test as not flaky

### DIFF
--- a/score/mw/com/test/methods/non_trivial_constructors/integration_test/BUILD
+++ b/score/mw/com/test/methods/non_trivial_constructors/integration_test/BUILD
@@ -28,5 +28,4 @@ integration_test(
         "non_trivial_constructors_test.py",
     ],
     filesystem = ":filesystem",
-    flaky = True,  # TODO: Remove flaky tag once test is stable: Refer to issue 386
 )


### PR DESCRIPTION
Since the root cause was fixed, removing flaky flag.