### PR TITLE
mw::com: update the default config value to true

### DIFF
--- a/score/mw/com/impl/configuration/config_parser.cpp
+++ b/score/mw/com/impl/configuration/config_parser.cpp
@@ -71,6 +71,8 @@ constexpr auto kMethodIdKey = "methodId"sv;
 constexpr auto kMethodQueueSizeKey = "queueSize"sv;
 constexpr auto kMethodEnabledKey = "use"sv;
 constexpr auto kMethodEnabledDefaultValue = true;
+constexpr auto kUseGetIfAvailableDefaultValue = true;
+constexpr auto kUseSetIfAvailableDefaultValue = true;
 constexpr auto kEventNumberOfSampleSlotsKey = "numberOfSampleSlots"sv;
 constexpr auto kEventMaxSamplesKey = "maxSamples"sv;
 constexpr auto kEventMaxSubscribersKey = "maxSubscribers"sv;
@@ -493,8 +495,10 @@ auto ParseLolaFieldInstanceDeployment(const score::json::Object& json_map, LolaS
         const auto number_of_tracing_slots =
             deployment_parser.RetrieveJsonElement<NumberOfIpcTracingSlots_t>(kNumberOfIpcTracingSlotsKey)
                 .value_or(kNumberOfIpcTracingSlotsDefault);
-        const auto use_get_if_available = deployment_parser.RetrieveJsonElement<bool>(kFieldUseGetIfAvailableKey);
-        const auto use_set_if_available = deployment_parser.RetrieveJsonElement<bool>(kFieldUseSetIfAvailableKey);
+        const auto use_get_if_available = deployment_parser.RetrieveJsonElement<bool>(kFieldUseGetIfAvailableKey)
+                                              .value_or(kUseGetIfAvailableDefaultValue);
+        const auto use_set_if_available = deployment_parser.RetrieveJsonElement<bool>(kFieldUseSetIfAvailableKey)
+                                              .value_or(kUseSetIfAvailableDefaultValue);
 
         auto field_deployment =
             LolaFieldInstanceDeployment(LolaEventInstanceDeployment(number_of_sample_slots,

--- a/score/mw/com/impl/configuration/config_parser_test.cpp
+++ b/score/mw/com/impl/configuration/config_parser_test.cpp
@@ -127,10 +127,8 @@ TEST_F(ConfigParserFixture, ParseExampleJson)
     EXPECT_EQ(secondDeploymentInfo.fields_.at("CurrentTemperatureFrontLeft")
                   .lola_event_instance_deployment_.max_concurrent_allocations_.value(),
               1);
-    EXPECT_EQ(secondDeploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_get_if_available_,
-              std::optional<bool>{true});
-    EXPECT_EQ(secondDeploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_set_if_available_,
-              std::optional<bool>{true});
+    EXPECT_EQ(secondDeploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_get_if_available_, true);
+    EXPECT_EQ(secondDeploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_set_if_available_, true);
     ASSERT_TRUE(secondDeploymentInfo.methods_.at("SetPressure").enabled_.has_value());
     EXPECT_TRUE(secondDeploymentInfo.methods_.at("SetPressure").enabled_.value());
 
@@ -2186,10 +2184,9 @@ TEST(ConfigParser, LolaFieldUseGetIfAvailableSetToTrue)
 
     const auto deploymentInfo = std::get<LolaServiceInstanceDeployment>(deployment.bindingInfo_);
 
-    // Then use_get_if_available_ is true and use_set_if_available_ is not set
-    EXPECT_EQ(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_get_if_available_,
-              std::optional<bool>{true});
-    EXPECT_EQ(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_set_if_available_, std::nullopt);
+    // Then use_get_if_available_ is true and use_set_if_available_ defaults to true
+    EXPECT_EQ(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_get_if_available_, true);
+    EXPECT_EQ(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_set_if_available_, true);
 }
 
 TEST(ConfigParser, LolaFieldUseSetIfAvailableSetToTrue)
@@ -2255,13 +2252,12 @@ TEST(ConfigParser, LolaFieldUseSetIfAvailableSetToTrue)
 
     const auto deploymentInfo = std::get<LolaServiceInstanceDeployment>(deployment.bindingInfo_);
 
-    // Then use_set_if_available_ is true and use_get_if_available_ is not set
-    EXPECT_EQ(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_get_if_available_, std::nullopt);
-    EXPECT_EQ(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_set_if_available_,
-              std::optional<bool>{true});
+    // Then use_set_if_available_ is true and use_get_if_available_ defaults to true
+    EXPECT_EQ(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_get_if_available_, true);
+    EXPECT_EQ(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_set_if_available_, true);
 }
 
-TEST(ConfigParser, LolaFieldOmittingBothFlagsKeepsBothUnset)
+TEST(ConfigParser, LolaFieldOmittingBothFlagsDefaultsToBothTrue)
 {
     // Given a JSON for a field without `useGetIfAvailable` or `useSetIfAvailable`
     auto j2 = R"(
@@ -2323,9 +2319,9 @@ TEST(ConfigParser, LolaFieldOmittingBothFlagsKeepsBothUnset)
 
     const auto deploymentInfo = std::get<LolaServiceInstanceDeployment>(deployment.bindingInfo_);
 
-    // Then both flags are not set
-    EXPECT_EQ(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_get_if_available_, std::nullopt);
-    EXPECT_EQ(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_set_if_available_, std::nullopt);
+    // Then both flags default to true
+    EXPECT_EQ(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_get_if_available_, true);
+    EXPECT_EQ(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_set_if_available_, true);
 }
 
 TEST(ConfigParser, LolaFieldBothFlagsSetToTrue)
@@ -2391,10 +2387,77 @@ TEST(ConfigParser, LolaFieldBothFlagsSetToTrue)
     const auto deploymentInfo = std::get<LolaServiceInstanceDeployment>(deployment.bindingInfo_);
 
     // Then both flags are true
-    EXPECT_EQ(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_get_if_available_,
-              std::optional<bool>{true});
-    EXPECT_EQ(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_set_if_available_,
-              std::optional<bool>{true});
+    EXPECT_EQ(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_get_if_available_, true);
+    EXPECT_EQ(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_set_if_available_, true);
+}
+
+TEST(ConfigParser, LolaFieldBothFlagsExplicitlySetToFalse)
+{
+    // Given a JSON with both `useGetIfAvailable` and `useSetIfAvailable` explicitly set to false for a field
+    auto j2 = R"(
+  {
+    "serviceTypes": [
+        {
+          "serviceTypeName": "/score/ncar/services/TirePressureService",
+          "version": {
+              "major": 12,
+              "minor": 34
+          },
+          "bindings": [
+              {
+                  "binding": "SHM",
+                  "serviceId": 1234,
+                  "fields": [
+                      {
+                          "fieldName": "CurrentTemperatureFrontLeft",
+                          "fieldId": 20
+                      }
+                  ]
+              }
+          ]
+        }
+    ],
+    "serviceInstances": [
+        {
+            "instanceSpecifier": "abc/abc/TirePressurePort",
+            "serviceTypeName": "/score/ncar/services/TirePressureService",
+            "version": {
+                "major": 12,
+                "minor": 34
+            },
+            "instances": [
+                {
+                  "instanceId": 1234,
+                  "asil-level": "QM",
+                  "binding": "SHM",
+                  "events": [],
+                  "fields": [
+                    {
+                          "fieldName": "CurrentTemperatureFrontLeft",
+                          "numberOfSampleSlots": 50,
+                          "maxSubscribers": 5,
+                          "useGetIfAvailable": false,
+                          "useSetIfAvailable": false
+                      }
+                  ]
+                }
+            ]
+        }
+    ]
+  }
+)"_json;
+
+    // When parsing the JSON
+    const auto config = score::mw::com::impl::configuration::Parse(std::move(j2));
+
+    const auto deployment =
+        config.GetServiceInstances().at(InstanceSpecifier::Create(std::string{"abc/abc/TirePressurePort"}).value());
+
+    const auto deploymentInfo = std::get<LolaServiceInstanceDeployment>(deployment.bindingInfo_);
+
+    // Then both flags are false (explicit false overrides the default of true)
+    EXPECT_EQ(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_get_if_available_, false);
+    EXPECT_EQ(deploymentInfo.fields_.at("CurrentTemperatureFrontLeft").use_set_if_available_, false);
 }
 
 TEST(ConfigParser, EmptyServiceTypes)

--- a/score/mw/com/impl/configuration/lola_field_instance_deployment.cpp
+++ b/score/mw/com/impl/configuration/lola_field_instance_deployment.cpp
@@ -30,8 +30,8 @@ constexpr auto kUseSetIfAvailableKey = "useSetIfAvailable";
 }  // namespace
 
 LolaFieldInstanceDeployment::LolaFieldInstanceDeployment(LolaEventInstanceDeployment event_deployment,
-                                                         const std::optional<bool> use_get_if_available,
-                                                         const std::optional<bool> use_set_if_available) noexcept
+                                                         const bool use_get_if_available,
+                                                         const bool use_set_if_available) noexcept
     : lola_event_instance_deployment_{std::move(event_deployment)},
       use_get_if_available_{use_get_if_available},
       use_set_if_available_{use_set_if_available}
@@ -48,8 +48,8 @@ LolaFieldInstanceDeployment LolaFieldInstanceDeployment::CreateFromJson(const sc
     // Delegate event-specific parsing to LolaEventInstanceDeployment (which also checks serialization version).
     auto event_deployment = LolaEventInstanceDeployment::CreateFromJson(json_object);
 
-    const auto use_get_if_available = GetOptionalValueFromJson<bool>(json_object, kUseGetIfAvailableKey);
-    const auto use_set_if_available = GetOptionalValueFromJson<bool>(json_object, kUseSetIfAvailableKey);
+    const bool use_get_if_available = GetValueFromJson<bool>(json_object, kUseGetIfAvailableKey);
+    const bool use_set_if_available = GetValueFromJson<bool>(json_object, kUseSetIfAvailableKey);
 
     return LolaFieldInstanceDeployment(std::move(event_deployment), use_get_if_available, use_set_if_available);
 }
@@ -58,15 +58,8 @@ score::json::Object LolaFieldInstanceDeployment::Serialize() const noexcept
 {
     auto json_object = lola_event_instance_deployment_.Serialize();
 
-    if (use_get_if_available_.has_value())
-    {
-        json_object[kUseGetIfAvailableKey] = score::json::Any{use_get_if_available_.value()};
-    }
-
-    if (use_set_if_available_.has_value())
-    {
-        json_object[kUseSetIfAvailableKey] = score::json::Any{use_set_if_available_.value()};
-    }
+    json_object[kUseGetIfAvailableKey] = score::json::Any{use_get_if_available_};
+    json_object[kUseSetIfAvailableKey] = score::json::Any{use_set_if_available_};
 
     return json_object;
 }

--- a/score/mw/com/impl/configuration/lola_field_instance_deployment.h
+++ b/score/mw/com/impl/configuration/lola_field_instance_deployment.h
@@ -28,8 +28,8 @@ class LolaFieldInstanceDeployment
 {
   public:
     explicit LolaFieldInstanceDeployment(LolaEventInstanceDeployment event_deployment,
-                                         const std::optional<bool> use_get_if_available,
-                                         const std::optional<bool> use_set_if_available) noexcept;
+                                         const bool use_get_if_available,
+                                         const bool use_set_if_available) noexcept;
 
     explicit LolaFieldInstanceDeployment(const score::json::Object& json_object) noexcept;
 
@@ -43,9 +43,9 @@ class LolaFieldInstanceDeployment
     // coverity[autosar_cpp14_m11_0_1_violation]
     LolaEventInstanceDeployment lola_event_instance_deployment_;
     // coverity[autosar_cpp14_m11_0_1_violation]
-    std::optional<bool> use_get_if_available_;
+    bool use_get_if_available_;
     // coverity[autosar_cpp14_m11_0_1_violation]
-    std::optional<bool> use_set_if_available_;
+    bool use_set_if_available_;
 
     // False positive, variable is used outside of the file.
     // coverity[autosar_cpp14_a0_1_1_violation : FALSE]

--- a/score/mw/com/impl/configuration/lola_field_instance_deployment_test.cpp
+++ b/score/mw/com/impl/configuration/lola_field_instance_deployment_test.cpp
@@ -101,8 +101,8 @@ TEST_P(LolaFieldInstanceDeploymentUseGetSetPairParamFixture,
     const auto serialized_unit{unit.Serialize()};
     const LolaFieldInstanceDeployment reconstructed_unit{serialized_unit};
 
-    EXPECT_EQ(reconstructed_unit.use_get_if_available_, std::optional<bool>{use_get_if_available});
-    EXPECT_EQ(reconstructed_unit.use_set_if_available_, std::optional<bool>{use_set_if_available});
+    EXPECT_EQ(reconstructed_unit.use_get_if_available_, use_get_if_available);
+    EXPECT_EQ(reconstructed_unit.use_set_if_available_, use_set_if_available);
 }
 
 INSTANTIATE_TEST_SUITE_P(UseGetAndSetCombinations,

--- a/score/mw/com/impl/configuration/mw_com_config_schema.json
+++ b/score/mw/com/impl/configuration/mw_com_config_schema.json
@@ -392,13 +392,13 @@
                                                 "type": "boolean",
                                                 "title": "Use Field Getter If Available",
                                                 "description": "When true, the getter for this field will be used if the service type declares one in the C++ service interface. Applicable for proxy/consumer side.",
-                                                "default": false
+                                                "default": true
                                             },
                                             "useSetIfAvailable": {
                                                 "type": "boolean",
                                                 "title": "Use Field Setter If Available",
                                                 "description": "When true, the setter for this field will be used if the service type declares one in the C++ service interface. Applicable for proxy/consumer side.",
-                                                "default": false
+                                                "default": true
                                             }
                                         }
                                     }

--- a/score/mw/com/impl/configuration/test/configuration_test_resources.cpp
+++ b/score/mw/com/impl/configuration/test/configuration_test_resources.cpp
@@ -50,8 +50,8 @@ LolaFieldInstanceDeployment MakeLolaFieldInstanceDeployment(
     const std::optional<std::uint8_t> max_concurrent_allocations,
     bool enforce_max_samples,
     std::uint8_t number_of_tracing_slots,
-    const std::optional<bool> use_get_if_available,
-    const std::optional<bool> use_set_if_available) noexcept
+    const bool use_get_if_available,
+    const bool use_set_if_available) noexcept
 {
     const LolaEventInstanceDeployment event_deployment{
         max_samples, max_subscribers, max_concurrent_allocations, enforce_max_samples, number_of_tracing_slots};

--- a/score/mw/com/impl/configuration/test/configuration_test_resources.h
+++ b/score/mw/com/impl/configuration/test/configuration_test_resources.h
@@ -53,8 +53,8 @@ LolaFieldInstanceDeployment MakeLolaFieldInstanceDeployment(
     const std::optional<std::uint8_t> max_concurrent_allocations = 14U,
     const bool enforce_max_samples = true,
     std::uint8_t number_of_tracing_slots = 1U,
-    const std::optional<bool> use_get_if_available = std::nullopt,
-    const std::optional<bool> use_set_if_available = std::nullopt) noexcept;
+    const bool use_get_if_available = true,
+    const bool use_set_if_available = true) noexcept;
 
 LolaMethodInstanceDeployment MakeDefaultLolaMethodInstanceDeployment() noexcept;
 


### PR DESCRIPTION
previously there was no default value for use_get/set_if_available paramter,
now we explicitly set it to true.