### PR TITLE
mw/com: Update event slot size based on field tags

### DIFF
--- a/score/mw/com/design/events_fields/README.md
+++ b/score/mw/com/design/events_fields/README.md
@@ -78,8 +78,31 @@ The same asymmetry shows up in how each side builds the field's event dispatch:
 
 The only combination we actually enforce is a `static_assert` on both `impl::ProxyField` and `impl::SkeletonField`: a
 field must have at least one of `WithGetter` or `WithNotifier`. Without one of them the consumer has no way to observe
-the value, which makes the field useless. We deliberately do not require a setter, since a read-only field is perfectly normal and the provider always sets the
-value itself via `Update()` with no explicit tag needed.
+the value, which makes the field useless. We deliberately do not require a setter, since a read-only field is perfectly 
+normal and the provider always sets the value itself via `Update()` with no explicit tag needed.
+
+The number of slots required for a field is dependent on the presence of `WithNotifier`, `WithGetter`, and `WithSetter`.
+If `WithNotifier` is present, the proxy can subscribe and receive notifications, so the configured value of
+`numberOfSampleSlots` is taken into account. The configured value should be calculated based on the total number of subscribers 
+and the max number of samples they subscribe with (see [here for details](#sizing-of-event_slots-and-state_slots-vectors)).
+If `WithNotifier` is not present, then `WithGetter` must be present (otherwise a consumer has no way of getting a field value).
+In this case, `numberOfSampleSlots` should be configured according to the number of `SampleAllocateePtrs` (can be allocated via a
+call to `Allocate()` on the `SkeletonField`) which can be made held while the maximum number of concurrent getter calls are in 
+progress. E.g. we currently support 1 concurrent getter call, so `numberOfSampleSlots` of 0 would mean that `Allocate()` can not
+be called while a getter call is in progress. `numberOfSampleSlots` of 1 would mean that `Allocate()` can be called once while a 
+getter call is in progress, but the next call to `Allocate()` would return an error until the getter completes or the previous 
+`SampleAllocateePtr` is released. This generalizes to `numberOfSampleSlots` of N.
+
+In addition, if `WithGetter` is present, the number of slots will be increased by the number of concurrent getter calls that 
+are allowed (currently 1), since each getter will reference (and thus prevent writing to the slot) while it copies the value 
+to the setter method call. 
+
+In addition, if `WithSetter` is present, the number of slots must be increased by 1, since the setter must call `Update()` 
+to write the new value into the slot, and thus must reference the slot while it copies the value from the setter method call. 
+These additional slots are added by the middleware implementation, and are not configurable by the user. 
+
+Configured `numberOfIpcTracingSlots` come on top of the used slot count in all cases, because tracing holds a
+reference to each traced sample until the trace call has completed.
 
 ## Event related datastructures in LoLa binding
 

--- a/score/mw/com/impl/BUILD
+++ b/score/mw/com/impl/BUILD
@@ -773,6 +773,18 @@ cc_library(
 )
 
 cc_library(
+    name = "field_tags_store",
+    srcs = ["field_tags_store.cpp"],
+    hdrs = ["field_tags_store.h"],
+    features = COMPILER_WARNING_FEATURES,
+    tags = ["FFI"],
+    visibility = ["//score/mw/com:__subpackages__"],
+    deps = [
+        ":field_tags",
+    ],
+)
+
+cc_library(
     name = "field_tags",
     srcs = ["field_tags.cpp"],
     hdrs = ["field_tags.h"],
@@ -786,6 +798,14 @@ cc_unit_test(
     srcs = ["field_tags_test.cpp"],
     deps = [
         ":field_tags",
+    ],
+)
+
+cc_unit_test(
+    name = "field_tags_store_test",
+    srcs = ["field_tags_store_test.cpp"],
+    deps = [
+        ":field_tags_store",
     ],
 )
 

--- a/score/mw/com/impl/bindings/lola/generic_skeleton_event.cpp
+++ b/score/mw/com/impl/bindings/lola/generic_skeleton_event.cpp
@@ -29,7 +29,7 @@ GenericSkeletonEvent::GenericSkeletonEvent(Skeleton& parent,
                                            impl::tracing::SkeletonEventTracingData tracing_data)
     : size_info_{size_info},
       event_data_storage_{nullptr},
-      skeleton_event_common_{parent, event_name, event_properties, element_fq_id, tracing_data, false}
+      skeleton_event_common_{parent, event_name, event_properties, element_fq_id, tracing_data}
 {
 }
 

--- a/score/mw/com/impl/bindings/lola/generic_skeleton_event_test.cpp
+++ b/score/mw/com/impl/bindings/lola/generic_skeleton_event_test.cpp
@@ -48,7 +48,7 @@ class GenericSkeletonEventFixture : public SkeletonEventFixture
                                     const std::uint8_t max_subscribers,
                                     const bool enforce_max_samples)
     {
-        const SkeletonEventProperties properties{max_samples, max_subscribers, enforce_max_samples};
+        const SkeletonEventProperties properties{max_samples, 0U, 0U, false, max_subscribers, enforce_max_samples};
         generic_skeleton_event_ = std::make_unique<GenericSkeletonEvent>(
             *skeleton_, event_name, properties, element_fq_id, size_info_, impl::tracing::SkeletonEventTracingData{});
     }

--- a/score/mw/com/impl/bindings/lola/proxy_event_common_test.cpp
+++ b/score/mw/com/impl/bindings/lola/proxy_event_common_test.cpp
@@ -74,7 +74,8 @@ class LolaProxyEventCommonFixture : public ProxyMockedMemoryFixture
     {
         EXPECT_CALL(event_handler_, Call()).Times(0);
 
-        InitialiseDummySkeletonEvent(kElementFqId, SkeletonEventProperties{kMaxNumSlots, kMaxSubscribers, true});
+        InitialiseDummySkeletonEvent(kElementFqId,
+                                     SkeletonEventProperties{kMaxNumSlots, 0U, 0U, false, kMaxSubscribers, true});
     }
 
     void InitialiseProxyAndEvent() noexcept

--- a/score/mw/com/impl/bindings/lola/proxy_test.cpp
+++ b/score/mw/com/impl/bindings/lola/proxy_test.cpp
@@ -651,7 +651,8 @@ using ProxyGetEventMetaInfoFixture = ProxyMockedMemoryFixture;
 TEST_F(ProxyGetEventMetaInfoFixture, GetEventMetaInfoWillReturnDataForEventThatWasCreatedBySkeleton)
 {
     // Given a dummy SkeletonEvent which creates the EventMeta Info
-    InitialiseDummySkeletonEvent(kDummyElementFqId, SkeletonEventProperties{kMaxNumSlots, kMaxSubscribers, true});
+    InitialiseDummySkeletonEvent(kDummyElementFqId,
+                                 SkeletonEventProperties{kMaxNumSlots, 0U, 0U, false, kMaxSubscribers, true});
 
     // and a constructed Proxy
     InitialiseProxyWithCreate(identifier_);
@@ -678,7 +679,8 @@ TEST_F(ProxyGetEventMetaInfoDeathTest, CallingGetEventMetaInfoWhenSkeletonEventD
 TEST_F(ProxyGetEventMetaInfoDeathTest, CallingGetEventMetaInfoWhenGettingDataSectionBaseAddressReturnsNullptrTerminates)
 {
     // Given a dummy SkeletonEvent which creates the EventMeta Info
-    InitialiseDummySkeletonEvent(kDummyElementFqId, SkeletonEventProperties{kMaxNumSlots, kMaxSubscribers, true});
+    InitialiseDummySkeletonEvent(kDummyElementFqId,
+                                 SkeletonEventProperties{kMaxNumSlots, 0U, 0U, false, kMaxSubscribers, true});
 
     // and a constructed Proxy
     InitialiseProxyWithCreate(identifier_);
@@ -746,7 +748,8 @@ class ProxyTransactionLogRollbackFixture : public ProxyMockedMemoryFixture
   protected:
     ProxyTransactionLogRollbackFixture() noexcept
     {
-        InitialiseDummySkeletonEvent(kDummyElementFqId, SkeletonEventProperties{kMaxNumSlots, kMaxSubscribers, true});
+        InitialiseDummySkeletonEvent(kDummyElementFqId,
+                                     SkeletonEventProperties{kMaxNumSlots, 0U, 0U, false, kMaxSubscribers, true});
         transaction_log_set_ = &event_control_->transaction_log_set_;
     }
 
@@ -834,7 +837,8 @@ TEST_F(ProxyIsEventProvidedFixture, IsEventProvidedReturnsTrueForEventPresentInS
 {
     // Given a service type deployment with the event mapped and the event initialised in shared memory
     lola_service_deployment_.events_.emplace(std::string{kDummyEventName}, kDummyElementFqId.element_id_);
-    InitialiseDummySkeletonEvent(kDummyElementFqId, SkeletonEventProperties{kMaxNumSlots, kMaxSubscribers, true});
+    InitialiseDummySkeletonEvent(kDummyElementFqId,
+                                 SkeletonEventProperties{kMaxNumSlots, 0U, 0U, false, kMaxSubscribers, true});
 
     // When creating a proxy
     InitialiseProxyWithConstructor(identifier_);
@@ -852,7 +856,8 @@ TEST_F(ProxyIsEventProvidedFixture, IsEventProvidedReturnsFalseForEventNotPresen
     // Given a service type deployment with two mapped events, where only one has a corresponding skeleton event
     lola_service_deployment_.events_.emplace(std::string{kDummyEventName}, kDummyElementFqId.element_id_);
     lola_service_deployment_.events_.emplace(std::string{kNotProvidedEventName}, kNotProvidedElementId);
-    InitialiseDummySkeletonEvent(kDummyElementFqId, SkeletonEventProperties{kMaxNumSlots, kMaxSubscribers, true});
+    InitialiseDummySkeletonEvent(kDummyElementFqId,
+                                 SkeletonEventProperties{kMaxNumSlots, 0U, 0U, false, kMaxSubscribers, true});
 
     // When creating a proxy
     InitialiseProxyWithConstructor(identifier_);

--- a/score/mw/com/impl/bindings/lola/skeleton_event.h
+++ b/score/mw/com/impl/bindings/lola/skeleton_event.h
@@ -70,8 +70,7 @@ class SkeletonEvent final : public SkeletonEventBinding<SampleType>
                   const ElementFqId element_fq_id,
                   const std::string_view event_name,
                   const SkeletonEventProperties properties,
-                  impl::tracing::SkeletonEventTracingData skeleton_event_tracing_data,
-                  bool field_getter_enabled) noexcept;
+                  impl::tracing::SkeletonEventTracingData skeleton_event_tracing_data) noexcept;
 
     SkeletonEvent(const SkeletonEvent&) = delete;
     SkeletonEvent(SkeletonEvent&&) noexcept = delete;
@@ -119,16 +118,10 @@ SkeletonEvent<SampleType>::SkeletonEvent(Skeleton& parent,
                                          const ElementFqId element_fq_id,
                                          const std::string_view event_name,
                                          const SkeletonEventProperties properties,
-                                         impl::tracing::SkeletonEventTracingData skeleton_event_tracing_data,
-                                         bool field_getter_enabled) noexcept
+                                         impl::tracing::SkeletonEventTracingData skeleton_event_tracing_data) noexcept
     : SkeletonEventBinding<SampleType>{},
       event_data_storage_{nullptr},
-      skeleton_event_common_{parent,
-                             event_name,
-                             properties,
-                             element_fq_id,
-                             skeleton_event_tracing_data,
-                             field_getter_enabled}
+      skeleton_event_common_{parent, event_name, properties, element_fq_id, skeleton_event_tracing_data}
 {
 }
 

--- a/score/mw/com/impl/bindings/lola/skeleton_event_common.h
+++ b/score/mw/com/impl/bindings/lola/skeleton_event_common.h
@@ -47,6 +47,9 @@ class SkeletonEventAttorney;
 
 class Skeleton;
 
+/// \brief Maximum number of concurrent SamplePtrs that can be held from GetLatestSample() at any time.
+static constexpr std::uint8_t kMaxConcurrentFieldGetterSamplePtrs{1U};
+
 /// @brief Common implementation for LoLa skeleton events, shared between SkeletonEvent and GenericSkeletonEvent.
 ///
 /// \tparam SampleType Will be the SampleType of the event for a regular SkeletonEvent and void for a
@@ -66,8 +69,7 @@ class SkeletonEventCommon
                         const std::string_view event_name,
                         const SkeletonEventProperties& event_properties,
                         const ElementFqId& element_fq_id,
-                        impl::tracing::SkeletonEventTracingData tracing_data,
-                        bool field_getter_enabled) noexcept;
+                        impl::tracing::SkeletonEventTracingData tracing_data) noexcept;
 
     SkeletonEventCommon(const SkeletonEventCommon&) = delete;
     SkeletonEventCommon(SkeletonEventCommon&&) noexcept = delete;
@@ -172,8 +174,6 @@ class SkeletonEventCommon
     EventSlotStatus::EventTimeStamp current_timestamp_;
     impl::tracing::SkeletonEventTracingData tracing_data_;
 
-    /// \brief Maximum number of concurrent SamplePtrs that can be held from GetLatestSample() at any time.
-    static constexpr std::uint8_t kMaxConcurrentFieldGetterSamplePtrs{1U};
     bool qm_disconnect_;
     bool field_getter_enabled_;
     SampleReferenceTracker getter_sample_tracker_;
@@ -211,8 +211,7 @@ SkeletonEventCommon<SampleType>::SkeletonEventCommon(Skeleton& parent,
                                                      const std::string_view event_name,
                                                      const SkeletonEventProperties& event_properties,
                                                      const ElementFqId& element_fq_id,
-                                                     impl::tracing::SkeletonEventTracingData tracing_data,
-                                                     bool field_getter_enabled) noexcept
+                                                     impl::tracing::SkeletonEventTracingData tracing_data) noexcept
     : parent_{parent},
       event_name_{event_name},
       event_properties_{event_properties},
@@ -221,7 +220,7 @@ SkeletonEventCommon<SampleType>::SkeletonEventCommon(Skeleton& parent,
       current_timestamp_{EventSlotStatus::INVALID_TIMESTAMP},
       tracing_data_{tracing_data},
       qm_disconnect_{false},
-      field_getter_enabled_{field_getter_enabled},
+      field_getter_enabled_{event_properties_.GetNumberOfFieldGetterSlots() > 0U},
       getter_sample_tracker_{kMaxConcurrentFieldGetterSamplePtrs}
 {
 }

--- a/score/mw/com/impl/bindings/lola/skeleton_event_common_test.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_event_common_test.cpp
@@ -29,8 +29,8 @@ using ::testing::Return;
 using ::testing::ReturnRef;
 
 static constexpr bool kEnforceMaxSamples{true};
-static constexpr bool kFieldGetterDisabled{false};
-static constexpr bool kFieldGetterEnabled{true};
+static constexpr std::size_t kNumberOfSlotsForDisabledFieldGetter{0U};
+static constexpr std::size_t kNumberOfSlotsForEnabledFieldGetter{kMaxConcurrentFieldGetterSamplePtrs};
 
 class SkeletonEventCommonFixture : public SkeletonEventFixture
 {
@@ -62,9 +62,9 @@ class SkeletonEventCommonFixture : public SkeletonEventFixture
             *skeleton_,
             element_fq_id,
             service_element_name,
-            SkeletonEventProperties{max_samples, max_subscribers, enforce_max_samples},
-            skeleton_event_tracing_data,
-            kFieldGetterDisabled);
+            SkeletonEventProperties{
+                max_samples, 0U, kNumberOfSlotsForDisabledFieldGetter, false, max_subscribers, enforce_max_samples},
+            skeleton_event_tracing_data);
 
         // Call PrepareOffer on the skeleton event to trigger Skeleton::Register, which populates
         // the event_controls_ maps in ServiceDataControl for both QM and (if ASIL-B) ASIL-B.
@@ -74,10 +74,10 @@ class SkeletonEventCommonFixture : public SkeletonEventFixture
             std::make_unique<score::mw::com::impl::lola::SkeletonEventCommon<test::TestSampleType>>(
                 *skeleton_,
                 event_name_,
-                SkeletonEventProperties{max_samples, max_subscribers, enforce_max_samples},
+                SkeletonEventProperties{
+                    max_samples, 0U, kNumberOfSlotsForDisabledFieldGetter, false, max_subscribers, enforce_max_samples},
                 element_fq_id,
-                skeleton_event_tracing_data,
-                kFieldGetterDisabled);
+                skeleton_event_tracing_data);
     }
 
   protected:
@@ -175,7 +175,7 @@ TEST_F(SkeletonEventCommonPrepareOfferFixture,
                             max_subscribers_,
                             kEnforceMaxSamples,
                             kDisabledTracingData,
-                            kFieldGetterEnabled,
+                            kNumberOfSlotsForEnabledFieldGetter,
                             kValidAsilBInstanceIdentifier);
 
     // When Skeleton Event is Offered
@@ -196,7 +196,7 @@ TEST_F(SkeletonEventCommonPrepareOfferFixture,
                             max_subscribers_,
                             kEnforceMaxSamples,
                             kDisabledTracingData,
-                            kFieldGetterEnabled,
+                            kNumberOfSlotsForEnabledFieldGetter,
                             kValidQmInstanceIdentifier);
 
     // When Skeleton Event is Offered
@@ -219,7 +219,7 @@ TEST_F(SkeletonEventCommonPrepareOfferFixture, WhenGetterAndTracingDisabledForAs
                             max_subscribers_,
                             kEnforceMaxSamples,
                             kDisabledTracingData,
-                            kFieldGetterDisabled,
+                            kNumberOfSlotsForDisabledFieldGetter,
                             kValidAsilBInstanceIdentifier);
 
     // When Skeleton Event is Offered
@@ -239,7 +239,7 @@ TEST_F(SkeletonEventCommonPrepareOfferFixture, WhenGetterAndTracingDisabledForQm
                             max_subscribers_,
                             kEnforceMaxSamples,
                             kDisabledTracingData,
-                            kFieldGetterDisabled,
+                            kNumberOfSlotsForDisabledFieldGetter,
                             kValidQmInstanceIdentifier);
 
     // When Skeleton Event Offer
@@ -265,7 +265,7 @@ TEST_F(SkeletonEventCommonPrepareStopOfferFixture,
                             max_subscribers_,
                             kEnforceMaxSamples,
                             kDisabledTracingData,
-                            kFieldGetterEnabled,
+                            kNumberOfSlotsForEnabledFieldGetter,
                             kValidAsilBInstanceIdentifier);
 
     // When the Skeleton Event is Offered

--- a/score/mw/com/impl/bindings/lola/skeleton_event_properties.h
+++ b/score/mw/com/impl/bindings/lola/skeleton_event_properties.h
@@ -18,9 +18,43 @@
 namespace score::mw::com::impl::lola
 {
 
-struct SkeletonEventProperties
+class SkeletonEventProperties
 {
-    std::size_t number_of_slots;
+  public:
+    SkeletonEventProperties(std::size_t number_of_slots,
+                            std::size_t number_of_tracing_slots,
+                            std::size_t number_of_field_getter_slots,
+                            bool is_setter_enabled,
+                            std::size_t max_subscribers_in,
+                            bool enforce_max_samples_in)
+        : max_subscribers(max_subscribers_in),
+          enforce_max_samples(enforce_max_samples_in),
+          number_of_slots_(number_of_slots),
+          number_of_tracing_slots_(number_of_tracing_slots),
+          number_of_field_getter_slots_(number_of_field_getter_slots),
+          is_setter_enabled_(is_setter_enabled)
+    {
+    }
+
+    /// \brief Returns the total number of slots for the event (or field) configured by the user (via
+    /// numberOfSampleSlots and numberOfIpcTracingSlots configuration properties) and required to support field Getter
+    /// / Setter fuctionality (in case a SkeletonField has WithGetter / WithSetter enabled).
+    [[nodiscard]] std::size_t GetTotalNumberOfSlots() const
+    {
+        const std::size_t number_of_field_setter_slots = is_setter_enabled_ ? 1 : 0;
+        return number_of_slots_ + number_of_tracing_slots_ + number_of_field_getter_slots_ +
+               number_of_field_setter_slots;
+    }
+
+    /// \brief Returns the number of slots required to support Getter functionality.
+    ///
+    /// This will return 0 for an event or field without WithGetter enabled. For a field with WithGetter enabled, this
+    /// will return the number of slots required to support the maximum number of concurrent Getter calls.
+    [[nodiscard]] std::size_t GetNumberOfFieldGetterSlots() const
+    {
+        return number_of_field_getter_slots_;
+    }
+
     std::size_t max_subscribers;
 
     // Suppress "AUTOSAR C++14 A9-6-1" rule findings. This rule declares: "Data types used for interfacing with hardware
@@ -31,6 +65,48 @@ struct SkeletonEventProperties
     // individually.
     // coverity[autosar_cpp14_a9_6_1_violation : FALSE]
     bool enforce_max_samples;
+
+  private:
+    /// \brief The number of slots configured by the user for the event (or field) via numberOfSampleSlots configuration
+    /// property.
+    ///
+    /// For an event, this is the number of slots that the provider needs to provide its consumers with. E.g. if the
+    /// provider has 2 consumers which each want to access 2 samples, this value would be 4 (or 5 if they want to ensure
+    /// that the provider can always provide a sample a new value even if all other consumers are using their samples).
+    /// For a field with a Notifier enabled, the same logic applies as for an event. For a field without a Notifier
+    /// enabled (which by definition has a Getter enabled), this value in general can be 0..n:
+    ///     0 - If the maximum number of concurrent Getter calls are currently being called, then a call to Allocate()
+    ///     will return an error (This allows the provider to reduce the memory footprint by reducing the slot vector
+    ///     size. This could be useful if the provider doesn't want to update the value for example so they don't have
+    ///     to worry about being blocked by Getter calls).
+    ///     1 - If the maximum number of concurrent Getter calls are currently being called, then a call to Allocate()
+    ///     will always succeed (This is the general, non-power use case).
+    ///     n - If the maximum number of concurrent Getter calls are currently being called, then n SampleAllocateePtrs
+    ///     from calls to Allocate can be held at one time. Once n SampleAllocateePtrs are held, then a call to
+    ///     Allocate() will return an error.
+    std::size_t number_of_slots_;
+
+    /// \brief The number of slots configured by the user for the event (or field) via numberOfIpcTracingSlots
+    /// configuration
+    std::size_t number_of_tracing_slots_;
+
+    /// \brief The number of slots that are required to support the maximum number of concurrent Getter calls for a
+    /// field with a Getter enabled.
+    ///
+    /// The maximum number of concurrent Getter calls is defined by the static constexpr
+    /// kMaxConcurrentFieldGetterSamplePtrs in SkeletonEventCommon. This value is not configured by the user but rather
+    /// chosen by the implementation of a field on the lola binding level.
+    std::size_t number_of_field_getter_slots_;
+
+    // if setter enabled: add 1 slot (because this is different to allocate in that setter is called by consumer process
+    // so provider cannot control calls and we don't want consumers to block provider).
+
+    /// \brief Indicates whether the field has a Setter enabled which will require an additional slot to be allocated.
+    ///
+    /// We currently only support a single setter call at a time as we don't see a reasonable use case for multiple
+    /// concurrent setter calls. So we use a flag instead of a number of slots required to make this distinction
+    /// clearer.
+    bool is_setter_enabled_;
 };
 
 }  // namespace score::mw::com::impl::lola

--- a/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
@@ -210,7 +210,7 @@ void* SkeletonMemoryManager::CreateGenericEventDataInCreatedSharedMemory(
 
     // Calculate the aligned size for a single sample to ensure proper padding between slots
     const auto aligned_sample_size = memory::shared::CalculateAlignedSize(sample_size, sample_alignment);
-    const auto total_data_size_bytes = aligned_sample_size * element_properties.number_of_slots;
+    const auto total_data_size_bytes = aligned_sample_size * element_properties.GetTotalNumberOfSlots();
 
     // Convert total bytes to the number of std::max_align_t elements needed (round up)
     const size_t num_max_align_elements =
@@ -252,7 +252,7 @@ void* SkeletonMemoryManager::RetrieveGenericEventDataFromOpenedSharedMemory(
     const auto aligned_sample_size =
         memory::shared::CalculateAlignedSize(sample_size, static_cast<std::size_t>(sample_alignment));
     const auto total_event_slots_size = safe_math::Multiply<safe_math::ReturnMode::kAbortOnError>(
-        aligned_sample_size, element_properties.number_of_slots);
+        aligned_sample_size, element_properties.GetTotalNumberOfSlots());
 
     void* const event_slots_raw_array = event_meta_info_it->second.event_slots_raw_array_.get(total_event_slots_size);
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(event_slots_raw_array != nullptr,
@@ -732,7 +732,7 @@ EventControl& SkeletonMemoryManager::EmplaceEventControl(const QualityType asil_
     auto control_qm =
         service_data_control->event_controls_.emplace(std::piecewise_construct,
                                                       std::forward_as_tuple(element_fq_id),
-                                                      std::forward_as_tuple(element_properties.number_of_slots,
+                                                      std::forward_as_tuple(element_properties.GetTotalNumberOfSlots(),
                                                                             element_properties.max_subscribers,
                                                                             element_properties.enforce_max_samples,
                                                                             *memory_resource));

--- a/score/mw/com/impl/bindings/lola/skeleton_memory_manager.h
+++ b/score/mw/com/impl/bindings/lola/skeleton_memory_manager.h
@@ -295,7 +295,7 @@ EventDataStorage<SampleType>& SkeletonMemoryManager::EmplaceEventDataStorage(
     const SkeletonEventProperties& element_properties)
 {
     auto* typed_event_data_storage_ptr = storage_resource_->construct<EventDataStorage<SampleType>>(
-        element_properties.number_of_slots,
+        element_properties.GetTotalNumberOfSlots(),
         memory::shared::PolymorphicOffsetPtrAllocator<SampleType>(*storage_resource_));
 
     auto inserted_data_slots = storage_->events_.emplace(std::piecewise_construct,

--- a/score/mw/com/impl/bindings/lola/skeleton_test.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_test.cpp
@@ -1376,12 +1376,12 @@ TEST_P(SkeletonRegisterParamaterisedFixture, ValidEventMetaInfoExistAfterEventIs
 
     const auto foo_event_slots_size = GetEventSlotsArraySize(event_foo_meta_info_ptr->data_type_info_.size,
                                                              event_foo_meta_info_ptr->data_type_info_.alignment,
-                                                             test::kDefaultEventProperties.number_of_slots);
+                                                             test::kDefaultEventProperties.GetTotalNumberOfSlots());
     ASSERT_EQ(event_foo_meta_info_ptr->event_slots_raw_array_.get(foo_event_slots_size), foo_event_data_storage);
 
     const auto dumb_event_slots_size = GetEventSlotsArraySize(event_foo_meta_info_ptr->data_type_info_.size,
                                                               event_foo_meta_info_ptr->data_type_info_.alignment,
-                                                              test::kDefaultEventProperties.number_of_slots);
+                                                              test::kDefaultEventProperties.GetTotalNumberOfSlots());
     ASSERT_EQ(event_dumb_meta_info_ptr->event_slots_raw_array_.get(dumb_event_slots_size), dumb_event_data_storage);
 
     CleanUpSkeleton();

--- a/score/mw/com/impl/bindings/lola/test/proxy_component_test.cpp
+++ b/score/mw/com/impl/bindings/lola/test/proxy_component_test.cpp
@@ -192,7 +192,7 @@ TEST_F(ProxyWithRealMemFixture, IsEventProvidedOnlyReturnsTrueIfEventIsInSharedM
     ASSERT_NE(fake_data_result, nullptr);
 
     // Only provide the first event in shared memory
-    fake_data_result->AddEvent<std::uint8_t>(kElementFqId, SkeletonEventProperties{10U, 3U, true});
+    fake_data_result->AddEvent<std::uint8_t>(kElementFqId, SkeletonEventProperties{10U, 0U, 0U, false, 3U, true});
 
     const auto handle = config_store_->GetHandle();
 

--- a/score/mw/com/impl/bindings/lola/test/proxy_event_test_resources.cpp
+++ b/score/mw/com/impl/bindings/lola/test/proxy_event_test_resources.cpp
@@ -178,7 +178,8 @@ void ProxyMockedMemoryFixture::InitialiseDummySkeletonEvent(const ElementFqId el
 
 LolaProxyEventResources::LolaProxyEventResources() : ProxyMockedMemoryFixture{}
 {
-    InitialiseDummySkeletonEvent(element_fq_id_, SkeletonEventProperties{max_num_slots_, max_subscribers_, true});
+    InitialiseDummySkeletonEvent(element_fq_id_,
+                                 SkeletonEventProperties{max_num_slots_, 0U, 0U, false, max_subscribers_, true});
     InitialiseProxyWithConstructor(identifier_);
 }
 

--- a/score/mw/com/impl/bindings/lola/test/skeleton_event_component_test.cpp
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_event_component_test.cpp
@@ -249,9 +249,8 @@ class SkeletonEventComponentTestTemplateFixture : public ::testing::Test
         *parent_skeleton_,
         fake_element_fq_id_,
         fake_event_name_,
-        SkeletonEventProperties{MaxSamples, max_subscribers_, enforce_max_samples_},
-        disabled_tracing_data_,
-        field_getter_disabled_};
+        SkeletonEventProperties{MaxSamples, 0U, 0U, false, max_subscribers_, enforce_max_samples_},
+        disabled_tracing_data_};
 };
 
 using SkeletonEventComponentTestFixture = SkeletonEventComponentTestTemplateFixture<5>;

--- a/score/mw/com/impl/bindings/lola/test/skeleton_event_test_resources.cpp
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_event_test_resources.cpp
@@ -50,13 +50,15 @@ void SkeletonEventFixture::InitialiseSkeletonEvent(const ElementFqId element_fq_
     std::optional<SkeletonBinding::RegisterShmObjectTraceCallback> register_shm_object_trace_callback{};
     std::ignore = skeleton_->PrepareOffer(events, fields, std::move(register_shm_object_trace_callback));
 
+    const auto number_of_field_getter_slots = field_getter_enabled ? kMaxConcurrentFieldGetterSamplePtrs : 0U;
+
     skeleton_event_ = std::make_unique<SkeletonEvent<test::TestSampleType>>(
         *skeleton_,
         element_fq_id,
         service_element_name,
-        SkeletonEventProperties{max_samples, max_subscribers, enforce_max_samples},
-        skeleton_event_tracing_data,
-        field_getter_enabled);
+        SkeletonEventProperties{
+            max_samples, 0U, number_of_field_getter_slots, false, max_subscribers, enforce_max_samples},
+        skeleton_event_tracing_data);
 }
 
 EventControl* SkeletonEventFixture::GetEventControl(const ElementFqId element_fq_id,

--- a/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h
@@ -148,7 +148,7 @@ static const auto kDumbFieldName{"dumbField"};
 static const auto kFooMethodName{"fooMethod"};
 static const auto kDumbMethodName{"barMethod"};
 
-static const SkeletonEventProperties kDefaultEventProperties{10, 5, true};
+static const SkeletonEventProperties kDefaultEventProperties{10U, 0U, 0U, false, 5U, true};
 
 static constexpr std::uint16_t kFooEventId{1U};
 static constexpr std::uint16_t kDumbEventId{2U};

--- a/score/mw/com/impl/bindings/lola/test_doubles/fake_mocked_service_data.h
+++ b/score/mw/com/impl/bindings/lola/test_doubles/fake_mocked_service_data.h
@@ -60,19 +60,20 @@ inline std::tuple<EventControl*, EventDataStorage<SampleType>*> FakeMockedServic
     const SkeletonEventProperties event_properties)
 {
     bool inserted;
+    const auto total_number_of_slots = event_properties.GetTotalNumberOfSlots();
 
     score::memory::shared::Map<ElementFqId, EventControl>::iterator inserted_control;
     std::tie(inserted_control, inserted) =
         data_control->event_controls_.emplace(std::piecewise_construct,
                                               std::forward_as_tuple(id),
-                                              std::forward_as_tuple(event_properties.number_of_slots,
+                                              std::forward_as_tuple(total_number_of_slots,
                                                                     event_properties.max_subscribers,
                                                                     event_properties.enforce_max_samples,
                                                                     *control_memory));
     auto& event_control = std::get<EventControl>(*inserted_control);
 
     EventDataStorage<SampleType>* event_data_slots =
-        data_memory->construct<EventDataStorage<SampleType>>(event_properties.number_of_slots, *data_memory);
+        data_memory->construct<EventDataStorage<SampleType>>(total_number_of_slots, *data_memory);
     const memory::shared::OffsetPtr<void> rel_event_data_buffer{static_cast<void*>(event_data_slots)};
     data_storage->events_.emplace(id, rel_event_data_buffer);
 

--- a/score/mw/com/impl/bindings/lola/test_doubles/fake_service_data.h
+++ b/score/mw/com/impl/bindings/lola/test_doubles/fake_service_data.h
@@ -89,18 +89,19 @@ inline std::tuple<EventControl*, EventDataStorage<SampleType>*> FakeServiceData:
     const SkeletonEventProperties event_properties) noexcept
 {
     bool inserted;
+    const auto total_number_of_slots = event_properties.GetTotalNumberOfSlots();
     score::memory::shared::Map<ElementFqId, EventControl>::iterator inserted_control;
     std::tie(inserted_control, inserted) =
         data_control->event_controls_.emplace(std::piecewise_construct,
                                               std::forward_as_tuple(id),
-                                              std::forward_as_tuple(event_properties.number_of_slots,
+                                              std::forward_as_tuple(total_number_of_slots,
                                                                     event_properties.max_subscribers,
                                                                     event_properties.enforce_max_samples,
                                                                     *control_memory));
     auto& event_control = std::get<EventControl>(*inserted_control);
 
     EventDataStorage<SampleType>* event_data_slots =
-        data_memory->construct<EventDataStorage<SampleType>>(event_properties.number_of_slots, *data_memory);
+        data_memory->construct<EventDataStorage<SampleType>>(total_number_of_slots, *data_memory);
     const memory::shared::OffsetPtr<void> rel_event_data_buffer{static_cast<void*>(event_data_slots)};
     data_storage->events_.emplace(id, rel_event_data_buffer);
 

--- a/score/mw/com/impl/bindings/lola/transaction_log_rollback_executor_test.cpp
+++ b/score/mw/com/impl/bindings/lola/transaction_log_rollback_executor_test.cpp
@@ -55,7 +55,7 @@ const SkeletonInstanceIdentifier kSkeletonInstanceIdentifier{kDummyElementFqId.s
 
 constexpr std::size_t kNumberOfSlots{20U};
 constexpr std::size_t kMaxSubscribers{20U};
-const SkeletonEventProperties kDummySkeletonEventProperties{kNumberOfSlots, kMaxSubscribers, true};
+const SkeletonEventProperties kDummySkeletonEventProperties{kNumberOfSlots, 0U, 0U, false, kMaxSubscribers, true};
 
 class TransactionLogRollbackExecutorFixture : public ::testing::Test
 {
@@ -88,7 +88,7 @@ class TransactionLogRollbackExecutorFixture : public ::testing::Test
         const auto emplace_result = service_data_control_->event_controls_.emplace(
             std::piecewise_construct,
             std::forward_as_tuple(element_fq_id),
-            std::forward_as_tuple(skeleton_event_properties.number_of_slots,
+            std::forward_as_tuple(skeleton_event_properties.GetTotalNumberOfSlots(),
                                   skeleton_event_properties.max_subscribers,
                                   skeleton_event_properties.enforce_max_samples,
                                   memory_resource_mock_));

--- a/score/mw/com/impl/configuration/README.md
+++ b/score/mw/com/impl/configuration/README.md
@@ -387,6 +387,9 @@ The properties of a field or an event object on the instance level are:
   `numberOfSampleSlots`. I.e. The sum of all `maxSamples` values of all subscribing consumers must not exceed
   `numberOfSampleSlots`. Otherwise, the subscribe call will be rejected. However, this check is not ASIL level
   overarching. See explanation in the `maxSubscribers` section below.
+  **Note**: In case of a field without `WithNotifier` this property is rather the number of 
+  SampleAllocateePtrs (can be allocated via a call to `Allocate()` on the `SkeletonField`) which can be 
+  held while the maximum number of concurrent getter calls are in progress.
 - `maxSubscribers`: (mandatory on provider side) - how many consumers are allowed to subscribe to this event or field.
   This number is the combined number of `QM` and `ASIL-B` consumers.
   **Note**: The maximum number of subscribers can't currently be supervised ASIL level **overarching**. I.e. in case of
@@ -394,6 +397,8 @@ The properties of a field or an event object on the instance level are:
   subscribers doesn't exceed the configured `maxSubscribers`. The same applies to an `ASIL-B` proxy. It can only verify,
   that its subscription doesn't exceed the configured number `maxSubscribers` by ASIL-B subscribers. But there is no
   cross-check between QM and ASIL-B subscribers.
+  **Note**: Similar to `maxSubscribers`, for a field without `WithNotifier` this property is ignored, since no consumer 
+  can subscribe to it.
 - `enforceMaxSamples`: (optional on provider side, default is `true`) - normally &ndash; this property being set to
   `true` &ndash; it is checked in every subscribe call to an event or field, that the call with its given sample count
   will **not** exceed the number configured in `numberOfSampleSlots`.

--- a/score/mw/com/impl/configuration/lola_event_instance_deployment.cpp
+++ b/score/mw/com/impl/configuration/lola_event_instance_deployment.cpp
@@ -134,11 +134,7 @@ auto LolaEventInstanceDeployment::GetNumberOfSampleSlots() const noexcept -> std
 auto LolaEventInstanceDeployment::GetNumberOfSampleSlotsExcludingTracingSlot() const noexcept
     -> std::optional<SampleSlotCountType>
 {
-    if (!number_of_sample_slots_.has_value())
-    {
-        return {};
-    }
-    return *number_of_sample_slots_;
+    return number_of_sample_slots_;
 }
 
 auto LolaEventInstanceDeployment::GetNumberOfTracingSlots() const noexcept -> TracingSlotSizeType

--- a/score/mw/com/impl/configuration/mw_com_config_schema.json
+++ b/score/mw/com/impl/configuration/mw_com_config_schema.json
@@ -366,14 +366,14 @@
                                             "numberOfSampleSlots": {
                                                 "type": "integer",
                                                 "title": "Number of sample slots",
-                                                "description": "Mandatory LoLa specific provider/skeleton side setting, how many sample slots shall be allocated. Value needs to be between 1 and 65535!",
-                                                "minimum": 1,
+                                                "description": "Mandatory LoLa specific provider/skeleton side setting, how many sample slots shall be allocated. Value needs to be between 1 and 65535 when the field has Notifier enabled! For a field with Notifier disabled, this value denotes the number of SampleAllocateePtrs that can be held (from a call to Allocate() on the Skeleton Field) at one time while the maximum supported number of concurrent getter calls are being processed. A value of 0 can therefore be provided which means that Allocate() can not be called while the getter calls are being processed. A value of 1 is recommended for most use cases.",
+                                                "minimum": 0,
                                                 "maximum": 65535
                                             },
                                             "maxSubscribers": {
                                                 "type": "integer",
                                                 "title": "Maximum subscribers",
-                                                "description": "Mandatory LoLa specific provider/skeleton side setting, how many subscribers shall be supported at max."
+                                                "description": "Mandatory LoLa specific provider/skeleton side setting, how many subscribers shall be supported at max. For a field with Notifier disabled, this value is ignored."
                                             },
                                             "enforceMaxSamples": {
                                                 "type": "boolean",

--- a/score/mw/com/impl/field_tags_store.cpp
+++ b/score/mw/com/impl/field_tags_store.cpp
@@ -1,0 +1,24 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/impl/field_tags_store.h"
+
+namespace score::mw::com::impl
+{
+
+bool operator==(const FieldTagsStore& lhs, const FieldTagsStore& rhs)
+{
+    return lhs.HasGetter() == rhs.HasGetter() && lhs.HasSetter() == rhs.HasSetter() &&
+           lhs.HasNotifier() == rhs.HasNotifier();
+}
+
+}  // namespace score::mw::com::impl

--- a/score/mw/com/impl/field_tags_store.h
+++ b/score/mw/com/impl/field_tags_store.h
@@ -1,0 +1,65 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_IMPL_FIELD_TAGS_STORE_H
+#define SCORE_MW_COM_IMPL_FIELD_TAGS_STORE_H
+
+#include "score/mw/com/impl/field_tags.h"
+
+namespace score::mw::com::impl
+{
+
+/// \brief Helper class for storing field tags represented as variadic template parameters as a set of booleans.
+///
+/// This allows us to pass around the tags without having to template all functions / classes with the tags.
+class FieldTagsStore
+{
+  public:
+    template <typename... Tags>
+    static FieldTagsStore Create()
+    {
+        return {contains_type<WithNotifier, Tags...>::value,
+                contains_type<WithSetter, Tags...>::value,
+                contains_type<WithGetter, Tags...>::value};
+    }
+
+    [[nodiscard]] bool HasNotifier() const
+    {
+        return has_notifier_;
+    }
+
+    [[nodiscard]] bool HasSetter() const
+    {
+        return has_setter_;
+    }
+
+    [[nodiscard]] bool HasGetter() const
+    {
+        return has_getter_;
+    }
+
+  private:
+    FieldTagsStore(bool has_notifier, bool has_setter, bool has_getter)
+        : has_notifier_{has_notifier}, has_setter_{has_setter}, has_getter_{has_getter}
+    {
+    }
+
+    bool has_notifier_;
+    bool has_setter_;
+    bool has_getter_;
+};
+
+bool operator==(const FieldTagsStore& lhs, const FieldTagsStore& rhs);
+
+}  // namespace score::mw::com::impl
+
+#endif  // SCORE_MW_COM_IMPL_FIELD_TAGS_STORE_H

--- a/score/mw/com/impl/field_tags_store_test.cpp
+++ b/score/mw/com/impl/field_tags_store_test.cpp
@@ -1,0 +1,78 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/impl/field_tags_store.h"
+
+#include <gtest/gtest.h>
+
+namespace score::mw::com::impl
+{
+namespace
+{
+
+TEST(FieldTagsStoreTest, CreatingWithNotifierReturnsTrueOnlyForHasNotifier)
+{
+    // When creating a FieldTagsStore with WithNotifier tag
+    auto store = FieldTagsStore::Create<WithNotifier>();
+
+    // Then only HasNotifier() returns true
+    EXPECT_TRUE(store.HasNotifier());
+    EXPECT_FALSE(store.HasSetter());
+    EXPECT_FALSE(store.HasGetter());
+}
+
+TEST(FieldTagsStoreTest, CreatingWithGetterReturnsTrueOnlyForHasGetter)
+{
+    // When creating a FieldTagsStore with WithGetter tag
+    auto store = FieldTagsStore::Create<WithGetter>();
+
+    // Then only HasGetter() returns true
+    EXPECT_FALSE(store.HasNotifier());
+    EXPECT_FALSE(store.HasSetter());
+    EXPECT_TRUE(store.HasGetter());
+}
+
+TEST(FieldTagsStoreTest, CreatingWithNotifierAndSetterReturnsTrueForNotifierAndSetter)
+{
+    // When creating a FieldTagsStore with WithNotifier and WithSetter tags
+    auto store = FieldTagsStore::Create<WithNotifier, WithSetter>();
+
+    // Then only HasNotifier() and HasSetter() return true
+    EXPECT_TRUE(store.HasNotifier());
+    EXPECT_TRUE(store.HasSetter());
+    EXPECT_FALSE(store.HasGetter());
+}
+
+TEST(FieldTagsStoreTest, CreatingWithGetterAndSetterReturnsTrueForGetterAndSetter)
+{
+    // When creating a FieldTagsStore with WithGetter and WithSetter tags
+    auto store = FieldTagsStore::Create<WithGetter, WithSetter>();
+
+    // Then only HasGetter() and HasSetter() return true
+    EXPECT_FALSE(store.HasNotifier());
+    EXPECT_TRUE(store.HasSetter());
+    EXPECT_TRUE(store.HasGetter());
+}
+
+TEST(FieldTagsStoreTest, CreatingWithNotifierAndGetterAndSetterReturnsTrueForAllTags)
+{
+    // When creating a FieldTagsStore with the same tags as in SkeletonFieldCreationFixture
+    auto store = FieldTagsStore::Create<WithNotifier, WithGetter, WithSetter>();
+
+    // Then all corresponding tag flags return true
+    EXPECT_TRUE(store.HasNotifier());
+    EXPECT_TRUE(store.HasSetter());
+    EXPECT_TRUE(store.HasGetter());
+}
+
+}  // namespace
+}  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/BUILD
+++ b/score/mw/com/impl/plumbing/BUILD
@@ -255,6 +255,7 @@ cc_library(
         "//score/mw/com/impl/plumbing:__subpackages__",
     ],
     deps = [
+        "//score/mw/com/impl:field_tags_store",
         "//score/mw/com/impl:instance_identifier",
         "//score/mw/com/impl:skeleton_base",
         "@score_baselibs//score/language/futurecpp",
@@ -377,6 +378,7 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     deps = [
+        "//score/mw/com/impl:field_tags_store",
         "//score/mw/com/impl:skeleton_base",
         "//score/mw/com/impl/bindings/lola",
         "//score/mw/com/impl/configuration",
@@ -408,6 +410,7 @@ cc_library(
     deps = [
         ":i_skeleton_field_binding_factory",
         ":skeleton_service_element_binding_factory_impl",
+        "//score/mw/com/impl:field_tags",
         "@score_baselibs//score/language/futurecpp",
     ],
 )
@@ -509,6 +512,7 @@ cc_library(
     deps = [
         "skeleton_field_binding_factory_impl",
         ":i_skeleton_field_binding_factory",
+        "//score/mw/com/impl:field_tags",
         "@score_baselibs//score/language/futurecpp",
     ],
 )
@@ -615,6 +619,7 @@ cc_library(
     ],
     deps = [
         ":i_skeleton_field_binding_factory",
+        "//score/mw/com/impl:field_tags",
         "@googletest//:gtest",
     ],
 )
@@ -641,7 +646,6 @@ cc_library(
     srcs = ["generic_skeleton_event_binding_factory.cpp"],
     hdrs = [
         "generic_skeleton_event_binding_factory.h",
-        "skeleton_service_element_binding_factory_impl.h",
     ],
     features = COMPILER_WARNING_FEATURES,
     implementation_deps = [
@@ -653,6 +657,7 @@ cc_library(
         "//score/mw/com/impl:__subpackages__",
     ],
     deps = [
+        ":skeleton_service_element_binding_factory_impl",
         "//score/mw/com/impl:i_generic_skeleton_event_binding_factory",
         "//score/mw/com/impl/bindings/lola:generic_skeleton_event",
     ],
@@ -859,6 +864,10 @@ cc_unit_test(
     features = COMPILER_WARNING_FEATURES,
     deps = [
         ":skeleton_event_binding_factory",
+        "//score/mw/com/impl/bindings/lola/test:skeleton_test_resources",
+        "//score/mw/com/impl/bindings/mock_binding",
+        "//score/mw/com/impl/configuration/test:configuration_store",
+        "//score/mw/com/impl/test:dummy_instance_identifier_builder",
     ],
 )
 
@@ -870,6 +879,10 @@ cc_unit_test(
     features = COMPILER_WARNING_FEATURES,
     deps = [
         ":skeleton_field_binding_factory",
+        "//score/mw/com/impl/bindings/lola/test:skeleton_test_resources",
+        "//score/mw/com/impl/bindings/mock_binding",
+        "//score/mw/com/impl/configuration/test:configuration_store",
+        "//score/mw/com/impl/test:dummy_instance_identifier_builder",
     ],
 )
 

--- a/score/mw/com/impl/plumbing/i_skeleton_field_binding_factory.h
+++ b/score/mw/com/impl/plumbing/i_skeleton_field_binding_factory.h
@@ -13,6 +13,7 @@
 #ifndef SCORE_MW_COM_IMPL_PLUMBING_I_SKELETON_FIELD_BINDING_FACTORY_H
 #define SCORE_MW_COM_IMPL_PLUMBING_I_SKELETON_FIELD_BINDING_FACTORY_H
 
+#include "score/mw/com/impl/field_tags_store.h"
 #include "score/mw/com/impl/handle_type.h"
 #include "score/mw/com/impl/instance_identifier.h"
 #include "score/mw/com/impl/skeleton_base.h"
@@ -44,10 +45,12 @@ class ISkeletonFieldBindingFactory
     /// \param identifier The instance identifier containing the binding information.
     /// \param parent A reference to the Skeleton which owns this event.
     /// \param field_name The binding unspecific name of the field inside the skeleton denoted by instance identifier.
+    /// \param field_tags_store The field tags store containing the field abilities (notifier, setter, getter).
     /// \return An instance of SkeletonEventBinding or nullptr in case of an error.
     virtual auto CreateEventBinding(const InstanceIdentifier& identifier,
                                     SkeletonBinding& parent_binding,
-                                    const std::string_view field_name) noexcept
+                                    const std::string_view field_name,
+                                    const FieldTagsStore field_tags_store) noexcept
         -> std::unique_ptr<SkeletonEventBinding<SampleType>> = 0;
 };
 

--- a/score/mw/com/impl/plumbing/proxy_event_field_binding_factory_test.cpp
+++ b/score/mw/com/impl/plumbing/proxy_event_field_binding_factory_test.cpp
@@ -54,7 +54,7 @@ constexpr std::uint16_t kDummyGenericProxyId{7U};
 
 constexpr uint16_t kInstanceId = 0x31U;
 const LolaServiceId kServiceId{1U};
-constexpr lola::SkeletonEventProperties kSkeletonEventProperties{5U, 3U, true};
+const lola::SkeletonEventProperties kSkeletonEventProperties{5U, 0U, 0U, false, 3U, true};
 const auto kInstanceSpecifier = InstanceSpecifier::Create(std::string{"/my_dummy_instance_specifier"}).value();
 
 const LolaServiceInstanceDeployment kLolaServiceInstanceDeployment{

--- a/score/mw/com/impl/plumbing/skeleton_event_binding_factory_impl.h
+++ b/score/mw/com/impl/plumbing/skeleton_event_binding_factory_impl.h
@@ -13,17 +13,16 @@
 #ifndef SCORE_MW_COM_IMPL_PLUMBING_SKELETON_EVENT_BINDING_FACTORY_IMPL_H
 #define SCORE_MW_COM_IMPL_PLUMBING_SKELETON_EVENT_BINDING_FACTORY_IMPL_H
 
-#include "score/mw/com/impl/bindings/lola/element_fq_id.h"
 #include "score/mw/com/impl/bindings/lola/skeleton_event.h"
 #include "score/mw/com/impl/instance_identifier.h"
 #include "score/mw/com/impl/plumbing/i_skeleton_event_binding_factory.h"
 #include "score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_impl.h"
-#include "score/mw/com/impl/skeleton_base.h"
 #include "score/mw/com/impl/skeleton_event_binding.h"
 
 #include <score/assert.hpp>
 
 #include <memory>
+#include <optional>
 #include <string_view>
 
 namespace score::mw::com::impl
@@ -54,9 +53,11 @@ auto SkeletonEventBindingFactoryImpl<SampleType>::Create(const InstanceIdentifie
                                                          const std::string_view event_name) noexcept
     -> std::unique_ptr<SkeletonEventBinding<SampleType>>
 {
+    const std::optional<FieldTagsStore> empty_field_tags_store{};
     return CreateSkeletonEventOrField<SkeletonEventBinding<SampleType>,
                                       lola::SkeletonEvent<SampleType>,
-                                      ServiceElementType::EVENT>(identifier, parent_binding, event_name, false);
+                                      ServiceElementType::EVENT>(
+        identifier, parent_binding, event_name, empty_field_tags_store);
 }
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/skeleton_event_binding_factory_test.cpp
+++ b/score/mw/com/impl/plumbing/skeleton_event_binding_factory_test.cpp
@@ -10,7 +10,88 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-// Unit tests for SkeletonEventBindingFactory are implemented in skeleton_service_element_binding_factory_test.cpp. We
-// do this since the tests for SkeletonEventBindingFactory and SkeletonFieldBindingFactory are almost identical, so we
-// create templated tests in skeleton_service_element_binding_factory_test.cpp. Any tests which are only relevant to
-// SkeletonEventBindingFactory and NOT SkeletonFieldBindingFactory can be added here.
+// Unit tests for SkeletonEventBindingFactory which are identical to tests for SkeletonFieldBindingFactory are
+// implemented in skeleton_service_element_binding_factory_test.cpp. We do this to minimise code duplication by creating
+// templated tests in skeleton_service_element_binding_factory_test.cpp. The tests which are only relevant to
+// SkeletonEventBindingFactory and NOT SkeletonFieldBindingFactory are added here.
+
+#include "score/mw/com/impl/plumbing/skeleton_event_binding_factory.h"
+#include "score/mw/com/impl/bindings/lola/skeleton_event_common.h"
+#include "score/mw/com/impl/bindings/lola/skeleton_event_properties.h"
+#include "score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h"
+#include "score/mw/com/impl/configuration/test/configuration_store.h"
+
+#include <gtest/gtest.h>
+
+namespace score::mw::com::impl
+{
+
+namespace lola
+{
+
+template <typename SampleType>
+class SkeletonEventAttorney
+{
+  public:
+    static const SkeletonEventProperties& GetSkeletonEventProperties(const SkeletonEvent<SampleType>& skeleton_event)
+    {
+        return skeleton_event.skeleton_event_common_.GetEventProperties();
+    }
+};
+
+}  // namespace lola
+
+namespace
+{
+
+using TestSampleType = std::uint32_t;
+
+constexpr auto kDummyEventName{"Event1"};
+constexpr std::uint16_t kDummyEventId{5U};
+
+constexpr std::size_t kNumberOfConfiguredSlots{5U};
+constexpr std::size_t kNumberOfConfiguredTracingSlots{3U};
+
+constexpr uint16_t kInstanceId = 0x31U;
+const LolaServiceId kServiceId{1U};
+const auto kInstanceSpecifier = InstanceSpecifier::Create(std::string{"/my_dummy_instance_specifier"}).value();
+
+const LolaServiceInstanceDeployment kLolaServiceInstanceDeployment{
+    LolaServiceInstanceId{kInstanceId},
+    {{kDummyEventName,
+      LolaEventInstanceDeployment{{kNumberOfConfiguredSlots}, {3U}, 1U, true, kNumberOfConfiguredTracingSlots}}},
+    {}};
+const LolaServiceTypeDeployment kLolaServiceTypeDeployment{kServiceId, {{kDummyEventName, kDummyEventId}}, {}};
+
+ConfigurationStore kConfigStoreAsilQM{kInstanceSpecifier,
+                                      make_ServiceIdentifierType("/a/service/somewhere/out/there", 13U, 37U),
+                                      QualityType::kASIL_QM,
+                                      kLolaServiceTypeDeployment,
+                                      kLolaServiceInstanceDeployment};
+
+class SkeletonEventBindingFactoryFixture : public lola::SkeletonMockedMemoryFixture
+{
+};
+
+TEST_F(SkeletonEventBindingFactoryFixture, CreatingEventBindingCreatesBindingWithConfiguredNumberOfEvents)
+{
+    // Given a fake Skeleton that uses a lola binding
+    const auto& instance_identifier = kConfigStoreAsilQM.GetInstanceIdentifier();
+    InitialiseSkeleton(instance_identifier);
+
+    // When creating a SkeletonEventBinding
+    auto skeleton_event_binding = SkeletonEventBindingFactory<TestSampleType>::Create(
+        kConfigStoreAsilQM.GetInstanceIdentifier(), *skeleton_, kDummyEventName);
+
+    // Then the created lola binding has the expected number of events in SkeletonEventProperties
+    auto skeleton_event_lola_binding = dynamic_cast<lola::SkeletonEvent<TestSampleType>*>(skeleton_event_binding.get());
+    ASSERT_NE(skeleton_event_lola_binding, nullptr);
+    const auto skeleton_event_properties =
+        lola::SkeletonEventAttorney<TestSampleType>::GetSkeletonEventProperties(*skeleton_event_lola_binding);
+    EXPECT_EQ(skeleton_event_properties.GetTotalNumberOfSlots(),
+              kNumberOfConfiguredSlots + kNumberOfConfiguredTracingSlots);
+    EXPECT_EQ(skeleton_event_properties.GetNumberOfFieldGetterSlots(), 0U);
+}
+
+}  // namespace
+}  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/skeleton_field_binding_factory.h
+++ b/score/mw/com/impl/plumbing/skeleton_field_binding_factory.h
@@ -16,6 +16,7 @@
 #include "score/mw/com/impl/bindings/lola/element_fq_id.h"
 #include "score/mw/com/impl/bindings/lola/skeleton_event.h"
 #include "score/mw/com/impl/configuration/service_type_deployment.h"
+#include "score/mw/com/impl/field_tags.h"
 #include "score/mw/com/impl/instance_identifier.h"
 #include "score/mw/com/impl/plumbing/i_skeleton_field_binding_factory.h"
 #include "score/mw/com/impl/plumbing/skeleton_field_binding_factory_impl.h"
@@ -39,9 +40,10 @@ class SkeletonFieldBindingFactory final
     /// \brief See documentation in ISkeletonFieldBindingFactory.
     static std::unique_ptr<SkeletonEventBinding<SampleType>> CreateEventBinding(const InstanceIdentifier& identifier,
                                                                                 SkeletonBinding& parent_binding,
-                                                                                const std::string_view field_name)
+                                                                                const std::string_view field_name,
+                                                                                const FieldTagsStore field_tags_store)
     {
-        return instance().CreateEventBinding(identifier, parent_binding, field_name);
+        return instance().CreateEventBinding(identifier, parent_binding, field_name, field_tags_store);
     }
 
     /// \brief Inject a mock ISkeletonFieldBindingFactory. If a mock is injected, then all calls on

--- a/score/mw/com/impl/plumbing/skeleton_field_binding_factory_impl.h
+++ b/score/mw/com/impl/plumbing/skeleton_field_binding_factory_impl.h
@@ -15,13 +15,17 @@
 
 #include "score/mw/com/impl/bindings/lola/element_fq_id.h"
 #include "score/mw/com/impl/bindings/lola/skeleton_event.h"
+#include "score/mw/com/impl/bindings/lola/skeleton_event_properties.h"
+#include "score/mw/com/impl/field_tags.h"
 #include "score/mw/com/impl/instance_identifier.h"
 #include "score/mw/com/impl/plumbing/i_skeleton_field_binding_factory.h"
 #include "score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_impl.h"
 #include "score/mw/com/impl/skeleton_base.h"
 #include "score/mw/com/impl/skeleton_event_binding.h"
 
+#include <cstdint>
 #include <memory>
+#include <optional>
 #include <string_view>
 
 namespace score::mw::com::impl
@@ -36,7 +40,8 @@ class SkeletonFieldBindingFactoryImpl : public ISkeletonFieldBindingFactory<Samp
     std::unique_ptr<SkeletonEventBinding<SampleType>> CreateEventBinding(
         const InstanceIdentifier& identifier,
         SkeletonBinding& parent_binding,
-        const std::string_view field_name) noexcept override;
+        const std::string_view field_name,
+        const FieldTagsStore field_tags_store) noexcept override;
 };
 
 template <typename SampleType>
@@ -50,14 +55,14 @@ template <typename SampleType>
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
 auto SkeletonFieldBindingFactoryImpl<SampleType>::CreateEventBinding(const InstanceIdentifier& identifier,
                                                                      SkeletonBinding& parent_binding,
-                                                                     const std::string_view field_name) noexcept
+                                                                     const std::string_view field_name,
+                                                                     const FieldTagsStore field_tags_store) noexcept
     -> std::unique_ptr<SkeletonEventBinding<SampleType>>
 {
-    // TODO: Currently field_getter_enabled is hard coded to false, will add support
-    //  when getter functionality of field is implemented.
     return CreateSkeletonEventOrField<SkeletonEventBinding<SampleType>,
                                       lola::SkeletonEvent<SampleType>,
-                                      ServiceElementType::FIELD>(identifier, parent_binding, field_name, false);
+                                      ServiceElementType::FIELD>(
+        identifier, parent_binding, field_name, field_tags_store);
 }
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/skeleton_field_binding_factory_mock.h
+++ b/score/mw/com/impl/plumbing/skeleton_field_binding_factory_mock.h
@@ -13,6 +13,7 @@
 #ifndef SCORE_MW_COM_IMPL_PLUMBING_SKELETON_FIELD_BINDING_FACTORY_MOCK_H
 #define SCORE_MW_COM_IMPL_PLUMBING_SKELETON_FIELD_BINDING_FACTORY_MOCK_H
 
+#include "score/mw/com/impl/field_tags.h"
 #include "score/mw/com/impl/plumbing/i_skeleton_field_binding_factory.h"
 
 #include <gmock/gmock.h>
@@ -26,7 +27,7 @@ class SkeletonFieldBindingFactoryMock : public ISkeletonFieldBindingFactory<Samp
   public:
     MOCK_METHOD(std::unique_ptr<SkeletonEventBinding<SampleType>>,
                 CreateEventBinding,
-                (const InstanceIdentifier&, SkeletonBinding&, const std::string_view),
+                (const InstanceIdentifier&, SkeletonBinding&, const std::string_view, const FieldTagsStore),
                 (noexcept, override));
 };
 

--- a/score/mw/com/impl/plumbing/skeleton_field_binding_factory_test.cpp
+++ b/score/mw/com/impl/plumbing/skeleton_field_binding_factory_test.cpp
@@ -10,7 +10,149 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-// Unit tests for SkeletonFieldBindingFactory are implemented in skeleton_service_element_binding_factory_test.cpp. We
-// do this since the tests for SkeletonFieldBindingFactory and SkeletonEventBindingFactory are almost identical, so we
-// create templated tests in skeleton_service_element_binding_factory_test.cpp. Any tests which are only relevant to
-// SkeletonFieldBindingFactory and NOT SkeletonEventBindingFactory can be added here.
+// Unit tests for SkeletonFieldBindingFactory which are identical to tests for SkeletonEventBindingFactory are
+// implemented in skeleton_service_element_binding_factory_test.cpp. We do this to minimise code duplication by creating
+// templated tests in skeleton_service_element_binding_factory_test.cpp. The tests which are only relevant to
+// SkeletonFieldBindingFactory and NOT SkeletonEventBindingFactory are added here.
+
+#include "score/mw/com/impl/plumbing/skeleton_field_binding_factory.h"
+#include "score/mw/com/impl/bindings/lola/skeleton_event_common.h"
+#include "score/mw/com/impl/bindings/lola/skeleton_event_properties.h"
+#include "score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h"
+#include "score/mw/com/impl/configuration/test/configuration_store.h"
+
+#include <gtest/gtest.h>
+
+namespace score::mw::com::impl
+{
+
+namespace lola
+{
+
+template <typename SampleType>
+class SkeletonEventAttorney
+{
+  public:
+    static const SkeletonEventProperties& GetSkeletonEventProperties(const SkeletonEvent<SampleType>& skeleton_event)
+    {
+        return skeleton_event.skeleton_event_common_.GetEventProperties();
+    }
+};
+
+}  // namespace lola
+
+namespace
+{
+
+using TestSampleType = std::uint32_t;
+
+constexpr std::size_t kNumberOfConfiguredSlots{5U};
+constexpr std::size_t kNumberOfConfiguredTracingSlots{3U};
+constexpr std::size_t kExpectedAdditionalGetterSlots{1U};
+constexpr std::size_t kExpectedAdditionalSetterSlots{1U};
+
+constexpr auto kDummyFieldName{"Field1"};
+constexpr std::uint16_t kDummyFieldId{6U};
+
+constexpr uint16_t kInstanceId = 0x31U;
+const LolaServiceId kServiceId{1U};
+const auto kInstanceSpecifier = InstanceSpecifier::Create(std::string{"/my_dummy_instance_specifier"}).value();
+
+const LolaServiceInstanceDeployment kLolaServiceInstanceDeployment{
+    LolaServiceInstanceId{kInstanceId},
+    {},
+    {{kDummyFieldName,
+      LolaFieldInstanceDeployment{
+          LolaEventInstanceDeployment{{kNumberOfConfiguredSlots}, {3U}, 1U, true, kNumberOfConfiguredTracingSlots},
+          false,
+          false}}}};
+const LolaServiceTypeDeployment kLolaServiceTypeDeployment{kServiceId, {}, {{kDummyFieldName, kDummyFieldId}}};
+
+ConfigurationStore kConfigStoreAsilQM{kInstanceSpecifier,
+                                      make_ServiceIdentifierType("/a/service/somewhere/out/there", 13U, 37U),
+                                      QualityType::kASIL_QM,
+                                      kLolaServiceTypeDeployment,
+                                      kLolaServiceInstanceDeployment};
+
+struct TestParams
+{
+    FieldTagsStore field_tags;
+    std::size_t expected_total_number_of_slots;
+    std::size_t expected_number_of_getter_slots;
+};
+
+class SkeletonFieldBindingFactoryParamaterisedFixture : public lola::SkeletonMockedMemoryFixture,
+                                                        public ::testing::WithParamInterface<TestParams>
+{
+};
+
+INSTANTIATE_TEST_CASE_P(
+    SkeletonFieldBindingFactoryParamaterisedFixture,
+    SkeletonFieldBindingFactoryParamaterisedFixture,
+    ::testing::Values(
+        TestParams{FieldTagsStore::Create<WithNotifier>(),
+                   kNumberOfConfiguredSlots + kNumberOfConfiguredTracingSlots,
+                   0U},
+        TestParams{FieldTagsStore::Create<WithGetter>(),
+                   kNumberOfConfiguredSlots + kNumberOfConfiguredTracingSlots + kExpectedAdditionalGetterSlots,
+                   kExpectedAdditionalGetterSlots},
+        TestParams{FieldTagsStore::Create<WithNotifier, WithGetter>(),
+                   kNumberOfConfiguredSlots + kNumberOfConfiguredTracingSlots + kExpectedAdditionalGetterSlots,
+                   kExpectedAdditionalGetterSlots},
+        TestParams{FieldTagsStore::Create<WithNotifier, WithSetter>(),
+                   kNumberOfConfiguredSlots + kNumberOfConfiguredTracingSlots + kExpectedAdditionalSetterSlots,
+                   0U},
+        TestParams{FieldTagsStore::Create<WithGetter, WithSetter>(),
+                   kNumberOfConfiguredSlots + kNumberOfConfiguredTracingSlots + kExpectedAdditionalGetterSlots +
+                       kExpectedAdditionalSetterSlots,
+                   kExpectedAdditionalGetterSlots},
+        TestParams{FieldTagsStore::Create<WithNotifier, WithGetter, WithSetter>(),
+                   kNumberOfConfiguredSlots + kNumberOfConfiguredTracingSlots + kExpectedAdditionalGetterSlots +
+                       kExpectedAdditionalSetterSlots,
+                   kExpectedAdditionalGetterSlots}));
+
+TEST_P(SkeletonFieldBindingFactoryParamaterisedFixture, CreatingWithNotifierCreatesBindingWithConfiguredNumberOfSlots)
+{
+    const auto field_tags = GetParam().field_tags;
+    const auto expected_number_of_slots = GetParam().expected_total_number_of_slots;
+    const auto expected_number_of_getter_slots = GetParam().expected_number_of_getter_slots;
+
+    // Given a fake Skeleton that uses a lola binding
+    const auto& instance_identifier = kConfigStoreAsilQM.GetInstanceIdentifier();
+    InitialiseSkeleton(instance_identifier);
+
+    // When creating a SkeletonFieldBinding with specific field tags
+    auto skeleton_field_binding = SkeletonFieldBindingFactory<TestSampleType>::CreateEventBinding(
+        kConfigStoreAsilQM.GetInstanceIdentifier(), *skeleton_, kDummyFieldName, field_tags);
+
+    // Then the created lola binding has the expected number of slots
+    auto skeleton_field_lola_binding = dynamic_cast<lola::SkeletonEvent<TestSampleType>*>(skeleton_field_binding.get());
+    ASSERT_NE(skeleton_field_lola_binding, nullptr);
+    const auto skeleton_event_properties =
+        lola::SkeletonEventAttorney<TestSampleType>::GetSkeletonEventProperties(*skeleton_field_lola_binding);
+    EXPECT_EQ(skeleton_event_properties.GetTotalNumberOfSlots(), expected_number_of_slots);
+    EXPECT_EQ(skeleton_event_properties.GetNumberOfFieldGetterSlots(), expected_number_of_getter_slots);
+}
+
+class SkeletonFieldBindingFactoryFixture : public lola::SkeletonMockedMemoryFixture
+{
+};
+
+TEST_F(SkeletonFieldBindingFactoryFixture, CreatingWithoutNotifierOrGetterTerminates)
+{
+    // Given a fake Skeleton that uses a lola binding
+    const auto& instance_identifier = kConfigStoreAsilQM.GetInstanceIdentifier();
+    InitialiseSkeleton(instance_identifier);
+
+    // When creating a SkeletonFieldBinding without notifier or getter
+    // Then the program terminates
+    EXPECT_DEATH(score::cpp::ignore = SkeletonFieldBindingFactory<TestSampleType>::CreateEventBinding(
+                     kConfigStoreAsilQM.GetInstanceIdentifier(),
+                     *skeleton_,
+                     kDummyFieldName,
+                     FieldTagsStore::Create<WithSetter>()),
+                 ".*");
+}
+
+}  // namespace
+}  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_impl.h
+++ b/score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_impl.h
@@ -15,11 +15,13 @@
 
 #include "score/mw/com/impl/bindings/lola/element_fq_id.h"
 #include "score/mw/com/impl/bindings/lola/skeleton.h"
+#include "score/mw/com/impl/bindings/lola/skeleton_event_common.h"
 #include "score/mw/com/impl/bindings/lola/skeleton_event_properties.h"
 #include "score/mw/com/impl/configuration/binding_service_type_deployment.h"
 #include "score/mw/com/impl/configuration/lola_service_instance_deployment.h"
 #include "score/mw/com/impl/configuration/service_instance_deployment.h"
 #include "score/mw/com/impl/data_type_meta_info.h"
+#include "score/mw/com/impl/field_tags_store.h"
 #include "score/mw/com/impl/skeleton_base.h"
 #include "score/mw/com/impl/tracing/skeleton_event_tracing_data.h"
 
@@ -30,8 +32,10 @@
 #include <score/overload.hpp>
 
 #include <chrono>
+#include <cstdint>
 #include <exception>
 #include <memory>
+#include <optional>
 #include <string>
 #include <string_view>
 #include <thread>
@@ -43,33 +47,68 @@ namespace score::mw::com::impl
 namespace detail
 {
 
-inline lola::SkeletonEventProperties GetSkeletonEventProperties(
-    const LolaEventInstanceDeployment& lola_event_instance_deployment)
+/// \brief Creates a SkeletonEventProperties object from the configuration and field tags (for a field)
+///
+/// For an event, the number of slots and max subscribers comes purely from the configuration. For a field, we also take
+/// into account the field tags when calculating the number of slots that are needed.
+inline lola::SkeletonEventProperties CreateSkeletonEventProperties(
+    const LolaEventInstanceDeployment& lola_event_instance_deployment,
+    const std::optional<FieldTagsStore> field_tags_store)
 {
-    if (!lola_event_instance_deployment.GetNumberOfSampleSlots().has_value())
+    std::size_t max_subscribers{0U};
+
+    if (!lola_event_instance_deployment.GetNumberOfSampleSlotsExcludingTracingSlot().has_value())
     {
-        score::mw::log::LogFatal("lola")
-            << "Could not create SkeletonEventProperties from ServiceElementInstanceDeployment. Number of sample slots "
-               "was not specified in the configuration. Terminating.";
+        score::mw::log::LogFatal("lola") << "Could not create SkeletonEventProperties from "
+                                            "ServiceElementInstanceDeployment. Number of sample slots "
+                                            "was not specified in the configuration. Terminating.";
         std::terminate();
+    }
+    const auto number_of_slots = lola_event_instance_deployment.GetNumberOfSampleSlotsExcludingTracingSlot().value();
+
+    // If we are creating SkeletonEventProperties for an event of for a field with a notifier, then the user must
+    // provide the number of slots and number of subscribers in the configuration.
+    const bool is_event = !field_tags_store.has_value();
+    const bool is_field_with_subscription_semantics = !is_event && field_tags_store->HasNotifier();
+    if (is_field_with_subscription_semantics || is_event)
+    {
+        if (!lola_event_instance_deployment.max_subscribers_.has_value())
+        {
+            score::mw::log::LogFatal("lola") << "Could not create SkeletonEventProperties from "
+                                                "ServiceElementInstanceDeployment. Max subscribers was "
+                                                "not specified in the configuration. Terminating.";
+            std::terminate();
+        }
+
+        max_subscribers = lola_event_instance_deployment.max_subscribers_.value();
+    }
+    else
+    {
+        if (lola_event_instance_deployment.max_subscribers_.has_value())
+        {
+            score::mw::log::LogWarn("lola") << "Field has WithNotifier disabled; configured maxSubscribers is ignored.";
+        }
     }
 
-    if (!lola_event_instance_deployment.max_subscribers_.has_value())
-    {
-        score::mw::log::LogFatal("lola")
-            << "Could not create SkeletonEventProperties from ServiceElementInstanceDeployment. Max subscribers was "
-               "not specified in the configuration. Terminating.";
-        std::terminate();
-    }
-    return lola::SkeletonEventProperties{lola_event_instance_deployment.GetNumberOfSampleSlots().value(),
-                                         lola_event_instance_deployment.max_subscribers_.value(),
+    const bool is_getter_enabled = !is_event && field_tags_store->HasGetter();
+    const auto number_of_field_getter_slots = is_getter_enabled ? lola::kMaxConcurrentFieldGetterSamplePtrs : 0U;
+
+    const bool is_setter_enabled = !is_event && field_tags_store->HasSetter();
+
+    return lola::SkeletonEventProperties{number_of_slots,
+                                         lola_event_instance_deployment.GetNumberOfTracingSlots(),
+                                         number_of_field_getter_slots,
+                                         is_setter_enabled,
+                                         max_subscribers,
                                          lola_event_instance_deployment.enforce_max_samples_};
 }
 
-inline lola::SkeletonEventProperties GetSkeletonEventProperties(
-    const LolaFieldInstanceDeployment& lola_field_instance_deployment)
+inline lola::SkeletonEventProperties CreateSkeletonEventProperties(
+    const LolaFieldInstanceDeployment& lola_field_instance_deployment,
+    const std::optional<FieldTagsStore> field_tags_store)
 {
-    return GetSkeletonEventProperties(lola_field_instance_deployment.lola_event_instance_deployment_);
+    return CreateSkeletonEventProperties(lola_field_instance_deployment.lola_event_instance_deployment_,
+                                         field_tags_store);
 }
 
 }  // namespace detail
@@ -86,15 +125,29 @@ template <typename SkeletonServiceElementBinding, typename SkeletonServiceElemen
 auto CreateSkeletonEventOrField(const InstanceIdentifier& identifier,
                                 SkeletonBinding& parent_binding,
                                 const std::string_view service_element_name,
-                                bool field_getter_enabled) noexcept -> std::unique_ptr<SkeletonServiceElementBinding>
+                                std::optional<FieldTagsStore> field_tags_store) noexcept
+    -> std::unique_ptr<SkeletonServiceElementBinding>
 {
     static_assert((element_type == ServiceElementType::EVENT) || (element_type == ServiceElementType::FIELD));
+    if constexpr (element_type == ServiceElementType::FIELD)
+    {
+        SCORE_LANGUAGE_FUTURECPP_PRECONDITION(field_tags_store.has_value());
+    }
+    else if constexpr (element_type == ServiceElementType::EVENT)
+    {
+        SCORE_LANGUAGE_FUTURECPP_PRECONDITION(!field_tags_store.has_value());
+    }
+
+    if (field_tags_store.has_value())
+    {
+        SCORE_LANGUAGE_FUTURECPP_PRECONDITION(field_tags_store->HasGetter() || field_tags_store->HasNotifier());
+    }
 
     const InstanceIdentifierView identifier_view{identifier};
 
     using ReturnType = std::unique_ptr<SkeletonServiceElementBinding>;
     auto visitor = score::cpp::overload(
-        [identifier_view, &parent_binding, &service_element_name, field_getter_enabled](
+        [identifier_view, &parent_binding, &service_element_name, field_tags_store](
             const LolaServiceTypeDeployment& lola_service_type_deployment) -> ReturnType {
             auto* const lola_parent = dynamic_cast<lola::Skeleton*>(&parent_binding);
             if (lola_parent == nullptr)
@@ -111,8 +164,9 @@ auto CreateSkeletonEventOrField(const InstanceIdentifier& identifier,
             const std::string service_element_name_str{service_element_name};
             const auto& lola_service_element_instance_deployment = GetServiceElementInstanceDeployment<element_type>(
                 lola_service_instance_deployment, service_element_name_str);
+
             const lola::SkeletonEventProperties skeleton_event_properties =
-                detail::GetSkeletonEventProperties(lola_service_element_instance_deployment);
+                detail::CreateSkeletonEventProperties(lola_service_element_instance_deployment, field_tags_store);
 
             const auto lola_service_element_id =
                 GetServiceElementId<element_type>(lola_service_type_deployment, service_element_name_str);
@@ -125,8 +179,7 @@ auto CreateSkeletonEventOrField(const InstanceIdentifier& identifier,
                                                             element_fq_id,
                                                             service_element_name,
                                                             skeleton_event_properties,
-                                                            impl::tracing::SkeletonEventTracingData{},
-                                                            field_getter_enabled);
+                                                            impl::tracing::SkeletonEventTracingData{});
         },
         [](const score::cpp::blank&) noexcept -> ReturnType {
             return nullptr;
@@ -166,8 +219,10 @@ auto CreateGenericSkeletonEventOrField(const InstanceIdentifier& identifier,
 
             const auto& lola_service_element_instance_deployment = GetServiceElementInstanceDeployment<element_type>(
                 lola_service_instance_deployment, std::string{service_element_name});
-            const lola::SkeletonEventProperties skeleton_event_properties =
-                detail::GetSkeletonEventProperties(lola_service_element_instance_deployment);
+
+            // TODO: Pass in the FieldAbilities when GenericSkeletonFields are implemented.
+            const lola::SkeletonEventProperties skeleton_event_properties = detail::CreateSkeletonEventProperties(
+                lola_service_element_instance_deployment, std::optional<FieldTagsStore>{});
 
             const auto lola_service_element_id =
                 GetServiceElementId<element_type>(lola_service_type_deployment, std::string{service_element_name});

--- a/score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_test.cpp
+++ b/score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_test.cpp
@@ -16,7 +16,6 @@
 #include "score/mw/com/impl/configuration/lola_service_instance_deployment.h"
 #include "score/mw/com/impl/configuration/test/configuration_store.h"
 #include "score/mw/com/impl/instance_identifier.h"
-#include "score/mw/com/impl/plumbing/skeleton_binding_factory.h"
 #include "score/mw/com/impl/plumbing/skeleton_event_binding_factory.h"
 #include "score/mw/com/impl/plumbing/skeleton_field_binding_factory.h"
 #include "score/mw/com/impl/service_element_type.h"
@@ -26,7 +25,9 @@
 #include <gtest/gtest.h>
 #include <cstdint>
 #include <memory>
+#include <optional>
 #include <string>
+#include <string_view>
 
 namespace score::mw::com::impl
 {
@@ -98,7 +99,10 @@ class SkeletonServiceElementBindingFactoryParamaterisedFixture
                     instance_identifier, skeleton_binding, kDummyEventName);
             case ServiceElementType::FIELD:
                 return SkeletonFieldBindingFactory<TestSampleType>::CreateEventBinding(
-                    instance_identifier, skeleton_binding, kDummyFieldName);
+                    instance_identifier,
+                    skeleton_binding,
+                    kDummyFieldName,
+                    FieldTagsStore::Create<WithNotifier, WithGetter>());
             case ServiceElementType::METHOD:
             case ServiceElementType::INVALID:
             default:

--- a/score/mw/com/impl/skeleton_base_test.cpp
+++ b/score/mw/com/impl/skeleton_base_test.cpp
@@ -117,7 +117,7 @@ class SkeletonBaseFixture : public ::testing::Test
                     Create(instance_identifier, _, kDummyEventName2))
             .WillOnce(Return(ByMove(std::move(skeleton_event_mock_ptr_2))));
         EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_,
-                    CreateEventBinding(instance_identifier, _, kDummyFieldName))
+                    CreateEventBinding(instance_identifier, _, kDummyFieldName, _))
             .WillOnce(Return(ByMove(std::move(skeleton_field_mock_ptr))));
 
         EXPECT_CALL(*event_binding_mock_1_, GetBindingType()).WillOnce(Return(BindingType::kLoLa));
@@ -620,7 +620,7 @@ TEST_F(SkeletonBaseOfferFixture, NoStopOfferOnErrorIdentifier)
                 Create(instance_identifier, _, kDummyEventName2))
         .Times(0);
     EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_,
-                CreateEventBinding(GetInstanceIdentifierWithoutBinding(), _, kDummyFieldName))
+                CreateEventBinding(GetInstanceIdentifierWithoutBinding(), _, kDummyFieldName, _))
         .Times(0);
 
     // Given a constructed Skeleton with a invalid identifier

--- a/score/mw/com/impl/skeleton_field.h
+++ b/score/mw/com/impl/skeleton_field.h
@@ -239,13 +239,15 @@ class SkeletonFieldImpl : public SkeletonFieldBase
     static std::unique_ptr<SkeletonEvent<FieldType>> MakeSkeletonEvent(SkeletonBase& parent,
                                                                        const std::string_view field_name)
     {
-        // No kHasNotifier: the SkeletonEvent is always built because it provides Update/Allocate.
         const SkeletonBaseView skeleton_base_view{parent};
         return std::make_unique<SkeletonEvent<FieldType>>(
             parent,
             field_name,
             SkeletonFieldBindingFactory<SampleDataType>::CreateEventBinding(
-                skeleton_base_view.GetAssociatedInstanceIdentifier(), skeleton_base_view.GetBinding(), field_name),
+                skeleton_base_view.GetAssociatedInstanceIdentifier(),
+                skeleton_base_view.GetBinding(),
+                field_name,
+                FieldTagsStore::Create<Tags...>()),
             typename SkeletonEvent<FieldType>::FieldOnlyConstructorEnabler{});
     }
 

--- a/score/mw/com/impl/skeleton_field_test.cpp
+++ b/score/mw/com/impl/skeleton_field_test.cpp
@@ -28,6 +28,7 @@
 #include <cstdint>
 #include <functional>
 #include <memory>
+#include <optional>
 #include <string_view>
 #include <type_traits>
 #include <utility>
@@ -92,7 +93,7 @@ class SkeletonFieldTestFixture : public ::testing::Test
     void SetUp() override
     {
         ON_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_,
-                CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName))
+                CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName, _))
             .WillByDefault(InvokeWithoutArgs([this]() {
                 return std::make_unique<mock_binding::SkeletonEventFacade<TestSampleType>>(
                     skeleton_field_binding_mock_);
@@ -173,6 +174,79 @@ TEST(SkeletonFieldTest, SkeletonFieldContainsPublicSampleType)
     static_assert(std::is_same<typename SkeletonField<TestSampleType, WithGetter, WithNotifier, WithSetter>::FieldType,
                                TestSampleType>::value,
                   "Incorrect FieldType.");
+}
+
+using SkeletonFieldCreationFixture = SkeletonFieldTestFixture;
+TEST_F(SkeletonFieldCreationFixture, CreatingFieldWithNotifierCallsFactoryWithNotifier)
+{
+    // Expect that the factory is called with WithNotifier
+    EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_,
+                CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName, FieldTagsStore::Create<WithNotifier>()));
+
+    // When creating a SkeletonField with WithNotifier
+    SkeletonBase skeleton{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
+    SkeletonField<TestSampleType, WithNotifier> my_dummy_field{skeleton, kFieldName};
+}
+
+TEST_F(SkeletonFieldCreationFixture, CreatingFieldWithGetterCallsFactoryWithGetter)
+{
+    // Expect that the factory is called with WithGetter
+    EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_,
+                CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName, FieldTagsStore::Create<WithGetter>()));
+
+    // When creating a SkeletonField with WithGetter
+    SkeletonBase skeleton{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
+    SkeletonField<TestSampleType, WithGetter> my_dummy_field{skeleton, kFieldName};
+}
+
+TEST_F(SkeletonFieldCreationFixture, CreatingFieldWithNotifierAndSetterCallsFactoryWithNotifierAndSetter)
+{
+    // Expect that the factory is called with WithNotifier and WithSetter
+    EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_,
+                CreateEventBinding(
+                    kInstanceIdWithLolaBinding, _, kFieldName, FieldTagsStore::Create<WithNotifier, WithSetter>()));
+
+    // When creating a SkeletonField with WithNotifier and WithSetter
+    SkeletonBase skeleton{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
+    SkeletonField<TestSampleType, WithNotifier, WithSetter> my_dummy_field{skeleton, kFieldName};
+}
+
+TEST_F(SkeletonFieldCreationFixture, CreatingFieldWithGetterAndSetterCallsFactoryWithGetterAndSetter)
+{
+    // Expect that the factory is called with WithGetter and WithSetter
+    EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_,
+                CreateEventBinding(
+                    kInstanceIdWithLolaBinding, _, kFieldName, FieldTagsStore::Create<WithGetter, WithSetter>()));
+
+    // When creating a SkeletonField with WithGetter and WithSetter
+    SkeletonBase skeleton{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
+    SkeletonField<TestSampleType, WithGetter, WithSetter> my_dummy_field{skeleton, kFieldName};
+}
+
+TEST_F(SkeletonFieldCreationFixture, CreatingFieldWithNotifierAndGetterCallsFactoryWithNotifierAndGetter)
+{
+    // Expect that the factory is called with WithNotifier and WithGetter
+    EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_,
+                CreateEventBinding(
+                    kInstanceIdWithLolaBinding, _, kFieldName, FieldTagsStore::Create<WithNotifier, WithGetter>()));
+
+    // When creating a SkeletonField with WithNotifier and WithGetter
+    SkeletonBase skeleton{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
+    SkeletonField<TestSampleType, WithNotifier, WithGetter> my_dummy_field{skeleton, kFieldName};
+}
+
+TEST_F(SkeletonFieldCreationFixture,
+       CreatingFieldWithNotifierAndGetterAndSetterCallsFactoryWithNotifierAndGetterAndSetter)
+{
+    // Expect that the factory is called with WithNotifier, WithGetter and WithSetter
+    EXPECT_CALL(
+        skeleton_field_binding_factory_mock_guard_.factory_mock_,
+        CreateEventBinding(
+            kInstanceIdWithLolaBinding, _, kFieldName, FieldTagsStore::Create<WithNotifier, WithGetter, WithSetter>()));
+
+    // When creating a SkeletonField with WithNotifier, WithGetter and WithSetter
+    SkeletonBase skeleton{std::make_unique<mock_binding::Skeleton>(), kInstanceIdWithLolaBinding};
+    SkeletonField<TestSampleType, WithNotifier, WithGetter, WithSetter> my_dummy_field{skeleton, kFieldName};
 }
 
 // When Ticket-104261 is implemented, the Update call does not have to be deferred until OfferService is called. This
@@ -694,7 +768,7 @@ TEST(SkeletonFieldInitialValueTest, MoveAssigningFieldBeforePrepareOfferWillKeep
     auto skeleton_field_binding_mock_ptr = std::make_unique<mock_binding::SkeletonEvent<TestSampleType>>();
     auto& skeleton_field_binding_mock = *skeleton_field_binding_mock_ptr;
     EXPECT_CALL(skeleton_field_binding_factory_mock_guard.factory_mock_,
-                CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName))
+                CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName, _))
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
 
     EXPECT_CALL(skeleton_field_binding_mock, GetBindingType()).WillOnce(Return(BindingType::kLoLa));
@@ -725,7 +799,8 @@ TEST(SkeletonFieldInitialValueTest, MoveAssigningFieldBeforePrepareOfferWillKeep
     // and Expecting that a second SkeletonField binding is created
     auto skeleton_field_binding_mock_ptr_2 = std::make_unique<mock_binding::SkeletonEvent<TestSampleType>>();
     auto& skeleton_field_binding_mock_2 = *skeleton_field_binding_mock_ptr_2;
-    EXPECT_CALL(skeleton_field_binding_factory_mock_guard.factory_mock_, CreateEventBinding(identifier2, _, kFieldName))
+    EXPECT_CALL(skeleton_field_binding_factory_mock_guard.factory_mock_,
+                CreateEventBinding(identifier2, _, kFieldName, _))
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr_2))));
 
     EXPECT_CALL(skeleton_field_binding_mock_2, GetBindingType()).WillOnce(Return(BindingType::kLoLa));
@@ -840,7 +915,7 @@ TEST_F(SkeletonFieldDeathTest, DestroyingSkeletonFieldWhileHoldingSampleAllocate
     auto skeleton_field_binding_mock_ptr = std::make_unique<mock_binding::SkeletonEvent<TestSampleType>>();
     auto& skeleton_field_binding_mock = *skeleton_field_binding_mock_ptr;
     EXPECT_CALL(skeleton_field_binding_factory_mock_guard.factory_mock_,
-                CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName))
+                CreateEventBinding(kInstanceIdWithLolaBinding, _, kFieldName, _))
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
 
     // and that PrepareOffer() is called once on the field binding

--- a/score/mw/com/impl/tracing/test/skeleton_field_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/test/skeleton_field_tracing_test.cpp
@@ -85,7 +85,7 @@ TEST(SkeletonFieldTracingTest, TracePointsAreDisabledIfConfigNotReturnedByRuntim
     // Expecting that a SkeletonField binding is created
     auto skeleton_field_binding_mock_ptr = std::make_unique<mock_binding::SkeletonEvent<TestSampleType>>();
     EXPECT_CALL(skeleton_field_binding_factory_mock_guard.factory_mock_,
-                CreateEventBinding(kInstanceIdentifier, _, kFieldName))
+                CreateEventBinding(kInstanceIdentifier, _, kFieldName, _))
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
     EXPECT_CALL(runtime_mock_guard.runtime_mock_, GetTracingFilterConfig()).WillOnce(Return(nullptr));
 
@@ -125,7 +125,7 @@ TEST_P(SkeletonFieldTracingParamaterisedFixture, TracePointsAreCorrectlySet)
     auto skeleton_field_binding_mock_ptr = std::make_unique<mock_binding::SkeletonEvent<TestSampleType>>();
     auto& skeleton_field_binding_mock = *skeleton_field_binding_mock_ptr;
     EXPECT_CALL(skeleton_field_binding_factory_mock_guard.factory_mock_,
-                CreateEventBinding(kInstanceIdentifier, _, kFieldName))
+                CreateEventBinding(kInstanceIdentifier, _, kFieldName, _))
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
     EXPECT_CALL(runtime_mock_guard.runtime_mock_, GetTracingFilterConfig()).WillOnce(Return(&tracing_mock));
     EXPECT_CALL(runtime_mock_guard.runtime_mock_, GetTracingRuntime()).WillOnce(Return(&tracing_runtime_mock));
@@ -204,7 +204,7 @@ class SkeletonFieldTracingFixture : public ::testing::Test
     {
         auto skeleton_event_binding_mock_ptr = std::make_unique<mock_binding::SkeletonEvent<TestSampleType>>();
         mock_skeleton_field_binding_ = skeleton_event_binding_mock_ptr.get();
-        EXPECT_CALL(factory_mock_guard.factory_mock_, CreateEventBinding(kInstanceIdentifier, _, kFieldName))
+        EXPECT_CALL(factory_mock_guard.factory_mock_, CreateEventBinding(kInstanceIdentifier, _, kFieldName, _))
             .WillOnce(Return(ByMove(std::move(skeleton_event_binding_mock_ptr))));
     }
 

--- a/score/mw/com/impl/traits_test.cpp
+++ b/score/mw/com/impl/traits_test.cpp
@@ -690,7 +690,7 @@ class SkeletonCreationFixture : public ::testing::Test
 
         // By default the Create call on the SkeletonFieldBindingFactory returns valid bindings.
         ON_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_,
-                CreateEventBinding(identifier_with_valid_binding_, _, kFieldName))
+                CreateEventBinding(identifier_with_valid_binding_, _, kFieldName, _))
             .WillByDefault(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
 
         // By default the Create call on the SkeletonMethodBindingFactory returns valid bindings.
@@ -762,7 +762,7 @@ TEST_F(GeneratedSkeletonCreationInstanceSpecifierTestFixture,
                 Create(identifier_with_valid_binding_, _, kEventName))
         .WillOnce(Return(ByMove(std::move(skeleton_event_binding_mock_ptr))));
     EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_,
-                CreateEventBinding(identifier_with_valid_binding_, _, kFieldName))
+                CreateEventBinding(identifier_with_valid_binding_, _, kFieldName, _))
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
     EXPECT_CALL(skeleton_method_binding_factory_mock_guard_.factory_mock_,
                 Create(identifier_with_valid_binding_, _, kFieldName, MethodType::kSet))
@@ -836,7 +836,7 @@ TEST_F(GeneratedSkeletonCreationInstanceSpecifierTestFixture, ReturnErrorWhenCre
 
     // Expecting that the Create call on the SkeletonFieldBindingFactory returns an invalid binding for the field.
     EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_,
-                CreateEventBinding(identifier_with_valid_binding_, _, kFieldName))
+                CreateEventBinding(identifier_with_valid_binding_, _, kFieldName, _))
         .WillOnce(Return(ByMove(nullptr)));
 
     // When constructing a skeleton with an InstanceSpecifier
@@ -915,7 +915,7 @@ TEST_F(GeneratedSkeletonCreationInstanceIdentifierTestFixture, ConstructingFromE
                 Create(identifier_with_valid_binding_, _, kEventName))
         .WillOnce(Return(ByMove(std::move(skeleton_event_binding_mock_ptr))));
     EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_,
-                CreateEventBinding(identifier_with_valid_binding_, _, kFieldName))
+                CreateEventBinding(identifier_with_valid_binding_, _, kFieldName, _))
         .WillOnce(Return(ByMove(std::move(skeleton_field_binding_mock_ptr))));
 
     // When constructing a skeleton with an InstanceIdentifier
@@ -980,7 +980,7 @@ TEST_F(GeneratedSkeletonCreationInstanceIdentifierTestFixture, ConstructingFromI
 
     // Expecting that the Create call on the SkeletonFieldBindingFactory returns an invalid binding for the field.
     EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_,
-                CreateEventBinding(identifier_with_valid_binding_, _, kFieldName))
+                CreateEventBinding(identifier_with_valid_binding_, _, kFieldName, _))
         .WillOnce(Return(ByMove(nullptr)));
 
     // When constructing a skeleton with an InstanceIdentifier
@@ -1151,7 +1151,7 @@ class GeneratedSkeletonStopOfferServiceRaiiFixture : public SkeletonCreationFixt
         EXPECT_CALL(skeleton_event_binding_factory_mock_guard_.factory_mock_, Create(_, _, _))
             .WillOnce(Return(ByMove(
                 std::make_unique<mock_binding::SkeletonEventFacade<TestSampleType>>(skeleton_event_binding_mock_))));
-        EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_, CreateEventBinding(_, _, _))
+        EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_, CreateEventBinding(_, _, _, _))
             .WillOnce(Return(ByMove(
                 std::make_unique<mock_binding::SkeletonEventFacade<TestSampleType>>(skeleton_field_binding_mock_))));
         EXPECT_CALL(skeleton_method_binding_factory_mock_guard_.factory_mock_, Create(_, _, _, MethodType::kSet))
@@ -1169,7 +1169,7 @@ class GeneratedSkeletonStopOfferServiceRaiiFixture : public SkeletonCreationFixt
         EXPECT_CALL(skeleton_event_binding_factory_mock_guard_.factory_mock_, Create(_, _, _))
             .WillOnce(Return(ByMove(
                 std::make_unique<mock_binding::SkeletonEventFacade<TestSampleType>>(skeleton_event_binding_mock_2_))));
-        EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_, CreateEventBinding(_, _, _))
+        EXPECT_CALL(skeleton_field_binding_factory_mock_guard_.factory_mock_, CreateEventBinding(_, _, _, _))
             .WillOnce(Return(ByMove(
                 std::make_unique<mock_binding::SkeletonEventFacade<TestSampleType>>(skeleton_field_binding_mock_2_))));
         EXPECT_CALL(skeleton_method_binding_factory_mock_guard_.factory_mock_, Create(_, _, _, MethodType::kSet))


### PR DESCRIPTION
mw/com: Update event slot size based on field tags

The number of slots required for a field now takes into account the
slot requirements for different combinations of WithNotifier, WithGetter
and WithSetter. These are stored in SkeletonEventProperties which is
passed down to the lola binding. These values are used both to size the
event slot vectors and also by the lola::SkeletonEventCommon to
determine whether a getter was enabled or not. Further details are
documented in score/mw/com/design/events_fields/README.md.

Co-Authored-By: Krishna Satish Deshkulkarni Shankaranarayana <krishna-satish.deshkulkarni-shankaranarayana@bmw.de>