### PR TITLE
Fix dangling config pointer

### DIFF
--- a/score/mw/com/impl/instance_identifier.h
+++ b/score/mw/com/impl/instance_identifier.h
@@ -45,6 +45,15 @@ class InstanceIdentifier final
      * InstanceIdentifier::ToString()
      * \param serialized_format The serialized format to create the InstanceIdentifier from
      * \return The created InstanceIdentifier or an error
+     *
+     * \pre The score::mw::com::impl::Runtime singleton must have been created (then the configuration is "locked")
+     * before calling this API, i.e. Only then has a valid Configuration pointer been registered (by the Runtime
+     * constructor) into which the reconstructed deployments are added.
+     * Currently, there is no public API whose sole purpose is to initialize/create the Runtime singleton; in practice
+     * any prior public score::mw::com call that reaches Runtime::getInstance()
+     * (e.g. creating a Skeleton/Proxy, FindService, or - as a last resort - score::mw::com::runtime::ResolveInstanceIDs
+     * called with a dummy InstanceSpecifier) triggers this.
+     * If the configuration has not been set, kInvalidConfiguration is returned.
      */
     static score::Result<InstanceIdentifier> Create(std::string&& serialized_format) noexcept;
 

--- a/score/mw/com/impl/instance_identifier_test.cpp
+++ b/score/mw/com/impl/instance_identifier_test.cpp
@@ -33,6 +33,10 @@ class InstanceIdentifierAttorney
     {
         InstanceIdentifier::configuration_ = configuration;
     }
+    static Configuration* GetConfiguration() noexcept
+    {
+        return InstanceIdentifier::configuration_;
+    }
 };
 
 class ConfigurationGuard
@@ -304,6 +308,54 @@ TEST_F(InstanceIdentifierFixture, CanCreateFromSerializedObject)
         InstanceIdentifierView{identifier}.GetServiceInstanceDeployment());
     ExpectServiceTypeDeploymentObjectsEqual(InstanceIdentifierView{reconstructed_identifier}.GetServiceTypeDeployment(),
                                             InstanceIdentifierView{identifier}.GetServiceTypeDeployment());
+}
+
+TEST_F(InstanceIdentifierFixture, CreateStoresDeploymentsIntoConfiguredConfiguration)
+{
+    RecordProperty("Verifies", "SCR-18448357, SCR-18448382");
+    RecordProperty("Description",
+                   "Checks that InstanceIdentifier::Create adds the reconstructed ServiceType-/ServiceInstance-"
+                   "Deployments into the Configuration set via InstanceIdentifier::SetConfiguration.");
+    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("Priority", "1");
+    RecordProperty("DerivationTechnique", "Analysis of requirements");
+
+    // Given an empty Configuration registered as the InstanceIdentifier configuration
+    Configuration configuration{Configuration::ServiceTypeDeployments{},
+                                Configuration::ServiceInstanceDeployments{},
+                                GlobalConfiguration{},
+                                TracingConfiguration{}};
+    InstanceIdentifierAttorney::SetConfiguration(&configuration);
+
+    const ServiceIdentifierType dummy_service = make_ServiceIdentifierType("foo", 1U, 0U);
+    const ServiceInstanceDeployment service_instance_deployment{
+        dummy_service, MakeLolaServiceInstanceDeployment(), QualityType::kASIL_B, kInstanceSpecifier1};
+    const ServiceTypeDeployment service_type_deployment{MakeLolaServiceTypeDeployment()};
+    const auto identifier = make_InstanceIdentifier(service_instance_deployment, service_type_deployment);
+
+    // and given the configuration does not yet contain any of these deployments
+    ASSERT_TRUE(configuration.GetServiceTypes().empty());
+    ASSERT_TRUE(configuration.GetServiceInstances().empty());
+
+    // When creating an InstanceIdentifier from its serialized form
+    const score::Result<InstanceIdentifier> reconstructed_identifier_result =
+        InstanceIdentifier::Create(std::string{identifier.ToString()});
+    ASSERT_TRUE(reconstructed_identifier_result.has_value());
+
+    // Then the deserialized deployments have been added into the configured Configuration
+    const auto& service_types = configuration.GetServiceTypes();
+    ASSERT_EQ(service_types.size(), 1);
+    const auto type_it = service_types.find(dummy_service);
+    ASSERT_NE(type_it, service_types.cend());
+    ExpectServiceTypeDeploymentObjectsEqual(type_it->second, service_type_deployment);
+
+    const auto& service_instances = configuration.GetServiceInstances();
+    ASSERT_EQ(service_instances.size(), 1);
+    const auto instance_it = service_instances.find(kInstanceSpecifier1);
+    ASSERT_NE(instance_it, service_instances.cend());
+    ExpectServiceInstanceDeploymentObjectsEqual(instance_it->second, service_instance_deployment);
+
+    InstanceIdentifierAttorney::SetConfiguration(nullptr);
 }
 
 TEST_F(InstanceIdentifierFixture, CreatingFromInvalidSerializedObjectReturnsError)

--- a/score/mw/com/impl/runtime.cpp
+++ b/score/mw/com/impl/runtime.cpp
@@ -123,7 +123,7 @@ void Runtime::Initialize(const runtime::RuntimeConfiguration& runtime_configurat
     }
 
     auto config = configuration::Parse(runtime_configuration.GetConfigurationPath().Native());
-    StoreConfiguration(std::move(config));
+    score::cpp::ignore = initialization_config_.emplace(std::move(config));
 }
 
 auto Runtime::getInstance() noexcept -> IRuntime&
@@ -179,6 +179,11 @@ Runtime::Runtime(std::pair<Configuration&&, std::optional<TracingFilterConfig>&&
       service_discovery_{*this},
       long_running_threads_{}
 {
+    // The InstanceIdentifier deserialization API (InstanceIdentifier::Create) needs to add the reconstructed
+    // ServiceType-/ServiceInstance-Deployments into a Configuration and store pointers into it. It must point to the
+    // stable configuration_ member owned by this singleton Runtime (whose lifetime spans the whole process), NOT to the
+    // transient initialization_config_ optional, which gets moved-from and reset() during singleton construction.
+    InstanceIdentifier::SetConfiguration(&configuration_);
     binding_runtimes_ = BindingRuntimeFactory::CreateBindingRuntimes(
         configuration_, long_running_threads_, tracing_filter_configuration_);
     if (configuration_.GetTracingConfiguration().IsTracingEnabled())
@@ -205,7 +210,10 @@ Runtime::Runtime(std::pair<Configuration&&, std::optional<TracingFilterConfig>&&
 
 Runtime::~Runtime() noexcept
 {
-    mw::log::LogDebug("lola") << "Starting destrcution of mw::com runtime";
+    // Reset the pointer InstanceIdentifier holds into our configuration_ member to avoid it dangling once this
+    // singleton Runtime (and thus configuration_) is destroyed.
+    InstanceIdentifier::SetConfiguration(nullptr);
+    mw::log::LogDebug("lola") << "Starting destruction of mw::com runtime";
 }
 
 std::vector<InstanceIdentifier> Runtime::resolve(const InstanceSpecifier& specifier) const
@@ -270,12 +278,6 @@ tracing::ITracingRuntime* Runtime::GetTracingRuntime() const noexcept
 void Runtime::InjectMock(IRuntime* const mock) noexcept
 {
     mock_ = mock;
-}
-
-void Runtime::StoreConfiguration(Configuration config) noexcept
-{
-    score::cpp::ignore = initialization_config_.emplace(std::move(config));
-    InstanceIdentifier::SetConfiguration(&(*initialization_config_));
 }
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/runtime.h
+++ b/score/mw/com/impl/runtime.h
@@ -62,6 +62,12 @@ namespace score::mw::com::impl
  */
 class Runtime final : public IRuntime
 {
+    // Suppress "AUTOSAR C++14 A11-3-1", The rule states: "Friend declarations shall not be used".
+    // Design decision: The "*Attorney" class is a test-only helper, which accesses private members of this class to
+    // verify internal invariants (e.g. that the ctor wires InstanceIdentifier to the configuration_ member).
+    // coverity[autosar_cpp14_a11_3_1_violation]
+    friend class RuntimeAttorney;
+
   public:
     /// \brief static initializer for the runtime. Must be called once per process, which intends to use ara::com
     ///        functionality.
@@ -125,10 +131,6 @@ class Runtime final : public IRuntime
     /// \pre the internal static initialization_config_ has to be initialized with a Configuration.
     static Runtime& getInstanceInternal() noexcept;
 
-    /// \brief Helper function to store the configuration in the initialization_config_ and sets the configuration in
-    /// InstanceIdentifier
-    static void StoreConfiguration(Configuration config) noexcept;
-
     /// \brief pointer to a mock to be used (set via InjectMock())
     static score::mw::com::impl::IRuntime* mock_;
 
@@ -144,6 +146,12 @@ class Runtime final : public IRuntime
     static std::optional<Configuration> initialization_config_;
 
     /// \brief configuration
+    ///
+    /// This is the stable, process-lifetime configuration owned by the Runtime singleton.
+    ///
+    /// \details The Runtime constructor registers a pointer to this member via InstanceIdentifier::SetConfiguration()
+    /// so that the InstanceIdentifier deserialization API (InstanceIdentifier::Create) adds reconstructed deployments
+    /// into this configuration.
     Configuration configuration_;
 
     /// \brief Tracing configuration parsed from json

--- a/score/mw/com/impl/runtime_single_exec_test.cpp
+++ b/score/mw/com/impl/runtime_single_exec_test.cpp
@@ -38,6 +38,33 @@
 
 namespace score::mw::com::impl
 {
+
+// Test-only helper granting access to Runtime's private configuration_ member (befriended in runtime.h). Must live at
+// score::mw::com::impl scope (not in an anonymous namespace) so its name matches the friend declaration.
+class RuntimeAttorney
+{
+  public:
+    explicit RuntimeAttorney(Runtime& runtime) noexcept : runtime_{runtime} {}
+    const Configuration* GetConfigurationAddress() const noexcept
+    {
+        return &runtime_.configuration_;
+    }
+
+  private:
+    Runtime& runtime_;
+};
+
+// Test-only helper granting read access to the static InstanceIdentifier::configuration_ pointer (befriended in
+// instance_identifier.h). Must live at score::mw::com::impl scope so its name matches the friend declaration.
+class InstanceIdentifierAttorney
+{
+  public:
+    static const Configuration* GetConfiguration() noexcept
+    {
+        return InstanceIdentifier::configuration_;
+    }
+};
+
 namespace
 {
 
@@ -104,6 +131,56 @@ void WithConfigAtDefaultPath(const std::string& source_path)
 }
 
 using RuntimeInitializationTest = RuntimeSingleTestPerProcessFixture;
+
+TEST_F(RuntimeInitializationTest, ConstructorRegistersItsOwnConfigurationWithInstanceIdentifier)
+{
+    RecordProperty("Verifies", "SCR-18448357, SCR-18448382");
+    RecordProperty("Description",
+                   "The impl::Runtime constructor registers a pointer to its own "
+                   "configuration_ member with InstanceIdentifier::SetConfiguration, so that "
+                   "InstanceIdentifier::Create operates on the locked/stable runtime configuration.");
+    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("Priority", "1");
+    RecordProperty("DerivationTechnique", "Analysis of requirements");
+
+    TestInSeparateProcess([this]() {
+        // Given an explicitly initialized runtime
+        const auto runtime_configuration = runtime::RuntimeConfiguration{config_with_tire_pressure_port_};
+        Runtime::Initialize(runtime_configuration);
+
+        // When the Runtime singleton gets constructed (locked)
+        auto& runtime = static_cast<Runtime&>(Runtime::getInstance());
+
+        // Then InstanceIdentifier holds a pointer to exactly the runtime's own configuration_ member
+        const Configuration* const registered_configuration = InstanceIdentifierAttorney::GetConfiguration();
+        ASSERT_NE(registered_configuration, nullptr);
+        EXPECT_EQ(registered_configuration, RuntimeAttorney{runtime}.GetConfigurationAddress());
+    });
+}
+
+TEST_F(RuntimeInitializationTest, ImplicitInitializationAlsoRegistersConfigurationWithInstanceIdentifier)
+{
+    RecordProperty("Verifies", "SCR-18448357, SCR-18448382");
+    RecordProperty("Description",
+                   "Also for implicit (default) initialization the Runtime constructor registers its own "
+                   "configuration_ member with InstanceIdentifier, enabling InstanceIdentifier::Create.");
+    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("Priority", "1");
+    RecordProperty("DerivationTechnique", "Analysis of requirements");
+
+    TestInSeparateProcess([this]() {
+        // Given a configuration at the default location and implicit default initialization
+        WithConfigAtDefaultPath(config_with_tire_pressure_port_);
+
+        // When implicitly constructing the Runtime singleton
+        auto& runtime = static_cast<Runtime&>(Runtime::getInstance());
+
+        // Then InstanceIdentifier holds a pointer to exactly the runtime's own configuration_ member
+        const Configuration* const registered_configuration = InstanceIdentifierAttorney::GetConfiguration();
+        ASSERT_NE(registered_configuration, nullptr);
+        EXPECT_EQ(registered_configuration, RuntimeAttorney{runtime}.GetConfigurationAddress());
+    });
+}
 
 TEST_F(RuntimeInitializationTest, InitializationLoadsCorrectConfiguration)
 {


### PR DESCRIPTION
Fixed a dangling pointer issue in
impl::InstanceIdentifier::SetConfiguration():
It was called with a pointer to a configuration, which got dangling after the Runtime Meyer-singleton had been initialized.

impl::InstanceIdentifier::SetConfiguration() gets now called with a pointer to the config held internally by impl::Runtime, which remains stable throughout the lifetime.

Issue: #680