### PR TITLE
Temporarily disable tsan config for BidirectionalTransportTests

### DIFF
--- a/quality/coverage/coverage_justifications.yaml
+++ b/quality/coverage/coverage_justifications.yaml
@@ -74,19 +74,19 @@ justifications:
         line_end: 29
 
   - id: gateway-clear-nonblock-on-accepted-socket
-     category: defensive_programming
-     reason: >
+    category: defensive_programming
+    reason: >
        Defensive programming: Posix system call can only go wrong if the socket file descriptor is invalid,
        but socket has just been accepted in an earlier step.
 
-   - id: gateway-handle-response-only-ack-response
-     category: defensive_programming
-     reason: >
+  - id: gateway-handle-response-only-ack-response
+    category: defensive_programming
+    reason: >
        Defensive programming: Type has already been checked before this function has been called.
 
-   - id: gateway-dispatch-loop-calls-handler
-     category: tool_false_positive
-     reason: >
+  - id: gateway-dispatch-loop-calls-handler
+    category: tool_false_positive
+    reason: >
        Coverage tool incorrectly marks this line as not covered. Lines immediately before and after are covered.
        Covered by the test BidirectionalTransportSocketFixture.DispatchThreadDeliversQueuedMessageToHandler
        inside score/mw/com/gateway/transport_layer/sample/bidirectional_transport_test.cpp

--- a/score/mw/com/gateway/transport_layer/sample/BUILD
+++ b/score/mw/com/gateway/transport_layer/sample/BUILD
@@ -188,7 +188,10 @@ cc_test(
     tags = [
         "unit",
     ],
-    target_compatible_with = ["@platforms//os:linux"],  # @todo: Test works also under QNX, but in rare cases timeout of cc_unit_test is too strict.
+    target_compatible_with = [
+        "@platforms//os:linux",
+        "@score_cpp_policies//sanitizers/constraints:no_tsan",
+    ],  # @todo: Test works also under QNX, but in rare cases timeout of cc_unit_test is too strict. Timeouts when building with tsan. Should be reenabled after https://github.com/eclipse-score/communication/issues/712 has been fixed.
     visibility = [
         "//score/mw/com/gateway:__subpackages__",
     ],


### PR DESCRIPTION
When testing with tsan config, tests become flaky due to timeouts. Should be reenabled after https://github.com/eclipse-score/communication/issues/712 has been fixed.