### PR TITLE
Remove deprecated score::StringLiteral

### DIFF
--- a/score/mw/com/BUILD
+++ b/score/mw/com/BUILD
@@ -98,7 +98,6 @@ cc_library(
     deps = [
         "@score_baselibs//score/filesystem",
         "@score_baselibs//score/language/futurecpp",
-        "@score_baselibs//score/string_manipulation:string_literal",
     ],
 )
 

--- a/score/mw/com/api_surface.lock.json
+++ b/score/mw/com/api_surface.lock.json
@@ -29,7 +29,7 @@
       "name": "InitializeRuntime",
       "qualified_name": "score::mw::com::runtime::InitializeRuntime",
       "kind": "function",
-      "signature": "InitializeRuntime : void (const std::int32_t, score::StringLiteral *)"
+      "signature": "InitializeRuntime : void (const cpp::span<safecpp::zstring_view>)"
     },
     {
       "name": "InitializeRuntime",
@@ -47,7 +47,7 @@
       "name": "RuntimeConfiguration",
       "qualified_name": "score::mw::com::runtime::RuntimeConfiguration::RuntimeConfiguration",
       "kind": "constructor",
-      "signature": "RuntimeConfiguration : void (const std::int32_t, score::StringLiteral *)"
+      "signature": "RuntimeConfiguration : void (cpp::span<safecpp::zstring_view>)"
     },
     {
       "name": "RuntimeConfiguration",

--- a/score/mw/com/design/configuration/structural_view.puml
+++ b/score/mw/com/design/configuration/structural_view.puml
@@ -201,8 +201,7 @@ class "score::mw::com::impl::Runtime" {
   - configuration : Configuration const&
   __
   - Runtime(std::pair<Configuration&&, std::optional<tracing::TracingFilterConfig>&&> configs)
-  {static} + Initialize() : void
-  {static} + Initialize(const score::cpp::span<const score::StringLiteral> arguments) : void
+  {static} + Initialize(const runtime::RuntimeConfiguration& runtime_configuration) : void
   {static} + getInstance() : Runtime&
   + resolve(const InstanceSpecifier&): score::mw::com::InstanceIdentifierContainer
   + GetBindingRuntime(const BindingType binding) const : IBindingRuntime*

--- a/score/mw/com/design/configuration/structural_view_refactored.puml
+++ b/score/mw/com/design/configuration/structural_view_refactored.puml
@@ -129,8 +129,7 @@ class "score::mw::com::impl::Runtime" {
   - configuration_ : Configuration const&
   - parsing_strategy_ : std::unique_ptr<IConfigurationParsingStrategy>
   __
-  {static} + Initialize() : void
-  {static} + Initialize(arguments : score::cpp::span<const score::StringLiteral>) : void
+  {static} + Initialize(const runtime::RuntimeConfiguration& runtime_configuration) : void
   {static} + getInstance() : Runtime&
   + resolve(const InstanceSpecifier&) : InstanceIdentifierContainer
 }

--- a/score/mw/com/design/ipc_tracing/structural_view.puml
+++ b/score/mw/com/design/ipc_tracing/structural_view.puml
@@ -99,9 +99,7 @@ abstract class "mw::com::impl::IRuntime" {
 
 class "mw::com::impl::Runtime" {
   -binding_runtimes_ : std:unordered_map<BindingType, std::unique_ptr<IBindingRuntime>>
-  {static} +Initialize() : void
-  {static} +Initialize(int argc, score::StringLiteral argv) : void
-  {static} +Initialize(std::string const&) : void
+  {static} +Initialize(runtime::RuntimeConfiguration&) : void
   {static} +getInstance() : Runtime&
   +Runtime(Configuration&& config)
   +resolve(const InstanceSpecifier&) : std::vector<InstanceIdentifier>

--- a/score/mw/com/design/runtime/runtime_structural_view.puml
+++ b/score/mw/com/design/runtime/runtime_structural_view.puml
@@ -13,9 +13,7 @@ enum BindingType {
 
 class "mw::com::impl::Runtime" as Runtime {
     -binding_runtimes_ : std::unordered_map<BindingType, std::unique_ptr<IBindingRuntime>>
-    +{static} Initialize() : void
-    +{static} Initialize(int argc, score::StringLiteral argv) : void
-    +{static} Initialize(std::string const&) : void
+    +{static} Initialize(const runtime::RuntimeConfiguration& runtime_configuration) : void
     +{static} getInstance() : Runtime&
     +Runtime(Configuration&& config)
     +resolve(const InstanceSpecifier&) : std::vector<InstanceIdentifier>

--- a/score/mw/com/design/skeleton_proxy/proxy_binding_model.puml
+++ b/score/mw/com/design/skeleton_proxy/proxy_binding_model.puml
@@ -11,7 +11,7 @@ class "ComErrorDomain" {
 }
 
 class "<< Stereotype >>\nglobal function" as GlobalFunction {
-  +MakeError(code : ComErrc, message : score::StringLiteral) : score::result::Error
+  +MakeError(code : ComErrc, message : std::string_view) : score::result::Error
 }
 
 note top of ScoreResultErrorDomain

--- a/score/mw/com/design/skeleton_proxy/skeleton_proxy_binding_model.puml
+++ b/score/mw/com/design/skeleton_proxy/skeleton_proxy_binding_model.puml
@@ -11,7 +11,7 @@ class "ComErrorDomain" {
 }
 
 class "<< Stereotype >>\nglobal function" as GlobalFunction {
-  +MakeError(code : ComErrc, message : score::StringLiteral) : score::result::Error
+  +MakeError(code : ComErrc, message : std::string_view) : score::result::Error
 }
 
 note top of ScoreResultErrorDomain

--- a/score/mw/com/mocking/BUILD
+++ b/score/mw/com/mocking/BUILD
@@ -34,7 +34,6 @@ cc_library(
         "//score/mw/com/impl:instance_specifier",
         "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/result",
-        "@score_baselibs//score/string_manipulation:string_literal",
     ],
 )
 

--- a/score/mw/com/mocking/i_runtime.h
+++ b/score/mw/com/mocking/i_runtime.h
@@ -14,11 +14,9 @@
 #define SCORE_MW_COM_MOCKING_I_RUNTIME_H
 
 #include "score/mw/com/runtime_configuration.h"
-
 #include "score/mw/com/types.h"
 
 #include "score/result/result.h"
-#include "score/string_manipulation/string_literal.h"
 
 #include <score/span.hpp>
 
@@ -34,7 +32,11 @@ class IRuntime
     virtual ~IRuntime() = default;
 
     virtual score::Result<InstanceIdentifierContainer> ResolveInstanceIDs(const InstanceSpecifier model_name) = 0;
-    virtual void InitializeRuntime(const std::int32_t argc, score::cpp::span<const score::StringLiteral> argv) = 0;
+    [[deprecated(
+        "Please use InitializeRuntime(cpp::span<safecpp::zstring_view> command_line_arguments) for guaranteed NULL "
+        "terminated arguments")]]
+    virtual void InitializeRuntime(const std::int32_t argc, score::cpp::span<const char*> argv) = 0;
+    virtual void InitializeRuntime(const cpp::span<safecpp::zstring_view> command_line_arguments) = 0;
     virtual void InitializeRuntime(const runtime::RuntimeConfiguration& runtime_configuration) = 0;
 
   protected:

--- a/score/mw/com/mocking/runtime_mock.h
+++ b/score/mw/com/mocking/runtime_mock.h
@@ -24,10 +24,8 @@ class RuntimeMock : public IRuntime
 {
   public:
     MOCK_METHOD(score::Result<InstanceIdentifierContainer>, ResolveInstanceIDs, (const InstanceSpecifier), (override));
-    MOCK_METHOD(void,
-                InitializeRuntime,
-                (const std::int32_t, score::cpp::span<const score::StringLiteral>),
-                (override));
+    MOCK_METHOD(void, InitializeRuntime, (const std::int32_t, score::cpp::span<const char*>), (override));
+    MOCK_METHOD(void, InitializeRuntime, (const cpp::span<safecpp::zstring_view> command_line_arguments), (override));
     MOCK_METHOD(void, InitializeRuntime, (const runtime::RuntimeConfiguration&), (override));
 };
 

--- a/score/mw/com/mocking/runtime_mock_test.cpp
+++ b/score/mw/com/mocking/runtime_mock_test.cpp
@@ -18,7 +18,6 @@
 #include "score/mw/com/runtime_configuration.h"
 
 #include "score/filesystem/path.h"
-#include "score/string_manipulation/string_literal.h"
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
@@ -82,6 +81,7 @@ TEST_F(RuntimeMockFixture, ResolveInstanceIdsReturnsErrorWhenMockReturnsError)
     EXPECT_EQ(resolve_instance_ids_result.error(), error_code);
 }
 
+// TODO: Once InitializeRuntime(argc, argv) is removed, this test will also be removed
 TEST_F(RuntimeMockFixture, InitializeRuntimeDispatchesToMockAfterInjectingMock)
 {
     // Given that a mocked runtime has been injected
@@ -89,10 +89,10 @@ TEST_F(RuntimeMockFixture, InitializeRuntimeDispatchesToMockAfterInjectingMock)
     // Expecting that InitializeRuntime will be called on the mock with the same argc / argv that is passed to
     // InitializeRuntime (where argv has been converted to an score::cpp::span
     constexpr std::int32_t argc{1U};
-    score::StringLiteral argv[] = {"some_argument"};
+    const char* argv[] = {"some_argument"};
     EXPECT_CALL(runtime_mock_, InitializeRuntime(argc, _)).WillOnce(Invoke([argv](auto, auto argv_span) {
-        const score::cpp::span<const score::StringLiteral> expected_argv_span(
-            argv, static_cast<score::cpp::span<const score::StringLiteral>::size_type>(argc));
+        const score::cpp::span<const char*> expected_argv_span(
+            const_cast<const char**>(argv), static_cast<score::cpp::span<const char*>::size_type>(argc));
         ASSERT_EQ(argv_span.size(), expected_argv_span.size());
         for (std::size_t i = 0; i < argv_span.size(); ++i)
         {
@@ -104,15 +104,40 @@ TEST_F(RuntimeMockFixture, InitializeRuntimeDispatchesToMockAfterInjectingMock)
     InitializeRuntime(argc, argv);
 }
 
+TEST_F(RuntimeMockFixture, InitializeRuntimeWithZStringViewsDispatchesToMockAfterInjectingMock)
+{
+    // Given that a mocked runtime has been injected
+
+    // Expecting that InitializeRuntime will be called on the mock with the same span that is passed to
+    // InitializeRuntime
+    using safecpp::literals::operator""_zsv;
+    constexpr auto kDummyApplicationNameZsv = "dummyname"_zsv;
+    safecpp::zstring_view argv[] = {kDummyApplicationNameZsv};
+    score::cpp::span<safecpp::zstring_view> argv_span(argv, std::size(argv));
+
+    EXPECT_CALL(runtime_mock_, InitializeRuntime(An<cpp::span<safecpp::zstring_view>>()))
+        .WillOnce(Invoke([argv_span](auto arguments_span) {
+            ASSERT_EQ(argv_span.size(), arguments_span.size());
+            for (std::size_t i = 0; i < argv_span.size(); ++i)
+            {
+                EXPECT_EQ(argv_span.data()[i], arguments_span.data()[i]);
+            }
+        }));
+
+    // When calling InitializeRuntime
+    InitializeRuntime(argv);
+}
+
 TEST_F(RuntimeMockFixture, InitializeRuntimeWithRuntimeConfigurationDispatchesToMockAfterInjectingMock)
 {
     // Given that a mocked runtime has been injected
 
     // Expecting that InitializeRuntime will be called on the mock
     RuntimeConfiguration runtime_configuration{kDummyConfigurationPath};
-    EXPECT_CALL(runtime_mock_, InitializeRuntime(_)).WillOnce(Invoke([](auto& runtime_configuration) {
-        EXPECT_EQ(runtime_configuration.GetConfigurationPath(), kDummyConfigurationPath);
-    }));
+    EXPECT_CALL(runtime_mock_, InitializeRuntime(An<const RuntimeConfiguration&>()))
+        .WillOnce(Invoke([](auto& runtime_configuration) {
+            EXPECT_EQ(runtime_configuration.GetConfigurationPath(), kDummyConfigurationPath);
+        }));
 
     // When calling InitializeRuntime
     InitializeRuntime(runtime_configuration);

--- a/score/mw/com/runtime.cpp
+++ b/score/mw/com/runtime.cpp
@@ -16,7 +16,6 @@
 #include "score/mw/com/impl/runtime.h"
 
 #include "score/result/result.h"
-#include "score/string_manipulation/string_literal.h"
 
 #include <score/span.hpp>
 
@@ -48,18 +47,31 @@ score::Result<InstanceIdentifierContainer> ResolveInstanceIDs(const impl::Instan
     return instance_identifier_container;
 }
 
-// NOLINTNEXTLINE(modernize-avoid-c-arrays):C-style array tolerated for command line arguments
-void InitializeRuntime(const std::int32_t argc, score::StringLiteral argv[])
+// NOLINTNEXTLINE(modernize-avoid-c-arrays):C-style array tolerated for command line arguments. This API is deprecated
+// and it will be removed.
+void InitializeRuntime(const std::int32_t argc, const char* argv[])
 {
     if (auto* const runtime_mock_holder = detail::RuntimeMockHolder::GetRuntimeMock())
     {
-        const score::cpp::span<const score::StringLiteral> argv_span(
-            argv, static_cast<score::cpp::span<const score::StringLiteral>::size_type>(argc));
+        const score::cpp::span<const char*> argv_span(argv,
+                                                      static_cast<score::cpp::span<const char*>::size_type>(argc));
         runtime_mock_holder->InitializeRuntime(argc, argv_span);
         return;
     }
 
     const RuntimeConfiguration runtime_configuration{argc, argv};
+    InitializeRuntime(runtime_configuration);
+}
+
+void InitializeRuntime(const cpp::span<safecpp::zstring_view> command_line_arguments)
+{
+    if (auto* const runtime_mock_holder = detail::RuntimeMockHolder::GetRuntimeMock())
+    {
+        runtime_mock_holder->InitializeRuntime(command_line_arguments);
+        return;
+    }
+
+    const RuntimeConfiguration runtime_configuration{command_line_arguments};
     InitializeRuntime(runtime_configuration);
 }
 

--- a/score/mw/com/runtime.h
+++ b/score/mw/com/runtime.h
@@ -20,12 +20,12 @@
 #ifndef SCORE_MW_COM_RUNTIME_H
 #define SCORE_MW_COM_RUNTIME_H
 
+#include "score/language/safecpp/string_view/zstring_view.h"
 #include "score/mw/com/mocking/i_runtime.h"
 #include "score/mw/com/runtime_configuration.h"
 #include "score/mw/com/types.h"
-
 #include "score/result/result.h"
-#include "score/string_manipulation/string_literal.h"
+#include "score/span.hpp"
 
 #include <cstdint>
 
@@ -76,12 +76,37 @@ score::Result<score::mw::com::InstanceIdentifierContainer> ResolveInstanceIDs(co
  * \brief Initializes mw::com subsystem with the given configuration referenced in the command-line options.
  * \details This call is optional for a mw::com user. Only if the mw::com configuration (json) is not located in the
  *         default manifest path, this function shall be called with the commandline option
- *         "-service_instance_manifest" pointing to the json config file to be used.
+ *         "--service_instance_manifest" pointing to the json config file to be used.
  * \attention This function shall only be called ONCE per application/process lifetime! A second call may have no
  *            effect after an internal runtime singleton has been already created/is in use!
+ *            The arguments contained in argv are expected to be NULL-terminated.
+ *
+ * \param argc number of arguments in the upcoming argv array
+ * \param argv array of NULL-terminated c-style strings as handed over to applications main() entry-point.
+ *
+ * \deprecated Use InitializeRuntime(cpp::span<safecpp::zstring_view> command_line_arguments) for guaranteed NULL
+ * terminated arguments
  */
+[[deprecated(
+    "Please use InitializeRuntime(cpp::span<safecpp::zstring_view> command_line_arguments) for guaranteed NULL "
+    "terminated arguments")]]
 // NOLINTNEXTLINE(modernize-avoid-c-arrays):C-style array tolerated for command line arguments
-void InitializeRuntime(const std::int32_t argc, score::StringLiteral argv[]);
+void InitializeRuntime(const std::int32_t argc, const char* argv[]);
+
+/**
+ * \api
+ * \brief Initializes mw::com subsystem with the given configuration referenced in the command-line options.
+ * \details This call is optional for a mw::com user. Only if the mw::com configuration (json) is not located in the
+ *         default manifest path, this function shall be called with the commandline option
+ *         "--service_instance_manifest" pointing to the json config file to be used.
+ * \attention This function shall only be called ONCE per application/process lifetime! A second call may have no
+ *            effect after an internal runtime singleton has been already created/is in use!
+ *            Users should hand over the arguments received from const char* argv[] argument of main(). Since there the
+ *            OS assures, that each element in argv is a NULL-terminated string, user can build up each
+ *            safecpp::zstring_view in command_line_arguments by creating it from std::string_view(argv[i])
+ * @param command_line_arguments
+ */
+void InitializeRuntime(const cpp::span<safecpp::zstring_view> command_line_arguments);
 
 /**
  * \api

--- a/score/mw/com/runtime_configuration.cpp
+++ b/score/mw/com/runtime_configuration.cpp
@@ -14,9 +14,7 @@
 
 #include "score/filesystem/path.h"
 #include "score/mw/log/logging.h"
-#include "score/string_manipulation/string_literal.h"
 
-#include <score/assert.hpp>
 #include <score/span.hpp>
 
 #include <cstddef>
@@ -45,10 +43,26 @@ RuntimeConfiguration::RuntimeConfiguration(filesystem::Path configuration_path)
 }
 
 // NOLINTNEXTLINE(modernize-avoid-c-arrays):C-style array tolerated for command line arguments
-RuntimeConfiguration::RuntimeConfiguration(const std::int32_t argc, score::StringLiteral argv[]) : configuration_path_{}
+RuntimeConfiguration::RuntimeConfiguration(const std::int32_t argc, const char* argv[]) : configuration_path_{}
 {
-    const score::cpp::span<const score::StringLiteral> command_line_arguments(
-        argv, static_cast<score::cpp::span<const score::StringLiteral>::size_type>(argc));
+    // We convert the const char* arguments into safecpp::zstring_views to ensure that they are null-terminated and safe
+    // to use.
+    // This is a deprecated API for a reason! If the given argv[] is not null-terminated, it can lead to undefined
+    // behavior. But this isn't introduced newly by this conversion!
+    std::vector<safecpp::zstring_view> command_line_arguments{};
+    for (std::int32_t arg_idx = 0U; arg_idx < argc; arg_idx++)
+    {
+        auto argument = std::string_view{argv[arg_idx]};
+        command_line_arguments.push_back(safecpp::zstring_view{argument.data(), argument.size()});
+    }
+
+    auto configuration_path = ParseConfigurationPath(command_line_arguments);
+    configuration_path_ =
+        configuration_path.has_value() ? std::move(configuration_path).value() : kDefaultConfigurationPath;
+}
+
+RuntimeConfiguration::RuntimeConfiguration(cpp::span<safecpp::zstring_view> command_line_arguments)
+{
     auto configuration_path = ParseConfigurationPath(command_line_arguments);
     configuration_path_ =
         configuration_path.has_value() ? std::move(configuration_path).value() : kDefaultConfigurationPath;
@@ -60,15 +74,16 @@ const filesystem::Path& RuntimeConfiguration::GetConfigurationPath() const&
 }
 
 std::optional<filesystem::Path> RuntimeConfiguration::ParseConfigurationPath(
-    const score::cpp::span<const score::StringLiteral> command_line_args)
+    const score::cpp::span<safecpp::zstring_view> command_line_args)
 {
     const auto num_args = command_line_args.size();
 
     std::optional<std::string> configuration_path{};
     for (std::uint32_t arg_idx = 0U; arg_idx < num_args; arg_idx++)
     {
+        // TODO: Adapt code that we do not need to call `.data()` and that we do not have to rely on life time extension
         const std::string& command_line_argument_key{
-            score::cpp::at(command_line_args, static_cast<std::ptrdiff_t>(arg_idx))};
+            score::cpp::at(command_line_args, static_cast<std::ptrdiff_t>(arg_idx)).data()};
         if (command_line_argument_key == kConfigurationPathCommandLineKey)
         {
             const auto index_of_configuration_path = arg_idx + 1U;
@@ -79,7 +94,8 @@ std::optional<filesystem::Path> RuntimeConfiguration::ParseConfigurationPath(
                     << "\" but no corresponding value. Terminating.";
                 std::terminate();
             }
-            return score::cpp::at(command_line_args, static_cast<std::ptrdiff_t>(index_of_configuration_path));
+            // TODO: Adapt code that we do not need to call `.data()` and we can provide zstring_view to a filepath
+            return score::cpp::at(command_line_args, static_cast<std::ptrdiff_t>(index_of_configuration_path)).data();
         }
         if (command_line_argument_key == kDeprecatedConfigurationPathCommandLineKey)
         {
@@ -93,7 +109,8 @@ std::optional<filesystem::Path> RuntimeConfiguration::ParseConfigurationPath(
                     << "\" but no corresponding value. Terminating.";
                 std::terminate();
             }
-            return score::cpp::at(command_line_args, static_cast<std::ptrdiff_t>(index_of_configuration_path));
+            // TODO: Adapt code that we do not need to call `.data()` and we can provide zstring_view to a filepath
+            return score::cpp::at(command_line_args, static_cast<std::ptrdiff_t>(index_of_configuration_path)).data();
         }
     }
     return configuration_path;

--- a/score/mw/com/runtime_configuration.h
+++ b/score/mw/com/runtime_configuration.h
@@ -14,7 +14,7 @@
 #define SCORE_MW_COM_RUNTIME_CONFIGURATION_H
 
 #include "score/filesystem/path.h"
-#include "score/string_manipulation/string_literal.h"
+#include "score/language/safecpp/string_view/zstring_view.h"
 
 #include <score/span.hpp>
 
@@ -39,14 +39,30 @@ class RuntimeConfiguration
 
     /**
      * \api
-     * \brief Constructor which initialiases the stored configuration path from command line arguments.
+     * \brief Constructor which initializes the stored configuration path from command line arguments.
      * \details The constructor parses the command line arguments for a specific key to extract the configuration
      *          path. If the key is not found, a default path is used.
      * \param argc The number of command line arguments.
      * \param argv The array of command line arguments.
+     *
+     * \deprecated Please use RuntimeConfiguration(cpp::span<safecpp::zstring_view> command_line_arguments) for
+     * guaranteed NULL terminated arguments
      */
+    [[deprecated(
+        "Please use RuntimeConfiguration(cpp::span<safecpp::zstring_view> command_line_arguments) for guaranteed "
+        "NULL "
+        "terminated arguments")]]
     // NOLINTNEXTLINE(modernize-avoid-c-arrays):C-style array tolerated for command line arguments
-    RuntimeConfiguration(const std::int32_t argc, score::StringLiteral argv[]);
+    RuntimeConfiguration(const std::int32_t argc, const char* argv[]);
+
+    /**
+     * \api
+     * \brief Constructor which initializes the stored configuration path from command line arguments.
+     * \details The constructor parses the command line arguments for a specific key to extract the configuration
+     *          path. If the key is not found, a default path is used.
+     * \param command_line_arguments The command line arguments.
+     */
+    RuntimeConfiguration(cpp::span<safecpp::zstring_view> command_line_arguments);
 
     /**
      * \api
@@ -64,7 +80,7 @@ class RuntimeConfiguration
 
   private:
     static std::optional<filesystem::Path> ParseConfigurationPath(
-        const score::cpp::span<const score::StringLiteral> command_line_args);
+        const score::cpp::span<safecpp::zstring_view> command_line_args);
 
     filesystem::Path configuration_path_;
 };

--- a/score/mw/com/runtime_configuration_test.cpp
+++ b/score/mw/com/runtime_configuration_test.cpp
@@ -14,7 +14,6 @@
 
 #include "score/mw/log/logging.h"
 #include "score/mw/log/recorder_mock.h"
-#include "score/string_manipulation/string_literal.h"
 
 #include <score/assert.hpp>
 #include <score/span.hpp>
@@ -37,21 +36,14 @@ namespace
 using ::testing::_;
 using ::testing::Return;
 
-constexpr auto kDeprecatedConfigurationPathCommandLineKey = "-service_instance_manifest";
-constexpr auto kConfigurationPathCommandLineKey = "--service_instance_manifest";
 constexpr auto kDefaultConfigurationPath = "./etc/mw_com_config.json";
-
 constexpr auto kDummyConfigurationPath = "/my/configuration/path/mw_com_config.json";
-constexpr auto kDummyApplicationName = "dummyname";
 
-std::pair<std::int32_t, score::StringLiteral*> GenerateCommandLineArgs(std::vector<score::StringLiteral>& arguments)
-{
-    constexpr auto kMaxArguments =
-        static_cast<std::vector<score::StringLiteral>::size_type>(std::numeric_limits<std::int32_t>::max());
-    SCORE_LANGUAGE_FUTURECPP_ASSERT(arguments.size() < kMaxArguments);
-    const auto number_of_args = static_cast<std::int32_t>(arguments.size());
-    return std::make_pair(number_of_args, arguments.data());
-}
+using safecpp::literals::operator""_zsv;
+constexpr auto kDummyApplicationNameZsv = "dummyname"_zsv;
+constexpr auto kConfigurationPathCommandLineKeyZsv = "--service_instance_manifest"_zsv;
+constexpr auto kDeprecatedConfigurationPathCommandLineKeyZsv = "-service_instance_manifest"_zsv;
+constexpr auto kDummyConfigurationPathZsv = "/my/configuration/path/mw_com_config.json"_zsv;
 
 TEST(RuntimeConfigurationStringConstructorTest, ConfigurationPathContainsStringPassedToConstructor)
 {
@@ -76,12 +68,25 @@ TEST(RuntimeConfigurationCommandLineConstructorTest, ConfigurationPathContainsDe
 TEST(RuntimeConfigurationCommandLineConstructorTest, ConfigurationPathContainsPathInCommandLineArgs)
 {
     // Given command line arguments which contain a configuration path key and configuration path
-    std::vector<score::StringLiteral> arguments = {
-        kDummyApplicationName, kConfigurationPathCommandLineKey, kDummyConfigurationPath};
-    auto [argc, argv] = GenerateCommandLineArgs(arguments);
+    std::vector<safecpp::zstring_view> arguments = {
+        kDummyApplicationNameZsv, kConfigurationPathCommandLineKeyZsv, kDummyConfigurationPathZsv};
 
     // When constructing a RuntimeConfiguration
-    const RuntimeConfiguration runtime_configuration{argc, argv};
+    const RuntimeConfiguration runtime_configuration{arguments};
+
+    // Then the stored configuration path should be the same as the path provided in the command line arguments
+    const auto& stored_configuration_path = runtime_configuration.GetConfigurationPath();
+    EXPECT_EQ(stored_configuration_path.Native(), kDummyConfigurationPath);
+}
+
+TEST(RuntimeConfigurationCommandLineConstructorTest, ConfigurationZstringPathContainsPathInCommandLineArgs)
+{
+    // Given command line arguments which contain a configuration path key and configuration path
+    std::vector<safecpp::zstring_view> arguments = {
+        kDummyApplicationNameZsv, kConfigurationPathCommandLineKeyZsv, kDummyConfigurationPathZsv};
+
+    // When constructing a RuntimeConfiguration
+    const RuntimeConfiguration runtime_configuration{arguments};
 
     // Then the stored configuration path should be the same as the path provided in the command line arguments
     const auto& stored_configuration_path = runtime_configuration.GetConfigurationPath();
@@ -91,9 +96,8 @@ TEST(RuntimeConfigurationCommandLineConstructorTest, ConfigurationPathContainsPa
 TEST(RuntimeConfigurationCommandLineConstructorTest, DeprecatedConfigurationCommandLineArg)
 {
     // Given command line arguments which contain the deprecated argument
-    std::vector<score::StringLiteral> arguments = {
-        kDummyApplicationName, kDeprecatedConfigurationPathCommandLineKey, kDummyConfigurationPath};
-    auto [argc, argv] = GenerateCommandLineArgs(arguments);
+    std::vector<safecpp::zstring_view> arguments = {
+        kDummyApplicationNameZsv, kDeprecatedConfigurationPathCommandLineKeyZsv, kDummyConfigurationPathZsv};
 
     // Given a log recorder mock
     score::mw::log::RecorderMock recorder_mock{};
@@ -110,7 +114,7 @@ TEST(RuntimeConfigurationCommandLineConstructorTest, DeprecatedConfigurationComm
     EXPECT_CALL(recorder_mock, LogStringView(handle, std::string_view{"is deprecated, please use"}));
 
     // When constructing a RuntimeConfiguration
-    const RuntimeConfiguration runtime_configuration{argc, argv};
+    const RuntimeConfiguration runtime_configuration{arguments};
 
     // Reset the global recorder to nullptr so that it no longer points to the local recorder_mock.
     score::mw::log::SetLogRecorder(nullptr);
@@ -123,11 +127,10 @@ TEST(RuntimeConfigurationCommandLineConstructorTest, DeprecatedConfigurationComm
 TEST(RuntimeConfigurationCommandLineConstructorTest, ConfigurationPathContainsDefaultPathIfNoPathKeyInCommandLineArgs)
 {
     // Given command line arguments which do not contain a configuration path key
-    std::vector<score::StringLiteral> arguments = {kDummyApplicationName, kDummyConfigurationPath};
-    auto [argc, argv] = GenerateCommandLineArgs(arguments);
+    std::vector<safecpp::zstring_view> arguments = {kDummyApplicationNameZsv, kDummyConfigurationPathZsv};
 
     // When constructing a RuntimeConfiguration
-    const RuntimeConfiguration runtime_configuration{argc, argv};
+    const RuntimeConfiguration runtime_configuration{arguments};
 
     // Then the stored configuration path should be the default configuration path
     const auto& stored_configuration_path = runtime_configuration.GetConfigurationPath();
@@ -137,11 +140,10 @@ TEST(RuntimeConfigurationCommandLineConstructorTest, ConfigurationPathContainsDe
 TEST(RuntimeConfigurationCommandLineConstructorTest, ConfigurationPathContainsDefaultPathIfNoPathOrKeyInCommandLineArgs)
 {
     // Given command line arguments which do not contain a configuration path key or configuration path
-    std::vector<score::StringLiteral> arguments = {kDummyApplicationName};
-    auto [argc, argv] = GenerateCommandLineArgs(arguments);
+    std::vector<safecpp::zstring_view> arguments = {kDummyApplicationNameZsv};
 
     // When constructing a RuntimeConfiguration
-    const RuntimeConfiguration runtime_configuration{argc, argv};
+    const RuntimeConfiguration runtime_configuration{arguments};
 
     // Then the stored configuration path should be the default configuration path
     const auto& stored_configuration_path = runtime_configuration.GetConfigurationPath();
@@ -151,11 +153,10 @@ TEST(RuntimeConfigurationCommandLineConstructorTest, ConfigurationPathContainsDe
 TEST(RuntimeConfigurationCommandLineConstructorTest, ConfigurationPathContainsDefaultPathIfCommandLineArgumentsEmpty)
 {
     // Given command line arguments which are empty
-    std::vector<score::StringLiteral> arguments = {};
-    auto [argc, argv] = GenerateCommandLineArgs(arguments);
+    std::vector<safecpp::zstring_view> arguments = {};
 
     // When constructing a RuntimeConfiguration
-    const RuntimeConfiguration runtime_configuration{argc, argv};
+    const RuntimeConfiguration runtime_configuration{arguments};
 
     // Then the stored configuration path should be the default configuration path
     const auto& stored_configuration_path = runtime_configuration.GetConfigurationPath();
@@ -165,23 +166,24 @@ TEST(RuntimeConfigurationCommandLineConstructorTest, ConfigurationPathContainsDe
 TEST(RuntimeConfigurationCommandLineConstructorDeathTest, TerminatesIfCommandLineArgsContainPathKeyButNoPath)
 {
     // Given command line arguments which contain a configuration path key but no configuration path
-    std::vector<score::StringLiteral> arguments = {kDummyApplicationName, kConfigurationPathCommandLineKey};
-    auto [argc, argv] = GenerateCommandLineArgs(arguments);
+    std::vector<safecpp::zstring_view> arguments = {kDummyApplicationNameZsv, kConfigurationPathCommandLineKeyZsv};
+    cpp::span<safecpp::zstring_view> command_line_arguments(arguments.data(), arguments.size());
 
     // When constructing a RuntimeConfiguration
     // Then the process terminates
-    EXPECT_DEATH(RuntimeConfiguration(argc, argv), ".*");
+    EXPECT_DEATH(RuntimeConfiguration{command_line_arguments}, ".*");
 }
 
 TEST(RuntimeConfigurationCommandLineConstructorDeathTest, TerminatesIfCommandLineArgsContainDeprecatedPathKeyButNoPath)
 {
     // Given command line arguments which contain a configuration path key but no configuration path
-    std::vector<score::StringLiteral> arguments = {kDummyApplicationName, kDeprecatedConfigurationPathCommandLineKey};
-    auto [argc, argv] = GenerateCommandLineArgs(arguments);
+    std::vector<safecpp::zstring_view> arguments = {kDummyApplicationNameZsv,
+                                                    kDeprecatedConfigurationPathCommandLineKeyZsv};
+    cpp::span<safecpp::zstring_view> command_line_arguments(arguments.data(), arguments.size());
 
     // When constructing a RuntimeConfiguration
     // Then the process terminates
-    EXPECT_DEATH(RuntimeConfiguration(argc, argv), ".*");
+    EXPECT_DEATH(RuntimeConfiguration{command_line_arguments}, ".*");
 }
 
 }  // namespace

--- a/score/mw/com/runtime_test.cpp
+++ b/score/mw/com/runtime_test.cpp
@@ -14,7 +14,6 @@
 
 #include "score/mw/com/impl/com_error.h"
 #include "score/mw/com/impl/instance_identifier.h"
-#include "score/mw/com/impl/runtime.h"
 #include "score/mw/com/impl/runtime_mock.h"
 #include "score/mw/com/impl/test/runtime_mock_guard.h"
 
@@ -24,7 +23,6 @@
 #include <score/jthread.hpp>
 #include <cstdint>
 #include <string>
-#include <thread>
 
 #include <fstream>
 #include <iostream>
@@ -148,10 +146,11 @@ TEST_F(RuntimeTestExternalJsonFixture, ResolveInstanceIdsIsThreadSafe)
     constexpr std::size_t number_of_calls_per_thread{10U};
 
     // Given a runtime initialised with the path to a configuration file
+    using safecpp::literals::operator""_zsv;
     auto json_path = get_path("mw_com_config.json");
-    score::StringLiteral test_args[] = {"dummyname", "-service_instance_manifest", json_path.c_str()};
-    const std::int32_t num_test_args{3};
-    InitializeRuntime(num_test_args, test_args);
+    std::vector<safecpp::zstring_view> arguments = {"dummyname"_zsv, "--service_instance_manifest"_zsv, json_path};
+
+    InitializeRuntime(arguments);
 
     // and an instance identifier and InstanceSpecifier derived from the configuration
     const auto instance_specifier = InstanceSpecifier::Create(std::string{"abc/abc/TirePressurePort"}).value();


### PR DESCRIPTION
Fixed wrong/outdated structural diagrams.

Removed usage of deprecated score::StringLiteral in Runtime.
Replaced with const safecpp::zstring_view on implementation
level. Public/user facing APIs using StringLiteral or char*
have been marked deprecated and overloads taking
safecpp::zstring_view have been introduced.