### PR TITLE
apm release v1.0

### DIFF
--- a/RELEASE_NOTES.md
+++ b/RELEASE_NOTES.md
@@ -1,0 +1,10 @@
+# Release Notes
+
+## apm_release_v1.0
+
+- **Branched from tag:** `v0.2.1`
+- **Source tag commit:** `b021eccf1d811625d21eeb493071c0c4f4f6243a`
+- **Marker commit:** `3324b43bc6824e439eae33f23faa84a2c3c09308`
+- **Created on:** 2026-07-13
+
+This branch was created directly from the `v0.2.1` tag to track the `apm_release_v1.0` release line. The marker commit above is an empty commit at the branch root recording this origin; use `git log <marker-commit>` or `git describe --tags <marker-commit>^` to trace it back to the source tag.


### PR DESCRIPTION
Creating this branch for the apm release, which enables zero copy ipc for the inter-process, intra-process within a single domain.