### PR TITLE
fix(service): add proxy_data stub and fix ProvidedServices count trac…

### DIFF
--- a/quality/visibility_guard/public_targets.golden
+++ b/quality/visibility_guard/public_targets.golden
@@ -43,5 +43,6 @@
 //score/mw/service:factory
 //score/mw/service:provided_service
 //score/mw/service:provided_service_container
+//score/mw/service:proxy_data
 //score/mw/service:proxy_future
 //score/mw/service:service

--- a/score/mw/service/BUILD
+++ b/score/mw/service/BUILD
@@ -56,3 +56,13 @@ cc_library(
         ":service",
     ],
 )
+
+cc_library(
+    name = "proxy_data",
+    hdrs = ["proxy_data.h"],
+    features = COMPILER_WARNING_FEATURES,
+    visibility = ["//visibility:public"],
+    deps = [
+        ":service",
+    ],
+)

--- a/score/mw/service/provided_service_container.h
+++ b/score/mw/service/provided_service_container.h
@@ -69,12 +69,14 @@ class ProvidedServices final : public ProvidedServicesBase
     template <typename ServiceType, typename... Args>
     ProvidedServices& Add(Args&&... args) &
     {
+        ++count_;
         return *this;
     }
 
     template <typename ServiceType, typename... Args>
     ProvidedServices&& Add(Args&&... args) &&
     {
+        ++count_;
         return std::move(*this);
     }
 
@@ -168,7 +170,7 @@ class ProvidedServices final : public ProvidedServicesBase
 
     std::size_t Count() const noexcept override
     {
-        return 0;
+        return count_;
     }
 
     /// @brief Start all contained valid service instances
@@ -178,7 +180,13 @@ class ProvidedServices final : public ProvidedServicesBase
     void StopAll() override {}
 
     /// @brief Swap the content of this object with another one
-    void Swap(ProvidedServices& other) noexcept {}
+    void Swap(ProvidedServices& other) noexcept
+    {
+        std::swap(count_, other.count_);
+    }
+
+  private:
+    std::size_t count_{0U};
 };
 
 class ProvidedServiceContainer

--- a/score/mw/service/proxy_data.h
+++ b/score/mw/service/proxy_data.h
@@ -1,0 +1,35 @@
+// *******************************************************************************
+// Copyright (c) 2026 Contributors to the Eclipse Foundation
+//
+// See the NOTICE file(s) distributed with this work for additional
+// information regarding copyright ownership.
+//
+// This program and the accompanying materials are made available under the
+// terms of the Apache License Version 2.0 which is available at
+// https://www.apache.org/licenses/LICENSE-2.0
+//
+// SPDX-License-Identifier: Apache-2.0
+// *******************************************************************************
+
+#ifndef SCORE_MW_SERVICE_PROXY_DATA_H
+#define SCORE_MW_SERVICE_PROXY_DATA_H
+
+#include "score/mw/service/proxy_needs.h"
+
+namespace score
+{
+namespace mw
+{
+namespace service
+{
+
+/// @brief Stub alias for OptionalProxyData — wraps an optional proxy instance.
+/// @tparam T The proxy interface type
+template <typename T>
+using OptionalProxyData = Optional<T>;
+
+}  // namespace service
+}  // namespace mw
+}  // namespace score
+
+#endif  // SCORE_MW_SERVICE_PROXY_DATA_H


### PR DESCRIPTION
Based on v0.2.1 tag:
- Add proxy_data.h: OptionalProxyData<T> alias for Optional<T>
- Add proxy_data cc_library to score/mw/service/BUILD
- Fix ProvidedServices Add() to increment count_ so Count() returns the actual number of added services (was always returning 0)
- Fix Swap() to exchange count_ values
- Add private count_ member