### PR TITLE
Rework message passing threading model for QNX

### DIFF
--- a/score/message_passing/BUILD
+++ b/score/message_passing/BUILD
@@ -209,12 +209,14 @@ cc_library(
 cc_library(
     name = "message_passing_qnx_dispatch",
     srcs = [
+        "qnx_dispatch/dispatch_thread_runner.cpp",
         "qnx_dispatch/qnx_dispatch_client_factory.cpp",
         "qnx_dispatch/qnx_dispatch_engine.cpp",
         "qnx_dispatch/qnx_dispatch_server.cpp",
         "qnx_dispatch/qnx_dispatch_server_factory.cpp",
     ],
     hdrs = [
+        "qnx_dispatch/dispatch_thread_runner.h",
         "qnx_dispatch/qnx_dispatch_client_factory.h",
         "qnx_dispatch/qnx_dispatch_engine.h",
         "qnx_dispatch/qnx_dispatch_server.h",
@@ -298,6 +300,7 @@ cc_unit_test(
 cc_unit_test(
     name = "qnx_dispatch_test",
     srcs = [
+        "dispatch_thread_runner_test.cpp",
         "qnx_dispatch_engine_test.cpp",
         "qnx_dispatch_mocked_server_test.cpp",
         "qnx_dispatch_server_test.cpp",

--- a/score/message_passing/client_connection.cpp
+++ b/score/message_passing/client_connection.cpp
@@ -21,7 +21,6 @@
 
 #include <cstddef>
 #include <cstdint>
-#include <iostream>
 #include <thread>
 
 namespace score

--- a/score/message_passing/dispatch_thread_runner_test.cpp
+++ b/score/message_passing/dispatch_thread_runner_test.cpp
@@ -1,0 +1,172 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include <gtest/gtest.h>
+
+#include "score/message_passing/resource_manager_fixture_base.h"
+
+namespace score::message_passing::detail
+{
+namespace
+{
+
+using namespace ::testing;
+
+class DispatchThreadRunnerTestFixture : public ResourceManagerFixtureBase
+{
+  public:
+    void SetUp() override
+    {
+        ResourceManagerFixtureBase::SetUp();
+    }
+
+    void TearDown() override
+    {
+        ResourceManagerFixtureBase::TearDown();
+    }
+};
+
+using DispatchThreadRunnerDeathTest = DispatchThreadRunnerTestFixture;
+
+TEST_F(DispatchThreadRunnerTestFixture, RunnerCreatedButNotStarted)
+{
+    // Given a DispatchThreadRunner instance
+    DispatchThreadRunner runner(*channel_, *dispatch_, *signal_);
+
+    // When Start() is not called
+
+    // Then no activity is recorded by OSAL mocks
+}
+
+TEST_F(DispatchThreadRunnerDeathTest, RunnerStart_CreateChannel)
+{
+    // Times(AnyNumber()) to satisfy death test logic
+
+    // Given a DispatchThreadRunner instance
+    DispatchThreadRunner runner(*channel_, *dispatch_, *signal_);
+
+    // Expecting a failing dispatch_create_channel call
+    EXPECT_CALL(*dispatch_, dispatch_create_channel).Times(AnyNumber()).WillOnce(Return(kFakeOsError));
+
+    // Then we terminate at Start() call
+    EXPECT_DEATH(runner.Start([] {}), "Unable to allocate dispatch handle");
+}
+
+TEST_F(DispatchThreadRunnerDeathTest, RunnerStart_ConnectSideChannel)
+{
+    // Times(AnyNumber()) to satisfy death test logic
+
+    // Given a DispatchThreadRunner instance
+    DispatchThreadRunner runner(*channel_, *dispatch_, *signal_);
+
+    const std::size_t index = kClientIndex;
+    dispatch_t* const dispatch_ptr = reinterpret_cast<dispatch_t*>(&dispatches_[index]);
+
+    // Expecting a failing message_connect call
+    EXPECT_CALL(*dispatch_, dispatch_create_channel).Times(AnyNumber()).WillOnce(Return(dispatch_ptr));
+    EXPECT_CALL(*dispatch_, message_connect).Times(AnyNumber()).WillOnce(Return(kFakeOsError));
+
+    // Then we terminate at Start() call
+    EXPECT_DEATH(runner.Start([] {}), "Unable to create side channel");
+}
+
+TEST_F(DispatchThreadRunnerDeathTest, RunnerStart_AttachQuitPulse)
+{
+    // Times(AnyNumber()) to satisfy death test logic
+
+    // Given a DispatchThreadRunner instance
+    DispatchThreadRunner runner(*channel_, *dispatch_, *signal_);
+
+    const std::size_t index = kClientIndex;
+    dispatch_t* const dispatch_ptr = reinterpret_cast<dispatch_t*>(&dispatches_[index]);
+    const auto coid = static_cast<std::int32_t>(index);
+
+    // Expecting a failing message_connect call
+    EXPECT_CALL(*dispatch_, dispatch_create_channel).Times(AnyNumber()).WillOnce(Return(dispatch_ptr));
+    EXPECT_CALL(*dispatch_, message_connect).Times(AnyNumber()).WillOnce(Return(coid));
+    EXPECT_CALL(*dispatch_, pulse_attach(_, _, DispatchThreadRunner::kQuitPulseCode, _, _))
+        .Times(AnyNumber())
+        .WillOnce(Return(kFakeOsError));
+
+    // Then we terminate at Start() call
+    EXPECT_DEATH(runner.Start([] {}), "Unable to attach quit pulse code");
+}
+
+TEST_F(DispatchThreadRunnerDeathTest, RunnerStart_AllocateContext)
+{
+    // Times(AnyNumber()) to satisfy death test logic
+
+    // Given a DispatchThreadRunner instance
+    DispatchThreadRunner runner(*channel_, *dispatch_, *signal_);
+
+    const std::size_t index = kClientIndex;
+    ResourceManagerMockHelper& helper = helpers_[index];
+    dispatch_t* const dispatch_ptr = reinterpret_cast<dispatch_t*>(&dispatches_[index]);
+    const auto coid = static_cast<std::int32_t>(index);
+
+    // Expecting a failing dispatch_context_alloc call
+    EXPECT_CALL(*dispatch_, dispatch_create_channel).Times(AnyNumber()).WillOnce(Return(dispatch_ptr));
+    EXPECT_CALL(*dispatch_, message_connect).Times(AnyNumber()).WillOnce(Return(coid));
+    EXPECT_CALL(*dispatch_, pulse_attach(_, _, DispatchThreadRunner::kQuitPulseCode, _, _))
+        .Times(AnyNumber())
+        .WillOnce(Invoke(&helper, &ResourceManagerMockHelper::pulse_attach));
+    EXPECT_CALL(*dispatch_, dispatch_context_alloc).Times(AnyNumber()).WillOnce(Return(kFakeOsError));
+
+    // Then we terminate at Start() call
+    EXPECT_DEATH(runner.Start([] {}), "Unable to allocate context pointer");
+}
+
+TEST_F(DispatchThreadRunnerTestFixture, RunnerCreatedAndStarted)
+{
+    // Given a DispatchThreadRunner instance
+    DispatchThreadRunner runner(*channel_, *dispatch_, *signal_);
+
+    const std::size_t index = kClientIndex;
+    ResourceManagerMockHelper& helper = helpers_[index];
+    dispatch_t* const dispatch_ptr = reinterpret_cast<dispatch_t*>(&dispatches_[index]);
+    dispatch_context_t* const context_ptr = &helper.context_;
+    const auto coid = static_cast<std::int32_t>(index);
+
+    // Expecting a set of OSAL calls
+    EXPECT_CALL(*dispatch_, dispatch_create_channel).Times(1).WillOnce(Return(dispatch_ptr));
+    EXPECT_CALL(*dispatch_, message_connect).Times(1).WillOnce(Return(coid));
+    EXPECT_CALL(*dispatch_, pulse_attach(_, _, DispatchThreadRunner::kQuitPulseCode, _, _))
+        .Times(1)
+        .WillOnce(Invoke(&helper, &ResourceManagerMockHelper::pulse_attach));
+
+    EXPECT_CALL(*dispatch_, dispatch_context_alloc).Times(1).WillOnce(Return(context_ptr));
+    EXPECT_CALL(*signal_, SigEmptySet).Times(1);
+    EXPECT_CALL(*signal_, AddTerminationSignal).Times(1);
+    EXPECT_CALL(*signal_, PthreadSigMask(_, _, _)).Times(1);
+    EXPECT_CALL(*signal_, PthreadSigMask(_, _)).Times(1);
+
+    EXPECT_CALL(*dispatch_, dispatch_block)
+        .Times(AnyNumber())
+        .WillRepeatedly(Invoke(&helper, &ResourceManagerMockHelper::dispatch_block));
+    EXPECT_CALL(*dispatch_, dispatch_handler)
+        .Times(AnyNumber())
+        .WillRepeatedly(Invoke(&helper, &ResourceManagerMockHelper::dispatch_handler));
+    EXPECT_CALL(*channel_, MsgSendPulse)
+        .Times(AnyNumber())
+        .WillRepeatedly(Invoke(&helper, &ResourceManagerMockHelper::MsgSendPulse));
+
+    // When we call Start()
+    runner.Start([] {});
+
+    EXPECT_CALL(*channel_, ConnectDetach).Times(1);
+    EXPECT_CALL(*dispatch_, dispatch_destroy).Times(1);
+    EXPECT_CALL(*dispatch_, dispatch_context_free).Times(1);
+    // And another set of OSAL calls when we destroy the runner
+}
+
+}  // namespace
+}  // namespace score::message_passing::detail

--- a/score/message_passing/qnx_dispatch/dispatch_thread_runner.cpp
+++ b/score/message_passing/qnx_dispatch/dispatch_thread_runner.cpp
@@ -1,0 +1,181 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/message_passing/qnx_dispatch/dispatch_thread_runner.h"
+
+#include <iostream>
+
+namespace score::message_passing::detail
+{
+
+namespace
+{
+
+template <typename T>
+// Suppress "AUTOSAR C++14 A9-5-1" rule finding: "Unions shall not be used.".
+// coverity[autosar_cpp14_a9_5_1_violation: FALSE]. False positive: no any union in the following line. (Ticket-219101)
+// coverity[autosar_cpp14_m7_3_1_violation] false-positive: namespace-scoped function, not a global (Ticket-234468)
+auto ValueOrTerminate(const score::cpp::expected<T, score::os::Error> expected, const std::string_view error_text) -> T
+{
+    if (!expected.has_value())
+    {
+        std::cerr << "DispatchThreadRunner: " << error_text << ": "
+                  << expected.error().ToString()
+                  // Suppress AUTOSAR C++14 M8-4-4, rule finding: "A function identifier shall either be used to call
+                  // the function or it shall be preceded by &". Passing std::endl to std::cout object with the stream
+                  // operator follows the idiomatic way that both features in conjunction were designed in the C++
+                  // standard.
+                  // coverity[autosar_cpp14_m8_4_4_violation : FALSE] Ticket-219101
+                  << std::endl;
+        std::terminate();
+    }
+    return expected.value();
+}
+
+template <typename T>
+// coverity[autosar_cpp14_m7_3_1_violation] false-positive: namespace-scoped function, not a global (Ticket-234468)
+void IfUnexpectedTerminate(const score::cpp::expected<T, score::os::Error> expected, const std::string_view error_text)
+{
+    if (!expected.has_value())
+    {
+        std::cerr << "DispatchThreadRunner: " << error_text << ": "
+                  << expected.error().ToString()
+                  // Suppress AUTOSAR C++14 M8-4-4, rule finding: "A function identifier shall either be used to call
+                  // the function or it shall be preceded by &". Passing std::endl to std::cout object with the stream
+                  // operator follows the idiomatic way that both features in conjunction were designed in the C++
+                  // standard.
+                  // coverity[autosar_cpp14_m8_4_4_violation : FALSE] Ticket-219101
+                  << std::endl;
+        std::terminate();
+    }
+}
+
+}  // namespace
+
+DispatchThreadRunner::DispatchThreadRunner(score::os::Channel& channel,
+                                           score::os::Dispatch& dispatch,
+                                           score::os::Signal& signal) noexcept
+    : channel_{channel},
+      dispatch_{dispatch},
+      signal_{signal},
+      quit_flag_{false},
+      thread_{},
+      thread_mutex_{},
+      dispatch_pointer_{nullptr},
+      context_pointer_{},
+      side_channel_coid_{}
+{
+}
+
+void DispatchThreadRunner::StartPreInit() noexcept
+{
+    dispatch_pointer_ =  // NOLINTNEXTLINE(score-banned-function) implementing FFI wrapper
+        ValueOrTerminate(dispatch_.dispatch_create_channel(-1, 0U), "Unable to allocate dispatch handle");
+    side_channel_coid_ = ValueOrTerminate(dispatch_.message_connect(dispatch_pointer_, MSG_FLAG_SIDE_CHANNEL),
+                                          "Unable to create side channel");
+    IfUnexpectedTerminate(dispatch_.pulse_attach(dispatch_pointer_, 0, kQuitPulseCode, &QuitPulseCallback, this),
+                          "Unable to attach quit pulse code");
+}
+
+void DispatchThreadRunner::StartPostInit() noexcept
+{
+    // NOLINTNEXTLINE(score-banned-function) implementing FFI wrapper
+    context_pointer_ =
+        ValueOrTerminate(dispatch_.dispatch_context_alloc(dispatch_pointer_), "Unable to allocate context pointer");
+
+    // Normally, during the application lifecycle initialization, LifeCycleManager blocks the SIGTERM on the main
+    // thread and creates a separate thread that catches all the SIGTERM signals coming to the process. The other
+    // threads created after that will inherit the sigmask of the main thread with SIGTERM blocked.
+    // However, LifeCycleManager starts using Logging before it blocks SIGTERM on the main thread. When this happens,
+    // Logging will initialize Message Passing, which will create the Message Passing background thread with a sigmask
+    // inherited without SIGTERM being blocked yet.
+    // Thus, we need to mask SIGTERM for this thread specifically, to let the LifeCycleManager desicated SIGTERM
+    // thread do its job.
+    sigset_t new_set;
+    sigset_t old_set;
+    // the signal functions below, used with the parameters below, can only return EOK
+    score::cpp::ignore = signal_.SigEmptySet(new_set);
+    score::cpp::ignore = signal_.AddTerminationSignal(new_set);
+    // NOLINTNEXTLINE(score-banned-function) by design of LifeCycleManager.
+    score::cpp::ignore = signal_.PthreadSigMask(SIG_BLOCK, new_set, old_set);
+    {
+        thread_ = std::thread([this]() noexcept {
+            {
+                std::lock_guard release(thread_mutex_);  // guarantees that this->thread_ is already assigned
+            }
+            RunOnThread();
+        });
+    }
+    // NOLINTNEXTLINE(score-banned-function) by design of LifeCycleManager.
+    score::cpp::ignore = signal_.PthreadSigMask(SIG_SETMASK, old_set);
+}
+
+DispatchThreadRunner::~DispatchThreadRunner() noexcept
+{
+    if (dispatch_pointer_ == nullptr)
+    {
+        return;
+    }
+
+    SendQuitPulse();
+    thread_.join();
+
+    score::cpp::ignore = channel_.ConnectDetach(side_channel_coid_);
+    // NOLINTNEXTLINE(score-banned-function) implementing FFI wrapper
+    score::cpp::ignore = dispatch_.dispatch_destroy(dispatch_pointer_);
+    // NOLINTNEXTLINE(score-banned-function) implementing FFI wrapper
+    dispatch_.dispatch_context_free(context_pointer_);
+}
+
+void DispatchThreadRunner::RunOnThread() noexcept
+{
+    while (!quit_flag_)
+    {
+        // NOLINTNEXTLINE(score-banned-function) implementing FFI wrapper
+        if (dispatch_.dispatch_block(context_pointer_))
+        {
+            // NOLINTNEXTLINE(score-banned-function) implementing FFI wrapper
+            score::cpp::ignore = dispatch_.dispatch_handler(context_pointer_);
+        }
+    }
+}
+
+// Note 'C++14 A8-4-10':
+// Suppress AUTOSAR C++14 A8-4-10 rule findigs: "A parameter shall be passed by reference if it can't be NULL."
+// Justification: raw pointers are used in method signatures to maintain compatibility with the QNX API,
+// which provides parameters as raw pointers.
+
+// coverity[autosar_cpp14_a8_4_10_violation]: see "Note 'C++14 A8-4-10'"
+// coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
+// coverity[autosar_cpp14_a0_1_3_violation] false-positive: used as a pulse callback
+int DispatchThreadRunner::QuitPulseCallback(message_context_t* /*ctp*/,
+                                            int /*code*/,
+                                            unsigned /*flags*/,
+                                            // coverity[autosar_cpp14_a8_4_10_violation]: see "Note 'C++14 A8-4-10'"
+                                            void* handle) noexcept
+{
+    // Suppress "AUTOSAR C++14 M5-2-8" rule finding: "An object with integer type or pointer to void type shall not be
+    // converted to an object with pointer type".
+    // QNX API
+    // coverity[autosar_cpp14_m5_2_8_violation]
+    auto& self = *static_cast<DispatchThreadRunner*>(handle);
+    self.quit_flag_ = true;
+    return 0;
+}
+
+void DispatchThreadRunner::SendQuitPulse() noexcept
+{
+    // NOLINTNEXTLINE(score-banned-function) implementing FFI wrapper
+    score::cpp::ignore = channel_.MsgSendPulse(side_channel_coid_, -1, kQuitPulseCode, 0);
+}
+
+}  // namespace score::message_passing::detail

--- a/score/message_passing/qnx_dispatch/dispatch_thread_runner.h
+++ b/score/message_passing/qnx_dispatch/dispatch_thread_runner.h
@@ -1,0 +1,116 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_LIB_MESSAGE_PASSING_QNX_DISPATCH_DISPATCH_THREAD_RUNNER_H
+#define SCORE_LIB_MESSAGE_PASSING_QNX_DISPATCH_DISPATCH_THREAD_RUNNER_H
+
+#include "score/os/qnx/channel.h"
+#include "score/os/qnx/dispatch.h"
+#include "score/os/utils/signal_impl.h"
+
+#include <condition_variable>
+#include <mutex>
+#include <thread>
+
+namespace score::message_passing
+{
+
+class QnxDispatchEngine;
+
+}  // namespace score::message_passing
+
+namespace score::message_passing::detail
+{
+
+/// \brief Class encapsulating resources and logic needed to run QNX diapatch thread
+/// \details Separate instances of this class are used to run dispatch loops responsible for client and server
+///          functionality of QnxDispachEngine, to avoid deadlocks for client-server system topology with cycles.
+class DispatchThreadRunner
+{
+  public:
+    DispatchThreadRunner(score::os::Channel& channel,
+                         score::os::Dispatch& dispatch,
+                         score::os::Signal& signal) noexcept;
+    ~DispatchThreadRunner() noexcept;
+
+    DispatchThreadRunner(const DispatchThreadRunner&) = delete;
+    DispatchThreadRunner(DispatchThreadRunner&&) = delete;
+    DispatchThreadRunner& operator=(const DispatchThreadRunner&) = delete;
+    DispatchThreadRunner& operator=(DispatchThreadRunner&&) = delete;
+
+    bool IsMyThread(const std::thread::id id) const noexcept
+    {
+        return id == thread_.get_id();
+    }
+
+    static constexpr std::int32_t kQuitPulseCode = _PULSE_CODE_MINAVAIL;
+
+    template <typename Init>
+    void Start(Init init) noexcept
+    {
+        // block concurrent creation attempts and postpone RunOnThread() till we assign thread_
+        std::lock_guard lock(thread_mutex_);
+        if (dispatch_pointer_ != nullptr)
+        {
+            // already started; duplicate initialization not to be done
+            return;
+        }
+        StartPreInit();
+        init();
+        StartPostInit();
+    }
+
+    dispatch_t* GetDispatchPointer() const noexcept
+    {
+        return dispatch_pointer_;
+    }
+    std::int32_t GetSideChannelCoid() const noexcept
+    {
+        return side_channel_coid_;
+    }
+    std::mutex& GetMutex() noexcept
+    {
+        return thread_mutex_;
+    }
+
+  private:
+    void StartPreInit() noexcept;
+    void StartPostInit() noexcept;
+    void RunOnThread() noexcept;
+
+    static int QuitPulseCallback(message_context_t* ctp, int code, unsigned flags, void* handle) noexcept;
+
+    void SendQuitPulse() noexcept;
+
+    score::os::Channel& channel_;
+    score::os::Dispatch& dispatch_;
+    score::os::Signal& signal_;
+
+    bool quit_flag_;
+
+    // NOLINTNEXTLINE(score-banned-type) TODO: wait for new clarification of CB #26380215 from QNX
+    std::thread thread_;
+    std::mutex thread_mutex_;
+
+    dispatch_t* dispatch_pointer_;
+    dispatch_context_t* context_pointer_;
+    std::int32_t side_channel_coid_;
+
+    // Suppress "AUTOSAR C++14 A11-3-1" rule finding: "Friend declarations shall not be used."
+    // QnxDispatchEngine acts like a module scope
+    // coverity[autosar_cpp14_a11_3_1_violation]
+    friend QnxDispatchEngine;
+};
+
+}  // namespace score::message_passing::detail
+
+#endif  // SCORE_LIB_MESSAGE_PASSING_QNX_DISPATCH_DISPATCH_THREAD_RUNNER_H

--- a/score/message_passing/qnx_dispatch/qnx_dispatch_engine.cpp
+++ b/score/message_passing/qnx_dispatch/qnx_dispatch_engine.cpp
@@ -33,14 +33,6 @@ struct select_msg_t
     sigevent ping_event;
 };
 
-// false-positive: vars are being used in pulse _attach _detach calls
-// coverity[autosar_cpp14_a0_1_1_violation]
-constexpr std::int32_t kTimerPulseCode = _PULSE_CODE_MINAVAIL;
-// coverity[autosar_cpp14_a0_1_1_violation]
-constexpr std::int32_t kEventPulseCode = _PULSE_CODE_MINAVAIL + 1;
-// coverity[autosar_cpp14_a0_1_1_violation]
-constexpr std::int32_t kSelectPulseCode = _PULSE_CODE_MINAVAIL + 2;
-
 constexpr std::uint16_t kIomgrStickySelect = _IOMGR_PRIVATE_BASE;
 
 // Pulse signals from server to client that we have...
@@ -116,55 +108,31 @@ QnxDispatchEngine::QnxDispatchEngine(score::cpp::pmr::memory_resource* memory_re
       memory_resource_{memory_resource},
       os_resources_{std::move(os_resources)},
       logger_{std::move(logger)},
-      quit_flag_{false},
-      thread_{},
-      thread_mutex_{},
-      thread_condition_{},
+      server_runner_{*os_resources_.channel, *os_resources_.dispatch, *os_resources_.signal},
+      client_runner_{*os_resources_.channel, *os_resources_.dispatch, *os_resources_.signal},
+      cleanup_ready_condition_{},
       poll_endpoints_{memory_resource},
       timer_queue_{},
       posix_endpoint_list_{},
       posix_receive_buffer_{memory_resource},
-      dispatch_pointer_{},
-      context_pointer_{},
-      side_channel_coid_{},
       timer_id_{},
-      attach_mutex_{},
+      // attach_mutex_{},
       connect_funcs_{},
       io_funcs_{}
 {
-    dispatch_pointer_ =  // NOLINTNEXTLINE(score-banned-function) implementing FFI wrapper
-        ValueOrTerminate(os_resources_.dispatch->dispatch_create_channel(-1, 0U), "Unable to allocate dispatch handle");
-    IfUnexpectedTerminate(
-        os_resources_.dispatch->pulse_attach(dispatch_pointer_, 0, kTimerPulseCode, &TimerPulseCallback, this),
-        "Unable to attach timer pulse code");
-    IfUnexpectedTerminate(
-        os_resources_.dispatch->pulse_attach(dispatch_pointer_, 0, kEventPulseCode, &EventPulseCallback, this),
-        "Unable to attach event pulse code");
-    IfUnexpectedTerminate(
-        os_resources_.dispatch->pulse_attach(dispatch_pointer_, 0, kSelectPulseCode, &SelectPulseCallback, this),
-        "Unable to attach select pulse code");
-    IfUnexpectedTerminate(os_resources_.dispatch->pulse_attach(
-                              dispatch_pointer_, 0, _PULSE_CODE_COIDDEATH, &CoidDeathPulseCallback, this),
-                          "Unable to attach CoidDeath pulse code");
+    SetupResourceManagerCallbacks();
 
-    /* resmgr_attach */
-    side_channel_coid_ =
-        ValueOrTerminate(os_resources_.dispatch->message_connect(dispatch_pointer_, MSG_FLAG_SIDE_CHANNEL),
-                         "Unable to create side channel");
+    client_runner_.Start([this]() noexcept {
+        InitClientThread();
+    });
+    server_runner_.Start([this]() noexcept {
+        InitServerThread();
+    });
+}
 
-    struct sigevent event{};
-    // Suppress "AUTOSAR C++14 M5-0-21" rule finding: "Bitwise operators shall only be applied to operands of unsigned
-    // underlying type.". 'SIGEV_PULSE' is a macro of QNX API, which defines bitwise operation of two flags. This macro
-    // cannot be modified.
-    // coverity[autosar_cpp14_m5_0_21_violation]
-    event.sigev_notify = static_cast<decltype(event.sigev_notify)>(SIGEV_PULSE);
-    event.sigev_coid = side_channel_coid_;
-    event.sigev_priority = SIGEV_PULSE_PRIO_INHERIT;
-    static_assert(kTimerPulseCode <= std::numeric_limits<decltype(event.sigev_code)>::max());
-    event.sigev_code = static_cast<decltype(event.sigev_code)>(kTimerPulseCode);
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access) C API
-    event.sigev_value.sival_int = 0;
-    timer_id_ = ValueOrTerminate(os_resources_.timer->TimerCreate(CLOCK_MONOTONIC, &event), "Unable to create timer");
+void QnxDispatchEngine::InitServerThread() noexcept
+{
+    dispatch_t* dispatch_pointer = server_runner_.GetDispatchPointer();
 
     // it's actually the default settings for resmgr buffers; we are just making them explicit here
     // Ourselves, we are not limited by these values, as we use resmgr_msgget() and we don't use ctp.iov
@@ -172,43 +140,36 @@ QnxDispatchEngine::QnxDispatchEngine(score::cpp::pmr::memory_resource* memory_re
     resmgr_attr.nparts_max = 1U;
     resmgr_attr.msg_max_size = 2088U;
     IfUnexpectedTerminate(os_resources_.dispatch->resmgr_attach(
-                              dispatch_pointer_, &resmgr_attr, nullptr, _FTYPE_ANY, 0U, nullptr, nullptr, nullptr),
+                              dispatch_pointer, &resmgr_attr, nullptr, _FTYPE_ANY, 0U, nullptr, nullptr, nullptr),
                           "Unable to set up resource manager operations");
+}
 
-    // NOLINTNEXTLINE(score-banned-function) implementing FFI wrapper
-    context_pointer_ = ValueOrTerminate(os_resources_.dispatch->dispatch_context_alloc(dispatch_pointer_),
-                                        "Unable to allocate context pointer");
-
-    SetupResourceManagerCallbacks();
-
-    // Normally, during the application lifecycle initialization, LifeCycleManager blocks the SIGTERM on the main
-    // thread and creates a separate thread that catches all the SIGTERM signals coming to the process. The other
-    // threads created after that will inherit the sigmask of the main thread with SIGTERM blocked.
-    // However, LifeCycleManager starts using Logging before it blocks SIGTERM on the main thread. When this happens,
-    // Logging will initialize Message Passing, which will create the Message Passing background thread with a sigmask
-    // inherited without SIGTERM being blocked yet.
-    // Thus, we need to mask SIGTERM for this thread specifically, to let the LifeCycleManager desicated SIGTERM
-    // thread do its job.
-    sigset_t new_set;
-    sigset_t old_set;
-    // the signal functions below, used with the parameters below, can only return EOK
-    score::cpp::ignore = os_resources_.signal->SigEmptySet(new_set);
-    score::cpp::ignore = os_resources_.signal->AddTerminationSignal(new_set);
-    // NOLINTNEXTLINE(score-banned-function) by design of LifeCycleManager. Also see Ticket-101432
-    score::cpp::ignore = os_resources_.signal->PthreadSigMask(SIG_BLOCK, new_set, old_set);
-    {
-        LogDebug(logger_, "QnxDispatchEngine thread-start ", this);
-        std::lock_guard acquire(thread_mutex_);  // postpone RunOnThread() till we assign thread_
-        thread_ = std::thread([this]() noexcept {
-            {
-                std::lock_guard release(thread_mutex_);  // guarantees that this->thread_ is already assigned
-            }
-            LogDebug(logger_, "QnxDispatchEngine thread-start-sync ", this);
-            RunOnThread();
-        });
-    }
-    // NOLINTNEXTLINE(score-banned-function) by design of LifeCycleManager. Also see Ticket-101432
-    score::cpp::ignore = os_resources_.signal->PthreadSigMask(SIG_SETMASK, old_set);
+void QnxDispatchEngine::InitClientThread() noexcept
+{
+    dispatch_t* dispatch_pointer = client_runner_.GetDispatchPointer();
+    std::int32_t side_channel_coid = client_runner_.GetSideChannelCoid();
+    IfUnexpectedTerminate(
+        os_resources_.dispatch->pulse_attach(dispatch_pointer, 0, kTimerPulseCode, &TimerPulseCallback, this),
+        "Unable to attach timer pulse code");
+    IfUnexpectedTerminate(
+        os_resources_.dispatch->pulse_attach(dispatch_pointer, 0, kSelectPulseCode, &SelectPulseCallback, this),
+        "Unable to attach select pulse code");
+    IfUnexpectedTerminate(
+        os_resources_.dispatch->pulse_attach(dispatch_pointer, 0, _PULSE_CODE_COIDDEATH, &CoidDeathPulseCallback, this),
+        "Unable to attach CoidDeath pulse code");
+    struct sigevent event{};
+    // Suppress "AUTOSAR C++14 M5-0-21" rule finding: "Bitwise operators shall only be applied to operands of unsigned
+    // underlying type.". 'SIGEV_PULSE' is a macro of QNX API, which defines bitwise operation of two flags. This macro
+    // cannot be modified.
+    // coverity[autosar_cpp14_m5_0_21_violation]
+    event.sigev_notify = static_cast<decltype(event.sigev_notify)>(SIGEV_PULSE);
+    event.sigev_coid = side_channel_coid;
+    event.sigev_priority = SIGEV_PULSE_PRIO_INHERIT;
+    static_assert(kTimerPulseCode <= std::numeric_limits<decltype(event.sigev_code)>::max());
+    event.sigev_code = static_cast<decltype(event.sigev_code)>(kTimerPulseCode);
+    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access) C API
+    event.sigev_value.sival_int = 0;
+    timer_id_ = ValueOrTerminate(os_resources_.timer->TimerCreate(CLOCK_MONOTONIC, &event), "Unable to create timer");
 }
 
 // Note 'C++14 A8-4-10':
@@ -235,25 +196,6 @@ int QnxDispatchEngine::TimerPulseCallback(message_context_t* /*ctp*/,
 // coverity[autosar_cpp14_a8_4_10_violation]: see "Note 'C++14 A8-4-10'"
 // coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
 // coverity[autosar_cpp14_a0_1_3_violation] false-positive: used as a pulse callback
-int QnxDispatchEngine::EventPulseCallback(message_context_t* ctp,
-                                          int /*code*/,
-                                          unsigned /*flags*/,
-                                          // coverity[autosar_cpp14_a8_4_10_violation]: see "Note 'C++14 A8-4-10'"
-                                          void* handle) noexcept
-{
-    // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access) C API
-    const auto pulse_event = static_cast<std::int32_t>(ctp->msg->pulse.value.sival_int);
-    // Suppress "AUTOSAR C++14 M5-2-8" rule finding: "An object with integer type or pointer to void type shall not be
-    // converted to an object with pointer type".
-    // QNX API
-    // coverity[autosar_cpp14_m5_2_8_violation]
-    static_cast<QnxDispatchEngine*>(handle)->ProcessPulseEvent(pulse_event);
-    return 0;
-}
-
-// coverity[autosar_cpp14_a8_4_10_violation]: see "Note 'C++14 A8-4-10'"
-// coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
-// coverity[autosar_cpp14_a0_1_3_violation] false-positive: used as a pulse callback
 int QnxDispatchEngine::SelectPulseCallback(message_context_t* ctp,
                                            int /*code*/,
                                            unsigned /*flags*/,
@@ -265,7 +207,6 @@ int QnxDispatchEngine::SelectPulseCallback(message_context_t* ctp,
     // QNX API
     // coverity[autosar_cpp14_m5_2_8_violation]
     QnxDispatchEngine& self = *static_cast<QnxDispatchEngine*>(handle);
-    LogDebug(self.logger_, "QnxDispatchEngine::SelectPulseCallback ", &self);
 
     // NOLINTNEXTLINE(cppcoreguidelines-pro-type-union-access) C API
     const auto pulse_value = reinterpret_cast<std::uintptr_t>(ctp->msg->pulse.value.sival_ptr);
@@ -273,20 +214,17 @@ int QnxDispatchEngine::SelectPulseCallback(message_context_t* ctp,
     if ((value.index >= self.poll_endpoints_.size()) || (self.poll_endpoints_[value.index].nonce != value.nonce) ||
         (self.poll_endpoints_[value.index].endpoint == nullptr))
     {
-        LogDebug(self.logger_, "QnxDispatchEngine::SelectPulseCallback pulse obsolete ", &self);
         // invalid or obsolete pulse; return without doing anything
         return 0;
     }
     if (value.signal == kSignalPing)
     {
-        LogDebug(self.logger_, "=== Pulse: ping ", &self);
         self.poll_endpoints_[value.index].endpoint->ping();
     }
     else
     {
         // event though it comes from IPC, we can only receive signals that we have registered locally,
         // and we only register kSignalPing and kSignalNewData. So, it's kSignalNewData here.
-        LogDebug(self.logger_, "=== Pulse: input ", &self);
         self.poll_endpoints_[value.index].endpoint->input();
     }
     return 0;
@@ -334,18 +272,11 @@ int QnxDispatchEngine::CoidDeathPulseCallback(message_context_t* ctp,
 
 QnxDispatchEngine::~QnxDispatchEngine() noexcept
 {
-    SendPulseEvent(PulseEvent::QUIT);
-    thread_.join();
-    score::cpp::ignore = os_resources_.timer->TimerDestroy(timer_id_);
-    score::cpp::ignore = os_resources_.channel->ConnectDetach(side_channel_coid_);
-    score::cpp::ignore = os_resources_.dispatch->pulse_detach(dispatch_pointer_, _PULSE_CODE_COIDDEATH, 0);
-    score::cpp::ignore = os_resources_.dispatch->pulse_detach(dispatch_pointer_, kSelectPulseCode, 0);
-    score::cpp::ignore = os_resources_.dispatch->pulse_detach(dispatch_pointer_, kEventPulseCode, 0);
-    score::cpp::ignore = os_resources_.dispatch->pulse_detach(dispatch_pointer_, kTimerPulseCode, 0);
-    // NOLINTNEXTLINE(score-banned-function) implementing FFI wrapper
-    score::cpp::ignore = os_resources_.dispatch->dispatch_destroy(dispatch_pointer_);
-    // NOLINTNEXTLINE(score-banned-function) implementing FFI wrapper
-    os_resources_.dispatch->dispatch_context_free(context_pointer_);
+    if (client_runner_.GetDispatchPointer() != nullptr)
+    {
+        // client was initialized, which means timer was created
+        score::cpp::ignore = os_resources_.timer->TimerDestroy(timer_id_);
+    }
 }
 
 // coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
@@ -419,7 +350,8 @@ void QnxDispatchEngine::RegisterPosixEndpoint(PosixEndpointEntry& endpoint) noex
         value.nonce = nonce;
         const uintptr_t pulse_value = PackSelectPulseValue(value);
 
-        SIGEV_PULSE_INIT(event_ptr, side_channel_coid_, SIGEV_PULSE_PRIO_INHERIT, kSelectPulseCode, pulse_value);
+        std::int32_t side_channel_coid = client_runner_.GetSideChannelCoid();
+        SIGEV_PULSE_INIT(event_ptr, side_channel_coid, SIGEV_PULSE_PRIO_INHERIT, kSelectPulseCode, pulse_value);
 
         // NOLINTNEXTLINE(score-banned-function) implementing FFI wrapper
         const auto register_expected = os_resources_.channel->MsgRegisterEvent(event_ptr, endpoint.fd);
@@ -478,7 +410,8 @@ void QnxDispatchEngine::UnselectEndpoint(PosixEndpointEntry& endpoint) noexcept
             value.nonce = nonce;
             const uintptr_t pulse_value = PackSelectPulseValue(value);
 
-            SIGEV_PULSE_INIT(&event, side_channel_coid_, SIGEV_PULSE_PRIO_INHERIT, kSelectPulseCode, pulse_value);
+            std::int32_t side_channel_coid = client_runner_.GetSideChannelCoid();
+            SIGEV_PULSE_INIT(&event, side_channel_coid, SIGEV_PULSE_PRIO_INHERIT, kSelectPulseCode, pulse_value);
             // NOLINTNEXTLINE(score-banned-function) implementing FFI wrapper
             score::cpp::ignore = os_resources_.channel->MsgUnregisterEvent(&event);
         }
@@ -497,7 +430,7 @@ void QnxDispatchEngine::EnqueueCommand(CommandQueueEntry& entry,
                                        const void* const owner) noexcept
 {
     timer_queue_.RegisterTimedEntry(entry, until, std::move(callback), owner);
-    SendPulseEvent(PulseEvent::TIMER);
+    WakeUpTimerQueue();
 }
 
 void QnxDispatchEngine::CleanUpOwner(const void* const owner) noexcept
@@ -512,7 +445,7 @@ void QnxDispatchEngine::CleanUpOwner(const void* const owner) noexcept
     }
     else
     {
-        detail::NonAllocatingFuture future(thread_mutex_, thread_condition_);
+        detail::NonAllocatingFuture future(client_runner_.GetMutex(), cleanup_ready_condition_);
         detail::TimedCommandQueue::Entry cleanup_command;
         timer_queue_.RegisterImmediateEntry(
             cleanup_command,
@@ -521,7 +454,7 @@ void QnxDispatchEngine::CleanUpOwner(const void* const owner) noexcept
                 future.MarkReady();
             },
             owner);
-        SendPulseEvent(PulseEvent::TIMER);
+        WakeUpTimerQueue();
         future.Wait();
     }
 }
@@ -578,23 +511,11 @@ score::cpp::expected<score::cpp::span<const std::uint8_t>, score::os::Error> Qnx
     return score::cpp::span<const std::uint8_t>{&posix_receive_buffer_[1], span_size};
 }
 
-void QnxDispatchEngine::SendPulseEvent(const PulseEvent pulse_event) noexcept
+void QnxDispatchEngine::WakeUpTimerQueue() noexcept
 {
+    std::int32_t side_channel_coid = client_runner_.GetSideChannelCoid();
     // NOLINTNEXTLINE(score-banned-function) implementing FFI wrapper
-    score::cpp::ignore = os_resources_.channel->MsgSendPulse(
-        side_channel_coid_, -1, kEventPulseCode, static_cast<std::int32_t>(pulse_event));
-}
-
-void QnxDispatchEngine::ProcessPulseEvent(const std::int32_t pulse_event) noexcept
-{
-    if (pulse_event == score::cpp::to_underlying(PulseEvent::TIMER))
-    {
-        ProcessTimerQueue();
-    }
-    else
-    {
-        quit_flag_ = true;
-    }
+    score::cpp::ignore = os_resources_.channel->MsgSendPulse(side_channel_coid, -1, kTimerPulseCode, 0);
 }
 
 void QnxDispatchEngine::ProcessCleanup(const void* const owner) noexcept
@@ -608,19 +529,6 @@ void QnxDispatchEngine::ProcessCleanup(const void* const owner) noexcept
         });
 
     timer_queue_.CleanUpOwner(owner);
-}
-
-void QnxDispatchEngine::RunOnThread() noexcept
-{
-    while (!quit_flag_)
-    {
-        // NOLINTNEXTLINE(score-banned-function) implementing FFI wrapper
-        if (os_resources_.dispatch->dispatch_block(context_pointer_))
-        {
-            // NOLINTNEXTLINE(score-banned-function) implementing FFI wrapper
-            score::cpp::ignore = os_resources_.dispatch->dispatch_handler(context_pointer_);
-        }
-    }
 }
 
 void QnxDispatchEngine::ProcessTimerQueue() noexcept
@@ -663,9 +571,9 @@ score::cpp::expected_blank<score::os::Error> QnxDispatchEngine::StartServer(Reso
                                                                             const QnxResourcePath& path) noexcept
 {
     // QNX defect PR# 2561573: resmgr_attach/message_attach calls are not thread-safe for the same dispatch_pointer
-    std::lock_guard guard(attach_mutex_);
+    std::lock_guard guard(server_runner_.GetMutex());
 
-    const auto id_expected = os_resources_.dispatch->resmgr_attach(dispatch_pointer_,
+    const auto id_expected = os_resources_.dispatch->resmgr_attach(server_runner_.GetDispatchPointer(),
                                                                    nullptr,
                                                                    path.c_str(),
                                                                    _FTYPE_ANY,
@@ -699,9 +607,9 @@ void QnxDispatchEngine::StopServer(ResourceManagerServer& server) noexcept
     if (server.resmgr_id_ != -1)
     {
         // QNX defect PR# 2561573: resmgr_attach/message_attach calls are not thread-safe for the same dispatch_pointer
-        std::lock_guard guard(attach_mutex_);
+        std::lock_guard guard(server_runner_.GetMutex());
         score::cpp::ignore = os_resources_.dispatch->resmgr_detach(
-            dispatch_pointer_, server.resmgr_id_, static_cast<std::uint32_t>(_RESMGR_DETACH_CLOSE));
+            server_runner_.GetDispatchPointer(), server.resmgr_id_, static_cast<std::uint32_t>(_RESMGR_DETACH_CLOSE));
         server.resmgr_id_ = -1;
     }
 }

--- a/score/message_passing/qnx_dispatch/qnx_dispatch_engine.h
+++ b/score/message_passing/qnx_dispatch/qnx_dispatch_engine.h
@@ -19,6 +19,7 @@
 #include <score/vector.hpp>
 
 #include "score/message_passing/i_shared_resource_engine.h"
+#include "score/message_passing/qnx_dispatch/dispatch_thread_runner.h"
 #include "score/message_passing/qnx_dispatch/qnx_resource_path.h"
 #include "score/message_passing/timed_command_queue.h"
 #include "score/os/fcntl.h"
@@ -244,8 +245,13 @@ class QnxDispatchEngine final : public ISharedResourceEngine
 
     bool IsOnCallbackThread() const noexcept override
     {
-        return std::this_thread::get_id() == thread_.get_id();
+        const std::thread::id id = std::this_thread::get_id();
+        return client_runner_.IsMyThread(id) || server_runner_.IsMyThread(id);
     }
+
+    // public, used in testing
+    constexpr static std::int32_t kTimerPulseCode = detail::DispatchThreadRunner::kQuitPulseCode + 1;
+    constexpr static std::int32_t kSelectPulseCode = kTimerPulseCode + 1;
 
   private:
     enum class PulseEvent : std::int32_t
@@ -254,13 +260,13 @@ class QnxDispatchEngine final : public ISharedResourceEngine
         TIMER
     };
 
-    void SendPulseEvent(const PulseEvent pulse_event) noexcept;
-    void ProcessPulseEvent(const std::int32_t pulse_event) noexcept;
+    void InitServerThread() noexcept;
+    void InitClientThread() noexcept;
+
+    void WakeUpTimerQueue() noexcept;
     void ProcessCleanup(const void* const owner) noexcept;
-    void RunOnThread() noexcept;
 
     static int TimerPulseCallback(message_context_t* ctp, int code, unsigned flags, void* handle) noexcept;
-    static int EventPulseCallback(message_context_t* ctp, int code, unsigned flags, void* handle) noexcept;
     static int SelectPulseCallback(message_context_t* ctp, int code, unsigned flags, void* handle) noexcept;
     static int CoidDeathPulseCallback(message_context_t* ctp, int code, unsigned flags, void* handle) noexcept;
 
@@ -316,11 +322,10 @@ class QnxDispatchEngine final : public ISharedResourceEngine
     OsResources os_resources_;
     LoggingCallback logger_;
 
-    bool quit_flag_;
-    // NOLINTNEXTLINE(score-banned-type) TODO: wait for new clarification of CB #26380215 from QNX
-    std::thread thread_;
-    std::mutex thread_mutex_;
-    std::condition_variable thread_condition_;
+    detail::DispatchThreadRunner server_runner_;
+    detail::DispatchThreadRunner client_runner_;
+
+    std::condition_variable cleanup_ready_condition_;
 
     struct PollEndpoint
     {
@@ -334,11 +339,7 @@ class QnxDispatchEngine final : public ISharedResourceEngine
     score::containers::intrusive_list<PosixEndpointEntry> posix_endpoint_list_;
     score::cpp::pmr::vector<std::uint8_t> posix_receive_buffer_;
 
-    dispatch_t* dispatch_pointer_;
-    dispatch_context_t* context_pointer_;
-    std::int32_t side_channel_coid_;
     timer_t timer_id_;
-    std::mutex attach_mutex_;
 
     resmgr_connect_funcs_t connect_funcs_;
     resmgr_io_funcs_t io_funcs_;

--- a/score/message_passing/qnx_dispatch_engine_test.cpp
+++ b/score/message_passing/qnx_dispatch_engine_test.cpp
@@ -83,80 +83,45 @@ class QnxDispatchEngineTestFixture : public ResourceManagerFixtureBase
         EXPECT_CALL(*server_, ProcessConnect)
             .Times(1)
             .WillOnce([this](resmgr_context_t* const ctp, io_open_t* const msg) {
-                EXPECT_TRUE(helper_.HelperIsLocked());
+                EXPECT_TRUE(server_helper_.HelperIsLocked());
                 score::cpp::ignore = engine_->AttachConnection(ctp, msg, *server_, connection_);
                 return EOK;
             });
 
-        helper_.HelperInsertIoOpen(score::cpp::blank{});
-        EXPECT_EQ(helper_.promises_.open.get_future().get(), EOK);
-        helper_.promises_.open = std::promise<std::int32_t>();  // reset
-        EXPECT_FALSE(helper_.HelperIsLocked());
+        server_helper_.HelperInsertIoOpen(score::cpp::blank{});
+        EXPECT_EQ(server_helper_.promises_.open.get_future().get(), EOK);
+        server_helper_.promises_.open = std::promise<std::int32_t>();  // reset
+        EXPECT_FALSE(server_helper_.HelperIsLocked());
     }
 
     std::optional<StrictMock<ResourceManagerServerMock>> server_;
     StrictMock<ResourceManagerConnectionMock> connection_;
+    ResourceManagerMockHelper& server_helper_{helpers_[kServerIndex]};
 };
 
 using QnxDispatchEngineDeathTest = QnxDispatchEngineTestFixture;
 
-TEST_F(QnxDispatchEngineDeathTest, EngineCreation_CreateChannel)
-{
-    // Times(AnyNumber()) to satisfy death test logic
-    EXPECT_CALL(*dispatch_, dispatch_create_channel).Times(AnyNumber()).WillOnce(Return(kFakeOsError));
-
-    std::optional<QnxDispatchEngine> engine;
-    EXPECT_DEATH(engine.emplace(score::cpp::pmr::get_default_resource(), MoveMockOsResources()),
-                 "Unable to allocate dispatch handle");
-}
-
 TEST_F(QnxDispatchEngineDeathTest, EngineCreation_AttachTimerPulse)
 {
-    // Times(AnyNumber()) to satisfy death test logic
-    EXPECT_CALL(*dispatch_, dispatch_create_channel).Times(AnyNumber()).WillOnce(Return(kFakeDispatchPtr));
-    EXPECT_CALL(*dispatch_, pulse_attach).Times(AnyNumber()).WillOnce(Return(kFakeOsError));
+    ExpectEngineInConstructionForDeathTests();
+
+    EXPECT_CALL(*dispatch_, pulse_attach(_, _, QnxDispatchEngine::kTimerPulseCode, _, _))
+        .Times(AnyNumber())
+        .WillOnce(Return(kFakeOsError));
 
     std::optional<QnxDispatchEngine> engine;
     EXPECT_DEATH(engine.emplace(score::cpp::pmr::get_default_resource(), MoveMockOsResources()),
                  "Unable to attach timer pulse code");
 }
 
-TEST_F(QnxDispatchEngineDeathTest, EngineCreation_AttachEventPulse)
-{
-    // Times(AnyNumber()) to satisfy death test logic
-    EXPECT_CALL(*dispatch_, dispatch_create_channel).Times(AnyNumber()).WillOnce(Return(kFakeDispatchPtr));
-    EXPECT_CALL(*dispatch_, pulse_attach)
-        .Times(AnyNumber())
-        .WillOnce(Invoke(&helper_, &ResourceManagerMockHelper::pulse_attach))
-        .WillOnce(Return(kFakeOsError));
-
-    std::optional<QnxDispatchEngine> engine;
-    EXPECT_DEATH(engine.emplace(score::cpp::pmr::get_default_resource(), MoveMockOsResources()),
-                 "Unable to attach event pulse code");
-}
-
-TEST_F(QnxDispatchEngineDeathTest, EngineCreation_ConnectSideChannel)
-{
-    // Times(AnyNumber()) to satisfy death test logic
-    EXPECT_CALL(*dispatch_, dispatch_create_channel).Times(AnyNumber()).WillOnce(Return(kFakeDispatchPtr));
-    EXPECT_CALL(*dispatch_, pulse_attach)
-        .Times(AnyNumber())
-        .WillRepeatedly(Invoke(&helper_, &ResourceManagerMockHelper::pulse_attach));
-    EXPECT_CALL(*dispatch_, message_connect).Times(AnyNumber()).WillOnce(Return(kFakeOsError));
-
-    std::optional<QnxDispatchEngine> engine;
-    EXPECT_DEATH(engine.emplace(score::cpp::pmr::get_default_resource(), MoveMockOsResources()),
-                 "Unable to create side channel");
-}
-
 TEST_F(QnxDispatchEngineDeathTest, EngineCreation_CreateTimer)
 {
-    // Times(AnyNumber()) to satisfy death test logic
-    EXPECT_CALL(*dispatch_, dispatch_create_channel).Times(AnyNumber()).WillOnce(Return(kFakeDispatchPtr));
-    EXPECT_CALL(*dispatch_, pulse_attach)
-        .Times(AnyNumber())
-        .WillRepeatedly(Invoke(&helper_, &ResourceManagerMockHelper::pulse_attach));
-    EXPECT_CALL(*dispatch_, message_connect).Times(AnyNumber()).WillOnce(Return(kFakeCoid));
+    ExpectEngineInConstructionForDeathTests();
+
+    EXPECT_CALL(*dispatch_, pulse_attach(_, _, QnxDispatchEngine::kTimerPulseCode, _, _)).Times(AnyNumber());
+    EXPECT_CALL(*dispatch_, pulse_attach(_, _, QnxDispatchEngine::kSelectPulseCode, _, _)).Times(AnyNumber());
+    EXPECT_CALL(*dispatch_, pulse_attach(_, _, _PULSE_CODE_COIDDEATH, _, _)).Times(AnyNumber());
+
     EXPECT_CALL(*timer_, TimerCreate).Times(AnyNumber()).WillOnce(Return(kFakeOsError));
 
     std::optional<QnxDispatchEngine> engine;
@@ -166,13 +131,13 @@ TEST_F(QnxDispatchEngineDeathTest, EngineCreation_CreateTimer)
 
 TEST_F(QnxDispatchEngineDeathTest, EngineCreation_SetUpResourceManager)
 {
-    // Times(AnyNumber()) to satisfy death test logic
-    EXPECT_CALL(*dispatch_, dispatch_create_channel).Times(AnyNumber()).WillOnce(Return(kFakeDispatchPtr));
-    EXPECT_CALL(*dispatch_, pulse_attach)
-        .Times(AnyNumber())
-        .WillRepeatedly(Invoke(&helper_, &ResourceManagerMockHelper::pulse_attach));
-    EXPECT_CALL(*dispatch_, message_connect).Times(AnyNumber()).WillOnce(Return(kFakeCoid));
-    EXPECT_CALL(*timer_, TimerCreate).Times(AnyNumber()).WillOnce(Return(kFakeTimerId));
+    ExpectEngineInConstructionForDeathTests();
+
+    EXPECT_CALL(*dispatch_, pulse_attach(_, _, QnxDispatchEngine::kTimerPulseCode, _, _)).Times(AnyNumber());
+    EXPECT_CALL(*dispatch_, pulse_attach(_, _, QnxDispatchEngine::kSelectPulseCode, _, _)).Times(AnyNumber());
+    EXPECT_CALL(*dispatch_, pulse_attach(_, _, _PULSE_CODE_COIDDEATH, _, _)).Times(AnyNumber());
+    EXPECT_CALL(*timer_, TimerCreate).Times(AnyNumber());
+
     EXPECT_CALL(*dispatch_, resmgr_attach(_, _, IsNull(), _, _, _, _, _))
         .Times(AnyNumber())
         .WillOnce(Return(kFakeOsError));
@@ -182,33 +147,13 @@ TEST_F(QnxDispatchEngineDeathTest, EngineCreation_SetUpResourceManager)
                  "Unable to set up resource manager operations");
 }
 
-TEST_F(QnxDispatchEngineDeathTest, EngineCreation_AllocateContext)
-{
-    // Times(AnyNumber()) to satisfy death test logic
-    EXPECT_CALL(*dispatch_, dispatch_create_channel).Times(AnyNumber()).WillOnce(Return(kFakeDispatchPtr));
-    EXPECT_CALL(*dispatch_, pulse_attach)
-        .Times(AnyNumber())
-        .WillRepeatedly(Invoke(&helper_, &ResourceManagerMockHelper::pulse_attach));
-    EXPECT_CALL(*dispatch_, message_connect).Times(AnyNumber()).WillOnce(Return(kFakeCoid));
-    EXPECT_CALL(*timer_, TimerCreate).Times(AnyNumber()).WillOnce(Return(kFakeTimerId));
-    EXPECT_CALL(*dispatch_, resmgr_attach(_, _, IsNull(), _, _, _, _, _))
-        .Times(AnyNumber())
-        .WillOnce(Return(kFakeResmgrEmptyId));
-    EXPECT_CALL(*dispatch_, dispatch_context_alloc).Times(AnyNumber()).WillOnce(Return(kFakeOsError));
-
-    std::optional<QnxDispatchEngine> engine;
-    EXPECT_DEATH(engine.emplace(score::cpp::pmr::get_default_resource(), MoveMockOsResources()),
-                 "Unable to allocate context pointer");
-}
-
 TEST_F(QnxDispatchEngineTestFixture, EngineCreationAndDestruction)
 {
     ExpectEngineConstructed();
-    ExpectEngineThreadRunning();
     QnxDispatchEngine engine(score::cpp::pmr::get_default_resource(), MoveMockOsResources());
 
     // Check that dispatch_block error does not break dispatch loop
-    helper_.HelperInsertDispatchBlockError(ENOMEM);
+    server_helper_.HelperInsertDispatchBlockError(ENOMEM);
 
     ExpectEngineDestructed();
 }
@@ -216,7 +161,6 @@ TEST_F(QnxDispatchEngineTestFixture, EngineCreationAndDestruction)
 TEST_F(QnxDispatchEngineDeathTest, PosixEndpoint_RegisterNotOnCallbackThread)
 {
     ExpectEngineConstructed();
-    ExpectEngineThreadRunning();
     QnxDispatchEngine engine(score::cpp::pmr::get_default_resource(), MoveMockOsResources());
 
     ISharedResourceEngine::PosixEndpointEntry posix_endpoint;
@@ -229,7 +173,6 @@ TEST_F(QnxDispatchEngineDeathTest, PosixEndpoint_RegisterNotOnCallbackThread)
 TEST_F(QnxDispatchEngineDeathTest, PosixEndpoint_UnregisterNotOnCallbackThread)
 {
     ExpectEngineConstructed();
-    ExpectEngineThreadRunning();
     QnxDispatchEngine engine(score::cpp::pmr::get_default_resource(), MoveMockOsResources());
 
     ISharedResourceEngine::PosixEndpointEntry posix_endpoint;
@@ -275,9 +218,9 @@ TEST_F(QnxDispatchEngineTestFixture, ServerOpenCheckFailure)
     WithEngineRunningAndServerAttached();
 
     ExpectConnectionOpen();
-    helper_.HelperInsertIoOpen(score::cpp::unexpected{ENOMEM});
-    EXPECT_EQ(helper_.promises_.open.get_future().get(), ENOMEM);
-    EXPECT_FALSE(helper_.HelperIsLocked());
+    server_helper_.HelperInsertIoOpen(score::cpp::unexpected{ENOMEM});
+    EXPECT_EQ(server_helper_.promises_.open.get_future().get(), ENOMEM);
+    EXPECT_FALSE(server_helper_.HelperIsLocked());
 }
 
 TEST_F(QnxDispatchEngineTestFixture, ServerOpenCheckSuccess)
@@ -286,13 +229,13 @@ TEST_F(QnxDispatchEngineTestFixture, ServerOpenCheckSuccess)
 
     ExpectConnectionOpen();
     EXPECT_CALL(*server_, ProcessConnect).Times(1).WillOnce([this](auto&&...) {
-        EXPECT_TRUE(helper_.HelperIsLocked());
+        EXPECT_TRUE(server_helper_.HelperIsLocked());
         return EOK;
     });
 
-    helper_.HelperInsertIoOpen(score::cpp::blank{});
-    EXPECT_EQ(helper_.promises_.open.get_future().get(), EOK);
-    EXPECT_FALSE(helper_.HelperIsLocked());
+    server_helper_.HelperInsertIoOpen(score::cpp::blank{});
+    EXPECT_EQ(server_helper_.promises_.open.get_future().get(), EOK);
+    EXPECT_FALSE(server_helper_.HelperIsLocked());
 }
 
 TEST_F(QnxDispatchEngineTestFixture, ServerOpenCheckSuccessConnectionAttached)
@@ -307,14 +250,14 @@ TEST_F(QnxDispatchEngineTestFixture, ServerOpenCheckSuccessConnectionAttached)
     EXPECT_CALL(*server_, ProcessConnect)
         .Times(1)
         .WillOnce([this, &connection](resmgr_context_t* const ctp, io_open_t* const msg) {
-            EXPECT_TRUE(helper_.HelperIsLocked());
+            EXPECT_TRUE(server_helper_.HelperIsLocked());
             score::cpp::ignore = engine_->AttachConnection(ctp, msg, *server_, connection);
             return EOK;
         });
 
-    helper_.HelperInsertIoOpen(score::cpp::blank{});
-    EXPECT_EQ(helper_.promises_.open.get_future().get(), EOK);
-    EXPECT_FALSE(helper_.HelperIsLocked());
+    server_helper_.HelperInsertIoOpen(score::cpp::blank{});
+    EXPECT_EQ(server_helper_.promises_.open.get_future().get(), EOK);
+    EXPECT_FALSE(server_helper_.HelperIsLocked());
 }
 
 TEST_F(QnxDispatchEngineTestFixture, ServerWriteChecksFailure)
@@ -325,30 +268,30 @@ TEST_F(QnxDispatchEngineTestFixture, ServerWriteChecksFailure)
 
     EXPECT_CALL(*iofunc_, iofunc_write_verify)
         .Times(AnyNumber())
-        .WillRepeatedly(Invoke(&helper_, &ResourceManagerMockHelper::iofunc_write_verify));
+        .WillRepeatedly(Invoke(&server_helper_, &ResourceManagerMockHelper::iofunc_write_verify));
 
     ::testing::Test::RecordProperty(
         "when", "write requests arrive with invalid xtype, zero nbytes, or size exceeding protocol limit");
     // iofunc_write_verify unexpected
-    helper_.HelperInsertIoWrite(score::cpp::unexpected{ENOMEM});
+    server_helper_.HelperInsertIoWrite(score::cpp::unexpected{ENOMEM});
     ::testing::Test::RecordProperty(
         "then", "engine rejects each with ``ENOMEM``, ``ENOSYS``, ``EBADMSG``, or ``EMSGSIZE`` respectively");
-    EXPECT_EQ(helper_.promises_.write.get_future().get(), ENOMEM);
-    helper_.promises_.write = std::promise<std::int32_t>();  // reset
+    EXPECT_EQ(server_helper_.promises_.write.get_future().get(), ENOMEM);
+    server_helper_.promises_.write = std::promise<std::int32_t>();  // reset
 
     // unsupported write request type
-    helper_.HelperInsertIoWrite(score::cpp::blank{}, _IO_XTYPE_READDIR);
-    EXPECT_EQ(helper_.promises_.write.get_future().get(), ENOSYS);
-    helper_.promises_.write = std::promise<std::int32_t>();  // reset
+    server_helper_.HelperInsertIoWrite(score::cpp::blank{}, _IO_XTYPE_READDIR);
+    EXPECT_EQ(server_helper_.promises_.write.get_future().get(), ENOSYS);
+    server_helper_.promises_.write = std::promise<std::int32_t>();  // reset
 
     // too small write request size
-    helper_.HelperInsertIoWrite(score::cpp::blank{}, _IO_XTYPE_NONE, 0UL, 4UL);
-    EXPECT_EQ(helper_.promises_.write.get_future().get(), EBADMSG);
-    helper_.promises_.write = std::promise<std::int32_t>();  // reset
+    server_helper_.HelperInsertIoWrite(score::cpp::blank{}, _IO_XTYPE_NONE, 0UL, 4UL);
+    EXPECT_EQ(server_helper_.promises_.write.get_future().get(), EBADMSG);
+    server_helper_.promises_.write = std::promise<std::int32_t>();  // reset
 
     // too large write request size
-    helper_.HelperInsertIoWrite(score::cpp::blank{}, _IO_XTYPE_NONE, 8UL, 4UL);
-    EXPECT_EQ(helper_.promises_.write.get_future().get(), EMSGSIZE);
+    server_helper_.HelperInsertIoWrite(score::cpp::blank{}, _IO_XTYPE_NONE, 8UL, 4UL);
+    EXPECT_EQ(server_helper_.promises_.write.get_future().get(), EMSGSIZE);
 }
 
 TEST_F(QnxDispatchEngineTestFixture, ServerWriteChecksSuccess)
@@ -357,7 +300,7 @@ TEST_F(QnxDispatchEngineTestFixture, ServerWriteChecksSuccess)
 
     EXPECT_CALL(*iofunc_, iofunc_write_verify)
         .Times(AnyNumber())
-        .WillRepeatedly(Invoke(&helper_, &ResourceManagerMockHelper::iofunc_write_verify));
+        .WillRepeatedly(Invoke(&server_helper_, &ResourceManagerMockHelper::iofunc_write_verify));
 
     EXPECT_CALL(connection_, ProcessInput)
         .Times(1)
@@ -367,8 +310,8 @@ TEST_F(QnxDispatchEngineTestFixture, ServerWriteChecksSuccess)
             return EOK;
         });
 
-    helper_.HelperInsertIoWrite(score::cpp::blank{}, _IO_XTYPE_NONE, 4UL, 4UL);
-    EXPECT_EQ(helper_.promises_.write.get_future().get(), EOK);
+    server_helper_.HelperInsertIoWrite(score::cpp::blank{}, _IO_XTYPE_NONE, 4UL, 4UL);
+    EXPECT_EQ(server_helper_.promises_.write.get_future().get(), EOK);
 }
 
 TEST_F(QnxDispatchEngineTestFixture, ServerReadChecksFailure)
@@ -377,21 +320,21 @@ TEST_F(QnxDispatchEngineTestFixture, ServerReadChecksFailure)
 
     EXPECT_CALL(*iofunc_, iofunc_read_verify)
         .Times(AnyNumber())
-        .WillRepeatedly(Invoke(&helper_, &ResourceManagerMockHelper::iofunc_read_verify));
+        .WillRepeatedly(Invoke(&server_helper_, &ResourceManagerMockHelper::iofunc_read_verify));
 
     // iofunc_reaf_verify unexpected
-    helper_.HelperInsertIoRead(score::cpp::unexpected{ENOMEM});
-    EXPECT_EQ(helper_.promises_.read.get_future().get(), ENOMEM);
-    helper_.promises_.read = std::promise<std::int32_t>();  // reset
+    server_helper_.HelperInsertIoRead(score::cpp::unexpected{ENOMEM});
+    EXPECT_EQ(server_helper_.promises_.read.get_future().get(), ENOMEM);
+    server_helper_.promises_.read = std::promise<std::int32_t>();  // reset
 
     // unsupported read request type
-    helper_.HelperInsertIoRead(score::cpp::blank{}, _IO_XTYPE_READDIR);
-    EXPECT_EQ(helper_.promises_.read.get_future().get(), ENOSYS);
-    helper_.promises_.read = std::promise<std::int32_t>();  // reset
+    server_helper_.HelperInsertIoRead(score::cpp::blank{}, _IO_XTYPE_READDIR);
+    EXPECT_EQ(server_helper_.promises_.read.get_future().get(), ENOSYS);
+    server_helper_.promises_.read = std::promise<std::int32_t>();  // reset
 
     // too small read request size
-    helper_.HelperInsertIoRead(score::cpp::blank{}, _IO_XTYPE_NONE, 0UL);
-    EXPECT_EQ(helper_.promises_.read.get_future().get(), _RESMGR_NPARTS(0));
+    server_helper_.HelperInsertIoRead(score::cpp::blank{}, _IO_XTYPE_NONE, 0UL);
+    EXPECT_EQ(server_helper_.promises_.read.get_future().get(), _RESMGR_NPARTS(0));
 }
 
 TEST_F(QnxDispatchEngineTestFixture, ServerReadChecksSuccess)
@@ -400,14 +343,14 @@ TEST_F(QnxDispatchEngineTestFixture, ServerReadChecksSuccess)
 
     EXPECT_CALL(*iofunc_, iofunc_read_verify)
         .Times(AnyNumber())
-        .WillRepeatedly(Invoke(&helper_, &ResourceManagerMockHelper::iofunc_read_verify));
+        .WillRepeatedly(Invoke(&server_helper_, &ResourceManagerMockHelper::iofunc_read_verify));
 
     EXPECT_CALL(connection_, ProcessReadRequest).Times(1).WillOnce([](auto) noexcept {
         return _RESMGR_NPARTS(1);
     });
 
-    helper_.HelperInsertIoRead(score::cpp::blank{}, _IO_XTYPE_NONE, 4UL);
-    EXPECT_EQ(helper_.promises_.read.get_future().get(), _RESMGR_NPARTS(1));
+    server_helper_.HelperInsertIoRead(score::cpp::blank{}, _IO_XTYPE_NONE, 4UL);
+    EXPECT_EQ(server_helper_.promises_.read.get_future().get(), _RESMGR_NPARTS(1));
 }
 
 TEST_F(QnxDispatchEngineTestFixture, ServerIoMsgSuccessScenarios)
@@ -429,12 +372,12 @@ TEST_F(QnxDispatchEngineTestFixture, ServerIoMsgSuccessScenarios)
         EXPECT_CALL(connection_, HasSomethingToRead).WillOnce(Return(true));
         EXPECT_CALL(*channel_, MsgDeliverEvent).Times(1);
     }
-    helper_.HelperInsertIoMsg(kIomgrStickySelect);
-    EXPECT_EQ(helper_.promises_.msg.get_future().get(), EOK);
-    helper_.promises_.msg = std::promise<std::int32_t>();  // reset
+    server_helper_.HelperInsertIoMsg(kIomgrStickySelect);
+    EXPECT_EQ(server_helper_.promises_.msg.get_future().get(), EOK);
+    server_helper_.promises_.msg = std::promise<std::int32_t>();  // reset
 
-    helper_.HelperInsertIoMsg(kIomgrStickySelect);
-    EXPECT_EQ(helper_.promises_.msg.get_future().get(), EOK);
+    server_helper_.HelperInsertIoMsg(kIomgrStickySelect);
+    EXPECT_EQ(server_helper_.promises_.msg.get_future().get(), EOK);
 }
 
 TEST_F(QnxDispatchEngineTestFixture, ServerIoMsgFailureScenarios)
@@ -445,16 +388,16 @@ TEST_F(QnxDispatchEngineTestFixture, ServerIoMsgFailureScenarios)
         .WillOnce(Return(score::cpp::make_unexpected(score::os::Error::createFromErrno(EFAULT))))
         .WillOnce(Return(1U));
 
-    helper_.HelperInsertIoMsg(kIomgrInvalidCode);
-    EXPECT_EQ(helper_.promises_.msg.get_future().get(), ENOSYS);
-    helper_.promises_.msg = std::promise<std::int32_t>();  // reset
+    server_helper_.HelperInsertIoMsg(kIomgrInvalidCode);
+    EXPECT_EQ(server_helper_.promises_.msg.get_future().get(), ENOSYS);
+    server_helper_.promises_.msg = std::promise<std::int32_t>();  // reset
 
-    helper_.HelperInsertIoMsg(kIomgrStickySelect);
-    EXPECT_EQ(helper_.promises_.msg.get_future().get(), EFAULT);
-    helper_.promises_.msg = std::promise<std::int32_t>();  // reset
+    server_helper_.HelperInsertIoMsg(kIomgrStickySelect);
+    EXPECT_EQ(server_helper_.promises_.msg.get_future().get(), EFAULT);
+    server_helper_.promises_.msg = std::promise<std::int32_t>();  // reset
 
-    helper_.HelperInsertIoMsg(kIomgrStickySelect);
-    EXPECT_EQ(helper_.promises_.msg.get_future().get(), EBADMSG);
+    server_helper_.HelperInsertIoMsg(kIomgrStickySelect);
+    EXPECT_EQ(server_helper_.promises_.msg.get_future().get(), EBADMSG);
 }
 
 TEST_F(QnxDispatchEngineTestFixture, PosixEndpoint)
@@ -536,6 +479,8 @@ TEST_F(QnxDispatchEngineTestFixture, PosixEndpointCoidDeathPulse)
 {
     ::testing::Test::RecordProperty("lobster-tracing", "MessagePassing.OsIpcFaultHandling");
     ::testing::Test::RecordProperty("given", "QNX dispatch engine running with a registered POSIX endpoint");
+    ResourceManagerMockHelper& client_helper = helpers_[kClientIndex];
+
     std::int32_t obsolete_counter{0};
     std::int32_t crash_counter{0};
     LoggingCallback logger = [&obsolete_counter, &crash_counter](LogSeverity severity, LogItems items) -> void {
@@ -588,26 +533,26 @@ TEST_F(QnxDispatchEngineTestFixture, PosixEndpointCoidDeathPulse)
 
     // death pulses for unregistered endpoints are ignored
     ::testing::Test::RecordProperty("when", "a death pulse arrives indicating the connected peer's coid is dead");
-    helper_.HelperInsertPulse(_PULSE_CODE_COIDDEATH, kTestCoid + 1);
-    helper_.promises_.pulse.get_future().wait();
+    client_helper.HelperInsertPulse(_PULSE_CODE_COIDDEATH, kTestCoid + 1);
+    client_helper.promises_.pulse.get_future().wait();
     EXPECT_EQ(obsolete_counter, 0);
     EXPECT_EQ(crash_counter, 0);
-    helper_.promises_.pulse = std::promise<void>();  // reset
+    client_helper.promises_.pulse = std::promise<void>();  // reset
 
     // death pulses for the connections existing for QNX kernel
     // (ConnectServerInfo returns the same coid) are considered obsolete
     // (connections are newer than pulses)
-    helper_.HelperInsertPulse(_PULSE_CODE_COIDDEATH, kTestCoid);
-    helper_.promises_.pulse.get_future().wait();
+    client_helper.HelperInsertPulse(_PULSE_CODE_COIDDEATH, kTestCoid);
+    client_helper.promises_.pulse.get_future().wait();
     EXPECT_EQ(obsolete_counter, 1);
     EXPECT_EQ(crash_counter, 0);
-    helper_.promises_.pulse = std::promise<void>();  // reset
+    client_helper.promises_.pulse = std::promise<void>();  // reset
 
     // death pulses for the connections not existing for QNX kernel
     // (ConnectServerInfo returns the "next" coid) are considered the result of server crash
     // and lead to input callback that would cause connection closure
-    helper_.HelperInsertPulse(_PULSE_CODE_COIDDEATH, kTestCoid);
-    helper_.promises_.pulse.get_future().wait();
+    client_helper.HelperInsertPulse(_PULSE_CODE_COIDDEATH, kTestCoid);
+    client_helper.promises_.pulse.get_future().wait();
     EXPECT_EQ(obsolete_counter, 1);
     EXPECT_EQ(crash_counter, 1);
 

--- a/score/message_passing/qnx_dispatch_mocked_server_test.cpp
+++ b/score/message_passing/qnx_dispatch_mocked_server_test.cpp
@@ -29,6 +29,9 @@ using QnxDispatchMockedServerFixture = ResourceManagerFixtureBase;
 
 TEST_F(QnxDispatchMockedServerFixture, ServerOpenConnectClientInfoFailure)
 {
+    const std::size_t index = kServerIndex;
+    ResourceManagerMockHelper& helper = helpers_[index];
+
     WithEngineRunning();
 
     ServiceProtocolConfig protocol_config{"fake_path", 0U, 0U, 0U};
@@ -47,8 +50,8 @@ TEST_F(QnxDispatchMockedServerFixture, ServerOpenConnectClientInfoFailure)
     ASSERT_TRUE(server.StartListening(connect_callback, DisconnectCallback{}, MessageCallback{}, MessageCallback{})
                     .has_value());
 
-    helper_.HelperInsertIoOpen(score::cpp::blank{});
-    EXPECT_EQ(helper_.promises_.open.get_future().get(), EINVAL);
+    helper.HelperInsertIoOpen(score::cpp::blank{});
+    EXPECT_EQ(helper.promises_.open.get_future().get(), EINVAL);
 
     ExpectServerDetached();
     server.StopListening();
@@ -58,6 +61,9 @@ TEST_F(QnxDispatchMockedServerFixture, ServerOpenConnectOcbAttachFailure)
 {
     ::testing::Test::RecordProperty("lobster-tracing", "MessagePassing.OsIpcFaultHandling");
     ::testing::Test::RecordProperty("given", "QNX dispatch server listening with ``MockOs``");
+    const std::size_t index = kServerIndex;
+    ResourceManagerMockHelper& helper = helpers_[index];
+
     WithEngineRunning();
 
     ServiceProtocolConfig protocol_config{"fake_path", 0U, 0U, 0U};
@@ -77,9 +83,9 @@ TEST_F(QnxDispatchMockedServerFixture, ServerOpenConnectOcbAttachFailure)
     EXPECT_CALL(*channel_, ConnectClientInfo).Times(1);
     EXPECT_CALL(*iofunc_, iofunc_ocb_attach).WillOnce(Return(score::cpp::make_unexpected(EIO)));
     ExpectConnectionOpen();
-    helper_.HelperInsertIoOpen(score::cpp::blank{});
+    helper.HelperInsertIoOpen(score::cpp::blank{});
     ::testing::Test::RecordProperty("then", "server reports the open failure with error code ``EIO``");
-    EXPECT_EQ(helper_.promises_.open.get_future().get(), EIO);
+    EXPECT_EQ(helper.promises_.open.get_future().get(), EIO);
 
     ExpectServerDetached();
     server.StopListening();

--- a/score/message_passing/qnx_dispatch_server_to_client_test.cpp
+++ b/score/message_passing/qnx_dispatch_server_to_client_test.cpp
@@ -438,6 +438,7 @@ class ServerToClientQnxFixture : public ::testing::Test, public testing::WithPar
                 promise.set_value(message.size() == static_cast<std::size_t>(notify_message.size()));
             };
             auto send_expected = client_->Send(message);
+            ASSERT_TRUE(send_expected.has_value());
             auto future = promise.get_future();
             ASSERT_EQ(future.wait_for(kFutureWaitTimeout), std::future_status::ready);
             EXPECT_TRUE(future.get());
@@ -451,6 +452,7 @@ class ServerToClientQnxFixture : public ::testing::Test, public testing::WithPar
             promise.set_value(0 == static_cast<std::size_t>(notify_message.size()));
         };
         auto send_expected = client_->Send({});
+        ASSERT_TRUE(send_expected.has_value());
         auto future = promise.get_future();
         ASSERT_EQ(future.wait_for(kFutureWaitTimeout), std::future_status::ready);
         EXPECT_TRUE(future.get());
@@ -610,8 +612,7 @@ TEST_P(ServerToClientQnxFixture, EchoServerClientRestart)
     WaitClientStoppedExpectStatusStopped();
 }
 
-// "same engine" does not work for in-process client-server communications (_RESMGR_FLAG_SELF) on a single shared thread
-INSTANTIATE_TEST_SUITE_P(QnxDispatch, ServerToClientQnxFixture, testing::Values(false /*, true*/));
+INSTANTIATE_TEST_SUITE_P(QnxDispatch, ServerToClientQnxFixture, testing::Values(false, true));
 
 }  // namespace
 }  // namespace message_passing

--- a/score/message_passing/resource_manager_fixture_base.h
+++ b/score/message_passing/resource_manager_fixture_base.h
@@ -101,6 +101,7 @@ class ResourceManagerMockHelper
     /// Blocks the dispatch loop till it has an event to process. Special treatment for `ErrnoPseudoMessage` event
     score::cpp::expected_blank<score::os::Error> dispatch_block(dispatch_context_t* const /*ctp*/) noexcept
     {
+        std::cerr << "dispatch_block 0" << std::endl;
         const auto max_wait = std::chrono::milliseconds(1000);
 
         auto result = message_queue_.Pop(max_wait, score::cpp::stop_token{});
@@ -121,12 +122,12 @@ class ResourceManagerMockHelper
     score::cpp::expected_blank<std::int32_t> dispatch_handler(dispatch_context_t* const /*ctp*/) noexcept
     {
         std::cerr << "dispatch_handler 0" << std::endl;
+        resmgr_context_t& context = context_.resmgr_context;
         if (std::holds_alternative<InternalPulseMessage>(current_message_))
         {
             std::cerr << "dispatch_handler InternalPulseMessage 0" << std::endl;
             auto& pulse = std::get<InternalPulseMessage>(current_message_);
 
-            message_context_t context{};
             resmgr_iomsgs_t message{};
             context.msg = &message;
             message.pulse.value.sival_int = pulse.value;
@@ -140,7 +141,6 @@ class ResourceManagerMockHelper
             std::cerr << "dispatch_handler TestPulseMessage 0" << std::endl;
             auto& pulse = std::get<TestPulseMessage>(current_message_);
 
-            message_context_t context{};
             resmgr_iomsgs_t message{};
             context.msg = &message;
             message.pulse.value.sival_int = pulse.value;
@@ -153,7 +153,6 @@ class ResourceManagerMockHelper
         else if (std::holds_alternative<IoOpenMessage>(current_message_))
         {
             std::cerr << "dispatch_handler IoOpenMessage 0" << std::endl;
-            resmgr_context_t context{};
             io_open_t message{};
 
             const auto result = (*connect_funcs_->open)(&context, &message, handle_, nullptr);
@@ -163,7 +162,6 @@ class ResourceManagerMockHelper
         else if (std::holds_alternative<IoWriteMessage>(current_message_))
         {
             auto& io_write = std::get<IoWriteMessage>(current_message_);
-            resmgr_context_t context{};
             struct IoWriteData
             {
                 io_write_t message;
@@ -181,7 +179,6 @@ class ResourceManagerMockHelper
         else if (std::holds_alternative<IoReadMessage>(current_message_))
         {
             auto& io_read = std::get<IoReadMessage>(current_message_);
-            resmgr_context_t context{};
             io_read_t message{};
             message.i.xtype = io_read.xtype;
             message.i.nbytes = io_read.nbytes;
@@ -192,7 +189,6 @@ class ResourceManagerMockHelper
         else if (std::holds_alternative<IoMsgMessage>(current_message_))
         {
             auto& io_msg = std::get<IoMsgMessage>(current_message_);
-            resmgr_context_t context{};
             io_msg_t message{};
             message.i.mgrid = io_msg.mgrid;
 
@@ -328,6 +324,8 @@ class ResourceManagerMockHelper
     };
 
     Promises promises_{};
+
+    dispatch_context_t context_{};
 
   private:
     struct InternalPulseMessage
@@ -477,58 +475,165 @@ class ResourceManagerFixtureBase : public ::testing::Test
                 unistd_.MoveOwnership()};
     }
 
-    void ExpectEngineConstructed()
+    void ExpectRunnerStarted(bool is_client, testing::Sequence& s)
     {
         using namespace testing;
 
-        EXPECT_CALL(*dispatch_, dispatch_create_channel).Times(1).WillOnce(Return(kFakeDispatchPtr));
-        EXPECT_CALL(*dispatch_, pulse_attach)
-            .Times(4)
-            .WillRepeatedly(Invoke(&helper_, &ResourceManagerMockHelper::pulse_attach));
-        EXPECT_CALL(*dispatch_, message_connect).Times(1).WillOnce(Return(kFakeCoid));
-        EXPECT_CALL(*dispatch_, resmgr_attach(_, _, IsNull(), _, _, _, _, _))
+        const std::size_t index = is_client ? kClientIndex : kServerIndex;
+
+        ResourceManagerMockHelper& helper = helpers_[index];
+        dispatch_t* const dispatch_ptr = reinterpret_cast<dispatch_t*>(&dispatches_[index]);
+        dispatch_context_t* const context_ptr = &helper.context_;
+        const auto coid = static_cast<std::int32_t>(index);
+
+        // StartPreInit
+        EXPECT_CALL(*dispatch_, dispatch_create_channel).InSequence(s).WillOnce(Return(dispatch_ptr));
+        EXPECT_CALL(*dispatch_, pulse_attach(dispatch_ptr, _, detail::DispatchThreadRunner::kQuitPulseCode, _, _))
             .Times(1)
-            .WillOnce(Return(kFakeResmgrEmptyId));
-        EXPECT_CALL(*dispatch_, dispatch_context_alloc).Times(1).WillOnce(Return(kFakeContextPtr));
-        EXPECT_CALL(*timer_, TimerCreate).Times(1).WillOnce(Return(kFakeTimerId));
-        EXPECT_CALL(*iofunc_, iofunc_func_init).Times(1);
-        EXPECT_CALL(*signal_, SigEmptySet).Times(1);
-        EXPECT_CALL(*signal_, AddTerminationSignal).Times(1);
-        EXPECT_CALL(*signal_, PthreadSigMask(SIG_BLOCK, _, _)).Times(1);
-        EXPECT_CALL(*signal_, PthreadSigMask(SIG_SETMASK, _)).Times(1);
+            .WillOnce(Invoke(&helper, &ResourceManagerMockHelper::pulse_attach));
+        EXPECT_CALL(*dispatch_, message_connect(dispatch_ptr, _)).Times(1).WillOnce(Return(coid));
+
+        // Init
+        if (is_client)
+        {
+            EXPECT_CALL(*dispatch_, pulse_attach(dispatch_ptr, _, QnxDispatchEngine::kTimerPulseCode, _, _))
+                .Times(1)
+                .WillOnce(Invoke(&helper, &ResourceManagerMockHelper::pulse_attach));
+            EXPECT_CALL(*dispatch_, pulse_attach(dispatch_ptr, _, QnxDispatchEngine::kSelectPulseCode, _, _))
+                .Times(1)
+                .WillOnce(Invoke(&helper, &ResourceManagerMockHelper::pulse_attach));
+            EXPECT_CALL(*dispatch_, pulse_attach(dispatch_ptr, _, _PULSE_CODE_COIDDEATH, _, _))
+                .Times(1)
+                .WillOnce(Invoke(&helper, &ResourceManagerMockHelper::pulse_attach));
+            EXPECT_CALL(*timer_, TimerCreate).Times(1).WillOnce(Return(kFakeTimerId));
+        }
+        else
+        {
+            EXPECT_CALL(*dispatch_, resmgr_attach(dispatch_ptr, _, IsNull(), _, _, _, _, _))
+                .Times(1)
+                .WillOnce(Return(kFakeResmgrEmptyId));
+        }
+
+        // StartPostInit
+        EXPECT_CALL(*dispatch_, dispatch_context_alloc(dispatch_ptr)).Times(1).WillOnce(Return(context_ptr));
+        EXPECT_CALL(*signal_, SigEmptySet).Times(1).InSequence(s);
+        EXPECT_CALL(*signal_, AddTerminationSignal).Times(1).InSequence(s);
+        EXPECT_CALL(*signal_, PthreadSigMask(SIG_BLOCK, _, _)).Times(1).InSequence(s);
+        EXPECT_CALL(*signal_, PthreadSigMask(SIG_SETMASK, _)).Times(1).InSequence(s);
+
+        // RunOnThread
+        EXPECT_CALL(*dispatch_, dispatch_block(context_ptr))
+            .Times(AnyNumber())
+            .WillRepeatedly(Invoke(&helper, &ResourceManagerMockHelper::dispatch_block));
+        EXPECT_CALL(*dispatch_, dispatch_handler(context_ptr))
+            .Times(AnyNumber())
+            .WillRepeatedly(Invoke(&helper, &ResourceManagerMockHelper::dispatch_handler));
+        EXPECT_CALL(*channel_, MsgSendPulse(coid, _, _, _))
+            .Times(AnyNumber())
+            .WillRepeatedly(Invoke(&helper, &ResourceManagerMockHelper::MsgSendPulse));
     }
 
-    void ExpectEngineThreadRunning()
+    void ExpectClientRunnerStarted(testing::Sequence& s)
+    {
+        ExpectRunnerStarted(true, s);
+    }
+
+    void ExpectServerRunnerStarted(testing::Sequence& s)
+    {
+        ExpectRunnerStarted(false, s);
+    }
+
+    void ExpectEngineConstructed()
+    {
+        EXPECT_CALL(*iofunc_, iofunc_func_init).Times(1);
+        testing::Sequence dispatch_allocation_sequence;
+        ExpectClientRunnerStarted(dispatch_allocation_sequence);
+        ExpectServerRunnerStarted(dispatch_allocation_sequence);
+    }
+
+    void ExpectEngineInConstructionForDeathTests()
     {
         using namespace testing;
 
-        EXPECT_CALL(*dispatch_, dispatch_block)
+        EXPECT_CALL(*iofunc_, iofunc_func_init).Times(AnyNumber());
+
+        const std::size_t index = kClientIndex;  // doesn't matter which one
+
+        ResourceManagerMockHelper& helper = helpers_[index];
+        dispatch_t* const dispatch_ptr = reinterpret_cast<dispatch_t*>(&dispatches_[index]);
+        dispatch_context_t* const context_ptr = &helper.context_;
+        const auto coid = static_cast<std::int32_t>(index);
+
+        // StartPreInit
+        EXPECT_CALL(*dispatch_, dispatch_create_channel).Times(AnyNumber()).WillRepeatedly(Return(dispatch_ptr));
+        EXPECT_CALL(*dispatch_, pulse_attach(dispatch_ptr, _, detail::DispatchThreadRunner::kQuitPulseCode, _, _))
+            .Times(AnyNumber());
+        EXPECT_CALL(*dispatch_, message_connect(dispatch_ptr, _)).Times(AnyNumber()).WillOnce(Return(coid));
+
+        // Init will be test-specific
+
+        // StartPostInit
+        EXPECT_CALL(*dispatch_, dispatch_context_alloc(dispatch_ptr)).Times(AnyNumber()).WillOnce(Return(context_ptr));
+        EXPECT_CALL(*signal_, SigEmptySet).Times(AnyNumber());
+        EXPECT_CALL(*signal_, AddTerminationSignal).Times(AnyNumber());
+        EXPECT_CALL(*signal_, PthreadSigMask(SIG_BLOCK, _, _)).Times(AnyNumber());
+        EXPECT_CALL(*signal_, PthreadSigMask(SIG_SETMASK, _)).Times(AnyNumber());
+
+        // RunOnThread
+        EXPECT_CALL(*dispatch_, dispatch_block(context_ptr))
             .Times(AnyNumber())
-            .WillRepeatedly(Invoke(&helper_, &ResourceManagerMockHelper::dispatch_block));
-        EXPECT_CALL(*dispatch_, dispatch_handler)
+            .WillRepeatedly(Invoke(&helper, &ResourceManagerMockHelper::dispatch_block));
+        EXPECT_CALL(*dispatch_, dispatch_handler(context_ptr))
             .Times(AnyNumber())
-            .WillRepeatedly(Invoke(&helper_, &ResourceManagerMockHelper::dispatch_handler));
-        EXPECT_CALL(*channel_, MsgSendPulse)
+            .WillRepeatedly(Invoke(&helper, &ResourceManagerMockHelper::dispatch_handler));
+        EXPECT_CALL(*channel_, MsgSendPulse(coid, _, _, _))
             .Times(AnyNumber())
-            .WillRepeatedly(Invoke(&helper_, &ResourceManagerMockHelper::MsgSendPulse));
+            .WillRepeatedly(Invoke(&helper, &ResourceManagerMockHelper::MsgSendPulse));
+    }
+
+    void ExpectRunnerStopped(bool is_client)
+    {
+        using namespace testing;
+
+        const std::size_t index = is_client ? kClientIndex : kServerIndex;
+        ResourceManagerMockHelper& helper = helpers_[index];
+        dispatch_t* const dispatch_ptr = reinterpret_cast<dispatch_t*>(&dispatches_[index]);
+        dispatch_context_t* const context_ptr = &helper.context_;
+        const auto coid = static_cast<std::int32_t>(index);
+
+        EXPECT_CALL(*channel_, ConnectDetach(coid)).Times(1);
+        EXPECT_CALL(*dispatch_, dispatch_destroy(dispatch_ptr)).Times(1);
+        EXPECT_CALL(*dispatch_, dispatch_context_free(context_ptr)).Times(1);
+    }
+
+    void ExpectClientRunnerStopped()
+    {
+        ExpectRunnerStopped(true);
+    }
+
+    void ExpectServerRunnerStopped()
+    {
+        ExpectRunnerStopped(false);
     }
 
     void ExpectEngineDestructed()
     {
         EXPECT_CALL(*timer_, TimerDestroy).Times(1);
-        EXPECT_CALL(*channel_, ConnectDetach).Times(1);
-        EXPECT_CALL(*dispatch_, pulse_detach).Times(4);
-        EXPECT_CALL(*dispatch_, dispatch_destroy).Times(1);
-        EXPECT_CALL(*dispatch_, dispatch_context_free).Times(1);
+        ExpectServerRunnerStopped();
+        ExpectClientRunnerStopped();
     }
 
     void ExpectServerAttached()
     {
         using namespace testing;
 
-        EXPECT_CALL(*dispatch_, resmgr_attach(_, _, NotNull(), _, _, _, _, _))
+        const std::size_t index = kServerIndex;
+        ResourceManagerMockHelper& helper = helpers_[index];
+        dispatch_t* const dispatch_ptr = reinterpret_cast<dispatch_t*>(&dispatches_[index]);
+
+        EXPECT_CALL(*dispatch_, resmgr_attach(dispatch_ptr, _, NotNull(), _, _, _, _, _))
             .Times(1)
-            .WillOnce(Invoke(&helper_, &ResourceManagerMockHelper::resmgr_attach));
+            .WillOnce(Invoke(&helper, &ResourceManagerMockHelper::resmgr_attach));
         EXPECT_CALL(*iofunc_, iofunc_attr_init).Times(1);
     }
 
@@ -536,37 +641,49 @@ class ResourceManagerFixtureBase : public ::testing::Test
     {
         using namespace testing;
 
+        const std::size_t index = kServerIndex;
+        dispatch_t* const dispatch_ptr = reinterpret_cast<dispatch_t*>(&dispatches_[index]);
+
         EXPECT_CALL(*dispatch_,
-                    resmgr_detach(_, kFakeResmgrServerId, static_cast<std::uint32_t>(_RESMGR_DETACH_CLOSE)));
+                    resmgr_detach(dispatch_ptr, kFakeResmgrServerId, static_cast<std::uint32_t>(_RESMGR_DETACH_CLOSE)));
     }
 
     void ExpectConnectionOpen()
     {
         using namespace testing;
 
+        const std::size_t index = kServerIndex;
+        ResourceManagerMockHelper& helper = helpers_[index];
+        resmgr_context_t* const context_ptr = &helper.context_.resmgr_context;
+
         InSequence is;
         EXPECT_CALL(*iofunc_, iofunc_attr_lock)
             .Times(1)
-            .WillOnce(Invoke(&helper_, &ResourceManagerMockHelper::iofunc_attr_lock));
-        EXPECT_CALL(*iofunc_, iofunc_open).Times(1).WillOnce(Invoke(&helper_, &ResourceManagerMockHelper::iofunc_open));
+            .WillOnce(Invoke(&helper, &ResourceManagerMockHelper::iofunc_attr_lock));
+        EXPECT_CALL(*iofunc_, iofunc_open(context_ptr, _, _, _, _))
+            .Times(1)
+            .WillOnce(Invoke(&helper, &ResourceManagerMockHelper::iofunc_open));
         EXPECT_CALL(*iofunc_, iofunc_attr_unlock)
             .Times(1)
-            .WillOnce(Invoke(&helper_, &ResourceManagerMockHelper::iofunc_attr_unlock));
+            .WillOnce(Invoke(&helper, &ResourceManagerMockHelper::iofunc_attr_unlock));
     }
 
     void ExpectConnectionAccepted()
     {
         using namespace testing;
 
-        EXPECT_CALL(*iofunc_, iofunc_ocb_attach)
+        const std::size_t index = kServerIndex;
+        ResourceManagerMockHelper& helper = helpers_[index];
+        resmgr_context_t* const context_ptr = &helper.context_.resmgr_context;
+
+        EXPECT_CALL(*iofunc_, iofunc_ocb_attach(context_ptr, _, _, _, _))
             .Times(1)
-            .WillOnce(Invoke(&helper_, &ResourceManagerMockHelper::iofunc_ocb_attach));
+            .WillOnce(Invoke(&helper, &ResourceManagerMockHelper::iofunc_ocb_attach));
     }
 
     void WithEngineRunning(LoggingCallback logger = {})
     {
         ExpectEngineConstructed();
-        ExpectEngineThreadRunning();
         if (!logger.empty())
         {
             engine_ = std::make_shared<QnxDispatchEngine>(
@@ -588,11 +705,16 @@ class ResourceManagerFixtureBase : public ::testing::Test
     mock_ptr<score::os::SysUioMock> sysuio_;
     mock_ptr<score::os::UnistdMock> unistd_;
 
-    ResourceManagerMockHelper helper_;
+    constexpr static std::size_t kMaxDispatches{2};
+    constexpr static std::size_t kClientIndex{0};
+    constexpr static std::size_t kServerIndex{1};
+
+    std::array<std::byte, kMaxDispatches> dispatches_{};
+    // std::array<dispatch_context_t, kMaxDispatches> contexts_{};
+    std::array<ResourceManagerMockHelper, kMaxDispatches> helpers_{};
+
     std::shared_ptr<QnxDispatchEngine> engine_;
 
-    constexpr static dispatch_t* kFakeDispatchPtr{nullptr};
-    constexpr static dispatch_context_t* kFakeContextPtr{nullptr};
     constexpr static std::int32_t kFakeCoid{0};
     constexpr static std::int32_t kFakeTimerId{0};
     constexpr static std::int32_t kFakeResmgrEmptyId{0};


### PR DESCRIPTION
Move the background activity for client and server functionalities into separate threads to avoid possible deadlocks on cyclic client-server graphs.