### PR TITLE
impl/lola: Added shm-size calculation by analysis for DATA/CONTROL

### DIFF
--- a/score/mw/com/design/shared_mem_layout/README.md
+++ b/score/mw/com/design/shared_mem_layout/README.md
@@ -62,7 +62,8 @@ placed into the `SharedMemoryResource` for **Data** is an instance of `lola::Ser
 `LoLa` skeleton instance during `lola::Skeleton::PrepareOffer()` within the initialization callback of the
 newly created shared-memory object.
 This anchor element of the `SharedMemoryResource` contains two members:
-* `events_`: a map for the data storage (slots) of every event the service provides.
+* `events_`: a fixed-capacity, associative container (`lola::LinearSearchMap`) for the data storage (slots) of every
+  event the service provides.
   Note, that the storage slots, which are effectively vectors of `SampleType`s:
   ```
   template <typename SampleType>
@@ -72,8 +73,18 @@ This anchor element of the `SharedMemoryResource` contains two members:
   type and only later when the skeleton events register themselves dynamically or access that storage they are cast to
   the effective/concrete type.
 
-* `events_metainfo_`: a map for meta information of every event the service provides
+* `events_metainfo_`: a fixed-capacity, associative container (`lola::LinearSearchMap`) for meta information of every
+  event the service provides
 * `skeleton_pid_`: PID of the provider/skeleton process.
+
+> **Note on container choice / shared-memory sizing:** `ServiceDataStorage` deliberately does **not** use dynamically
+> allocating map-types (like `std::map` / `boost::interprocess::map`) anymore. Instead it uses `lola::LinearSearchMap`,
+> a flat, fixed-capacity container built on `score::containers::NonRelocatableVector`. Its capacity (the number of
+> service-elements = events + fields) is known up-front, so the container performs exactly one allocation of a
+> deterministic size on construction. This makes the total size of the **Data** shared-memory object analytically
+> computable via `SkeletonMemoryManager::CalculateDataShmResourceStorageSize()` (selected through the
+> `ShmSizeCalculationMode::kAnalysis` mode), avoiding the otherwise necessary (and costly) heap-based "simulation
+> run".
 
 ## Shared-Memory Object for Control
 
@@ -82,7 +93,9 @@ placed into the `SharedMemoryResource` for **Control** is an instance of `lola::
 created by a `LoLa` skeleton instance during `lola::Skeleton::PrepareOffer()` within the initialization
 callback of the newly created shared-memory object.
 This anchor element of the `SharedMemoryResource` contains the members:
-* `event_controls_`: a map containing an `EventControl` entry for every event the service provides. Each `EventControl`
+* `event_controls_`: a fixed-capacity `lola::LinearSearchMap` containing an `EventControl` entry for every event the
+  service provides. Its capacity equals the number of offered service elements (events + fields), which is known
+  up-front, so the required shared-memory size can be computed analytically (no simulation run). Each `EventControl`
   aggregates the event's data control slots (`EventDataControl`), subscription control (`EventSubscriptionControl`), and
   the transaction log set (`TransactionLogSet`).
 * `application_id_pid_mapping_`: a mapping from application identifiers to process IDs, used by proxy instances to

--- a/score/mw/com/design/shared_mem_layout/shared_mem_layout_classdiagram.puml
+++ b/score/mw/com/design/shared_mem_layout/shared_mem_layout_classdiagram.puml
@@ -13,8 +13,8 @@ class "lola::Skeleton" {
 }
 
 class "lola::ServiceDataStorage" <<Shared Memory>> {
-  +events_ : score::memory::shared::Map<ElementFqId, score::memory::shared::OffsetPtr<void>>
-  +events_metainfo_ : score::memory::shared::Map<ElementFqId, EventMetaInfo>
+  +events_ : lola::LinearSearchMap<ElementFqId, score::memory::shared::OffsetPtr<void>>
+  +events_metainfo_ : lola::LinearSearchMap<ElementFqId, EventMetaInfo>
   +skeleton_pid_ : pid_t
 }
 
@@ -33,7 +33,7 @@ class "lola::EventDataStorage<SampleType>" <<Shared Memory>> <<typedef>> {
 }
 
 class "lola::ServiceDataControl" <<Shared Memory>> {
-  +event_controls_ : score::memory::shared::Map<ElementFqId, EventControl>
+  +event_controls_ : lola::LinearSearchMap<ElementFqId, EventControl>
   +application_id_pid_mapping_ : ApplicationIdPidMapping<score::memory::shared::PolymorphicOffsetPtrAllocator<ApplicationIdPidMappingEntry>>
 }
 

--- a/score/mw/com/design/shared_mem_layout/shared_mem_layout_objectdiagram.puml
+++ b/score/mw/com/design/shared_mem_layout/shared_mem_layout_objectdiagram.puml
@@ -28,17 +28,17 @@ object "shmResource_control_asil_SI_1 : SharedMemoryResource" as control_asil_re
 }
 
 object "<< Shared Memory >>\nserviceDataStorage_SI_1 : lola::ServiceDataStorage" as storage {
-  +events_ : score::memory::shared::Map<ElementFqId, score::memory::shared::OffsetPtr<void>>
-  +events_metainfo_ : score::memory::shared::Map<ElementFqId, EventMetaInfo>
+  +events_ : lola::LinearSearchMap<ElementFqId, score::memory::shared::OffsetPtr<void>>
+  +events_metainfo_ : lola::LinearSearchMap<ElementFqId, EventMetaInfo>
 }
 
 object "<< Shared Memory >>\nserviceDataControl_qm_SI_1 : lola::ServiceDataControl" as control_qm {
-  +event_controls_ : score::memory::shared::Map<ElementFqId, EventControl>
+  +event_controls_ : lola::LinearSearchMap<ElementFqId, EventControl>
   +application_id_pid_mapping_ : ApplicationIdPidMapping<...>
 }
 
 object "<< Shared Memory >>\nserviceDataControl_asil_SI_1 : lola::ServiceDataControl" as control_asil {
-  +event_controls_ : score::memory::shared::Map<ElementFqId, EventControl>
+  +event_controls_ : lola::LinearSearchMap<ElementFqId, EventControl>
   +application_id_pid_mapping_ : ApplicationIdPidMapping<...>
 }
 

--- a/score/mw/com/impl/bindings/lola/BUILD
+++ b/score/mw/com/impl/bindings/lola/BUILD
@@ -266,18 +266,28 @@ cc_library(
 cc_library(
     name = "service_data_storage",
     srcs = ["service_data_storage.cpp"],
-    hdrs = ["service_data_storage.h"],
+    hdrs = [
+        "service_data_storage.h",
+    ],
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     visibility = [
+        "//score/mw/com/impl/bindings/lola:__pkg__",
+        "//score/mw/com/impl/bindings/lola/test:__pkg__",
         "//score/mw/com/impl/bindings/lola/test_doubles:__pkg__",
     ],
     deps = [
         ":element_fq_id",
+        ":event_data_storage",
         ":event_meta_info",
         ":i_runtime",
+        ":linear_search_map",
         "//score/memory/shared",
+        "//score/memory/shared:pointer_arithmetic_util",
         "//score/mw/com/impl:runtime",
+        "@score_baselibs//score/containers:non_relocatable_vector",
+        "@score_baselibs//score/language/futurecpp",
+        "@score_baselibs//score/memory:data_type_size_info",
         "@score_baselibs//score/os:unistd",
     ],
 )
@@ -289,13 +299,22 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],
     visibility = [
+        "//score/mw/com/impl/bindings/lola/test:__pkg__",
         "//score/mw/com/impl/bindings/lola/test_doubles:__pkg__",
     ],
     deps = [
         ":application_id_pid_mapping",
+        ":application_id_pid_mapping_entry",
         ":element_fq_id",
         ":event_control",
+        ":event_data_control",
+        ":linear_search_map",
+        ":transaction_log",
+        ":transaction_log_set",
         "//score/memory/shared",
+        "//score/memory/shared:pointer_arithmetic_util",
+        "@score_baselibs//score/language/futurecpp",
+        "@score_baselibs//score/memory:data_type_size_info",
     ],
 )
 
@@ -1339,12 +1358,27 @@ cc_unit_test(
         ":event_meta_info",
         ":runtime_mock",
         ":service_data_storage",
-        "//score/memory/shared:map",
         "//score/memory/shared:new_delete_delegate_resource",
         "//score/mw/com/impl:binding_type",
         "//score/mw/com/impl/test:runtime_mock_guard",
+        "@score_baselibs//score/memory:data_type_size_info",
         "@score_baselibs//score/os:object_seam",
         "@score_baselibs//score/os/mocklib:unistd_mock",
+    ],
+)
+
+cc_unit_test(
+    name = "service_data_control_test",
+    srcs = [
+        "service_data_control_test.cpp",
+    ],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        ":element_fq_id",
+        ":event_control",
+        ":service_data_control",
+        "//score/memory/shared:new_delete_delegate_resource",
+        "//score/mw/com/impl:service_element_type",
     ],
 )
 

--- a/score/mw/com/impl/bindings/lola/BUILD
+++ b/score/mw/com/impl/bindings/lola/BUILD
@@ -246,6 +246,24 @@ cc_library(
 )
 
 cc_library(
+    name = "linear_search_map",
+    srcs = ["linear_search_map.cpp"],
+    hdrs = [
+        "linear_search_map.h",
+    ],
+    features = COMPILER_WARNING_FEATURES,
+    tags = ["FFI"],
+    visibility = [
+        "//score/mw/com/impl/bindings/lola:__pkg__",
+        "//score/mw/com/impl/bindings/lola/test_doubles:__pkg__",
+    ],
+    deps = [
+        "//score/memory/shared",
+        "@score_baselibs//score/containers:non_relocatable_vector",
+    ],
+)
+
+cc_library(
     name = "service_data_storage",
     srcs = ["service_data_storage.cpp"],
     hdrs = ["service_data_storage.h"],
@@ -1327,6 +1345,19 @@ cc_unit_test(
         "//score/mw/com/impl/test:runtime_mock_guard",
         "@score_baselibs//score/os:object_seam",
         "@score_baselibs//score/os/mocklib:unistd_mock",
+    ],
+)
+
+cc_unit_test(
+    name = "linear_search_map_test",
+    srcs = [
+        "linear_search_map_test.cpp",
+    ],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        ":linear_search_map",
+        "//score/memory/shared:new_delete_delegate_resource",
+        "@score_baselibs//score/mw/log",
     ],
 )
 

--- a/score/mw/com/impl/bindings/lola/generic_skeleton_event.h
+++ b/score/mw/com/impl/bindings/lola/generic_skeleton_event.h
@@ -63,6 +63,11 @@ class GenericSkeletonEvent : public GenericSkeletonEventBinding
         return size_info_.Size();
     }
 
+    std::size_t GetAlignment() const noexcept override
+    {
+        return size_info_.Alignment();
+    }
+
     /// \brief Set callback, to get notified, when either the 1st event-notification has been registered or the last
     /// event-notification has been unregistered.
     /// \detail This extension has been added to GenericSkeletonEvent only (not "typed" SkeletonEvent),

--- a/score/mw/com/impl/bindings/lola/generic_skeleton_event_test.cpp
+++ b/score/mw/com/impl/bindings/lola/generic_skeleton_event_test.cpp
@@ -35,9 +35,11 @@ class GenericSkeletonEventFixture : public SkeletonEventFixture
         // Initialize the skeleton
         InitialiseSkeleton(GetValidInstanceIdentifier());
 
-        // Prepare the skeleton with empty bindings
+        // Prepare the skeleton offering a single service-element, so the fixed-capacity containers within
+        // ServiceDataStorage are sized to hold the one generic event that the tests register below.
         SkeletonBinding::SkeletonEventBindings events{};
         SkeletonBinding::SkeletonFieldBindings fields{};
+        events.emplace(fake_event_name_, mock_event_binding_);
         std::optional<SkeletonBinding::RegisterShmObjectTraceCallback> register_shm_object_trace_callback{};
         std::ignore = skeleton_->PrepareOffer(events, fields, std::move(register_shm_object_trace_callback));
     }

--- a/score/mw/com/impl/bindings/lola/linear_search_map.cpp
+++ b/score/mw/com/impl/bindings/lola/linear_search_map.cpp
@@ -1,0 +1,13 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/impl/bindings/lola/linear_search_map.h"

--- a/score/mw/com/impl/bindings/lola/linear_search_map.h
+++ b/score/mw/com/impl/bindings/lola/linear_search_map.h
@@ -1,0 +1,292 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_IMPL_BINDINGS_LOLA_LINEAR_SEARCH_MAP_H
+#define SCORE_MW_COM_IMPL_BINDINGS_LOLA_LINEAR_SEARCH_MAP_H
+
+#include "score/containers/non_relocatable_vector.h"
+#include "score/memory/shared/managed_memory_resource.h"
+#include "score/memory/shared/polymorphic_offset_ptr_allocator.h"
+
+#include <score/assert.hpp>
+
+#include <cstddef>
+#include <functional>
+#include <scoped_allocator>
+#include <tuple>
+#include <utility>
+
+namespace score::mw::com::impl::lola
+{
+
+/// \brief A fixed-capacity, associative container with a std::map-like interface backed by a contiguous array.
+///
+/// \details LinearSearchMap replaces the previously used std::map / boost::interprocess::map inside the shared-memory
+/// data structures (e.g. ServiceDataStorage). Those map-types allocate memory dynamically on each insertion
+/// (the exact amount depends on the implementation) which makes it impossible to calculate the exact size of the
+/// surrounding shared-memory object up-front (without a costly simulation run). LinearSearchMap in contrast allocates
+/// all of its storage exactly once on construction (via score::containers::NonRelocatableVector) with a capacity equal
+/// to the maximum number of elements. This capacity is always known in advance (it equals the number of
+/// service-elements of a service-instance). Hence the memory needed by a LinearSearchMap can be calculated
+/// deterministically.
+///
+/// Since the number of elements is small (number of events + fields of a single service-instance) and the container is
+/// filled once during initialization and only searched afterwards, a simple linear search is sufficient.
+///
+/// LinearSearchMap is designed to be placeable in shared-memory: it uses the provided (shared-memory capable) allocator
+/// and NonRelocatableVector guarantees that no reallocation (which would invalidate offset-pointers) ever takes place.
+///
+/// \note The complexity for lookup (find/at) is currently O(n). Since we typically use LinearSearchMap for a small
+/// number of elements (number of events + fields of a single service-instance), this is acceptable. If the number of
+/// elements grows, we could sort the underlying vector and then use std::binary_search for O(log n) lookup.
+/// This should be done if necessary.
+///
+/// \attention Adding more elements to it as defined in the ctor via max_number_of_elements will lead to termination.
+///
+/// \tparam Key key type used to identify an element. Must be copy-constructible and comparable via KeyEqual.
+/// \tparam MappedType mapped value type.
+/// \tparam KeyEqual binary predicate used to compare two keys for equality. Defaults to std::equal_to<Key> (i.e.
+///         operator==). A custom predicate can be supplied for keys without a suitable operator== or for alternative
+///         equality semantics (analogous to the KeyEqual parameter of std::unordered_map). Be careful: When placing
+///         the LinearSearchMap in shared-memory, the KeyEqual predicate must be stateless and trivially copyable
+///         (i.e. it must not contain any non-offset pointers or references).
+/// \tparam Allocator allocator used for the underlying storage. Defaults to the shared-memory capable
+///         PolymorphicOffsetPtrAllocator.
+template <typename Key,
+          typename MappedType,
+          typename KeyEqual = std::equal_to<Key>,
+          typename Allocator =
+              std::scoped_allocator_adaptor<memory::shared::PolymorphicOffsetPtrAllocator<std::pair<Key, MappedType>>>>
+class LinearSearchMap
+{
+  public:
+    using key_type = Key;
+    using mapped_type = MappedType;
+    using value_type = std::pair<Key, MappedType>;
+    using size_type = std::size_t;
+    using key_equal = KeyEqual;
+    using iterator = value_type*;
+    using const_iterator = const value_type*;
+
+    /// \brief Constructs an empty LinearSearchMap which can hold up to max_number_of_elements elements.
+    /// \param max_number_of_elements maximum number of elements the map can hold (its fixed capacity).
+    /// \param resource memory resource used to allocate the underlying storage.
+    /// \param key_equal binary predicate used to compare keys for equality.
+    LinearSearchMap(const size_type max_number_of_elements,
+                    memory::shared::ManagedMemoryResource& resource,
+                    const KeyEqual& key_equal = KeyEqual{});
+
+    iterator begin() noexcept;
+    const_iterator begin() const noexcept;
+    const_iterator cbegin() const noexcept;
+
+    iterator end() noexcept;
+    const_iterator end() const noexcept;
+    const_iterator cend() const noexcept;
+
+    size_type size() const noexcept;
+
+    size_type capacity() const noexcept;
+
+    bool empty() const noexcept;
+
+    iterator find(const Key& key) noexcept;
+
+    const_iterator find(const Key& key) const noexcept;
+
+    /// \brief Returns the key-equality predicate used by this map.
+    key_equal key_eq() const;
+
+    mapped_type& at(const Key& key);
+
+    const mapped_type& at(const Key& key) const;
+
+    /// \brief Inserts a new element constructed in-place from the given piecewise tuples (std::map-like).
+    /// \details If an element with the same key already exists, no insertion takes place.
+    /// \attention emplacing more elements as specified in ctor max_number_of_elements will lead to termination.
+    /// \return pair of an iterator to the (existing or newly inserted) element and a bool that is true if an insertion
+    ///         took place.
+    template <typename... KeyArgs, typename... MappedArgs>
+    std::pair<iterator, bool> emplace(std::piecewise_construct_t,
+                                      std::tuple<KeyArgs...> key_args,
+                                      std::tuple<MappedArgs...> mapped_args);
+
+    /// \brief Inserts a new element with the given key and mapped value (std::map-like).
+    /// \details If an element with the same key already exists, no insertion takes place.
+    /// \attention emplacing more elements as specified in ctor max_number_of_elements will lead to termination.
+    template <typename MappedArg>
+    std::pair<iterator, bool> emplace(const Key& key, MappedArg&& mapped_value);
+
+  private:
+    score::containers::NonRelocatableVector<value_type, Allocator> storage_;
+    KeyEqual key_equal_;
+};
+
+template <typename Key, typename MappedType, typename KeyEqual, typename Allocator>
+LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::LinearSearchMap(const size_type max_number_of_elements,
+                                                                       memory::shared::ManagedMemoryResource& resource,
+                                                                       const KeyEqual& key_equal)
+    : storage_{max_number_of_elements, Allocator{resource}}, key_equal_{key_equal}
+{
+}
+
+template <typename Key, typename MappedType, typename KeyEqual, typename Allocator>
+typename LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::iterator
+LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::begin() noexcept
+{
+    return storage_.begin();
+}
+
+template <typename Key, typename MappedType, typename KeyEqual, typename Allocator>
+typename LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::const_iterator
+LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::begin() const noexcept
+{
+    return storage_.begin();
+}
+
+template <typename Key, typename MappedType, typename KeyEqual, typename Allocator>
+typename LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::const_iterator
+LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::cbegin() const noexcept
+{
+    return storage_.cbegin();
+}
+
+template <typename Key, typename MappedType, typename KeyEqual, typename Allocator>
+typename LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::iterator
+LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::end() noexcept
+{
+    return storage_.end();
+}
+
+template <typename Key, typename MappedType, typename KeyEqual, typename Allocator>
+typename LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::const_iterator
+LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::end() const noexcept
+{
+    return storage_.end();
+}
+
+template <typename Key, typename MappedType, typename KeyEqual, typename Allocator>
+typename LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::const_iterator
+LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::cend() const noexcept
+{
+    return storage_.cend();
+}
+
+template <typename Key, typename MappedType, typename KeyEqual, typename Allocator>
+typename LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::size_type
+LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::size() const noexcept
+{
+    return storage_.size();
+}
+
+template <typename Key, typename MappedType, typename KeyEqual, typename Allocator>
+typename LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::size_type
+LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::capacity() const noexcept
+{
+    return storage_.capacity();
+}
+
+template <typename Key, typename MappedType, typename KeyEqual, typename Allocator>
+bool LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::empty() const noexcept
+{
+    return storage_.size() == 0U;
+}
+
+template <typename Key, typename MappedType, typename KeyEqual, typename Allocator>
+typename LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::iterator
+LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::find(const Key& key) noexcept
+{
+    for (auto it = begin(); it != end(); ++it)
+    {
+        if (key_equal_(it->first, key))
+        {
+            return it;
+        }
+    }
+    return end();
+}
+
+template <typename Key, typename MappedType, typename KeyEqual, typename Allocator>
+typename LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::const_iterator
+LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::find(const Key& key) const noexcept
+{
+    for (auto it = cbegin(); it != cend(); ++it)
+    {
+        if (key_equal_(it->first, key))
+        {
+            return it;
+        }
+    }
+    return cend();
+}
+
+template <typename Key, typename MappedType, typename KeyEqual, typename Allocator>
+typename LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::key_equal
+LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::key_eq() const
+{
+    return key_equal_;
+}
+
+template <typename Key, typename MappedType, typename KeyEqual, typename Allocator>
+typename LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::mapped_type&
+LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::at(const Key& key)
+{
+    const auto it = find(key);
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(it != end(), "LinearSearchMap::at: key not found.");
+    return it->second;
+}
+
+template <typename Key, typename MappedType, typename KeyEqual, typename Allocator>
+const typename LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::mapped_type&
+LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::at(const Key& key) const
+{
+    const auto it = find(key);
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(it != cend(), "LinearSearchMap::at: key not found.");
+    return it->second;
+}
+
+template <typename Key, typename MappedType, typename KeyEqual, typename Allocator>
+template <typename... KeyArgs, typename... MappedArgs>
+std::pair<typename LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::iterator, bool>
+LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::emplace(std::piecewise_construct_t,
+                                                               std::tuple<KeyArgs...> key_args,
+                                                               std::tuple<MappedArgs...> mapped_args)
+{
+    const Key key = std::make_from_tuple<Key>(key_args);
+    const auto existing = find(key);
+    if (existing != end())
+    {
+        return {existing, false};
+    }
+    auto& inserted = storage_.emplace_back(std::piecewise_construct, std::move(key_args), std::move(mapped_args));
+    return {&inserted, true};
+}
+
+template <typename Key, typename MappedType, typename KeyEqual, typename Allocator>
+template <typename MappedArg>
+std::pair<typename LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::iterator, bool>
+LinearSearchMap<Key, MappedType, KeyEqual, Allocator>::emplace(const Key& key, MappedArg&& mapped_value)
+{
+    const auto existing = find(key);
+    if (existing != end())
+    {
+        return {existing, false};
+    }
+    auto& inserted = storage_.emplace_back(std::piecewise_construct,
+                                           std::forward_as_tuple(key),
+                                           std::forward_as_tuple(std::forward<MappedArg>(mapped_value)));
+    return {&inserted, true};
+}
+
+}  // namespace score::mw::com::impl::lola
+
+#endif  // SCORE_MW_COM_IMPL_BINDINGS_LOLA_LINEAR_SEARCH_MAP_H

--- a/score/mw/com/impl/bindings/lola/linear_search_map_test.cpp
+++ b/score/mw/com/impl/bindings/lola/linear_search_map_test.cpp
@@ -1,0 +1,269 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/impl/bindings/lola/linear_search_map.h"
+
+#include "score/memory/shared/new_delete_delegate_resource.h"
+
+#include <gtest/gtest.h>
+
+#include <cstdint>
+#include <tuple>
+#include <utility>
+
+namespace score::mw::com::impl::lola
+{
+namespace
+{
+
+const std::uint64_t kMemoryResourceId{42U};
+constexpr std::int32_t kSomeKey{1};
+constexpr std::int32_t kSomeValue{100};
+
+using TestMap = LinearSearchMap<std::int32_t, std::int32_t>;
+
+class LinearSearchMapFixture : public ::testing::Test
+{
+  protected:
+    memory::shared::NewDeleteDelegateMemoryResource memory_{kMemoryResourceId};
+};
+
+TEST_F(LinearSearchMapFixture, IsEmptyAfterConstruction)
+{
+    // When constructing a LinearSearchMap with a capacity of 4
+    TestMap unit{4U, memory_};
+
+    // Then it is empty, has size 0 and reports the requested capacity
+    EXPECT_TRUE(unit.empty());
+    EXPECT_EQ(unit.size(), 0U);
+    EXPECT_EQ(unit.capacity(), 4U);
+}
+
+TEST_F(LinearSearchMapFixture, BeginAndEndEqualAfterConstruction)
+{
+    // When constructing a LinearSearchMap with a capacity of 4
+    TestMap unit{4U, memory_};
+
+    // Then begin and end iterators are equal (no elements to iterate)
+    EXPECT_EQ(unit.begin(), unit.end());
+}
+
+TEST_F(LinearSearchMapFixture, EmplaceSucceedsAndReturnsCorrectIterator)
+{
+    // Given an empty LinearSearchMap
+    TestMap unit{4U, memory_};
+
+    // When emplacing a new key/value pair
+    const auto result = unit.emplace(kSomeKey, kSomeValue);
+
+    // Then the insertion succeeds and the element is retrievable via the returned iterator
+    EXPECT_TRUE(result.second);
+    ASSERT_NE(result.first, unit.end());
+    EXPECT_EQ(result.first->first, kSomeKey);
+    EXPECT_EQ(result.first->second, kSomeValue);
+    EXPECT_EQ(unit.size(), 1U);
+    EXPECT_FALSE(unit.empty());
+}
+
+TEST_F(LinearSearchMapFixture, EmplaceWithPiecewiseConstructSucceedsAndReturnsCorrectIterator)
+{
+    // Given an empty LinearSearchMap
+    TestMap unit{4U, memory_};
+
+    // When emplacing a new element using the piecewise-construct overload
+    const auto result =
+        unit.emplace(std::piecewise_construct, std::forward_as_tuple(kSomeKey), std::forward_as_tuple(kSomeValue));
+
+    // Then the insertion succeeds and the element is retrievable via the returned iterator
+    EXPECT_TRUE(result.second);
+    ASSERT_NE(result.first, unit.end());
+    EXPECT_EQ(result.first->first, kSomeKey);
+    EXPECT_EQ(result.first->second, kSomeValue);
+}
+
+TEST_F(LinearSearchMapFixture, EmplaceWithDuplicateKeyDoesNotInsert)
+{
+    // Given a LinearSearchMap that already contains the key 1
+    TestMap unit{4U, memory_};
+    std::ignore = unit.emplace(kSomeKey, kSomeValue);
+
+    // When emplacing another element with the same key and different value
+    const auto result = unit.emplace(kSomeKey, kSomeValue + 5);
+
+    // Then no insertion takes place and the originally inserted value is preserved
+    EXPECT_FALSE(result.second);
+    EXPECT_EQ(unit.size(), 1U);
+    EXPECT_EQ(result.first->second, kSomeValue);
+}
+
+TEST_F(LinearSearchMapFixture, FindReturnsInsertedElement)
+{
+    // Given a LinearSearchMap containing several elements
+    TestMap unit{4U, memory_};
+    std::ignore = unit.emplace(kSomeKey, kSomeValue);
+    std::ignore = unit.emplace(kSomeKey + 1, kSomeValue + 1);
+    std::ignore = unit.emplace(kSomeKey + 2, kSomeValue + 2);
+
+    // When searching for an existing key
+    const auto it = unit.find(kSomeKey);
+
+    // Then the corresponding element is returned
+    ASSERT_NE(it, unit.end());
+    EXPECT_EQ(it->second, kSomeValue);
+}
+
+TEST_F(LinearSearchMapFixture, FindReturnsEndForMissingKey)
+{
+    // Given a LinearSearchMap containing a single element
+    TestMap unit{4U, memory_};
+    std::ignore = unit.emplace(kSomeKey, kSomeValue);
+
+    // When searching for a key that is not present
+    // Then the end iterator is returned
+    EXPECT_EQ(unit.find(99), unit.end());
+}
+
+TEST_F(LinearSearchMapFixture, ConstFindReturnsInsertedElement)
+{
+    // Given a const reference to a LinearSearchMap containing one element
+    TestMap unit{4U, memory_};
+    std::ignore = unit.emplace(kSomeKey, kSomeValue);
+    const TestMap& const_unit = unit;
+
+    // When searching via the const overload of find
+    const auto it = const_unit.find(kSomeKey);
+
+    // Then an existing key is found and the value matches.
+    ASSERT_NE(it, const_unit.cend());
+    EXPECT_EQ(it->second, kSomeValue);
+}
+
+TEST_F(LinearSearchMapFixture, ConstFindReturnsEndForMissingKey)
+{
+    // Given a const reference to a LinearSearchMap containing one element
+    TestMap unit{4U, memory_};
+    std::ignore = unit.emplace(kSomeKey, kSomeValue);
+    const TestMap& const_unit = unit;
+
+    // When searching via the const overload of find for a non existent key
+    const auto it = const_unit.find(kSomeKey + 5);
+
+    // Then it yields the const end iterator
+    EXPECT_EQ(it, const_unit.cend());
+}
+
+TEST_F(LinearSearchMapFixture, AtReturnsMappedValue)
+{
+    // Given a LinearSearchMap containing one element
+    TestMap unit{4U, memory_};
+    std::ignore = unit.emplace(kSomeKey, kSomeValue);
+
+    // When accessing the mapped value via at
+    // Then the stored value is returned
+    EXPECT_EQ(unit.at(kSomeKey), kSomeValue);
+
+    // and can be modified through the returned reference
+    unit.at(kSomeKey) = kSomeValue + 1;
+    EXPECT_EQ(unit.at(kSomeKey), kSomeValue + 1);
+}
+
+TEST_F(LinearSearchMapFixture, IterationVisitsAllElements)
+{
+    // Given a LinearSearchMap containing two elements
+    TestMap unit{4U, memory_};
+    std::ignore = unit.emplace(kSomeKey, kSomeValue);
+    std::ignore = unit.emplace(kSomeKey + 1, kSomeValue + 1);
+
+    // When iterating over all elements and accumulating keys and values
+    std::int32_t sum_keys{0};
+    std::int32_t sum_values{0};
+    for (const auto& element : unit)
+    {
+        sum_keys += element.first;
+        sum_values += element.second;
+    }
+
+    // Then every element is visited exactly once
+    EXPECT_EQ(sum_keys, kSomeKey + (kSomeKey + 1));
+    EXPECT_EQ(sum_values, kSomeValue + (kSomeValue + 1));
+}
+
+// A custom key-equality predicate that considers two keys equal if they have the same absolute value.
+struct AbsoluteValueEqual
+{
+    bool operator()(const std::int32_t lhs, const std::int32_t rhs) const noexcept
+    {
+        return (lhs < 0 ? -lhs : lhs) == (rhs < 0 ? -rhs : rhs);
+    }
+};
+
+using CustomEqualMap = LinearSearchMap<std::int32_t, std::int32_t, AbsoluteValueEqual>;
+
+TEST_F(LinearSearchMapFixture, CustomKeyEqualIsUsedForFind)
+{
+    // Given a LinearSearchMap using a custom absolute-value key-equality predicate, containing the key kSomeKey
+    CustomEqualMap unit{4U, memory_};
+    std::ignore = unit.emplace(kSomeKey, kSomeValue);
+
+    // When searching for -kSomeKey, which the custom predicate considers equal to kSomeKey
+    const auto it = unit.find(-kSomeKey);
+
+    // Then the element stored under key kSomeKey is found
+    ASSERT_NE(it, unit.end());
+    EXPECT_EQ(it->second, kSomeValue);
+}
+
+TEST_F(LinearSearchMapFixture, CustomKeyEqualPreventsDuplicateInsertion)
+{
+    // Given a LinearSearchMap using a custom absolute-value key-equality predicate, containing the key kSomeKey
+    CustomEqualMap unit{4U, memory_};
+    std::ignore = unit.emplace(kSomeKey, kSomeValue);
+
+    // When emplacing -kSomeKey, which the custom predicate treats as a duplicate of kSomeKey
+    const auto result = unit.emplace(-kSomeKey, kSomeValue + 1);
+
+    // Then no insertion takes place and the original value is preserved
+    EXPECT_FALSE(result.second);
+    EXPECT_EQ(unit.size(), 1U);
+    EXPECT_EQ(result.first->second, kSomeValue);
+}
+
+TEST_F(LinearSearchMapFixture, KeyEqAccessorReturnsPredicate)
+{
+    // Given a LinearSearchMap using a custom absolute-value key-equality predicate
+    CustomEqualMap unit{4U, memory_};
+
+    // When retrieving the predicate via key_eq
+    const auto predicate = unit.key_eq();
+
+    // Then the returned predicate exhibits the custom equality semantics
+    EXPECT_TRUE(predicate(-7, 7));
+    EXPECT_FALSE(predicate(-7, 8));
+}
+
+using LinearSearchMapDeathTest = LinearSearchMapFixture;
+TEST_F(LinearSearchMapDeathTest, AddMoreElementsThanCapacity)
+{
+    // Given a LinearSearchMap which contains capacity count elements
+    TestMap unit{4U, memory_};
+    std::ignore = unit.emplace(kSomeKey, kSomeValue);
+    std::ignore = unit.emplace(kSomeKey + 1, kSomeValue + 1);
+    std::ignore = unit.emplace(kSomeKey + 2, kSomeValue + 2);
+    std::ignore = unit.emplace(kSomeKey + 3, kSomeValue + 3);
+
+    // When adding another element
+    // Then the program terminates
+    EXPECT_DEATH(unit.emplace(kSomeKey + 4, kSomeValue + 4), ".*");
+}
+
+}  // namespace
+}  // namespace score::mw::com::impl::lola

--- a/score/mw/com/impl/bindings/lola/service_data_control.cpp
+++ b/score/mw/com/impl/bindings/lola/service_data_control.cpp
@@ -11,3 +11,99 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 #include "score/mw/com/impl/bindings/lola/service_data_control.h"
+
+#include "score/mw/com/impl/bindings/lola/application_id_pid_mapping_entry.h"
+#include "score/mw/com/impl/bindings/lola/event_data_control.h"
+#include "score/mw/com/impl/bindings/lola/transaction_log.h"
+#include "score/mw/com/impl/bindings/lola/transaction_log_set.h"
+
+#include "score/memory/data_type_size_info.h"
+#include "score/memory/shared/pointer_arithmetic_util.h"
+
+#include <cstddef>
+#include <vector>
+
+namespace score::mw::com::impl::lola
+{
+
+std::size_t CalculateServiceDataControlShmSize(
+    const score::cpp::span<const ServiceElementControlSizeInfo> events_and_fields_size_info)
+{
+    // The number of events + fields determines the (fixed) capacity of the event_controls_ LinearSearchMap within the
+    // ServiceDataControl. It equals the number of sizing entries handed over.
+    const auto number_of_events_and_fields = events_and_fields_size_info.size();
+
+    // The real construction of a ServiceDataControl and its contained EventControls performs a fixed, deterministic
+    // sequence of allocations from the (strictly monotonic) shared-memory resource, which itself always starts
+    // allocating at a std::max_align_t aligned location. Since we know the exact size/alignment of every single one
+    // of these allocations and the exact order in which they happen, we can reconstruct the exact sequence here and
+    // let memory::shared::CalculateAlignedSizeOfSequence() compute the exact (not just worst-case) total size, taking
+    // into account the exact alignment-padding between consecutive allocations.
+    std::vector<score::memory::DataTypeSizeInfo> allocation_sequence{};
+
+    // (1) The ServiceDataControl object itself (including the inline bookkeeping of its event_controls_ LinearSearchMap
+    // and of its application_id_pid_mapping_).
+    allocation_sequence.emplace_back(sizeof(ServiceDataControl), alignof(ServiceDataControl));
+
+    // (2) The allocated array of the event_controls_ LinearSearchMap (allocated once, with capacity ==
+    // number_of_events_and_fields).
+    allocation_sequence.emplace_back(
+        number_of_events_and_fields * sizeof(decltype(ServiceDataControl::event_controls_)::value_type),
+        alignof(decltype(ServiceDataControl::event_controls_)::value_type));
+
+    // (3) The backing array of the application_id_pid_mapping_ (a fixed-capacity DynamicArray with a capacity of
+    // kMaxApplicationIdPidMappings). It is allocated once during ServiceDataControl construction, independent of the
+    // number of events + fields.
+    allocation_sequence.emplace_back(static_cast<std::size_t>(ServiceDataControl::kMaxApplicationIdPidMappings) *
+                                         sizeof(ApplicationIdPidMappingEntry),
+                                     alignof(ApplicationIdPidMappingEntry));
+
+    // (4) For each event/field: the (deeply) nested fixed-capacity DynamicArrays contained within its EventControl.
+    // The EventControl object itself is stored inline within the event_controls_ backing array (accounted for in (2));
+    // only the allocated arrays of its nested DynamicArrays allocate separately and are accounted for here.
+    for (const auto& service_element : events_and_fields_size_info)
+    {
+        const std::size_t number_of_slots = service_element.number_of_slots;
+        const std::size_t max_subscribers = service_element.max_subscribers;
+
+        // (4a) EventControl::data_control (EventDataControl): its state_slots_ is a DynamicArray<ControlSlotType>
+        // with a capacity of number_of_slots.
+        allocation_sequence.emplace_back(number_of_slots * sizeof(EventDataControl::EventControlSlots::value_type),
+                                         alignof(EventDataControl::EventControlSlots::value_type));
+
+        // (4b) EventControl::transaction_log_set_ (TransactionLogSet):
+        //   proxy_transaction_logs_(max_subscribers, TransactionLogNode{number_of_slots, resource}, resource) is
+        //   constructed via the DynamicArray fill-constructor. The exact allocation order is:
+        //     * one reference_count_slots_ array for the temporary prototype TransactionLogNode, which is
+        //       constructed (as a function argument) before the DynamicArray constructor itself even runs. This
+        //       constucts the TransactionLog for the given TransactionLogNode, which contains a DynamicArray of
+        //       TransactionLogSlots representing the TransactionLog for slot-referencing.
+        const std::size_t transaction_log_slots_array_raw_size =
+            number_of_slots * sizeof(TransactionLog::TransactionLogSlots::value_type);
+        const std::size_t transaction_log_slots_array_alignment =
+            alignof(TransactionLog::TransactionLogSlots::value_type);
+        allocation_sequence.emplace_back(transaction_log_slots_array_raw_size, transaction_log_slots_array_alignment);
+
+        //     * then the backing array of proxy_transaction_logs_ itself (max_subscribers elements of
+        //       TransactionLogNode), allocated in a single allocation.
+        allocation_sequence.emplace_back(max_subscribers * sizeof(TransactionLogSet::TransactionLogNode),
+                                         alignof(TransactionLogSet::TransactionLogNode));
+
+        //     * then, one at a time (in order), each of the max_subscribers elements of proxy_transaction_logs_ gets
+        //       copy-constructed from the prototype, each copy-construction allocating its own, separate
+        //       reference_count_slots_ array.
+        for (std::size_t i = 0U; i < max_subscribers; ++i)
+        {
+            allocation_sequence.emplace_back(transaction_log_slots_array_raw_size,
+                                             transaction_log_slots_array_alignment);
+        }
+
+        //   - finally, the inline skeleton_tracing_transaction_log_ member is constructed, allocating one more
+        //     reference_count_slots_ array.
+        allocation_sequence.emplace_back(transaction_log_slots_array_raw_size, transaction_log_slots_array_alignment);
+    }
+
+    return score::memory::shared::CalculateAlignedSizeOfSequence(allocation_sequence);
+}
+
+}  // namespace score::mw::com::impl::lola

--- a/score/mw/com/impl/bindings/lola/service_data_control.h
+++ b/score/mw/com/impl/bindings/lola/service_data_control.h
@@ -16,9 +16,13 @@
 #include "score/mw/com/impl/bindings/lola/application_id_pid_mapping.h"
 #include "score/mw/com/impl/bindings/lola/element_fq_id.h"
 #include "score/mw/com/impl/bindings/lola/event_control.h"
+#include "score/mw/com/impl/bindings/lola/linear_search_map.h"
 
-#include "score/memory/shared/map.h"
 #include "score/memory/shared/polymorphic_offset_ptr_allocator.h"
+
+#include <score/span.hpp>
+
+#include <cstddef>
 
 namespace score::mw::com::impl::lola
 {
@@ -30,15 +34,18 @@ class ServiceDataControl
     ///       calculation based on config settings and then hand over this calculated number ...
     static constexpr std::uint16_t kMaxApplicationIdPidMappings = 50U;
 
-    /// \brief Ctor for the ServiceDataControl to place it in given shared memory resource identified via given
-    ///        memory resource proxy.
+    /// \brief Ctor for the ServiceDataControl with a given memory resource to be used.
     /// \details ServiceDataControl is designed to be located in shared memory, therefore the explicit
-    ///          MemoryResourceProxy argument! (Yes one could come up with a MemoryResourceProxy pointing to a local
-    ///          memory resource, but this would be "uncommon")
-    /// \param proxy MemoryResourceProxy pointing to the memory-resource to be used
+    ///          ManagedMemoryResource argument!
+    /// \param number_of_events_and_fields the (fixed) number of events + fields this service-instance provides. It is
+    ///        used as the fixed capacity of the event_controls_ container. Since event_controls_ uses a
+    ///        fixed-capacity container (LinearSearchMap), its capacity must be known at construction time.
+    /// \param resource ManagedMemoryResource used for allocating underlying storage
 
-    explicit ServiceDataControl(score::memory::shared::ManagedMemoryResource& resource)
-        : event_controls_(resource), application_id_pid_mapping_(kMaxApplicationIdPidMappings, resource)
+    explicit ServiceDataControl(const std::size_t number_of_events_and_fields,
+                                score::memory::shared::ManagedMemoryResource& resource)
+        : event_controls_(number_of_events_and_fields, resource),
+          application_id_pid_mapping_(kMaxApplicationIdPidMappings, resource)
     {
     }
 
@@ -53,7 +60,7 @@ class ServiceDataControl
     // be private.". There are no class invariants to maintain which could be violated by directly accessing member
     // variables.
     // coverity[autosar_cpp14_m11_0_1_violation]
-    score::memory::shared::Map<ElementFqId, EventControl> event_controls_;
+    LinearSearchMap<ElementFqId, EventControl> event_controls_;
 
     /// \brief mapping of a proxy's application identifier to its process ID (pid).
     /// \details Every proxy instance for this service shall register itself in this mapping. The identifier used is
@@ -70,6 +77,35 @@ class ServiceDataControl
     ApplicationIdPidMapping<score::memory::shared::PolymorphicOffsetPtrAllocator<ApplicationIdPidMappingEntry>>
         application_id_pid_mapping_;
 };
+
+/// \brief Per service-element (event/field) information required to analytically size a ServiceDataControl.
+struct ServiceElementControlSizeInfo
+{
+    /// \brief Number of event-data slots the service-element provides.
+    std::size_t number_of_slots;
+    /// \brief Maximum number of subscribers configured for the service-element.
+    std::size_t max_subscribers;
+};
+
+/// \brief Analytically calculates the exact number of bytes a (single) ServiceDataControl (a control shm-object)
+///        occupies.
+/// \details This is used by SkeletonMemoryManager, but located next to ServiceDataControl so that the layout-dependent
+///          size algorithm stays coupled to the data structure it reasons about.
+///          It does NOT allocate any memory nor construct a ServiceDataControl; the size is
+///          derived purely from the (fixed) container capacities.
+///          The same size applies to the QM and (if present) the ASIL-B control shm-object, as both hold a
+///          ServiceDataControl created with the very same configuration.
+///          The result is exact (not just a bound): since all our allocations happen strictly sequentially (single
+///          threaded, on a (monotonic) shared-memory resource which always starts allocating at a std::max_align_t
+///          aligned location) and we know the size/alignment/order of every individual allocation performed by the
+///          real construction, we can reconstruct the exact same sequence of allocations here and compute the exact
+///          alignment-padding between them (see score::memory::shared::CalculateAlignedSizeOfSequence()).
+/// \param events_and_fields_size_info per service-element sizing information. Its size equals the number of
+///        service-elements (events + fields), which is the fixed capacity the event_controls_ container is constructed
+///        with.
+/// \return the exact number of bytes needed for a single control shm-object.
+std::size_t CalculateServiceDataControlShmSize(
+    score::cpp::span<const ServiceElementControlSizeInfo> events_and_fields_size_info);
 
 }  // namespace score::mw::com::impl::lola
 

--- a/score/mw/com/impl/bindings/lola/service_data_control_test.cpp
+++ b/score/mw/com/impl/bindings/lola/service_data_control_test.cpp
@@ -1,0 +1,163 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/impl/bindings/lola/service_data_control.h"
+
+#include "score/mw/com/impl/bindings/lola/element_fq_id.h"
+#include "score/mw/com/impl/bindings/lola/event_control.h"
+#include "score/mw/com/impl/service_element_type.h"
+
+#include "score/memory/shared/new_delete_delegate_resource.h"
+
+#include <score/span.hpp>
+
+#include <gtest/gtest.h>
+
+#include <cstddef>
+#include <cstdint>
+#include <utility>
+#include <vector>
+
+namespace score::mw::com::impl::lola
+{
+namespace
+{
+
+const std::uint64_t kMemoryResourceId{42U};
+
+// The exact numeric value of enforce_max_samples is irrelevant for the shm-layout, as it does not influence the
+// capacity of any of the underlying (fixed-capacity) containers.
+constexpr bool kEnforceMaxSamples{false};
+
+/// \brief Constructs a real ServiceDataControl on the given resource and populates its event_controls_ with one
+/// EventControl per entry of service_elements_size_info (mirroring what SkeletonMemoryManager does at runtime).
+/// \return the number of bytes the given resource reports as allocated after construction.
+std::size_t ConstructServiceDataControlAndGetAllocatedBytes(
+    const std::vector<ServiceElementControlSizeInfo>& service_elements_size_info,
+    memory::shared::ManagedMemoryResource& resource)
+{
+    auto& control = *resource.construct<ServiceDataControl>(service_elements_size_info.size(), resource);
+
+    std::uint16_t element_id{0U};
+    for (const auto& service_element : service_elements_size_info)
+    {
+        const ElementFqId element_fq_id{1U, element_id, 1U, ServiceElementType::EVENT};
+        score::cpp::ignore = control.event_controls_.emplace(
+            std::piecewise_construct,
+            std::forward_as_tuple(element_fq_id),
+            std::forward_as_tuple(static_cast<SlotIndexType>(service_element.number_of_slots),
+                                  static_cast<EventControl::SubscriberCountType>(service_element.max_subscribers),
+                                  kEnforceMaxSamples,
+                                  resource));
+        ++element_id;
+    }
+
+    return resource.GetUserAllocatedBytes();
+}
+
+using ServiceElementsSizeInfo = std::vector<ServiceElementControlSizeInfo>;
+
+class ServiceDataControlShmSizeParameterizedTestFixture : public ::testing::TestWithParam<ServiceElementsSizeInfo>
+{
+};
+
+TEST_P(ServiceDataControlShmSizeParameterizedTestFixture, CalculatedSizeMatchesActualAllocation)
+{
+    // Given the sizing information of some (possibly zero) service-elements (events/fields)
+    const auto& service_elements_size_info = GetParam();
+
+    // When calculating the required shm-size for a ServiceDataControl holding these service-elements
+    const auto calculated_size = CalculateServiceDataControlShmSize(
+        score::cpp::span<const ServiceElementControlSizeInfo>{service_elements_size_info});
+
+    // Then the calculated size exactly matches the number of bytes actually allocated when constructing a real
+    // ServiceDataControl (and its EventControls) with the very same sizing information.
+    memory::shared::NewDeleteDelegateMemoryResource resource{kMemoryResourceId};
+    const auto actual_allocated_bytes =
+        ConstructServiceDataControlAndGetAllocatedBytes(service_elements_size_info, resource);
+
+    EXPECT_EQ(calculated_size, actual_allocated_bytes);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ServiceDataControlShmSizeTests,
+    ServiceDataControlShmSizeParameterizedTestFixture,
+    ::testing::Values(
+        // No service-elements at all (an empty span)
+        ServiceElementsSizeInfo{},
+        // A single service-element (event/field)
+        ServiceElementsSizeInfo{ServiceElementControlSizeInfo{5U, 3U}},
+        // Multiple service-elements (events/fields) with differing numbers of slots and maximum subscribers
+        ServiceElementsSizeInfo{
+            ServiceElementControlSizeInfo{2U, 1U},
+            ServiceElementControlSizeInfo{7U, 4U},
+            ServiceElementControlSizeInfo{1U, 10U},
+        }));
+
+TEST(ServiceDataControlShmSizeTest, IncreasingNumberOfSlotsOfAServiceElementIncreasesCalculatedSize)
+{
+    // Given two sizing infos for a single service-element that only differ in their number of slots
+    const std::vector<ServiceElementControlSizeInfo> service_elements_with_fewer_slots{
+        ServiceElementControlSizeInfo{2U, 3U}};
+    const std::vector<ServiceElementControlSizeInfo> service_elements_with_more_slots{
+        ServiceElementControlSizeInfo{20U, 3U}};
+
+    // When calculating the required shm-size for both sizing infos
+    const auto size_with_fewer_slots = CalculateServiceDataControlShmSize(
+        score::cpp::span<const ServiceElementControlSizeInfo>{service_elements_with_fewer_slots});
+    const auto size_with_more_slots = CalculateServiceDataControlShmSize(
+        score::cpp::span<const ServiceElementControlSizeInfo>{service_elements_with_more_slots});
+
+    // Then the calculated size for the service-element with more slots is bigger, since each slot requires (amongst
+    // others) additional space in the event's EventDataControl and in every subscriber's TransactionLog.
+    EXPECT_GT(size_with_more_slots, size_with_fewer_slots);
+}
+
+TEST(ServiceDataControlShmSizeTest, IncreasingMaxSubscribersOfAServiceElementIncreasesCalculatedSize)
+{
+    // Given two sizing infos for a single service-element that only differ in their maximum number of subscribers
+    const std::vector<ServiceElementControlSizeInfo> service_elements_with_fewer_subscribers{
+        ServiceElementControlSizeInfo{2U, 1U}};
+    const std::vector<ServiceElementControlSizeInfo> service_elements_with_more_subscribers{
+        ServiceElementControlSizeInfo{2U, 20U}};
+
+    // When calculating the required shm-size for both sizing infos
+    const auto size_with_fewer_subscribers = CalculateServiceDataControlShmSize(
+        score::cpp::span<const ServiceElementControlSizeInfo>{service_elements_with_fewer_subscribers});
+    const auto size_with_more_subscribers = CalculateServiceDataControlShmSize(
+        score::cpp::span<const ServiceElementControlSizeInfo>{service_elements_with_more_subscribers});
+
+    // Then the calculated size for the service-element with more subscribers is bigger, since every additional
+    // subscriber requires its own TransactionLogNode (and the TransactionLog's slots array nested within it).
+    EXPECT_GT(size_with_more_subscribers, size_with_fewer_subscribers);
+}
+
+TEST(ServiceDataControlShmSizeTest, AddingAnAdditionalServiceElementIncreasesCalculatedSize)
+{
+    // Given the sizing information of one service-element and, additionally, the very same sizing information for
+    // two service-elements
+    const std::vector<ServiceElementControlSizeInfo> single_service_element{ServiceElementControlSizeInfo{3U, 2U}};
+    const std::vector<ServiceElementControlSizeInfo> two_service_elements{ServiceElementControlSizeInfo{3U, 2U},
+                                                                          ServiceElementControlSizeInfo{3U, 2U}};
+
+    // When calculating the required shm-size for both sizing infos
+    const auto size_for_single_service_element = CalculateServiceDataControlShmSize(
+        score::cpp::span<const ServiceElementControlSizeInfo>{single_service_element});
+    const auto size_for_two_service_elements =
+        CalculateServiceDataControlShmSize(score::cpp::span<const ServiceElementControlSizeInfo>{two_service_elements});
+
+    // Then the calculated size for two service-elements is bigger than for a single one.
+    EXPECT_GT(size_for_two_service_elements, size_for_single_service_element);
+}
+
+}  // namespace
+}  // namespace score::mw::com::impl::lola

--- a/score/mw/com/impl/bindings/lola/service_data_storage.cpp
+++ b/score/mw/com/impl/bindings/lola/service_data_storage.cpp
@@ -11,3 +11,61 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 #include "score/mw/com/impl/bindings/lola/service_data_storage.h"
+
+#include "score/mw/com/impl/bindings/lola/event_data_storage.h"
+
+#include "score/memory/data_type_size_info.h"
+#include "score/memory/shared/pointer_arithmetic_util.h"
+
+#include <cstddef>
+#include <vector>
+
+namespace score::mw::com::impl::lola
+{
+
+std::size_t CalculateServiceDataStorageShmSize(
+    const score::cpp::span<const score::memory::DataTypeSizeInfo> event_and_fields_size_info)
+{
+    // The number of events + fields determines the (fixed) capacity of the two LinearSearchMaps within the
+    // ServiceDataStorage. It equals the number of sizing entries handed over.
+    const auto number_of_events_and_fields = event_and_fields_size_info.size();
+
+    // The real construction of a ServiceDataStorage and the EventDataStorage of each of its events/fields performs a
+    // fixed, deterministic sequence of allocations from the (strictly monotonic) shared-memory resource, which itself
+    // always starts allocating at a std::max_align_t aligned location. Since we know the exact size/alignment of
+    // every single one of these allocations and the exact order in which they happen, we can reconstruct the exact
+    // sequence here and let memory::shared::CalculateAlignedSizeOfSequence() compute the exact (not just worst-case)
+    // total size, taking into account the exact alignment-padding between consecutive allocations.
+    std::vector<score::memory::DataTypeSizeInfo> allocation_sequence{};
+
+    // (1) The ServiceDataStorage object itself (including the inline bookkeeping of its two LinearSearchMaps).
+    allocation_sequence.emplace_back(sizeof(ServiceDataStorage), alignof(ServiceDataStorage));
+
+    // (2) The two allocated arrays of the LinearSearchMaps (allocated once, with capacity ==
+    // number_of_events_and_fields).
+    allocation_sequence.emplace_back(
+        number_of_events_and_fields * sizeof(ServiceDataStorage::EventDataStorageMap::value_type),
+        alignof(ServiceDataStorage::EventDataStorageMap::value_type));
+    allocation_sequence.emplace_back(
+        number_of_events_and_fields * sizeof(ServiceDataStorage::EventMetaInfoMap::value_type),
+        alignof(ServiceDataStorage::EventMetaInfoMap::value_type));
+
+    // (3) For each event/field (in the exact order it gets registered/offered): the EventDataStorage object plus its
+    // raw slot-array. The exact size/alignment of the slot-array (which differs between typed and generic
+    // events/fields, see SkeletonMemoryManager::CreateEventDataInCreatedSharedMemory() resp.
+    // CreateGenericEventDataInCreatedSharedMemory()) is provided by the caller.
+
+    // The size/alignment of the EventDataStorage control structure (a DynamicArray) is independent of the concrete
+    // sample-type (it only holds an offset-pointer, an allocator and two size_t members).
+    constexpr std::size_t event_data_storage_object_size = sizeof(EventDataStorage<std::max_align_t>);
+    constexpr std::size_t event_data_storage_object_alignment = alignof(EventDataStorage<std::max_align_t>);
+    for (const auto& service_element : event_and_fields_size_info)
+    {
+        allocation_sequence.emplace_back(event_data_storage_object_size, event_data_storage_object_alignment);
+        allocation_sequence.emplace_back(service_element.Size(), service_element.Alignment());
+    }
+
+    return score::memory::shared::CalculateAlignedSizeOfSequence(allocation_sequence);
+}
+
+}  // namespace score::mw::com::impl::lola

--- a/score/mw/com/impl/bindings/lola/service_data_storage.h
+++ b/score/mw/com/impl/bindings/lola/service_data_storage.h
@@ -17,12 +17,17 @@
 #include "score/mw/com/impl/bindings/lola/element_fq_id.h"
 #include "score/mw/com/impl/bindings/lola/event_meta_info.h"
 #include "score/mw/com/impl/bindings/lola/i_runtime.h"
+#include "score/mw/com/impl/bindings/lola/linear_search_map.h"
 #include "score/mw/com/impl/runtime.h"
 
-#include "score/memory/shared/map.h"
-#include "score/memory/shared/memory_resource_proxy.h"
+#include "score/memory/data_type_size_info.h"
+#include "score/memory/shared/managed_memory_resource.h"
 #include "score/memory/shared/offset_ptr.h"
 #include "score/os/unistd.h"
+
+#include <score/span.hpp>
+
+#include <cstddef>
 
 namespace score::mw::com::impl::lola
 {
@@ -30,9 +35,28 @@ namespace score::mw::com::impl::lola
 class ServiceDataStorage
 {
   public:
-    explicit ServiceDataStorage(score::memory::shared::ManagedMemoryResource& resource)
-        : events_(resource),
-          events_metainfo_(resource),
+    /// \brief associative container mapping a service-element (event/field) to the raw storage of its event-data slots.
+    /// \details The value-type of the map is a type-erased pointer to the raw storage of the event-data slots.
+    ///          The OffsetPtr points to a EventDataStorage<SampleType>, which gets created by events/fields, when
+    ///          calling Skeleton::Register()!
+    ///
+    using EventDataStorageMap = LinearSearchMap<ElementFqId, score::memory::shared::OffsetPtr<void>>;
+    /// \brief associative container mapping a service-element (event/field) to its (type-erased) meta-information.
+    using EventMetaInfoMap = LinearSearchMap<ElementFqId, EventMetaInfo>;
+
+    /// \brief Ctor for the ServiceDataStorage with a given memory resource to be used for internal storage allocation.
+    /// \details ServiceDataStorage no longer uses dynamically allocating map-types. Instead it uses fixed-capacity
+    ///          containers (LinearSearchMap) whose capacity has to be provided at construction time. The capacity
+    ///          equals the number of service-elements (events + fields) of the service-instance, which is known
+    ///          up-front. This makes the memory footprint of ServiceDataStorage deterministic and calculable without a
+    ///          simulation run.
+    /// \param number_of_events_and_fields maximum number of events + fields, that will be stored in events_ and
+    ///        events_metainfo_.
+    /// \param resource memory-resource to be used for the (single, up-front) allocation of the containers.
+    ServiceDataStorage(const std::size_t number_of_events_and_fields,
+                       score::memory::shared::ManagedMemoryResource& resource)
+        : events_(number_of_events_and_fields, resource),
+          events_metainfo_(number_of_events_and_fields, resource),
           skeleton_pid_{impl::GetBindingRuntime<lola::IRuntime>(BindingType::kLoLa).GetPid()},
           skeleton_uid_{os::Unistd::instance().getuid()}
     {
@@ -42,14 +66,38 @@ class ServiceDataStorage
     // be private.". There are no class invariants to maintain which could be violated by directly accessing member
     // variables.
     // coverity[autosar_cpp14_m11_0_1_violation]
-    score::memory::shared::Map<ElementFqId, score::memory::shared::OffsetPtr<void>> events_;
+    EventDataStorageMap events_;
     // coverity[autosar_cpp14_m11_0_1_violation]
-    score::memory::shared::Map<ElementFqId, EventMetaInfo> events_metainfo_;
+    EventMetaInfoMap events_metainfo_;
     // coverity[autosar_cpp14_m11_0_1_violation]
     pid_t skeleton_pid_;
     // coverity[autosar_cpp14_m11_0_1_violation]
     uid_t skeleton_uid_;
 };
+
+/// \brief Analytically calculates the exact number of bytes a ServiceDataStorage (the data shm-object) occupies.
+/// \details This is used by SkeletonMemoryManager, but located next to ServiceDataStorage so that the layout-dependent
+///          size algorithm stays coupled to the data structure it reasons about. It does NOT allocate any memory nor
+///          construct a ServiceDataStorage; the size is derived purely from the (fixed) container capacities.
+///          The result is exact (not just a bound): since all our allocations happen strictly sequentially (single
+///          threaded, on a (monotonic) shared-memory resource which always starts allocating at a std::max_align_t
+///          aligned location) and we know the size/alignment/order of every individual allocation performed by the
+///          real construction, we can reconstruct the exact same sequence of allocations here and compute the exact
+///          alignment-padding between them (see score::memory::shared::CalculateAlignedSizeOfSequence()).
+/// \param event_and_fields_size_info per service-element sizing information (Size() being the exact size, in bytes,
+///        of the raw slot-array that will be allocated for the service-element; Alignment() being its required
+///        alignment). The caller (SkeletonMemoryManager) is responsible for computing these values, since they
+///        depend on whether the service-element is a typed or a generic (type-erased) event/field:
+///        - typed events allocate exactly number_of_slots * sizeof(SampleType) bytes, aligned to alignof(SampleType)
+///          (see SkeletonMemoryManager::CreateEventDataInCreatedSharedMemory()).
+///        - generic events allocate number_of_slots * sample_size bytes rounded up to a whole number of
+///          std::max_align_t elements, aligned to alignof(std::max_align_t) (see
+///          SkeletonMemoryManager::CreateGenericEventDataInCreatedSharedMemory()).
+///        The size of the span equals the number of service-elements (events + fields), which is the fixed capacity
+///        the ServiceDataStorage containers are constructed with.
+/// \return the exact number of bytes needed for the data shm-object.
+std::size_t CalculateServiceDataStorageShmSize(
+    score::cpp::span<const score::memory::DataTypeSizeInfo> event_and_fields_size_info);
 
 }  // namespace score::mw::com::impl::lola
 

--- a/score/mw/com/impl/bindings/lola/service_data_storage_test.cpp
+++ b/score/mw/com/impl/bindings/lola/service_data_storage_test.cpp
@@ -14,22 +14,27 @@
 
 #include "score/mw/com/impl/binding_type.h"
 #include "score/mw/com/impl/bindings/lola/element_fq_id.h"
-#include "score/mw/com/impl/bindings/lola/event_meta_info.h"
+#include "score/mw/com/impl/bindings/lola/event_data_storage.h"
 #include "score/mw/com/impl/bindings/lola/runtime_mock.h"
 #include "score/mw/com/impl/configuration/global_configuration.h"
 #include "score/mw/com/impl/test/runtime_mock_guard.h"
 
-#include "score/memory/shared/map.h"
+#include "score/memory/data_type_size_info.h"
 #include "score/memory/shared/new_delete_delegate_resource.h"
+#include "score/memory/shared/polymorphic_offset_ptr_allocator.h"
 #include "score/os/ObjectSeam.h"
 #include "score/os/mocklib/unistdmock.h"
+
+#include <score/span.hpp>
 
 #include <gmock/gmock.h>
 #include <gtest/gtest.h>
 
 #include <sched.h>
 #include <sys/types.h>
+#include <cstddef>
 #include <type_traits>
+#include <vector>
 
 namespace score::mw::com::impl::lola
 {
@@ -37,8 +42,14 @@ namespace
 {
 
 const std::uint64_t kMemoryResourceId{10U};
+constexpr std::size_t kNumberOfServiceElements{4U};
 
-using namespace ::testing;
+// memory::DataTypeSizeInfo forbids constructing an instance with an alignment greater than
+// alignof(std::max_align_t) ("overaligned" types are not supported), so all alignments used throughout this test
+// file must not exceed this value.
+constexpr std::size_t kMaxSupportedAlignment{alignof(std::max_align_t)};
+
+using ::testing::Return;
 
 class ServiceDataStorageFixture : public ::testing::Test
 {
@@ -46,11 +57,14 @@ class ServiceDataStorageFixture : public ::testing::Test
     ServiceDataStorageFixture()
     {
         ON_CALL(runtime_mock_guard_.runtime_mock_, GetBindingRuntime(BindingType::kLoLa))
-            .WillByDefault(::testing::Return(&lola_runtime_mock_));
+            .WillByDefault(Return(&lola_runtime_mock_));
+        ON_CALL(lola_runtime_mock_, GetPid()).WillByDefault(Return(pid_t{42}));
+        ON_CALL(*unistd_mock_, getuid()).WillByDefault(Return(uid_t{42}));
     }
 
     RuntimeMockGuard runtime_mock_guard_{};
     RuntimeMock lola_runtime_mock_{};
+    os::MockGuard<os::UnistdMock> unistd_mock_{};
 };
 
 TEST(ServiceDataStorageTest, GenericProxyEventMetaInfoIsStoredInServiceDataStorage)
@@ -63,41 +77,9 @@ TEST(ServiceDataStorageTest, GenericProxyEventMetaInfoIsStoredInServiceDataStora
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
-    static_assert(std::is_same_v<score::memory::shared::Map<ElementFqId, EventMetaInfo>,
-                                 decltype(ServiceDataStorage::events_metainfo_)>,
+    static_assert(std::is_same_v<ServiceDataStorage::EventMetaInfoMap, decltype(ServiceDataStorage::events_metainfo_)>,
                   "ServiceDataStorage does not contain a map of EventMetaInfo.");
 }
-
-// When compiling for linux, we use a boost map. Since the tests for satisfying requirements must be on qnx, we only
-// check the service element event map type on qnx.
-#if !defined(__linux__)
-TEST_F(ServiceDataStorageFixture, ServiceElementsAreIndexedUsingElementFqId)
-{
-    RecordProperty("Verifies", "SCR-21555839");
-    RecordProperty("Description",
-                   "Checks that service elements are stored in a std::map within ServiceDataStorage. A std::map is "
-                   "provided by the standard library which is ASIL-B certified. The standard requires that searching "
-                   "for elements e.g. via find() will return the value corresponding to the provided key and not any "
-                   "other key. Therefore, resolving a service element from an EventFqId will never return the wrong "
-                   "storage location for the service element.");
-    RecordProperty("TestType", "Requirements-based test");
-    RecordProperty("DerivationTechnique", "Analysis of requirements");
-
-    memory::shared::NewDeleteDelegateMemoryResource memory{kMemoryResourceId};
-    const ServiceDataStorage unit{memory};
-    using ActualEventMapType = decltype(unit.events_);
-
-    using ExpectedKeyType = ElementFqId;
-    using ExpectedValueType = score::memory::shared::OffsetPtr<void>;
-    using ExpectedEventMapType = std::map<ExpectedKeyType,
-                                          ExpectedValueType,
-                                          std::less<ExpectedKeyType>,
-                                          std::scoped_allocator_adaptor<memory::shared::PolymorphicOffsetPtrAllocator<
-                                              typename std::map<ExpectedKeyType, ExpectedValueType>::value_type>>>;
-
-    static_assert(std::is_same_v<ActualEventMapType, ExpectedEventMapType>, "Event map is not a std::map");
-}
-#endif  // not __linux__
 
 TEST_F(ServiceDataStorageFixture, GetsPidFromUnistdAndStoresItOnConstruction)
 {
@@ -107,7 +89,7 @@ TEST_F(ServiceDataStorageFixture, GetsPidFromUnistdAndStoresItOnConstruction)
 
     memory::shared::NewDeleteDelegateMemoryResource memory{kMemoryResourceId};
     // When creating a ServiceDataStorage
-    const ServiceDataStorage unit{memory};
+    const ServiceDataStorage unit{kNumberOfServiceElements, memory};
 
     // Then the ServiceDataStorage will contain the returned PID
     EXPECT_EQ(unit.skeleton_pid_, pid);
@@ -115,19 +97,148 @@ TEST_F(ServiceDataStorageFixture, GetsPidFromUnistdAndStoresItOnConstruction)
 
 TEST_F(ServiceDataStorageFixture, GetsUidFromRuntimAndStoresItOnConstruction)
 {
-    const os::MockGuard<os::UnistdMock> unistd_mock{};
-
     // Expecting that getuid will be called
     const uid_t uid{456};
-    EXPECT_CALL(*unistd_mock, getuid()).WillOnce(Return(uid));
+    EXPECT_CALL(*unistd_mock_, getuid()).WillOnce(Return(uid));
 
     memory::shared::NewDeleteDelegateMemoryResource memory{kMemoryResourceId};
     // When creating a ServiceDataStorage
-    const ServiceDataStorage unit{memory};
+    const ServiceDataStorage unit{kNumberOfServiceElements, memory};
 
     // Then the ServiceDataStorage will contain the returned UID
     EXPECT_EQ(unit.skeleton_uid_, uid);
 }
+
+TEST(ServiceDataStorageShmSizeTest, IncreasingAlignedSlotArraySizeOfAServiceElementIncreasesCalculatedSize)
+{
+    // Given two sizing infos for a single service-element that only differ in the size of their raw slot-array
+    const std::vector<score::memory::DataTypeSizeInfo> service_elements_with_smaller_slot_array{
+        score::memory::DataTypeSizeInfo{32U, 16U}};
+    const std::vector<score::memory::DataTypeSizeInfo> service_elements_with_bigger_slot_array{
+        score::memory::DataTypeSizeInfo{320U, 16U}};
+
+    // When calculating the required shm-size for both sizing infos
+    const auto size_with_fewer_slots = CalculateServiceDataStorageShmSize(
+        score::cpp::span<const score::memory::DataTypeSizeInfo>{service_elements_with_smaller_slot_array});
+    const auto size_with_more_slots = CalculateServiceDataStorageShmSize(
+        score::cpp::span<const score::memory::DataTypeSizeInfo>{service_elements_with_bigger_slot_array});
+
+    // Then the calculated size for the service-element with the bigger raw slot-array is bigger.
+    EXPECT_GT(size_with_more_slots, size_with_fewer_slots);
+}
+
+TEST(ServiceDataStorageShmSizeTest, AddingAnAdditionalServiceElementIncreasesCalculatedSize)
+{
+    // Given the sizing information of one service-element and, additionally, the very same sizing information for
+    // two service-elements
+    const std::vector<score::memory::DataTypeSizeInfo> single_service_element{
+        score::memory::DataTypeSizeInfo{48U, 16U}};
+    const std::vector<score::memory::DataTypeSizeInfo> two_service_elements{score::memory::DataTypeSizeInfo{48U, 16U},
+                                                                            score::memory::DataTypeSizeInfo{48U, 16U}};
+
+    // When calculating the required shm-size for both sizing infos
+    const auto size_for_single_service_element = CalculateServiceDataStorageShmSize(
+        score::cpp::span<const score::memory::DataTypeSizeInfo>{single_service_element});
+    const auto size_for_two_service_elements = CalculateServiceDataStorageShmSize(
+        score::cpp::span<const score::memory::DataTypeSizeInfo>{two_service_elements});
+
+    // Then the calculated size for two service-elements is bigger than for a single one.
+    EXPECT_GT(size_for_two_service_elements, size_for_single_service_element);
+}
+
+/// \brief A trivial type of exactly Alignment bytes size, aligned to Alignment bytes.
+/// \details Used to construct a real EventDataStorage<AlignedBlock<Alignment>> whose raw slot-array has the very
+/// same size/alignment characteristics as a score::memory::DataTypeSizeInfo entry (Size() / Alignment()), by
+/// choosing the number of slots as Size() / Alignment. This lets the tests below verify
+/// CalculateServiceDataStorageShmSize's exact-size claim without needing to know the real (production) sample-type
+/// of each service-element.
+template <std::size_t Alignment>
+struct alignas(Alignment) AlignedBlock
+{
+    std::byte data[Alignment];
+};
+
+/// \brief Constructs a real EventDataStorage<AlignedBlock<Alignment>> (with Size() / Alignment slots) on the
+/// given resource, mirroring the size/alignment of the given service_element's raw slot-array.
+template <std::size_t Alignment>
+void ConstructEventDataStorage(const score::memory::DataTypeSizeInfo& service_element,
+                               memory::shared::ManagedMemoryResource& resource)
+{
+    const auto number_of_slots = service_element.Size() / Alignment;
+    score::cpp::ignore = resource.construct<EventDataStorage<AlignedBlock<Alignment>>>(
+        number_of_slots, memory::shared::PolymorphicOffsetPtrAllocator<AlignedBlock<Alignment>>(resource));
+}
+
+/// \brief Constructs a real ServiceDataStorage on the given resource and, for each entry of
+/// service_elements_size_info, a real EventDataStorage whose raw slot-array's size/alignment matches the entry
+/// (mirroring what SkeletonMemoryManager does at runtime for each event/field).
+/// \return the number of bytes the given resource reports as allocated after construction.
+std::size_t ConstructServiceDataStorageAndGetAllocatedBytes(
+    const std::vector<score::memory::DataTypeSizeInfo>& service_elements_size_info,
+    memory::shared::ManagedMemoryResource& resource)
+{
+    score::cpp::ignore = resource.construct<ServiceDataStorage>(service_elements_size_info.size(), resource);
+
+    for (const auto& service_element : service_elements_size_info)
+    {
+        // Only a handful of alignments are exercised by these tests; dispatch to the matching instantiation of
+        // ConstructEventDataStorage() so a real DynamicArray with the required alignment gets allocated.
+        switch (service_element.Alignment())
+        {
+            case 8U:
+                ConstructEventDataStorage<8U>(service_element, resource);
+                break;
+            case kMaxSupportedAlignment:
+                ConstructEventDataStorage<kMaxSupportedAlignment>(service_element, resource);
+                break;
+            default:
+                ADD_FAILURE() << "Unsupported alignment in test: " << service_element.Alignment();
+                break;
+        }
+    }
+
+    return resource.GetUserAllocatedBytes();
+}
+
+using ServiceElementsSizeInfo = std::vector<score::memory::DataTypeSizeInfo>;
+
+class ServiceDataStorageShmSizeParameterizedTestFixture : public ServiceDataStorageFixture,
+                                                          public ::testing::WithParamInterface<ServiceElementsSizeInfo>
+{
+};
+
+TEST_P(ServiceDataStorageShmSizeParameterizedTestFixture, CalculatedSizeMatchesActualAllocation)
+{
+    // Given the sizing information of some (possibly zero) service-elements (events/fields)
+    const auto& service_elements_size_info = GetParam();
+
+    // When calculating the required shm-size for a ServiceDataStorage holding these service-elements
+    const auto calculated_size = CalculateServiceDataStorageShmSize(
+        score::cpp::span<const score::memory::DataTypeSizeInfo>{service_elements_size_info});
+
+    // Then the calculated size exactly matches the number of bytes actually allocated when constructing a real
+    // ServiceDataStorage (and its EventDataStorages) with the very same sizing information.
+    memory::shared::NewDeleteDelegateMemoryResource resource{kMemoryResourceId};
+    const auto actual_allocated_bytes =
+        ConstructServiceDataStorageAndGetAllocatedBytes(service_elements_size_info, resource);
+
+    EXPECT_EQ(calculated_size, actual_allocated_bytes);
+}
+
+INSTANTIATE_TEST_SUITE_P(
+    ServiceDataStorageShmSizeTests,
+    ServiceDataStorageShmSizeParameterizedTestFixture,
+    ::testing::Values(
+        // No service-elements at all (an empty span)
+        ServiceElementsSizeInfo{},
+        // A single service-element (event/field)
+        ServiceElementsSizeInfo{score::memory::DataTypeSizeInfo{80U, 16U}},
+        // Multiple service-elements (events/fields) with differing raw slot-array sizes and alignments
+        ServiceElementsSizeInfo{
+            score::memory::DataTypeSizeInfo{16U, 8U},
+            score::memory::DataTypeSizeInfo{224U, kMaxSupportedAlignment},
+            score::memory::DataTypeSizeInfo{128U, kMaxSupportedAlignment},
+        }));
 
 }  // namespace
 }  // namespace score::mw::com::impl::lola

--- a/score/mw/com/impl/bindings/lola/skeleton_event_common_test.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_event_common_test.cpp
@@ -54,6 +54,7 @@ class SkeletonEventCommonFixture : public SkeletonEventFixture
 
         SkeletonBinding::SkeletonEventBindings events{};
         SkeletonBinding::SkeletonFieldBindings fields{};
+        events.emplace(service_element_name, mock_event_binding_);
         std::optional<SkeletonBinding::RegisterShmObjectTraceCallback> register_shm_object_trace_callback{};
 
         std::ignore = skeleton_->PrepareOffer(events, fields, std::move(register_shm_object_trace_callback));

--- a/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
@@ -11,20 +11,28 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 #include "score/mw/com/impl/bindings/lola/skeleton_memory_manager.h"
+#include "score/mw/com/impl/bindings/lola/application_id_pid_mapping_entry.h"
+#include "score/mw/com/impl/bindings/lola/event_control.h"
+#include "score/mw/com/impl/bindings/lola/event_data_control.h"
 #include "score/mw/com/impl/bindings/lola/i_shm_path_builder.h"
 #include "score/mw/com/impl/bindings/lola/service_data_control.h"
 #include "score/mw/com/impl/bindings/lola/service_data_storage.h"
 #include "score/mw/com/impl/bindings/lola/tracing/tracing_runtime.h"
+#include "score/mw/com/impl/bindings/lola/transaction_log.h"
+#include "score/mw/com/impl/bindings/lola/transaction_log_set.h"
 #include "score/mw/com/impl/com_error.h"
 #include "score/mw/com/impl/configuration/lola_service_instance_deployment.h"
 #include "score/mw/com/impl/configuration/lola_service_type_deployment.h"
 #include "score/mw/com/impl/configuration/quality_type.h"
+#include "score/mw/com/impl/generic_skeleton_event_binding.h"
 #include "score/mw/com/impl/runtime.h"
 #include "score/mw/com/impl/skeleton_event_binding.h"
 
 #include "score/language/safecpp/safe_math/safe_math.h"
+#include "score/memory/data_type_size_info.h"
 #include "score/memory/shared/managed_memory_resource.h"
 #include "score/memory/shared/new_delete_delegate_resource.h"
+#include "score/memory/shared/pointer_arithmetic_util.h"
 #include "score/memory/shared/shared_memory_factory.h"
 #include "score/mw/log/logging.h"
 #include "score/os/acl.h"
@@ -38,6 +46,7 @@
 #include <optional>
 #include <string>
 #include <unordered_map>
+#include <vector>
 
 namespace score::mw::com::impl::lola
 {
@@ -98,6 +107,25 @@ std::uint64_t CalculateMemoryResourceId(const LolaServiceTypeDeployment::Service
             (static_cast<std::uint64_t>(lola_instance_id) << 8U) + static_cast<std::uint8_t>(object_type));
 }
 
+/// \brief Determines whether the given event/field bindings are generic (type-erased) or typed bindings.
+/// \details Within a single Skeleton instance, event/field bindings are homogeneously either all generic
+/// (GenericSkeletonEventBinding, used exclusively by a GenericSkeleton) or all typed (SkeletonEventBinding<SampleType>,
+/// used exclusively by a code-generated, typed Skeleton<SampleType>) - a single skeleton instance never mixes both
+/// kinds. It is therefore sufficient to inspect a single (arbitrary) binding to determine which kind ALL of them are.
+/// \return true if the bindings are generic, false if they are typed. If both events and fields are empty, false is
+/// returned (the value is irrelevant in that case, as there is nothing to size).
+bool AreServiceElementBindingsGeneric(const SkeletonBinding::SkeletonEventBindings& events,
+                                      const SkeletonBinding::SkeletonFieldBindings& fields)
+{
+    const auto* const first_binding_map = !events.empty() ? &events : (!fields.empty() ? &fields : nullptr);
+    if (first_binding_map == nullptr)
+    {
+        return false;
+    }
+    const SkeletonEventBindingBase& first_binding = first_binding_map->begin()->second.get();
+    return dynamic_cast<const GenericSkeletonEventBinding*>(&first_binding) != nullptr;
+}
+
 }  // namespace
 
 SkeletonMemoryManager::SkeletonMemoryManager(QualityType quality_type,
@@ -118,6 +146,7 @@ SkeletonMemoryManager::SkeletonMemoryManager(QualityType quality_type,
       storage_{nullptr},
       control_qm_{nullptr},
       control_asil_b_{nullptr},
+      number_of_events_and_fields_{},
       storage_resource_{},
       control_qm_resource_{},
       control_asil_resource_{}
@@ -129,6 +158,12 @@ auto SkeletonMemoryManager::CreateSharedMemory(
     SkeletonBinding::SkeletonFieldBindings& fields,
     std::optional<SkeletonBinding::RegisterShmObjectTraceCallback> register_shm_object_trace_callback) -> Result<void>
 {
+    // The number of service-elements determines the (fixed) capacity of the containers within ServiceDataStorage and
+    // ServiceDataControl. It has to be known before either of them is constructed (in CreateSharedMemoryForData /
+    // CreateSharedMemoryForControl below), independent of how the shm-object sizes are determined (simulation,
+    // analytic estimation, or manually specified sizes).
+    number_of_events_and_fields_ = events.size() + fields.size();
+
     const auto storage_size_calc_result = CalculateShmResourceStorageSizes(events, fields);
 
     if (!CreateSharedMemoryForControl(
@@ -367,10 +402,12 @@ SkeletonMemoryManager::ShmResourceStorageSizes SkeletonMemoryManager::CalculateS
     SkeletonBinding::SkeletonEventBindings& events,
     SkeletonBinding::SkeletonFieldBindings& fields)
 {
-    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
-        GetBindingRuntime<lola::IRuntime>(BindingType::kLoLa).GetShmSizeCalculationMode() ==
-            ShmSizeCalculationMode::kSimulation,
-        "No other shm size calculation mode is currently suppored");
+    const auto shm_size_calculation_mode =
+        GetBindingRuntime<lola::IRuntime>(BindingType::kLoLa).GetShmSizeCalculationMode();
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE((shm_size_calculation_mode == ShmSizeCalculationMode::kSimulation) ||
+                                                    (shm_size_calculation_mode == ShmSizeCalculationMode::kAnalysis),
+                                                "No other shm size calculation mode is currently supported");
+
     if ((lola_service_instance_deployment_.shared_memory_size_.has_value()) &&
         (lola_service_instance_deployment_.control_asil_b_memory_size_.has_value()) &&
         (lola_service_instance_deployment_.control_qm_memory_size_.has_value()))
@@ -389,7 +426,25 @@ SkeletonMemoryManager::ShmResourceStorageSizes SkeletonMemoryManager::CalculateS
                 lola_service_instance_deployment_.control_asil_b_memory_size_.value()};
     }
 
-    auto required_shm_storage_size = CalculateShmResourceStorageSizesBySimulation(events, fields);
+    // Depending on the configured ShmSizeCalculationMode the required sizes of the shm-objects are determined either:
+    //  - analytically (kAnalysis): possible because ServiceDataStorage (data shm-object) and ServiceDataControl
+    //    (control shm-object) exclusively use fixed-capacity containers, or
+    //  - by a simulation dry-run (kSimulation): the shm-objects are constructed on a monitoring heap-memory-resource
+    //    and the resulting number of allocated bytes is read out.
+    ShmResourceStorageSizes required_shm_storage_size{};
+    if (shm_size_calculation_mode == ShmSizeCalculationMode::kAnalysis)
+    {
+        const std::size_t data_size = CalculateDataShmResourceStorageSize(events, fields);
+        const std::size_t control_size = CalculateControlShmResourceStorageSize(events, fields);
+        const auto control_asil_b_size = (quality_type_ == QualityType::kASIL_B)
+                                             ? std::optional<std::size_t>{control_size}
+                                             : std::optional<std::size_t>{};
+        required_shm_storage_size = ShmResourceStorageSizes{data_size, control_size, control_asil_b_size};
+    }
+    else
+    {
+        required_shm_storage_size = CalculateShmResourceStorageSizesBySimulation(events, fields);
+    }
 
     const std::size_t control_asil_b_size_result = required_shm_storage_size.control_asil_b_size.has_value()
                                                        ? required_shm_storage_size.control_asil_b_size.value()
@@ -502,6 +557,128 @@ SkeletonMemoryManager::ShmResourceStorageSizes SkeletonMemoryManager::CalculateS
                                          : std::optional<std::size_t>{};
 
     return ShmResourceStorageSizes{control_data_size, control_qm_size, control_asil_b_size};
+}
+
+std::size_t SkeletonMemoryManager::CalculateDataShmResourceStorageSize(
+    SkeletonBinding::SkeletonEventBindings& events,
+    SkeletonBinding::SkeletonFieldBindings& fields) const
+{
+    // Whether the event/field bindings are generic or typed is determined once, upfront (a skeleton instance never
+    // mixes both kinds - see AreServiceElementBindingsGeneric() for details). This distinction between generic/typed
+    // bindings is necessary as the memory allocation taking place is slightly different currently. When we switch to
+    // complete type-erasure at some point for the binding layer, this distinction will go away!
+    const bool are_bindings_generic = AreServiceElementBindingsGeneric(events, fields);
+
+    // Collect the per service-element sizing information from the deployment configuration and the (typed/generic)
+    // event bindings. The layout-dependent size algorithm itself lives next to ServiceDataStorage
+    // (CalculateServiceDataStorageShmSize), so that the data-structure and the algorithm reasoning about its memory
+    // footprint stay closely coupled.
+    const auto collect_service_elements =
+        [this, are_bindings_generic](std::vector<score::memory::DataTypeSizeInfo>& events_and_fields_size_infos,
+                                     auto& bindings,
+                                     const bool are_fields) {
+            for (const auto& binding : bindings)
+            {
+                const std::size_t number_of_slots = GetNumberOfSampleSlotsFromConfig(binding.first, are_fields);
+                SkeletonEventBindingBase& event_binding = binding.second.get();
+
+                // A generic (type-erased) event/field allocates its slot-array as an EventDataStorage<std::max_align_t>
+                // (see SkeletonMemoryManager::CreateGenericEventDataInCreatedSharedMemory()): the raw byte count gets
+                // rounded up to a whole number of std::max_align_t elements and the array is aligned to
+                // alignof(std::max_align_t). A typed event/field allocates its slot-array as an
+                // EventDataStorage<SampleType> (see SkeletonMemoryManager::CreateEventDataInCreatedSharedMemory()):
+                // exactly number_of_slots * sizeof(SampleType) bytes, aligned to alignof(SampleType) - no rounding.
+                if (are_bindings_generic)
+                {
+                    const auto& generic_event_binding = static_cast<const GenericSkeletonEventBinding&>(event_binding);
+                    const auto [sample_size, sample_alignment] = generic_event_binding.GetSizeInfo();
+                    const std::size_t total_data_size_bytes = number_of_slots * sample_size;
+                    const std::size_t num_max_align_elements =
+                        (total_data_size_bytes + sizeof(std::max_align_t) - 1U) / sizeof(std::max_align_t);
+                    const std::size_t slot_array_size = num_max_align_elements * sizeof(std::max_align_t);
+
+                    events_and_fields_size_infos.emplace_back(slot_array_size, alignof(std::max_align_t));
+                }
+                else
+                {
+                    const std::size_t slot_array_size = number_of_slots * event_binding.GetMaxSize();
+                    events_and_fields_size_infos.emplace_back(slot_array_size, event_binding.GetAlignment());
+                }
+            }
+        };
+    std::vector<score::memory::DataTypeSizeInfo> events_and_fields_size_infos{};
+    collect_service_elements(events_and_fields_size_infos, events, false);
+    collect_service_elements(events_and_fields_size_infos, fields, true);
+
+    return CalculateServiceDataStorageShmSize(events_and_fields_size_infos);
+}
+
+std::size_t SkeletonMemoryManager::CalculateControlShmResourceStorageSize(
+    SkeletonBinding::SkeletonEventBindings& events,
+    SkeletonBinding::SkeletonFieldBindings& fields) const
+{
+    // Collect the per service-element sizing information from the deployment configuration. The layout-dependent size
+    // algorithm itself lives next to ServiceDataControl (CalculateServiceDataControlShmSize), so that the
+    // data-structure and the algorithm reasoning about its memory footprint stay closely coupled.
+
+    const auto collect_service_elements = [this](
+                                              std::vector<ServiceElementControlSizeInfo>& events_and_fields_size_infos,
+                                              auto& bindings,
+                                              const bool are_fields) {
+        for (const auto& binding : bindings)
+        {
+            const std::size_t number_of_slots = GetNumberOfSampleSlotsFromConfig(binding.first, are_fields);
+            const std::size_t max_subscribers = GetMaxSubscribersFromConfig(binding.first, are_fields);
+            events_and_fields_size_infos.push_back(ServiceElementControlSizeInfo{number_of_slots, max_subscribers});
+        }
+    };
+    std::vector<ServiceElementControlSizeInfo> events_and_fields_size_infos{};
+    collect_service_elements(events_and_fields_size_infos, events, false);
+    collect_service_elements(events_and_fields_size_infos, fields, true);
+
+    return CalculateServiceDataControlShmSize(events_and_fields_size_infos);
+}
+
+std::size_t SkeletonMemoryManager::GetNumberOfSampleSlotsFromConfig(const std::string_view service_element_name,
+                                                                    const bool is_field) const
+{
+    const std::string name{service_element_name};
+    if (is_field)
+    {
+        const auto deployment =
+            GetServiceElementInstanceDeployment<ServiceElementType::FIELD>(lola_service_instance_deployment_, name);
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+            deployment.lola_event_instance_deployment_.GetNumberOfSampleSlots().has_value(),
+            "Number of sample slots need to be specified for field on provider side!");
+        return deployment.lola_event_instance_deployment_.GetNumberOfSampleSlots().value();
+    }
+
+    const auto deployment =
+        GetServiceElementInstanceDeployment<ServiceElementType::EVENT>(lola_service_instance_deployment_, name);
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+        deployment.GetNumberOfSampleSlots().has_value(),
+        "Number of sample slots need to be specified for event on provider side!");
+    return deployment.GetNumberOfSampleSlots().value();
+}
+
+std::size_t SkeletonMemoryManager::GetMaxSubscribersFromConfig(const std::string_view service_element_name,
+                                                               const bool is_field) const
+{
+    const std::string name{service_element_name};
+    if (is_field)
+    {
+        const auto deployment =
+            GetServiceElementInstanceDeployment<ServiceElementType::FIELD>(lola_service_instance_deployment_, name);
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+            deployment.lola_event_instance_deployment_.max_subscribers_.has_value(),
+            "Max subscribers need to be specified for field on provider side!");
+        return deployment.lola_event_instance_deployment_.max_subscribers_.value();
+    }
+    const auto deployment =
+        GetServiceElementInstanceDeployment<ServiceElementType::EVENT>(lola_service_instance_deployment_, name);
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(deployment.max_subscribers_.has_value(),
+                                                "Max subscribers need to be specified for event on provider side!");
+    return deployment.max_subscribers_.value();
 }
 
 // Suppress "AUTOSAR C++14 A15-5-3":
@@ -694,7 +871,10 @@ bool SkeletonMemoryManager::OpenSharedMemoryForControl(const QualityType asil_le
 void SkeletonMemoryManager::InitializeSharedMemoryForData(
     const std::shared_ptr<score::memory::shared::ManagedMemoryResource>& memory)
 {
-    storage_ = memory->construct<ServiceDataStorage>(*memory);
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+        number_of_events_and_fields_.has_value(),
+        "number_of_events_and_fields_ must be set before constructing the ServiceDataStorage.");
+    storage_ = memory->construct<ServiceDataStorage>(number_of_events_and_fields_.value(), *memory);
     storage_resource_ = memory;
     // Suppress "AUTOSAR C++14 A0-1-1", The rule states: "A project shall not contain instances of non-volatile
     // variables being given values that are not subsequently used"
@@ -714,7 +894,10 @@ void SkeletonMemoryManager::InitializeSharedMemoryForControl(
 {
     auto& control = (asil_level == QualityType::kASIL_QM) ? control_qm_ : control_asil_b_;
 
-    control = memory->construct<ServiceDataControl>(*memory);
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
+        number_of_events_and_fields_.has_value(),
+        "number_of_events_and_fields_ must be set before constructing the ServiceDataControl.");
+    control = memory->construct<ServiceDataControl>(number_of_events_and_fields_.value(), *memory);
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(control != nullptr);
 }
 

--- a/score/mw/com/impl/bindings/lola/skeleton_memory_manager.h
+++ b/score/mw/com/impl/bindings/lola/skeleton_memory_manager.h
@@ -33,6 +33,7 @@
 #include <memory>
 #include <optional>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <utility>
 
@@ -171,7 +172,7 @@ class SkeletonMemoryManager final
         std::optional<std::size_t> control_asil_b_size;
     };
 
-    /// \brief Calculates needed sizes for shm-objects for data and ctrl either via simulation or a rough estimation
+    /// \brief Calculates needed sizes for shm-objects for data and ctrl either via simulation or an analytic estimation
     /// depending on config.
     /// \return storage sizes for the different shm-objects
     ShmResourceStorageSizes CalculateShmResourceStorageSizes(SkeletonBinding::SkeletonEventBindings& events,
@@ -182,6 +183,36 @@ class SkeletonMemoryManager final
     ShmResourceStorageSizes CalculateShmResourceStorageSizesBySimulation(
         SkeletonBinding::SkeletonEventBindings& events,
         SkeletonBinding::SkeletonFieldBindings& fields);
+
+    /// \brief Calculates the needed size for the data shm-object (holding the ServiceDataStorage) analytically.
+    /// \details Does NOT allocate any (heap) memory and does not create a ServiceDataStorage. It collects the exact
+    /// per service-element sizing information (exact slot-array size/alignment, distinguishing typed and generic
+    /// events/fields) from the handed-over event/field bindings and the deployment configuration and delegates the
+    /// actual layout math to CalculateServiceDataStorageShmSize (located next to ServiceDataStorage), which computes
+    /// the exact size needed.
+    /// \return needed size (in bytes) for the data shm-object.
+    std::size_t CalculateDataShmResourceStorageSize(SkeletonBinding::SkeletonEventBindings& events,
+                                                    SkeletonBinding::SkeletonFieldBindings& fields) const;
+
+    /// \brief Calculates the needed size for a control shm-object (holding a ServiceDataControl) analytically.
+    /// \details Does NOT allocate any (heap) memory and does not create a ServiceDataControl. It collects the per
+    /// service-element sizing information (number of slots, max-subscribers) from the handed-over event/field bindings
+    /// and the deployment configuration and delegates the actual layout math to CalculateServiceDataControlShmSize
+    /// (located next to ServiceDataControl), which computes the exact size needed.
+    /// The same size applies to the QM and (if present) the ASIL-B control shm-object, as both hold a
+    /// ServiceDataControl created with the very same configuration.
+    /// \return needed size (in bytes) for a single control shm-object.
+    std::size_t CalculateControlShmResourceStorageSize(SkeletonBinding::SkeletonEventBindings& events,
+                                                       SkeletonBinding::SkeletonFieldBindings& fields) const;
+
+    /// \brief Looks up the configured number of sample-slots for the given service-element.
+    /// \param service_element_name name of the event/field.
+    std::size_t GetNumberOfSampleSlotsFromConfig(const std::string_view service_element_name,
+                                                 const bool is_field) const;
+
+    /// \brief Looks up the configured maximum number of subscribers for the given service-element.
+    /// \param service_element_name name of the event/field.
+    std::size_t GetMaxSubscribersFromConfig(const std::string_view service_element_name, const bool is_field) const;
 
     /// Functions for creating / opening / initializing shared memory within PrepareOffer.
     bool CreateSharedMemoryForData(
@@ -224,6 +255,13 @@ class SkeletonMemoryManager final
     ServiceDataStorage* storage_;
     ServiceDataControl* control_qm_;
     ServiceDataControl* control_asil_b_;
+
+    /// \brief Number of events + fields of the service-instance.
+    /// \details Determines the fixed capacity of the containers within ServiceDataStorage and ServiceDataControl.
+    /// Empty until it is set in CreateSharedMemory (before the ServiceDataStorage / ServiceDataControl are
+    /// constructed). Every read site asserts that the value has been set, so an accidental use before initialization is
+    /// caught deterministically instead of silently defaulting to a (potentially valid) capacity of 0.
+    std::optional<std::size_t> number_of_events_and_fields_;
 
     std::shared_ptr<score::memory::shared::ManagedMemoryResource> storage_resource_;
     std::shared_ptr<score::memory::shared::ManagedMemoryResource> control_qm_resource_;

--- a/score/mw/com/impl/bindings/lola/skeleton_test.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_test.cpp
@@ -945,6 +945,9 @@ class SkeletonRegisterParamaterisedFixture : public SkeletonTestMockedSharedMemo
 TEST_P(SkeletonRegisterParamaterisedFixture, RegisterWillCreateEventDataIfShmRegionWasCreated)
 {
     // Given a Skeleton constructed from a valid identifier referencing an ASIL-B deployment
+    // The event that will be registered below is also offered here, so that the fixed-capacity containers within
+    // ServiceDataStorage are sized to hold it.
+    events_.emplace(test::kFooEventName, mock_event_binding_);
     InitialiseSkeleton(GetValidASILInstanceIdentifier()).WithNoConnectedProxy();
 
     // when calling PrepareOffer ... expect, that it succeeds
@@ -1442,7 +1445,10 @@ TEST_P(SkeletonRegisterParamaterisedFixture, CallingRegisterWithSameServiceEleme
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
     auto test_function = [this]() noexcept {
-        // Given a Skeleton constructed from a valid identifier referencing a QM deployment
+        // Given a Skeleton constructed from a valid identifier referencing a QM deployment. The event that will be
+        // registered below is offered, so that the fixed-capacity containers within ServiceDataStorage can hold it and
+        // the (intended) termination is triggered by the duplicate registration rather than by a capacity overflow.
+        events_.emplace(test::kFooEventName, mock_event_binding_);
         InitialiseSkeleton(GetValidASILInstanceIdentifier());
 
         EXPECT_TRUE(

--- a/score/mw/com/impl/bindings/lola/test/BUILD
+++ b/score/mw/com/impl/bindings/lola/test/BUILD
@@ -83,6 +83,7 @@ cc_library(
         "//score/mw/com/impl:service_discovery_mock",
         "//score/mw/com/impl/bindings/lola:event",
         "//score/mw/com/impl/bindings/lola/messaging:message_passing_service_mock",
+        "//score/mw/com/impl/bindings/mock_binding",
         "@googletest//:gtest_main",
         "@score_baselibs//score/language/futurecpp",
     ],
@@ -144,6 +145,8 @@ cc_test(
     deps = [
         ":skeleton_test_resources",
         "//score/mw/com/impl:runtime",
+        "//score/mw/com/impl/bindings/lola:service_data_control",
+        "//score/mw/com/impl/bindings/lola:service_data_storage",
         "//score/mw/com/impl/bindings/mock_binding",
         "@googletest//:gtest_main",
         "@score_baselibs//score/language/safecpp/coverage_termination_handler",

--- a/score/mw/com/impl/bindings/lola/test/skeleton_component_test.cpp
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_component_test.cpp
@@ -12,6 +12,8 @@
  ********************************************************************************/
 #include "score/mw/com/impl/bindings/lola/messaging/message_passing_service_mock.h"
 #include "score/mw/com/impl/bindings/lola/partial_restart_path_builder.h"
+#include "score/mw/com/impl/bindings/lola/service_data_control.h"
+#include "score/mw/com/impl/bindings/lola/service_data_storage.h"
 #include "score/mw/com/impl/bindings/lola/shm_path_builder.h"
 #include "score/mw/com/impl/bindings/lola/skeleton.h"
 #include "score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h"
@@ -55,6 +57,7 @@ constexpr auto asil_control_shm = "/dev/shm/lola-ctl-0000000000000001-00016-b";
 
 const auto kInstanceSpecifier = InstanceSpecifier::Create(std::string{"abc/abc/TirePressurePort"}).value();
 constexpr std::size_t kNumberOfSlots{10U};
+const SkeletonEventProperties kEventProperties{kNumberOfSlots, 0U, 0U, false, 10U, true};
 
 SkeletonBinding::SkeletonEventBindings kEmptyEvents{};
 SkeletonBinding::SkeletonFieldBindings kEmptyFields{};
@@ -146,6 +149,9 @@ class SkeletonComponentTestFixture : public ::testing::Test
 
         ON_CALL(lola_runtime_mock_, GetLolaMessaging()).WillByDefault(ReturnRef(message_passing_service_mock_));
         ON_CALL(runtime_mock_, GetTracingRuntime()).WillByDefault(Return(&tracing_runtime_mock_));
+
+        ON_CALL(mock_event_binding_, GetMaxSize()).WillByDefault(Return(sizeof(TestSampleType)));
+        ON_CALL(mock_field_binding_, GetMaxSize()).WillByDefault(Return(sizeof(TestSampleType)));
     }
 
     void TearDown() override
@@ -186,7 +192,12 @@ class SkeletonComponentTestFixture : public ::testing::Test
     {
         events_.emplace(test::kFooEventName, mock_event_binding_);
         lola_event_instance_deployments_.push_back(
-            {test::kFooEventName, LolaEventInstanceDeployment{kNumberOfSlots, 10U, 1U, true, 0}});
+            {test::kFooEventName,
+             LolaEventInstanceDeployment{kEventProperties.GetTotalNumberOfSlots(),
+                                         kEventProperties.max_subscribers,
+                                         1U,
+                                         kEventProperties.enforce_max_samples,
+                                         0}});
         fields_.emplace(test::kFooFieldName, mock_field_binding_);
         lola_field_instance_deployments_.push_back(
             {test::kFooFieldName,
@@ -219,6 +230,28 @@ class SkeletonComponentTestFixture : public ::testing::Test
         EXPECT_NE(service_instance_deployment_, nullptr);
         EXPECT_NE(service_type_deployment_, nullptr);
         return make_InstanceIdentifier(*service_instance_deployment_, *service_type_deployment_);
+    }
+
+    /// \brief Wires the mock event- and field-bindings so that their PrepareOffer() registers the corresponding
+    ///        service-element at its parent lola::Skeleton (exactly like a real lola::SkeletonEvent does).
+    /// \details Without this the mock bindings PrepareOffer() would be a no-op and the service-elements would
+    ///          never be emplaced into the ServiceDataControl / ServiceDataStorage. As a consequence the shared-memory
+    ///          size calculation (simulation dry-run as well as the real construction) would omit all per-element
+    ///          allocations!
+    void RegisterEventAndFieldOnPrepareOffer(Skeleton& skeleton)
+    {
+        ON_CALL(mock_event_binding_, PrepareOffer()).WillByDefault(testing::Invoke([&skeleton]() -> Result<void> {
+            const ElementFqId element_fq_id{
+                test::kLolaServiceId, test::kFooEventId, test::kDefaultLolaInstanceId, ServiceElementType::EVENT};
+            skeleton.Register<TestSampleType>(element_fq_id, kEventProperties);
+            return {};
+        }));
+        ON_CALL(mock_field_binding_, PrepareOffer()).WillByDefault(testing::Invoke([&skeleton]() -> Result<void> {
+            const ElementFqId element_fq_id{
+                test::kLolaServiceId, test::kFooFieldId, test::kDefaultLolaInstanceId, ServiceElementType::FIELD};
+            skeleton.Register<TestSampleType>(element_fq_id, kEventProperties);
+            return {};
+        }));
     }
 
     /// mocks used by test
@@ -389,10 +422,10 @@ TEST_F(SkeletonComponentTestFixture, ASILShmIsCreated)
     EXPECT_GT(GetSize(asil_control_shm), test::kConfiguredDeploymentControlAsilBShmSize);
 }
 
-TEST_F(SkeletonComponentTestFixture, DataShmObjectSizeCalc_Simulation_QM)
+TEST_F(SkeletonComponentTestFixture, ShmObjectSizeCalc_Simulation_QM)
 {
     RecordProperty("Verifies", "SCR-5899126");
-    RecordProperty("Description", "Check if the data_shm is calculated correctly.");
+    RecordProperty("Description", "Check if the size of data and control shm is calculated correctly.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
@@ -413,24 +446,7 @@ TEST_F(SkeletonComponentTestFixture, DataShmObjectSizeCalc_Simulation_QM)
     EXPECT_CALL(lola_runtime_mock_, GetShmSizeCalculationMode()).WillOnce(Return(ShmSizeCalculationMode::kSimulation));
 
     // Expecting that the event and field are offered during the simulation dry run
-    ON_CALL(mock_event_binding_, PrepareOffer())
-        .WillByDefault(testing::Invoke([&unit, lola_service_type_deployment]() -> Result<void> {
-            ElementFqId element_fq_id{lola_service_type_deployment->service_id_,
-                                      test::kFooEventId,
-                                      test::kDefaultLolaInstanceId,
-                                      ServiceElementType::EVENT};
-            unit->Register<uint8_t>(element_fq_id, test::kDefaultEventProperties);
-            return {};
-        }));
-    ON_CALL(mock_field_binding_, PrepareOffer())
-        .WillByDefault(testing::Invoke([&unit, lola_service_type_deployment]() -> Result<void> {
-            ElementFqId element_fq_id{lola_service_type_deployment->service_id_,
-                                      test::kFooFieldId,
-                                      test::kDefaultLolaInstanceId,
-                                      ServiceElementType::FIELD};
-            unit->Register<uint8_t>(element_fq_id, test::kDefaultEventProperties);
-            return {};
-        }));
+    RegisterEventAndFieldOnPrepareOffer(*unit);
 
     // When offering a service and all events
     const auto val = unit->PrepareOffer(events_, fields_, {});
@@ -449,10 +465,10 @@ TEST_F(SkeletonComponentTestFixture, DataShmObjectSizeCalc_Simulation_QM)
     EXPECT_GE(GetSize(control_shm), CalculateLowerBoundControlShmSize({{sizeof(TestSampleType), kNumberOfSlots}}));
 }
 
-TEST_F(SkeletonComponentTestFixture, DataShmObjectSizeCalc_Simulation_AsilB)
+TEST_F(SkeletonComponentTestFixture, ShmObjectSizeCalc_Simulation_AsilB)
 {
     RecordProperty("Verifies", "SCR-5899126");
-    RecordProperty("Description", "Check if the data_shm is calculated correctly.");
+    RecordProperty("Description", "Check if the size of data and control shm is calculated correctly.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
@@ -473,24 +489,7 @@ TEST_F(SkeletonComponentTestFixture, DataShmObjectSizeCalc_Simulation_AsilB)
     EXPECT_CALL(lola_runtime_mock_, GetShmSizeCalculationMode()).WillOnce(Return(ShmSizeCalculationMode::kSimulation));
 
     // Expecting that the event and field are offered during the simulation dry run
-    ON_CALL(mock_event_binding_, PrepareOffer())
-        .WillByDefault(testing::Invoke([&unit, lola_service_type_deployment]() -> Result<void> {
-            ElementFqId element_fq_id{lola_service_type_deployment->service_id_,
-                                      test::kFooEventId,
-                                      test::kDefaultLolaInstanceId,
-                                      ServiceElementType::EVENT};
-            unit->Register<uint8_t>(element_fq_id, test::kDefaultEventProperties);
-            return {};
-        }));
-    ON_CALL(mock_field_binding_, PrepareOffer())
-        .WillByDefault(testing::Invoke([&unit, lola_service_type_deployment]() -> Result<void> {
-            ElementFqId element_fq_id{lola_service_type_deployment->service_id_,
-                                      test::kFooFieldId,
-                                      test::kDefaultLolaInstanceId,
-                                      ServiceElementType::FIELD};
-            unit->Register<uint8_t>(element_fq_id, test::kDefaultEventProperties);
-            return {};
-        }));
+    RegisterEventAndFieldOnPrepareOffer(*unit);
 
     // When offering a service and all events
     const auto val = unit->PrepareOffer(events_, fields_, {});
@@ -512,15 +511,15 @@ TEST_F(SkeletonComponentTestFixture, DataShmObjectSizeCalc_Simulation_AsilB)
 }
 
 TEST_F(SkeletonComponentTestFixture,
-       DataShmObjectSizeCalc_Simulation_QM_DoesNotTerminateWhenConfiguredSizeIsLargerThanEstimate)
+       ShmObjectSizeCalc_Simulation_QM_DoesNotTerminateWhenConfiguredDataShmSizeIsLargerThanDetermined)
 {
     RecordProperty("Verifies", "SCR-5899126");
-    RecordProperty("Description", "Check if the data_shm is calculated correctly.");
+    RecordProperty("Description", "Check if the size of data_shm is calculated correctly.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
-    // At the time of writing, 648 bytes is needed for the data segment used in this test.
+    // At the time of writing, the data segment requires 482 bytes for the event and field registered in this test.
     constexpr std::size_t large_enough_user_specified_memory_size{1000U};
 
     // Given a skeleton with one event "fooEvent" and one field "fooField" registered with a user configured shared
@@ -537,6 +536,9 @@ TEST_F(SkeletonComponentTestFixture,
         std::get_if<LolaServiceTypeDeployment>(&test::kValidMinimalTypeDeployment.binding_info_);
     ASSERT_NE(lola_service_type_deployment, nullptr);
 
+    // and that the event and field register themselves at their parent skeleton during the simulation dry-run
+    RegisterEventAndFieldOnPrepareOffer(*unit);
+
     // and that the LoLa runtime returns that ShmSize calculation shall be done via simulation
     EXPECT_CALL(lola_runtime_mock_, GetShmSizeCalculationMode()).WillOnce(Return(ShmSizeCalculationMode::kSimulation));
 
@@ -549,11 +551,109 @@ TEST_F(SkeletonComponentTestFixture,
     EXPECT_TRUE(prepare_offer_result.has_value());
 }
 
-using SkeletonComponentTestDeathTest = SkeletonComponentTestFixture;
-TEST_F(SkeletonComponentTestDeathTest, DataShmObjectSizeCalc_Simulation_QM_TerminatesWithTooSmallConfiguredSize)
+/// \brief Verifies that the data shared-memory object size can be calculated analytically (mode kAnalysis), i.e.
+///        WITHOUT relying on the value obtained from the simulation dry-run, and that the analytically sized shared
+///        memory is large enough to hold the actually registered events/fields.
+TEST_F(SkeletonComponentTestFixture, ShmObjectSizeCalc_Analysis_Data_QM)
 {
     RecordProperty("Verifies", "SCR-5899126");
-    RecordProperty("Description", "Check if the data_shm is calculated correctly.");
+    RecordProperty("Description",
+                   "Check that the data_shm size is calculated analytically (without a simulation run) and is "
+                   "sufficient to hold the registered events/fields.");
+    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("Priority", "1");
+    RecordProperty("DerivationTechnique", "Analysis of requirements");
+
+    // Given a skeleton with one event "fooEvent" and one field "fooField" registered
+    WithAServiceInstanceDeploymentContainingSingleEventAndField(QualityType::kASIL_QM)
+        .WithAServiceTypeDeploymentContainingSingleEventAndField();
+    const auto instance_identifier = CreateInstanceIdentifier();
+
+    auto unit = CreateSkeleton(instance_identifier);
+    ASSERT_NE(unit, nullptr);
+
+    const auto* const lola_service_type_deployment =
+        std::get_if<LolaServiceTypeDeployment>(&test::kValidMinimalTypeDeployment.binding_info_);
+    ASSERT_NE(lola_service_type_deployment, nullptr);
+
+    // Expect, that the LoLa runtime returns that ShmSize calculation shall be done via (analytic) estimation
+    EXPECT_CALL(lola_runtime_mock_, GetShmSizeCalculationMode()).WillOnce(Return(ShmSizeCalculationMode::kAnalysis));
+
+    // The analytic size calculation queries the maximum sample-size of each event/field binding. Since the events are
+    // registered below as uint8_t, GetMaxSize() has to report the matching size.
+    ON_CALL(mock_event_binding_, GetMaxSize()).WillByDefault(Return(sizeof(std::uint8_t)));
+    ON_CALL(mock_field_binding_, GetMaxSize()).WillByDefault(Return(sizeof(std::uint8_t)));
+
+    // Expecting that the event and field are registered
+    RegisterEventAndFieldOnPrepareOffer(*unit);
+
+    // When offering a service and registering all events/fields into the analytically-sized shared-memory
+    const auto val = unit->PrepareOffer(events_, fields_, {});
+    std::ignore = mock_event_binding_.PrepareOffer();
+    std::ignore = mock_field_binding_.PrepareOffer();
+
+    // then expect, that it succeeds (i.e. the analytically calculated data-shm size was sufficient; had it been too
+    // small, the construction of the event-storage in the fixed-size shared-memory would have aborted)
+    EXPECT_TRUE(val.has_value());
+
+    // and the created data-shm is at least as large as the pure payload it must hold
+    EXPECT_GE(GetSize(data_shm), CalculateLowerBoundDataShmSize({{sizeof(TestSampleType), kNumberOfSlots}}));
+}
+
+/// \brief Verifies that the control shared-memory object size can be calculated analytically (mode kAnalysis), i.e.
+///        WITHOUT relying on the value obtained from the simulation dry-run, and that the analytically sized control
+///        shared memory is large enough to hold the actually registered events/fields.
+TEST_F(SkeletonComponentTestFixture, ShmObjectSizeCalc_Analysis_Control_QM)
+{
+    RecordProperty("Verifies", "SCR-5899126");
+    RecordProperty("Description",
+                   "Check that the control_shm size is calculated analytically (without a simulation run) and is "
+                   "sufficient to hold the registered events/fields.");
+    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("Priority", "1");
+    RecordProperty("DerivationTechnique", "Analysis of requirements");
+
+    // Given a skeleton with one event "fooEvent" and one field "fooField" registered
+    WithAServiceInstanceDeploymentContainingSingleEventAndField(QualityType::kASIL_QM)
+        .WithAServiceTypeDeploymentContainingSingleEventAndField();
+    const auto instance_identifier = CreateInstanceIdentifier();
+
+    auto unit = CreateSkeleton(instance_identifier);
+    ASSERT_NE(unit, nullptr);
+
+    const auto* const lola_service_type_deployment =
+        std::get_if<LolaServiceTypeDeployment>(&test::kValidMinimalTypeDeployment.binding_info_);
+    ASSERT_NE(lola_service_type_deployment, nullptr);
+
+    // Expect, that the LoLa runtime returns that ShmSize calculation shall be done via (analytic) estimation
+    EXPECT_CALL(lola_runtime_mock_, GetShmSizeCalculationMode()).WillOnce(Return(ShmSizeCalculationMode::kAnalysis));
+
+    // The analytic size calculation queries the maximum sample-size of each event/field binding. Since the events are
+    // registered below as uint8_t, GetMaxSize() has to report the matching size.
+    ON_CALL(mock_event_binding_, GetMaxSize()).WillByDefault(Return(sizeof(std::uint8_t)));
+    ON_CALL(mock_field_binding_, GetMaxSize()).WillByDefault(Return(sizeof(std::uint8_t)));
+
+    // Expecting that the event and field are registered
+    RegisterEventAndFieldOnPrepareOffer(*unit);
+
+    // When offering a service and registering all events/fields into the analytically-sized shared-memory
+    const auto val = unit->PrepareOffer(events_, fields_, {});
+    std::ignore = mock_event_binding_.PrepareOffer();
+    std::ignore = mock_field_binding_.PrepareOffer();
+
+    // then expect, that it succeeds (i.e. the analytically calculated control-shm size was sufficient; had it been too
+    // small, the construction of the event-control in the fixed-size shared-memory would have aborted)
+    EXPECT_TRUE(val.has_value());
+
+    // and the created control-shm is at least as large as the pure payload it must hold
+    EXPECT_GE(GetSize(control_shm), CalculateLowerBoundControlShmSize({{sizeof(TestSampleType), kNumberOfSlots}}));
+}
+
+using SkeletonComponentTestDeathTest = SkeletonComponentTestFixture;
+TEST_F(SkeletonComponentTestDeathTest, ShmObjectSizeCalc_Simulation_QM_Data_TerminatesWithTooSmallConfiguredSize)
+{
+    RecordProperty("Verifies", "SCR-5899126");
+    RecordProperty("Description", "Check if the size of data_shm is calculated correctly.");
     RecordProperty("TestType", "Requirements-based test");
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
@@ -575,6 +675,9 @@ TEST_F(SkeletonComponentTestDeathTest, DataShmObjectSizeCalc_Simulation_QM_Termi
             std::get_if<LolaServiceTypeDeployment>(&test::kValidMinimalTypeDeployment.binding_info_);
         ASSERT_NE(lola_service_type_deployment, nullptr);
 
+        // and that the event and field register themselves at their parent skeleton during the simulation dry-run
+        RegisterEventAndFieldOnPrepareOffer(*unit);
+
         // and that the LoLa runtime returns that ShmSize calculation shall be done via simulation
         EXPECT_CALL(lola_runtime_mock_, GetShmSizeCalculationMode())
             .WillOnce(Return(ShmSizeCalculationMode::kSimulation));
@@ -587,7 +690,7 @@ TEST_F(SkeletonComponentTestDeathTest, DataShmObjectSizeCalc_Simulation_QM_Termi
 }
 
 TEST_F(SkeletonComponentTestFixture,
-       DataShmObjectSizeCalc_Simulation_QM_DoesNotTerminateWhenConfiguredControlQmSizeIsLargerThanEstimate)
+       ShmObjectSizeCalc_Simulation_QM_Control_DoesNotTerminateWhenConfiguredSizeIsLargerThanDetermined)
 {
     RecordProperty("Verifies", "SCR-5899126");
     RecordProperty("Description", "Check if the control_shm is calculated correctly.");
@@ -595,8 +698,8 @@ TEST_F(SkeletonComponentTestFixture,
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
-    // At the time of writing, 1000 bytes are sufficient for the control segment.
-    constexpr std::size_t large_enough_user_specified_control_qm_memory_size{1000U};
+    // At the time of writing, the control segment requires 2500 bytes for the event and field registered in this test.
+    constexpr std::size_t large_enough_user_specified_control_qm_memory_size{4000U};
 
     // Given a skeleton with one event "fooEvent" and one field "fooField" registered with a user configured shared
     // memory size which is larger than the required control qm shm size
@@ -614,10 +717,13 @@ TEST_F(SkeletonComponentTestFixture,
         std::get_if<LolaServiceTypeDeployment>(&test::kValidMinimalTypeDeployment.binding_info_);
     ASSERT_NE(lola_service_type_deployment, nullptr);
 
+    // and that the event and field register themselves at their parent skeleton during the simulation dry-run
+    RegisterEventAndFieldOnPrepareOffer(*unit);
+
     // and that the LoLa runtime returns that ShmSize calculation shall be done via simulation
     EXPECT_CALL(lola_runtime_mock_, GetShmSizeCalculationMode()).WillOnce(Return(ShmSizeCalculationMode::kSimulation));
 
-    // When preparing to offer a service
+    // When preparing to offer a service and its event and field
     const auto prepare_offer_result = unit->PrepareOffer(events_, fields_, {});
     std::ignore = mock_event_binding_.PrepareOffer();
     std::ignore = mock_field_binding_.PrepareOffer();
@@ -627,7 +733,7 @@ TEST_F(SkeletonComponentTestFixture,
 }
 
 TEST_F(SkeletonComponentTestFixture,
-       DataShmObjectSizeCalc_Simulation_QM_DoesNotTerminateWhenConfiguredControlAsilBSizeIsLargerThanEstimate)
+       ShmObjectSizeCalc_Simulation_QM_Control_DoesNotTerminateWhenConfiguredAsilBSizeIsLargerThanDetermined)
 {
     RecordProperty("Verifies", "SCR-5899126");
     RecordProperty("Description", "Check if the asil_control_shm is calculated correctly.");
@@ -635,8 +741,8 @@ TEST_F(SkeletonComponentTestFixture,
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
-    // At the time of writing, 1000 bytes are sufficient for the control segment.
-    constexpr std::size_t large_enough_user_specified_control_asil_b_memory_size{1000U};
+    // At the time of writing, the control segment requires 2500 bytes for the event and field registered in this test.
+    constexpr std::size_t large_enough_user_specified_control_asil_b_memory_size{4000U};
 
     // Given a skeleton with one event "fooEvent" and one field "fooField" registered with a user configured shared
     // memory size which is larger than the required control ASIL-B shm size
@@ -652,10 +758,13 @@ TEST_F(SkeletonComponentTestFixture,
         std::get_if<LolaServiceTypeDeployment>(&test::kValidMinimalTypeDeployment.binding_info_);
     ASSERT_NE(lola_service_type_deployment, nullptr);
 
+    // and that the event and field register themselves at their parent skeleton during the simulation dry-run
+    RegisterEventAndFieldOnPrepareOffer(*unit);
+
     // and that the LoLa runtime returns that ShmSize calculation shall be done via simulation
     EXPECT_CALL(lola_runtime_mock_, GetShmSizeCalculationMode()).WillOnce(Return(ShmSizeCalculationMode::kSimulation));
 
-    // When preparing to offer a service
+    // When preparing to offer a service and its event and field
     const auto prepare_offer_result = unit->PrepareOffer(events_, fields_, {});
     std::ignore = mock_event_binding_.PrepareOffer();
     std::ignore = mock_field_binding_.PrepareOffer();
@@ -665,7 +774,7 @@ TEST_F(SkeletonComponentTestFixture,
 }
 
 TEST_F(SkeletonComponentTestFixture,
-       DataShmObjectSizeCalc_Simulation_QM_DoesNotTerminateWhenShmSizesAreLargerThanEstimates)
+       ShmObjectSizeCalc_Simulation_QM_Data_Control_DoesNotTerminateWhenShmSizesAreLargerThanDetermined)
 {
     RecordProperty("Verifies", "SCR-5899126");
     RecordProperty("Description", "Check if all shm sizes are calculated correctly.");
@@ -673,10 +782,11 @@ TEST_F(SkeletonComponentTestFixture,
     RecordProperty("Priority", "1");
     RecordProperty("DerivationTechnique", "Analysis of requirements");
 
-    // At the time of writing, 1000 bytes are sufficient for every segment.
+    // At the time of writing, the registered event and field require ~482 bytes for the data segment and ~2500 bytes
+    // for each control segment.
     constexpr std::size_t large_enough_user_specified_data_shm_memory_size{1000U};
-    constexpr std::size_t large_enough_user_specified_control_asil_b_memory_size{1000U};
-    constexpr std::size_t large_enough_user_specified_control_qm_memory_size{1000U};
+    constexpr std::size_t large_enough_user_specified_control_asil_b_memory_size{4000U};
+    constexpr std::size_t large_enough_user_specified_control_qm_memory_size{4000U};
 
     // Given a skeleton with one event "fooEvent" and one field "fooField" registered with a user configured shared
     // memory size which is larger than the required control ASIL-B shm size
@@ -694,10 +804,13 @@ TEST_F(SkeletonComponentTestFixture,
         std::get_if<LolaServiceTypeDeployment>(&test::kValidMinimalTypeDeployment.binding_info_);
     ASSERT_NE(lola_service_type_deployment, nullptr);
 
+    // and that the event and field register themselves at their parent skeleton when offered
+    RegisterEventAndFieldOnPrepareOffer(*unit);
+
     // and that the LoLa runtime returns that ShmSize calculation shall be done via simulation
     EXPECT_CALL(lola_runtime_mock_, GetShmSizeCalculationMode()).WillOnce(Return(ShmSizeCalculationMode::kSimulation));
 
-    // When preparing to offer a service
+    // When preparing to offer a service and its event and field
     const auto prepare_offer_result = unit->PrepareOffer(events_, fields_, {});
     std::ignore = mock_event_binding_.PrepareOffer();
     std::ignore = mock_field_binding_.PrepareOffer();
@@ -706,9 +819,106 @@ TEST_F(SkeletonComponentTestFixture,
     EXPECT_TRUE(prepare_offer_result.has_value());
 }
 
+TEST_F(SkeletonComponentTestFixture, ShmObjectSizeCalc_Analysis_QM_Control_SizeMatchesSimulationResult)
+{
+    RecordProperty("Verifies", "SCR-5899126");
+    RecordProperty("Description", "Check if all shm sizes are calculated correctly.");
+    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("Priority", "1");
+    RecordProperty("DerivationTechnique", "Analysis of requirements");
+
+    // Given a skeleton with one event "fooEvent" and one field "fooField"
+    WithAServiceInstanceDeploymentContainingSingleEventAndField(QualityType::kASIL_QM)
+        .WithAServiceTypeDeploymentContainingSingleEventAndField();
+    const auto instance_identifier = CreateInstanceIdentifier();
+
+    auto unit = CreateSkeleton(instance_identifier);
+    ASSERT_NE(unit, nullptr);
+
+    // and that the event and field register themselves at their parent skeleton when offered
+    RegisterEventAndFieldOnPrepareOffer(*unit);
+
+    // and that the LoLa runtime returns that ShmSize calculation shall be done via simulation
+    EXPECT_CALL(lola_runtime_mock_, GetShmSizeCalculationMode()).WillOnce(Return(ShmSizeCalculationMode::kSimulation));
+
+    // When preparing to offer a service and its event and field
+    auto prepare_offer_result = unit->PrepareOffer(events_, fields_, {});
+    std::ignore = mock_event_binding_.PrepareOffer();
+    std::ignore = mock_field_binding_.PrepareOffer();
+
+    // then expect, that PrepareOffer was successful
+    EXPECT_TRUE(prepare_offer_result.has_value());
+    // then we store the actual size of the control-shm object
+    const auto control_shm_size_simulation = GetSize(control_shm);
+    // and PrepareStopOffer
+    unit->PrepareStopOffer(std::nullopt);
+
+    // expect, that the LoLa runtime returns that ShmSize calculation shall be done via kAnalysis
+    EXPECT_CALL(lola_runtime_mock_, GetShmSizeCalculationMode()).WillOnce(Return(ShmSizeCalculationMode::kAnalysis));
+    // When preparing to offer a service and its event and field a 2nd time
+    prepare_offer_result = unit->PrepareOffer(events_, fields_, {});
+    std::ignore = mock_event_binding_.PrepareOffer();
+    std::ignore = mock_field_binding_.PrepareOffer();
+
+    // then expect, that PrepareOffer was successful
+    EXPECT_TRUE(prepare_offer_result.has_value());
+
+    // and that the size calculated by analysis exactly matches the size resulting from simulation.
+    const auto control_shm_size_analysis = GetSize(control_shm);
+    EXPECT_EQ(control_shm_size_analysis, control_shm_size_simulation);
+}
+
+TEST_F(SkeletonComponentTestFixture, ShmObjectSizeCalc_Analysis_QM_Data_SizeMatchesSimulationResult)
+{
+    RecordProperty("Verifies", "SCR-5899126");
+    RecordProperty("Description", "Check if all shm sizes are calculated correctly.");
+    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("Priority", "1");
+    RecordProperty("DerivationTechnique", "Analysis of requirements");
+
+    // Given a skeleton with one event "fooEvent" and one field "fooField"
+    WithAServiceInstanceDeploymentContainingSingleEventAndField(QualityType::kASIL_QM)
+        .WithAServiceTypeDeploymentContainingSingleEventAndField();
+    const auto instance_identifier = CreateInstanceIdentifier();
+
+    auto unit = CreateSkeleton(instance_identifier);
+    ASSERT_NE(unit, nullptr);
+
+    // and that the event and field register themselves at their parent skeleton when offered
+    RegisterEventAndFieldOnPrepareOffer(*unit);
+
+    // and that the LoLa runtime returns that ShmSize calculation shall be done via simulation
+    EXPECT_CALL(lola_runtime_mock_, GetShmSizeCalculationMode()).WillOnce(Return(ShmSizeCalculationMode::kSimulation));
+
+    // When preparing to offer a service and its event and field
+    auto prepare_offer_result = unit->PrepareOffer(events_, fields_, {});
+    std::ignore = mock_event_binding_.PrepareOffer();
+    std::ignore = mock_field_binding_.PrepareOffer();
+
+    // then expect, that PrepareOffer was successful
+    EXPECT_TRUE(prepare_offer_result.has_value());
+    // then we store the actual size of the data-shm object
+    const auto data_shm_size_simulation = GetSize(data_shm);
+    // and PrepareStopOffer
+    unit->PrepareStopOffer(std::nullopt);
+
+    // expect, that the LoLa runtime returns that ShmSize calculation shall be done via kAnalysis
+    EXPECT_CALL(lola_runtime_mock_, GetShmSizeCalculationMode()).WillOnce(Return(ShmSizeCalculationMode::kAnalysis));
+    // When preparing to offer a service and its event and field a 2nd time
+    prepare_offer_result = unit->PrepareOffer(events_, fields_, {});
+    std::ignore = mock_event_binding_.PrepareOffer();
+    std::ignore = mock_field_binding_.PrepareOffer();
+
+    // then expect, that PrepareOffer was successful
+    EXPECT_TRUE(prepare_offer_result.has_value());
+
+    // and that the size calculated by analysis exactly matches the size resulting from simulation.
+    const auto data_shm_size_analysis = GetSize(data_shm);
+    EXPECT_EQ(data_shm_size_analysis, data_shm_size_simulation);
+}
+
 using SkeletonComponentTestDeathTest = SkeletonComponentTestFixture;
-TEST_F(SkeletonComponentTestDeathTest,
-       DataShmObjectSizeCalc_Simulation_QM_TerminatesWithTooSmallConfiguredControlQmSize)
+TEST_F(SkeletonComponentTestDeathTest, ShmObjectSizeCalc_Simulation_QM_Control_TerminatesWithTooSmallConfiguredSize)
 {
     RecordProperty("Verifies", "SCR-5899126");
     RecordProperty("Description", "Check if the control_shm is calculated correctly.");
@@ -735,6 +945,9 @@ TEST_F(SkeletonComponentTestDeathTest,
             std::get_if<LolaServiceTypeDeployment>(&test::kValidMinimalTypeDeployment.binding_info_);
         ASSERT_NE(lola_service_type_deployment, nullptr);
 
+        // and that the event and field register themselves at their parent skeleton during the simulation dry-run
+        RegisterEventAndFieldOnPrepareOffer(*unit);
+
         // and that the LoLa runtime returns that ShmSize calculation shall be done via simulation
         EXPECT_CALL(lola_runtime_mock_, GetShmSizeCalculationMode())
             .WillOnce(Return(ShmSizeCalculationMode::kSimulation));
@@ -748,7 +961,7 @@ TEST_F(SkeletonComponentTestDeathTest,
 
 using SkeletonComponentTestDeathTest = SkeletonComponentTestFixture;
 TEST_F(SkeletonComponentTestDeathTest,
-       DataShmObjectSizeCalc_Simulation_QM_TerminatesWithTooSmallConfiguredControlAsilBSize)
+       ShmObjectSizeCalc_Simulation_AsilB_Control_TerminatesWithTooSmallConfiguredAsilBSize)
 {
     RecordProperty("Verifies", "SCR-5899126");
     RecordProperty("Description", "Check if the asil_control_shm is calculated correctly.");
@@ -772,6 +985,9 @@ TEST_F(SkeletonComponentTestDeathTest,
         const auto* const lola_service_type_deployment =
             std::get_if<LolaServiceTypeDeployment>(&test::kValidMinimalTypeDeployment.binding_info_);
         ASSERT_NE(lola_service_type_deployment, nullptr);
+
+        // and that the event and field register themselves at their parent skeleton during the simulation dry-run
+        RegisterEventAndFieldOnPrepareOffer(*unit);
 
         // and that the LoLa runtime returns that ShmSize calculation shall be done via simulation
         EXPECT_CALL(lola_runtime_mock_, GetShmSizeCalculationMode())

--- a/score/mw/com/impl/bindings/lola/test/skeleton_event_test_resources.cpp
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_event_test_resources.cpp
@@ -47,6 +47,10 @@ void SkeletonEventFixture::InitialiseSkeletonEvent(const ElementFqId element_fq_
 
     SkeletonBinding::SkeletonEventBindings events{};
     SkeletonBinding::SkeletonFieldBindings fields{};
+    // Offer the single service-element that will be registered below (via the SkeletonEvent's own PrepareOffer). This
+    // sizes the fixed-capacity containers within ServiceDataStorage. The mock binding itself is only counted; no
+    // expectations on it are required for the offer/sizing path.
+    events.emplace(service_element_name, mock_event_binding_);
     std::optional<SkeletonBinding::RegisterShmObjectTraceCallback> register_shm_object_trace_callback{};
     std::ignore = skeleton_->PrepareOffer(events, fields, std::move(register_shm_object_trace_callback));
 

--- a/score/mw/com/impl/bindings/lola/test/skeleton_event_test_resources.h
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_event_test_resources.h
@@ -17,6 +17,7 @@
 #include "score/mw/com/impl/bindings/lola/skeleton_event.h"
 #include "score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h"
 #include "score/mw/com/impl/bindings/lola/transaction_log_set.h"
+#include "score/mw/com/impl/bindings/mock_binding/skeleton_event.h"
 #include "score/mw/com/impl/service_discovery_mock.h"
 
 #include <gmock/gmock.h>
@@ -82,6 +83,11 @@ class SkeletonEventFixture : public SkeletonMockedMemoryFixture
                                                             instance_specifier_};
 
     std::unique_ptr<SkeletonEvent<test::TestSampleType>> skeleton_event_;
+
+    /// \brief Mock event binding used only to "offer" a single service-element when the parent skeleton's
+    ///        PrepareOffer() is called (see InitialiseSkeletonEvent). Offering one binding sizes the fixed-capacity
+    ///        containers within ServiceDataStorage to hold the single event/field that the test subsequently registers.
+    mock_binding::SkeletonEvent<test::TestSampleType> mock_event_binding_{};
 
     /// mocks used by test
     ServiceDiscoveryMock service_discovery_mock_{};

--- a/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.cpp
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.cpp
@@ -346,7 +346,7 @@ std::unique_ptr<ServiceDataControl> SkeletonMockedMemoryFixture::CreateServiceDa
 {
     const auto created_resource = (quality_type == QualityType::kASIL_QM) ? control_qm_shared_memory_resource_mock_
                                                                           : control_asil_b_shared_memory_resource_mock_;
-    auto service_data_control = std::make_unique<ServiceDataControl>(*created_resource);
+    auto service_data_control = std::make_unique<ServiceDataControl>(1U, *created_resource);
 
     auto event_control =
         service_data_control->event_controls_.emplace(std::piecewise_construct,

--- a/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h
@@ -470,7 +470,7 @@ class SkeletonMockedMemoryFixture : public ::testing::Test
     template <typename SampleType>
     ServiceDataStorage CreateServiceDataStorageWithEvent(ElementFqId element_fq_id) noexcept
     {
-        ServiceDataStorage service_data_storage{*data_shared_memory_resource_mock_};
+        ServiceDataStorage service_data_storage{1U, *data_shared_memory_resource_mock_};
 
         auto* event_data_storage = data_shared_memory_resource_mock_->construct<EventDataStorage<SampleType>>(
             10U, *data_shared_memory_resource_mock_);

--- a/score/mw/com/impl/bindings/lola/test_doubles/fake_mocked_service_data.cpp
+++ b/score/mw/com/impl/bindings/lola/test_doubles/fake_mocked_service_data.cpp
@@ -31,6 +31,10 @@ using ::score::memory::shared::SharedMemoryResourceHeapAllocatorMock;
 const std::uint64_t kControlMemoryResourceId{std::numeric_limits<std::uint64_t>::max()};
 const std::uint64_t kDataMemoryResourceId{std::numeric_limits<std::uint64_t>::max() - 1U};
 
+// Fixed capacity used for the fixed-capacity containers within the fake ServiceDataStorage. Test-doubles add their
+// events dynamically, so we simply reserve a generous upper bound.
+constexpr std::size_t kMaxNumberOfServiceElements{100U};
+
 }  // namespace
 
 FakeMockedServiceData::FakeMockedServiceData(const pid_t skeleton_process_pid_in, uid_t skeleton_uid_in)
@@ -39,8 +43,8 @@ FakeMockedServiceData::FakeMockedServiceData(const pid_t skeleton_process_pid_in
         std::make_shared<::testing::NiceMock<SharedMemoryResourceHeapAllocatorMock>>(kControlMemoryResourceId);
     data_memory = std::make_shared<::testing::NiceMock<SharedMemoryResourceHeapAllocatorMock>>(kDataMemoryResourceId);
 
-    data_control = control_memory->construct<ServiceDataControl>(*control_memory);
-    data_storage = data_memory->construct<ServiceDataStorage>(*data_memory);
+    data_control = control_memory->construct<ServiceDataControl>(kMaxNumberOfServiceElements, *control_memory);
+    data_storage = data_memory->construct<ServiceDataStorage>(kMaxNumberOfServiceElements, *data_memory);
 
     data_storage->skeleton_pid_ = skeleton_process_pid_in;
     data_storage->skeleton_uid_ = skeleton_uid_in;

--- a/score/mw/com/impl/bindings/lola/test_doubles/fake_mocked_service_data.h
+++ b/score/mw/com/impl/bindings/lola/test_doubles/fake_mocked_service_data.h
@@ -62,7 +62,7 @@ inline std::tuple<EventControl*, EventDataStorage<SampleType>*> FakeMockedServic
     bool inserted;
     const auto total_number_of_slots = event_properties.GetTotalNumberOfSlots();
 
-    score::memory::shared::Map<ElementFqId, EventControl>::iterator inserted_control;
+    typename std::decay_t<decltype(data_control->event_controls_)>::iterator inserted_control;
     std::tie(inserted_control, inserted) =
         data_control->event_controls_.emplace(std::piecewise_construct,
                                               std::forward_as_tuple(id),

--- a/score/mw/com/impl/bindings/lola/test_doubles/fake_service_data.cpp
+++ b/score/mw/com/impl/bindings/lola/test_doubles/fake_service_data.cpp
@@ -20,6 +20,13 @@ namespace score::mw::com::impl::lola
 
 using ::score::memory::shared::ISharedMemoryResource;
 
+namespace
+{
+// Fixed capacity used for the fixed-capacity containers within the fake ServiceDataStorage. Test-doubles add their
+// events dynamically, so we simply reserve a generous upper bound.
+constexpr std::size_t kMaxNumberOfServiceElements{100U};
+}  // namespace
+
 std::unique_ptr<FakeServiceData> FakeServiceData::Create(const std::string& control_file_name,
                                                          const std::string& data_file_name,
                                                          const std::string& usage_marker_file,
@@ -73,7 +80,8 @@ FakeServiceData::FakeServiceData(const std::string& control_file_name,
         [this, initialise_skeleton_data](std::shared_ptr<ISharedMemoryResource> memory_resource) {
             if (initialise_skeleton_data)
             {
-                data_control = memory_resource->construct<ServiceDataControl>(*memory_resource);
+                data_control =
+                    memory_resource->construct<ServiceDataControl>(kMaxNumberOfServiceElements, *memory_resource);
             }
         },
         65535U);
@@ -84,7 +92,8 @@ FakeServiceData::FakeServiceData(const std::string& control_file_name,
             std::shared_ptr<ISharedMemoryResource> memory_resource) {
             if (initialise_skeleton_data)
             {
-                data_storage = memory_resource->construct<ServiceDataStorage>(*memory_resource);
+                data_storage =
+                    memory_resource->construct<ServiceDataStorage>(kMaxNumberOfServiceElements, *memory_resource);
                 data_storage->skeleton_pid_ = skeleton_process_pid_in;
                 data_storage->skeleton_uid_ = skeleton_uid_in;
             }

--- a/score/mw/com/impl/bindings/lola/test_doubles/fake_service_data.h
+++ b/score/mw/com/impl/bindings/lola/test_doubles/fake_service_data.h
@@ -90,7 +90,7 @@ inline std::tuple<EventControl*, EventDataStorage<SampleType>*> FakeServiceData:
 {
     bool inserted;
     const auto total_number_of_slots = event_properties.GetTotalNumberOfSlots();
-    score::memory::shared::Map<ElementFqId, EventControl>::iterator inserted_control;
+    typename std::decay_t<decltype(data_control->event_controls_)>::iterator inserted_control;
     std::tie(inserted_control, inserted) =
         data_control->event_controls_.emplace(std::piecewise_construct,
                                               std::forward_as_tuple(id),

--- a/score/mw/com/impl/bindings/lola/transaction_log_rollback_executor_test.cpp
+++ b/score/mw/com/impl/bindings/lola/transaction_log_rollback_executor_test.cpp
@@ -55,6 +55,9 @@ const SkeletonInstanceIdentifier kSkeletonInstanceIdentifier{kDummyElementFqId.s
 
 constexpr std::size_t kNumberOfSlots{20U};
 constexpr std::size_t kMaxSubscribers{20U};
+// The test registers a single event (see WithTransactionLogRollbackExecutor), hence a capacity of one is sufficient
+// for the fixed-capacity event_controls_ container within ServiceDataControl.
+constexpr std::size_t kNumberOfServiceElements{1U};
 const SkeletonEventProperties kDummySkeletonEventProperties{kNumberOfSlots, 0U, 0U, false, kMaxSubscribers, true};
 
 class TransactionLogRollbackExecutorFixture : public ::testing::Test
@@ -71,7 +74,7 @@ class TransactionLogRollbackExecutorFixture : public ::testing::Test
 
     TransactionLogRollbackExecutorFixture& WithTransactionLogRollbackExecutor()
     {
-        service_data_control_ = std::make_unique<ServiceDataControl>(memory_resource_mock_);
+        service_data_control_ = std::make_unique<ServiceDataControl>(kNumberOfServiceElements, memory_resource_mock_);
         AddEvent(kDummyElementFqId, kDummySkeletonEventProperties);
 
         unit_ = std::make_unique<TransactionLogRollbackExecutor>(*service_data_control_,

--- a/score/mw/com/impl/bindings/mock_binding/generic_skeleton_event.h
+++ b/score/mw/com/impl/bindings/mock_binding/generic_skeleton_event.h
@@ -42,6 +42,7 @@ class GenericSkeletonEvent : public GenericSkeletonEventBinding
     MOCK_METHOD(BindingType, GetBindingType, (), (const, noexcept, override));
     MOCK_METHOD(void, SetSkeletonEventTracingData, (impl::tracing::SkeletonEventTracingData), (noexcept, override));
     MOCK_METHOD(std::size_t, GetMaxSize, (), (const, noexcept, override));
+    MOCK_METHOD(std::size_t, GetAlignment, (), (const, noexcept, override));
     MOCK_METHOD(Result<void>,
                 SetReceiveHandlerRegistrationChangedHandler,
                 (ReceiveHandlerRegistrationChangedCallback),

--- a/score/mw/com/impl/bindings/mock_binding/skeleton_event.h
+++ b/score/mw/com/impl/bindings/mock_binding/skeleton_event.h
@@ -30,6 +30,7 @@ class SkeletonEventBase : public SkeletonEventBindingBase
     MOCK_METHOD(Result<void>, PrepareOffer, (), (noexcept, override));
     MOCK_METHOD(void, PrepareStopOffer, (), (noexcept, override));
     MOCK_METHOD(std::size_t, GetMaxSize, (), (const, noexcept, override));
+    MOCK_METHOD(std::size_t, GetAlignment, (), (const, noexcept, override));
     MOCK_METHOD(BindingType, GetBindingType, (), (const, noexcept, override));
     MOCK_METHOD(void, SetSkeletonEventTracingData, (impl::tracing::SkeletonEventTracingData), (noexcept, override));
 };

--- a/score/mw/com/impl/configuration/configuration_json_parsing_strategy.cpp
+++ b/score/mw/com/impl/configuration/configuration_json_parsing_strategy.cpp
@@ -109,6 +109,7 @@ constexpr auto kPermissionChecksKey = "permission-checks"sv;
 
 constexpr auto kShmBinding = "SHM"sv;
 constexpr auto kShmSizeCalcModeSimulation = "SIMULATION"sv;
+constexpr auto kShmSizeCalcModeAnalysis = "ANALYSIS"sv;
 
 constexpr auto kTracingTraceFilterConfigPathDefaultValue = "./etc/mw_com_trace_filter.json"sv;
 constexpr auto kStrictPermission = "strict"sv;
@@ -227,6 +228,10 @@ auto ParseShmSizeCalcMode(const score::json::Object& json_map) -> std::optional<
         if (shm_size_calc_mode_value == kShmSizeCalcModeSimulation)
         {
             return ShmSizeCalculationMode::kSimulation;
+        }
+        else if (shm_size_calc_mode_value == kShmSizeCalcModeAnalysis)
+        {
+            return ShmSizeCalculationMode::kAnalysis;
         }
         else
         {

--- a/score/mw/com/impl/configuration/configuration_json_parsing_strategy_test.cpp
+++ b/score/mw/com/impl/configuration/configuration_json_parsing_strategy_test.cpp
@@ -2865,6 +2865,8 @@ TEST_P(ShmSizeCalcMode, ValidShmSizeCalcMode)
 const std::vector<std::tuple<std::string, ShmSizeCalculationMode>> valid_global_shm_size_calc_modes{
     {R"json({"serviceTypes": [], "serviceInstances": [], "global": { "shm-size-calc-mode": "SIMULATION" }})json",
      ShmSizeCalculationMode::kSimulation},
+    {R"json({"serviceTypes": [], "serviceInstances": [], "global": { "shm-size-calc-mode": "ANALYSIS" }})json",
+     ShmSizeCalculationMode::kAnalysis},
     {R"json({"serviceTypes": [], "serviceInstances": [] })json", ShmSizeCalculationMode::kSimulation},
 };
 

--- a/score/mw/com/impl/configuration/mw_com_config_schema.json
+++ b/score/mw/com/impl/configuration/mw_com_config_schema.json
@@ -501,8 +501,9 @@
                 },
                 "shm-size-calc-mode": {
                     "title": "Calculation mode for shared memory size",
-                    "description": "How shall the sizes of the shm-objects get calculated (Currently we only support SIMULATION): Via an initial simulation run against a heap-memory resource. It has the advantage of perfect accuracy, but adds a minimal runtime overhead at startup plus some initial temporary heap allocation.",
+                    "description": "How shall the sizes of the shm-objects get calculated: Via an initial simulation run against a heap-memory resource. It has the advantage of perfect accuracy, but adds a minimal runtime overhead at startup plus some initial temporary heap allocation. Alternatively via an analysis based on the config/deployment. It has the advantage of no runtime overhead and no temporary heap allocation, but may lead to a slight overestimation of the required shm-size, because of conservative alignment usage. The default is simulation.",
                     "enum": [
+                        "ANALYSIS",
                         "SIMULATION"
                     ],
                     "default": "SIMULATION"

--- a/score/mw/com/impl/configuration/shm_size_calc_mode.cpp
+++ b/score/mw/com/impl/configuration/shm_size_calc_mode.cpp
@@ -22,6 +22,9 @@ std::ostream& operator<<(std::ostream& ostream_out, const ShmSizeCalculationMode
         case ShmSizeCalculationMode::kSimulation:
             ostream_out << "SIMULATION";
             break;
+        case ShmSizeCalculationMode::kAnalysis:
+            ostream_out << "ANALYSIS";
+            break;
         default:
             ostream_out << "(unknown)";
             break;

--- a/score/mw/com/impl/configuration/shm_size_calc_mode.h
+++ b/score/mw/com/impl/configuration/shm_size_calc_mode.h
@@ -22,6 +22,7 @@ namespace score::mw::com::impl
 enum class ShmSizeCalculationMode : std::uint8_t
 {
     kSimulation,
+    kAnalysis,
 };
 
 std::ostream& operator<<(std::ostream& ostream_out, const ShmSizeCalculationMode& mode);

--- a/score/mw/com/impl/configuration/shm_size_calc_mode_test.cpp
+++ b/score/mw/com/impl/configuration/shm_size_calc_mode_test.cpp
@@ -31,6 +31,18 @@ TEST(ShmSizeCalculationModeTest, OperatorStreamOutputsCorrectStringForkSimulatio
     EXPECT_EQ(oss.str(), "SIMULATION");
 }
 
+TEST(ShmSizeCalculationModeTest, OperatorStreamOutputsCorrectStringForkAnalysis)
+{
+    // Given a ShmSizeCalculationMode set to kAnalysis
+    std::ostringstream oss;
+
+    // When streaming  to ostringstream
+    oss << ShmSizeCalculationMode::kAnalysis;
+
+    // Then the output should match "ANALYSIS"
+    EXPECT_EQ(oss.str(), "ANALYSIS");
+}
+
 TEST(ShmSizeCalculationModeTest, OperatorStreamOutputsUnknownForInvalidValue)
 {
     // Given a ShmSizeCalculationMode set to an invalid value

--- a/score/mw/com/impl/skeleton_event_binding.h
+++ b/score/mw/com/impl/skeleton_event_binding.h
@@ -64,6 +64,9 @@ class SkeletonEventBindingBase
     /// allocations)
     virtual std::size_t GetMaxSize() const noexcept = 0;
 
+    /// \brief Alignment requirement (in bytes) of the underlying event-type's sample data.
+    virtual std::size_t GetAlignment() const noexcept = 0;
+
     /// \brief Gets the binding type of the binding
     virtual BindingType GetBindingType() const noexcept = 0;
 
@@ -98,6 +101,11 @@ class SkeletonEventBinding : public SkeletonEventBindingBase
     std::size_t GetMaxSize() const noexcept override
     {
         return sizeof(SampleType);
+    }
+
+    std::size_t GetAlignment() const noexcept override
+    {
+        return alignof(SampleType);
     }
 };
 


### PR DESCRIPTION
Currently we determine shm-sizes of the
CTRL and DATA shm-objects by a simulation run.
I.e. we initialize the content of both section
1st within a heap-allocated resource. At the end
we use the sizes to correctly size the shm-objects.
This "SIMULATION" method is exact but has high runtime costs
and might consume lots of memory during startup.

This change now redesigns the containers/dynamic data
types being used within the DATA/CTRL sections, to use only
classes, which we are in control of and where we exactly
know based on our configuration, how much size they will
need. Thus the whole simulation can be skipped and we calculate
the size correctly from the configuration settings for the
service instance.

We re-introduce therefore the ANALYSIS mode in parallel
to the SIMULATION mode. For now we keep both in parallel.
SIMULATION is still the default, when not otherwise stated
in the config global section. When the ANALYSIS mode is
field-proven, we might later decide to remove SIMULATION
to simplify code!