### PR TITLE
Rust::com Rust interface macro syntax fix 

### DIFF
--- a/score/mw/com/example/com-api-example/com-api-gen/com_api_gen.rs
+++ b/score/mw/com/example/com-api-example/com-api-gen/com_api_gen.rs
@@ -40,7 +40,7 @@ pub struct Exhaust {}
 // - VehicleOfferedProducer<R> struct that implements OfferedProducer trait for offering
 //   "left_tire" and "exhaust" events.
 interface!(
-    interface Vehicle, {
+    interface Vehicle {
         Id = "VehicleInterface",
         left_tire: Event<Tire>,
         exhaust: Event<Exhaust>,

--- a/score/mw/com/impl/rust/com-api/com-api-concept/interface_macros.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-concept/interface_macros.rs
@@ -59,7 +59,7 @@
 /// mod abc {
 ///     use com_api_concept::interface;
 ///     interface!(
-///         interface Vehicle, {
+///         interface Vehicle {
 ///             Id = "AbcInterface",
 ///             left_tire: Event<Tire>,
 ///             exhaust: Event<Exhaust>,
@@ -86,13 +86,25 @@ macro_rules! interface {
     };
 
     // Custom unique Id provided by the user
-    (interface $id:ident, {
+    (interface $id:ident {
         Id = $uid:expr,
         $($event_name:ident : Event<$event_type:ty>),+ $(,)?
     }) => {
         $crate::interface_common!($id, $uid);
         $crate::interface_consumer!($id, $($event_name, Event<$event_type>),+);
         $crate::interface_producer!($id, $($event_name, Event<$event_type>),+);
+    };
+
+    // This is for backward compatibility with existing users with comma (,)
+    (interface $id:ident, {
+        Id = $uid:expr,
+        $($event_name:ident : Event<$event_type:ty>),+ $(,)?
+    }) => {
+        $crate::interface! {
+            interface $id {
+            Id = $uid,
+            $($event_name : Event<$event_type>),+
+        }}
     };
 
     (interface $id:ident { $($event_name:ident : Method<$event_type:ty>),+$(,)? }) => {
@@ -292,7 +304,7 @@ mod tests {
     ///     }
     ///
     ///     interface!(
-    ///         interface Vehicle,{
+    ///         interface Vehicle {
     ///            Id = "CustomVehicleInterface",
     ///             left_tire: Event<Tire>,
     ///             exhaust: Event<Exhaust>,
@@ -306,6 +318,40 @@ mod tests {
     ///   trait implementations for the Vehicle interface.
     #[cfg(doctest)]
     fn interface_macro_with_custom_id() {}
+
+    /// ```
+    /// mod my_module {
+    ///     use com_api::{interface, CommData, Reloc, ProviderInfo, Subscriber, Publisher};
+    ///
+    ///     #[derive(Debug, Reloc)]
+    ///     #[repr(C)]
+    ///     pub struct Tire { pub pressure: f32 }
+    ///     impl CommData for Tire {
+    ///         const ID: &'static str = "Tire";
+    ///     }
+    ///
+    ///     #[derive(Debug, Reloc)]
+    ///     #[repr(C)]
+    ///     pub struct Exhaust {}
+    ///     impl CommData for Exhaust {
+    ///         const ID: &'static str = "Exhaust";
+    ///     }
+    ///
+    ///     interface!(
+    ///         interface Vehicle, {
+    ///            Id = "CustomVehicleInterface",
+    ///             left_tire: Event<Tire>,
+    ///             exhaust: Event<Exhaust>,
+    ///         }
+    ///     );
+    /// }
+    /// ```
+    /// This will generate the following types and trait implementations:
+    /// - `VehicleInterface` struct with `INTERFACE_ID = "CustomVehicleInterface"`
+    /// - `VehicleConsumer<R>`, `VehicleProducer<R>`, `VehicleOfferedProducer<R>` with appropriate
+    ///   trait implementations for the Vehicle interface.
+    #[cfg(doctest)]
+    fn interface_macro_with_custom_id_with_comma_for_backend_compatibility() {}
 
     /// ```compile_fail
     /// mod my_module {
@@ -326,7 +372,7 @@ mod tests {
     ///     }
     ///
     ///     interface!(
-    ///         interface Vehicle,{
+    ///         interface Vehicle {
     ///            Id = "CustomVehicleInterface",
     ///             left_tire: Method<Tire>,
     ///             exhaust: Method<Exhaust>,

--- a/score/mw/com/impl/rust/com-api/com-api-concept/interface_macros.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-concept/interface_macros.rs
@@ -95,7 +95,7 @@ macro_rules! interface {
         $crate::interface_producer!($id, $($event_name, Event<$event_type>),+);
     };
 
-    // This is for backward compatibility with existing users with comma (,)
+    // This is for backward compatibility for existing users with comma (,)
     (interface $id:ident, {
         Id = $uid:expr,
         $($event_name:ident : Event<$event_type:ty>),+ $(,)?

--- a/score/mw/com/test/basic_rust_api/bigdata_com_api_gen.rs
+++ b/score/mw/com/test/basic_rust_api/bigdata_com_api_gen.rs
@@ -94,7 +94,7 @@ impl Debug for DummyDataStamped {
 }
 
 interface!(
-    interface BigData, {
+    interface BigData {
         Id = "BigDataInterface",
         map_api_lanes_stamped_: Event<MapApiLanesStamped>,
         dummy_data_stamped_: Event<DummyDataStamped>,
@@ -206,5 +206,5 @@ define_com_type!(
     }
 );
 
-interface!(interface MixedPrimitives, { Id = "MixedPrimitivesInterface", mixed_event: Event<MixedPrimitivesPayload> });
-interface!(interface ComplexStruct, { Id = "ComplexStructInterface", complex_event: Event<ComplexStruct> });
+interface!(interface MixedPrimitives { Id = "MixedPrimitivesInterface", mixed_event: Event<MixedPrimitivesPayload> });
+interface!(interface ComplexStruct { Id = "ComplexStructInterface", complex_event: Event<ComplexStruct> });


### PR DESCRIPTION
https://github.com/eclipse-score/communication/issues/681