### PR TITLE
Mark gateway BidirectionalTransport integration test as flaky

### DIFF
--- a/score/mw/com/gateway/transport_layer/sample/test/integration_test/BUILD
+++ b/score/mw/com/gateway/transport_layer/sample/test/integration_test/BUILD
@@ -29,4 +29,8 @@ integration_test(
         "test_bidirectional_transport_reconnect.py",
     ],
     filesystem = "//score/mw/com/gateway/transport_layer/sample/test:application-pkg",
+    # Flaky: In rare cases the reconnect seems to happen too early so that App1 does not detect it and times out waiting,
+    # while App2 finishes successfully. Test will be replaced with complete integration test (not just covering
+    # socket side channel communication) in the near future.
+    flaky = True,
 )


### PR DESCRIPTION
Test should be replaced with complete integration test in the near future. Currently in some cases test fails because one app does not detect reconnect.