### PR TITLE
Do not create release in docs_deploy

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -111,16 +111,6 @@ jobs:
           echo "Files generated:"
           find docs_output -type f | head -20 || true  # head closes the pipe early, causing find to get SIGPIPE. prevents set -e from failing the step
 
-      - name: Upload docs to release
-        if: startsWith(github.ref, 'refs/tags/v')
-        env:
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          VERSION="${{ steps.version.outputs.version }}"
-          tar czf "docs-${VERSION}.tar.gz" -C docs_output .
-          gh release create "${VERSION}" --draft=false --notes "Release ${VERSION}" 2>/dev/null || true
-          gh release upload "${VERSION}" "docs-${VERSION}.tar.gz" --clobber
-
       - name: Download previously released versions
         if: github.event_name != 'pull_request'
         env:


### PR DESCRIPTION
The release shall only be created in the automated_release workflow.