### PR TITLE
Fix visibility guard test in setups with proxy

### DIFF
--- a/quality/visibility_guard/BUILD
+++ b/quality/visibility_guard/BUILD
@@ -31,6 +31,15 @@ py_test(
         "no-cache",
         "no-sandbox",
     ],
+    env_inherit = [
+        # Required for internal bazel execution to be able to resolve proxies
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "NO_PROXY",
+        "no_proxy",
+    ],
     target_compatible_with = ["@platforms//os:linux"],
     deps = [":parser"],
 )


### PR DESCRIPTION
Even with disabled sandbox Bazel still filters the env for hermeticity. Do not force users to work around this in their bazelrc and potentially breaking hermeticity for other targets.

Adapts the target to exclude proxy environment variables from filtering.