### PR TITLE
Fix visibility guard test in setups with proxy

### DIFF
--- a/quality/visibility_guard/BUILD
+++ b/quality/visibility_guard/BUILD
@@ -22,6 +22,15 @@ py_test(
     name = "visibility_guard_test",
     srcs = ["visibility_guard_test.py"],
     data = [":public_targets.golden"],
+    env_inherit = [
+        # Required for internal bazel execution to be able to resolve proxies
+        "HTTP_PROXY",
+        "http_proxy",
+        "HTTPS_PROXY",
+        "https_proxy",
+        "NO_PROXY",
+        "no_proxy",
+    ],
     # local=True: needs source tree access to read BUILD files across all packages.
     # The test is deterministic — same source tree always produces the same result.
     local = True,


### PR DESCRIPTION
Even with disabled sandbox Bazel still filters the env for hermeticity. Do not force users to work around this in their bazelrc and potentially breaking hermeticity for other targets.

Adapts the target to exclude proxy environment variables from filtering.