### PR TITLE
Bump rules_cc to 0.2.17 in integration test

### DIFF
--- a/module_integration_test/MODULE.bazel
+++ b/module_integration_test/MODULE.bazel
@@ -4,7 +4,7 @@ local_path_override(
     path = "..",
 )
 
-bazel_dep(name = "rules_cc", version = "0.1.5")
+bazel_dep(name = "rules_cc", version = "0.2.17")
 bazel_dep(name = "score_baselibs", version = "0.2.9")
 git_override(
     module_name = "score_baselibs",


### PR DESCRIPTION
The main repository requires rules_cc 0.2.17.

When the integration repo requires an older (but compatible) version, Bazel will just issue a warning and use the newer one.

Hence, bump to the same version to avoid the warning while keeping behavior unchanged.