### PR TITLE
Rust::com Enable the logging support in Rust Lib

### DIFF
--- a/score/mw/com/example/com-api-example/BUILD
+++ b/score/mw/com/example/com-api-example/BUILD
@@ -22,6 +22,7 @@ rust_library(
     deps = [
         "//score/mw/com/example/com-api-example/com-api-gen",
         "//score/mw/com/impl/rust/com-api/com-api",
+        "@score_baselibs//src/log/score_log",
         "@score_communication_crate_index//:clap",
         "@score_communication_crate_index//:futures",
     ],
@@ -30,14 +31,22 @@ rust_library(
 rust_binary(
     name = "com-api-example",
     srcs = ["main.rs"],
-    data = ["etc/mw_com_config.json"],
+    data = [
+        "etc/logging.json",
+        "etc/mw_com_config.json",
+    ],
     edition = "2024",
+    env = {
+        "MW_LOG_CONFIG_FILE": "score/mw/com/example/com-api-example/etc/logging.json",
+    },
     features = ["link_std_cpp_lib"],
     visibility = ["//visibility:public"],
     deps = [
         ":com-api-example-lib",
         "//score/mw/com/example/com-api-example/com-api-gen",
         "//score/mw/com/impl/rust/com-api/com-api",
+        "@score_baselibs//src/log/score_log",
+        "@score_baselibs//src/log/stdout_logger",
         "@score_communication_crate_index//:clap",
         "@score_communication_crate_index//:futures",
     ],

--- a/score/mw/com/example/com-api-example/com-api-gen/BUILD
+++ b/score/mw/com/example/com-api-example/com-api-gen/BUILD
@@ -26,6 +26,7 @@ rust_library(
     deps = [
         ":vehicle_gen_cpp",
         "//score/mw/com/impl/rust/com-api/com-api",
+        "@score_baselibs//src/log/score_log",
     ],
 )
 

--- a/score/mw/com/example/com-api-example/com-api-gen/com_api_gen.rs
+++ b/score/mw/com/example/com-api-example/com-api-gen/com_api_gen.rs
@@ -12,8 +12,9 @@
  ********************************************************************************/
 
 use com_api::{interface, CommData, ProviderInfo, Publisher, Reloc, Subscriber};
+use score_log::ScoreDebug;
 
-#[derive(Debug, Reloc, CommData)]
+#[derive(Debug, Reloc, CommData, ScoreDebug)]
 #[repr(C)]
 #[comm_data(id = "Tire")]
 pub struct Tire {

--- a/score/mw/com/example/com-api-example/etc/logging.json
+++ b/score/mw/com/example/com-api-example/etc/logging.json
@@ -1,0 +1,8 @@
+{
+    "ecuId": "com-api",
+    "appId": "EAPP",
+    "appDesc": "Example_Application",
+    "logMode": "kConsole",
+    "logLevel": "kInfo",
+    "logLevelThresholdConsole": "kInfo"
+}

--- a/score/mw/com/example/com-api-example/main.rs
+++ b/score/mw/com/example/com-api-example/main.rs
@@ -23,6 +23,9 @@ use std::path::PathBuf;
 use std::sync::Arc;
 use std::thread;
 
+use score_log as log;
+use stdout_logger::StdoutLoggerBuilder;
+
 use com_api::{Builder, InstanceSpecifier, LolaRuntimeBuilderImpl, Runtime, RuntimeBuilder};
 
 use com_api_example::{VehicleMonitorConsumer, VehicleMonitorProducer};
@@ -82,7 +85,7 @@ const ASYNC_PRODUCER_STARTUP_DELAY_MS: u64 = 2000;
 
 // Run the consumer with the specified runtime and example type
 fn run_consumer<R: Runtime>(name: &str, example_type: &ExampleType, runtime: &R) {
-    println!("\n=== Running Consumer with {name} runtime ===");
+    log::info!("Running with {} runtime", name);
     let service_id = InstanceSpecifier::new("/Vehicle/Service1/Instance")
         .expect("Failed to create InstanceSpecifier");
     if matches!(example_type, ExampleType::Sync) {
@@ -150,12 +153,12 @@ fn run_consumer<R: Runtime>(name: &str, example_type: &ExampleType, runtime: &R)
         }
     };
     consumer_monitor.unsubscribe();
-    println!("=== Consumer Operation Completed ===\n");
+    log::info!("runtime execution completed");
 }
 
 // Run the producer with the specified runtime and example type
 fn run_producer<R: Runtime>(name: &str, example_type: &ExampleType, runtime: &R) {
-    println!("\n=== Running Producer with {name} runtime ===");
+    log::info!("Running with {} runtime", name);
     let service_id = InstanceSpecifier::new("/Vehicle/Service1/Instance")
         .expect("Failed to create InstanceSpecifier");
     // In async examples, we will not wait before offering the service to simulate async discovery.
@@ -166,7 +169,7 @@ fn run_producer<R: Runtime>(name: &str, example_type: &ExampleType, runtime: &R)
     }
     let producer_monitor =
         VehicleMonitorProducer::new(runtime, service_id).expect("Failed to create producer");
-    println!("Producer created and offered successfully");
+    log::info!("Producer created and offered successfully");
     producer_monitor.run_publish_loop(INITIAL_TIRE_PRESSURE, SAMPLE_COUNT);
     producer_monitor.unoffer();
     println!("=== Producer Operation Completed ===\n");
@@ -184,7 +187,16 @@ fn create_lola_runtime_builder(config_path: &std::path::Path) -> LolaRuntimeBuil
     lola_runtime_builder
 }
 
+fn init_logging() {
+    StdoutLoggerBuilder::new()
+        .show_module(false)
+        .show_file(true)
+        .show_line(false)
+        .set_as_default_logger();
+}
+
 fn main() {
+    init_logging();
     let args = Arguments::parse();
     let lola_runtime_builder = create_lola_runtime_builder(&args.service_instance_manifest);
     let lola_runtime = Arc::new(

--- a/score/mw/com/example/com-api-example/src/consumer.rs
+++ b/score/mw/com/example/com-api-example/src/consumer.rs
@@ -22,6 +22,8 @@ use std::sync::mpsc;
 use std::thread;
 use std::time::Duration;
 
+use score_log as log;
+
 /// Timeout used when performing a cancellable async receive.
 const RECEIVE_TIMEOUT_MS: u64 = 500;
 /// Polling interval between iterations in synchronous receive loops.
@@ -61,14 +63,14 @@ impl<R: Runtime> VehicleMonitorConsumer<R> {
         S: std::ops::Deref<Target = Tire>,
     {
         match result {
-            Ok(0) => println!("No tire data received"),
+            Ok(0) => log::info!("No tire data received"),
             Ok(x) => {
                 let sample = sample_buf
                     .pop_front()
                     .expect("Sample buffer pop operation error");
-                println!("{x} samples received: sample[0] = {:?}", *sample);
+                log::info!("{} samples received: sample[0] = {:?}", x, *sample);
             }
-            Err(e) => eprintln!("Error receiving tire data: {:?}", e),
+            Err(e) => log::error!("Error receiving tire data: {:?}", e),
         }
     }
 
@@ -107,7 +109,7 @@ impl<R: Runtime> VehicleMonitorConsumer<R> {
 
     /// Reads tire data asynchronously without a timeout, returning a Result with the number of samples received.
     pub async fn read_tire_data_async_without_timeout(&self, count: usize) -> Result<String> {
-        println!("Performing asynchronous receive without timeout");
+        log::info!("Performing asynchronous receive without timeout");
         let mut sample_buf = SampleContainer::new(3);
         for _ in 0..count {
             let (mut buf, result) = self.tire_subscriber.receive(sample_buf, 1, 3).await;
@@ -119,7 +121,7 @@ impl<R: Runtime> VehicleMonitorConsumer<R> {
 
     /// Reads tire data asynchronously with a timeout, returning a Result with the number of samples received.
     pub async fn read_tire_data_async_with_timeout(&self, count: usize) -> Result<String> {
-        println!("Performing asynchronous receive with timeout");
+        log::info!("Performing asynchronous receive with timeout");
         let mut sample_buf = SampleContainer::new(3);
 
         // Thread for simulating a timeout mechanism.
@@ -155,10 +157,10 @@ impl<R: Runtime> VehicleMonitorConsumer<R> {
         let mut stream = self.tire_subscriber.to_stream();
         for _ in 0..count {
             match stream.next().await {
-                Some(Ok(sample)) => println!("Received tire data: {:?}", *sample),
-                Some(Err(e)) => eprintln!("Failed to receive tire data: {:?}", e),
+                Some(Ok(sample)) => log::info!("Received tire data: {:?}", *sample),
+                Some(Err(e)) => log::error!("Failed to receive tire data: {:?}", e),
                 None => {
-                    println!("Stream ended");
+                    log::info!("Stream ended");
                     break;
                 }
             }

--- a/score/mw/com/example/com-api-example/src/producer.rs
+++ b/score/mw/com/example/com-api-example/src/producer.rs
@@ -20,6 +20,8 @@ use com_api_gen::{Tire, VehicleInterface};
 use std::thread;
 use std::time::Duration;
 
+use score_log as log;
+
 // Delay between sample data sending in the producer loop.
 const PRODUCER_SEND_INTERVAL_MS: u64 = 1000;
 
@@ -44,7 +46,7 @@ impl<R: Runtime> VehicleMonitorProducer<R> {
         let uninit_sample = self.producer.left_tire.allocate()?;
         let sample = uninit_sample.write(tire);
         sample.send()?;
-        println!("Tire data sent");
+        log::info!("Tire data sent");
         Ok(())
     }
 
@@ -55,7 +57,7 @@ impl<R: Runtime> VehicleMonitorProducer<R> {
                 pressure: initial_pressure + i as f32,
             }) {
                 Ok(_) => (),
-                Err(e) => eprintln!("Failed to publish tire data: {:?}", e),
+                Err(e) => log::error!("Failed to publish tire data: {:?}", e),
             }
             thread::sleep(Duration::from_millis(PRODUCER_SEND_INTERVAL_MS));
         }
@@ -64,8 +66,8 @@ impl<R: Runtime> VehicleMonitorProducer<R> {
     /// Stop offering the service and release the producer.
     pub fn unoffer(self) {
         match self.producer.unoffer() {
-            Ok(_) => println!("Successfully unoffered the service"),
-            Err(e) => eprintln!("Failed to unoffer: {:?}", e),
+            Ok(_) => log::info!("Successfully unoffered the service"),
+            Err(e) => log::error!("Failed to unoffer: {:?}", e),
         }
     }
 }

--- a/score/mw/com/impl/rust/com-api/com-api-concept/BUILD
+++ b/score/mw/com/impl/rust/com-api/com-api-concept/BUILD
@@ -33,6 +33,7 @@ rust_library(
     ],
     deps = [
         "@score_baselibs//src/containers",
+        "@score_baselibs//src/log/score_log",
         "@score_communication_crate_index//:futures",
         "@score_communication_crate_index//:thiserror",
     ],

--- a/score/mw/com/impl/rust/com-api/com-api-concept/com_api_concept.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-concept/com_api_concept.rs
@@ -947,7 +947,7 @@ pub trait Subscription<T: CommData + Debug, R: Runtime + ?Sized> {
     /// If the stream encounters an error, it will yield `Err(Error)` for that sample, but will continue to yield subsequent samples as they become available.
     /// The stream only terminates when the subscription is unsubscribed or dropped or if the stream is explicitly dropped by the user.
     /// With this design, users can handle errors on it side and take appropriate actions.
-    fn to_stream<'a>(&'a mut  self) -> impl Stream<Item = Result<Self::Sample<'a>>> + Unpin + 'a;
+    fn to_stream<'a>(&'a mut self) -> impl Stream<Item = Result<Self::Sample<'a>>> + Unpin + 'a;
 }
 
 /// A trait for types that can be default-constructed in place, skipping intermediate moves.

--- a/score/mw/com/impl/rust/com-api/com-api-concept/error.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-concept/error.rs
@@ -11,11 +11,17 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 
+/// Both `Debug` and `ScoreDebug` are derived because `score_log` macros require `ScoreDebug`,
+/// while `Debug` is needed for standard Rust formatting. There is currently no blanket
+/// `impl<T: Debug> ScoreDebug for T` in `score_log_fmt`, so both must be explicitly derived
+/// for any type used across both contexts.
+// TODO: Need to explore if we can somehow avoid deriving both Debug and ScoreDebug for all types.
+use score_log::ScoreDebug;
 use thiserror::Error;
 
 /// Detailed information about Service Discovery failure reasons,
 /// including specific issues with service interfaces, instance specifiers, and handle retrieval.
-#[derive(Debug, Error)]
+#[derive(Debug, ScoreDebug, Error)]
 pub enum ServiceFailedReason {
     #[error("Invalid instance specifier format or content, which may not be according to the expected format or contain invalid content")]
     InstanceSpecifierInvalid,
@@ -28,7 +34,7 @@ pub enum ServiceFailedReason {
 }
 
 /// Reason for producer failure
-#[derive(Debug, Error)]
+#[derive(Debug, ScoreDebug, Error)]
 pub enum ProducerFailedReason {
     #[error("Invalid instance specifier format or content, which may not be according to the expected format or contain invalid content")]
     InstanceSpecifierInvalid,
@@ -39,7 +45,7 @@ pub enum ProducerFailedReason {
 }
 
 /// Reason for consumer failure
-#[derive(Debug, Error)]
+#[derive(Debug, ScoreDebug, Error)]
 pub enum ConsumerFailedReason {
     #[error("Invalid instance specifier format or content, which may not be according to the expected format or contain invalid content")]
     InstanceSpecifierInvalid,
@@ -50,7 +56,7 @@ pub enum ConsumerFailedReason {
 }
 
 /// Memory allocation error details
-#[derive(Debug, Error)]
+#[derive(Debug, ScoreDebug, Error)]
 pub enum AllocationFailureReason {
     #[error(
         "Requested size exceeds available memory which is configured during subscription setup"
@@ -63,7 +69,7 @@ pub enum AllocationFailureReason {
 }
 
 /// Comprehensive error reasons for receive failure
-#[derive(Debug, Error)]
+#[derive(Debug, ScoreDebug, Error)]
 pub enum ReceiveFailedReason {
     #[error("Error at the time of initializing receive operation")]
     InitializationFailed,
@@ -82,7 +88,7 @@ pub enum ReceiveFailedReason {
 }
 
 /// Comprehensive error reasons for event-related failures
-#[derive(Debug, Error)]
+#[derive(Debug, ScoreDebug, Error)]
 pub enum EventFailedReason {
     #[error("Event creation error, possibly due to invalid event type or internal error")]
     EventCreationFailed,
@@ -99,7 +105,7 @@ pub enum EventFailedReason {
 }
 
 /// Error enumeration for different failure cases in the Consumer/Producer/Runtime APIs.
-#[derive(Debug, Error)]
+#[derive(Debug, ScoreDebug, Error)]
 pub enum Error {
     #[error("Service error due to: {0}")]
     ServiceError(ServiceFailedReason),

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/BUILD
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/BUILD
@@ -73,5 +73,6 @@ rust_library(
     deps = [
         ":bridge_ffi_rs",
         "//score/mw/com/impl/plumbing/rust:sample_ptr_rs",
+        "@score_baselibs//src/log/score_log",
     ],
 )

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_lola.rs
@@ -12,6 +12,7 @@
  ********************************************************************************/
 
 use bridge_ffi_rs::*;
+use score_log as log;
 use std::ffi::CString;
 use std::path::Path;
 use std::ptr::NonNull;
@@ -35,7 +36,7 @@ unsafe extern "C" fn mw_com_impl_call_dyn_fnmut(ptr: *const FatPtr) {
     // SAFETY: the box is still alive (C++ only calls dispose after all invocations finish).
     if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| unsafe { (*dyn_fnmut)() })).is_err()
     {
-        // LOG the error here, Once logging mechanism is available.
+        log::error!("Panic caught in mw_com_impl_call_dyn_fnmut: aborting to prevent unwind across FFI boundary");
         // Abort to prevent a Rust panic from unwinding across the C++ stack boundary.
         std::process::abort();
     }
@@ -80,7 +81,7 @@ unsafe extern "C" fn mw_com_impl_call_dyn_ref_fnmut_sample(
     // Invoke the closure with the void* sample pointer.
     // catch_unwind prevents a Rust panic from unwinding across the C++ stack boundary.
     if std::panic::catch_unwind(std::panic::AssertUnwindSafe(|| callable(sample_ptr))).is_err() {
-        // LOG the error here, Once logging mechanism is available.
+        log::error!("Panic caught in mw_com_impl_call_dyn_ref_fnmut_sample: aborting to prevent unwind across FFI boundary");
         // Abort to prevent unwinding across FFI boundary
         std::process::abort();
     }
@@ -121,7 +122,7 @@ unsafe extern "C" fn mw_com_impl_call_dyn_ref_fnmut_find_service(
     }))
     .is_err()
     {
-        // LOG the error here, Once logging mechanism is available.
+        log::error!("Panic caught in mw_com_impl_call_dyn_ref_fnmut_find_service: aborting to prevent unwind across FFI boundary");
         // Abort to prevent unwinding across FFI boundary
         std::process::abort();
     }

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/BUILD
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/BUILD
@@ -31,6 +31,7 @@ rust_library(
         "//score/mw/com/impl/rust/com-api/com-api-concept",
         "//score/mw/com/impl/rust/com-api/com-api-ffi-lola:bridge_ffi_lola",
         "//score/mw/com/impl/rust/com-api/com-api-ffi-lola:bridge_ffi_rs",
+        "@score_baselibs//src/log/score_log",
         "@score_communication_crate_index//:futures",
     ],
 )

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/consumer.rs
@@ -44,6 +44,8 @@ use std::pin::Pin;
 use std::sync::atomic::{AtomicBool, AtomicUsize};
 use std::sync::Arc;
 
+use score_log as log;
+
 use com_api_concept::{
     Builder, CommData, Consumer, ConsumerBuilder, ConsumerDescriptor, ConsumerFailedReason, Error,
     EventFailedReason, InstanceSpecifier, Interface, ReceiveFailedReason, Result, SampleContainer,
@@ -314,6 +316,11 @@ impl<T: CommData + Debug, B: FFIBridge> Subscriber<T, LolaRuntimeImpl<B>>
 {
     type Subscription = SubscriberImpl<T, B>;
     fn new(identifier: &'static str, instance_info: LolaConsumerInfo<B>) -> Result<Self> {
+        log::info!(
+            "Creating subscriber for identifier: {} with interface_id: {}",
+            identifier,
+            instance_info.interface_id
+        );
         let handle = instance_info.get_handle().ok_or(Error::ConsumerError(
             ConsumerFailedReason::ServiceHandleNotFound,
         ))?;
@@ -328,7 +335,17 @@ impl<T: CommData + Debug, B: FFIBridge> Subscriber<T, LolaRuntimeImpl<B>>
         })
     }
     fn subscribe(self, max_num_samples: usize) -> Result<Self::Subscription> {
+        log::info!(
+            "Subscribing to event: {} for interface_id: {} with max_num_samples: {}",
+            self.identifier,
+            self.instance_info.interface_id,
+            max_num_samples
+        );
         if max_num_samples == 0 {
+            log::error!(
+                "Failed to subscribe: max_num_samples is 0 for event: {}",
+                self.identifier
+            );
             return Err(Error::EventError(EventFailedReason::InvalidMaxSamples));
         }
         let instance_info = self.instance_info.clone();
@@ -352,6 +369,11 @@ impl<T: CommData + Debug, B: FFIBridge> Subscriber<T, LolaRuntimeImpl<B>>
             )
         };
         if !status {
+            log::error!(
+                "Failed to subscribe to event: {} for interface_id: {}",
+                self.identifier,
+                self.instance_info.interface_id
+            );
             return Err(Error::EventError(EventFailedReason::EventNotAvailable));
         }
         let type_ops = unsafe {

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/producer.rs
@@ -36,6 +36,8 @@ use core::ops::{Deref, DerefMut};
 use core::ptr::NonNull;
 use std::sync::Arc;
 
+use score_log as log;
+
 use com_api_concept::{
     AllocationFailureReason, Builder, CommData, Error, EventFailedReason, InstanceSpecifier,
     Interface, Producer, ProducerBuilder, ProducerFailedReason, ProviderInfo, Result,
@@ -69,8 +71,18 @@ impl<B: FFIBridge> ProviderInfo for LolaProviderInfo<B> {
                 .skeleton_offer_service(self.skeleton_handle.0.handle.as_ptr())
         };
         if !status {
+            log::error!(
+                "Failed to offer service for interface: {} with instance specifier: {}",
+                self.interface_id,
+                self.instance_specifier.as_ref()
+            );
             return Err(Error::ServiceError(ServiceFailedReason::OfferServiceFailed));
         }
+        log::info!(
+            "Service offered successfully for interface: {} with instance specifier: {}",
+            self.interface_id,
+            self.instance_specifier.as_ref()
+        );
         Ok(())
     }
 
@@ -81,6 +93,11 @@ impl<B: FFIBridge> ProviderInfo for LolaProviderInfo<B> {
             self.bridge
                 .skeleton_stop_offer_service(self.skeleton_handle.0.handle.as_ptr())
         };
+        log::info!(
+            "Service stopped successfully for interface: {} with instance specifier: {}",
+            self.interface_id,
+            self.instance_specifier.as_ref()
+        );
         Ok(())
     }
 }
@@ -206,8 +223,10 @@ where
                 )
         };
         if !status {
+            log::error!("Failed to send sample");
             return Err(Error::EventError(EventFailedReason::SendingDataFailed));
         }
+        log::debug!("Sample sent successfully");
         Ok(())
     }
 }
@@ -444,6 +463,7 @@ where
     }
 
     fn new(identifier: &str, instance_info: LolaProviderInfo<B>) -> Result<Self> {
+        log::info!("Publisher created for event: {}", identifier);
         let skeleton_event = NativeSkeletonEventBase::new::<B>(&instance_info, identifier)?;
         let type_ops = unsafe {
             instance_info


### PR DESCRIPTION
Enable the logging support for com-api rust library.

https://github.com/eclipse-score/communication/issues/285

Depends-on: https://github.com/eclipse-score/communication/pull/556