### PR TITLE
mw/com/impl/doc: Fix tutorial bin names

### DIFF
--- a/score/mw/com/doc/tutorial/chapter_1/BUILD
+++ b/score/mw/com/doc/tutorial/chapter_1/BUILD
@@ -27,7 +27,7 @@ cc_library(
 )
 
 cc_binary(
-    name = "provider",
+    name = "provider_app",
     srcs = [
         "provider.cpp",
         "provider.h",
@@ -43,7 +43,7 @@ cc_binary(
 )
 
 cc_binary(
-    name = "consumer",
+    name = "consumer_app",
     srcs = [
         "consumer.cpp",
         "consumer.h",
@@ -61,7 +61,7 @@ cc_binary(
 pkg_application(
     name = "provider-pkg",
     app_name = "HelloWorldServer",
-    bin = [":provider"],
+    bin = [":provider_app"],
     etc = [
         "logging.json",
         "mw_com_config.json",
@@ -82,7 +82,7 @@ pkg_tar(
 pkg_application(
     name = "consumer-pkg",
     app_name = "HelloWorldClient",
-    bin = [":consumer"],
+    bin = [":consumer_app"],
     etc = [
         "logging.json",
         "mw_com_config.json",

--- a/score/mw/com/doc/tutorial/chapter_1/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_1/README.rst
@@ -76,7 +76,7 @@ To run provider/consumer apps, extract both archives (e.g. in a tmp-directory /t
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_1/opt/HelloWorldServer
-   bin/provider
+   bin/provider_app
 
 
 and the service-consumer in the 2nd terminal
@@ -84,7 +84,7 @@ and the service-consumer in the 2nd terminal
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_1/opt/HelloWorldClient
-   bin/consumer
+   bin/consumer_app
 
 
 .. note::

--- a/score/mw/com/doc/tutorial/chapter_10/BUILD
+++ b/score/mw/com/doc/tutorial/chapter_10/BUILD
@@ -27,7 +27,7 @@ cc_library(
 )
 
 cc_binary(
-    name = "provider",
+    name = "provider_app",
     srcs = [
         "provider/provider.cpp",
         "provider/provider.h",
@@ -43,7 +43,7 @@ cc_binary(
 )
 
 cc_binary(
-    name = "consumer",
+    name = "consumer_app",
     srcs = [
         "consumer/consumer.cpp",
         "consumer/consumer.h",
@@ -61,7 +61,7 @@ cc_binary(
 pkg_application(
     name = "provider-pkg",
     app_name = "HelloWorldServer",
-    bin = [":provider"],
+    bin = [":provider_app"],
     etc = [
         "provider/logging.json",
         "provider/mw_com_config.json",
@@ -82,7 +82,7 @@ pkg_tar(
 pkg_application(
     name = "consumer-pkg",
     app_name = "HelloWorldClient",
-    bin = [":consumer"],
+    bin = [":consumer_app"],
     etc = [
         "consumer/logging.json",
         "consumer/consumer_config.json",

--- a/score/mw/com/doc/tutorial/chapter_10/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_10/README.rst
@@ -191,7 +191,7 @@ Now start the service-provider application as ``uid`` **777** in the 1st termina
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_10/opt/HelloWorldServer
-   sudo -u provider777 bin/provider
+   sudo -u provider777 bin/provider_app
 
 
 ... and the service-consumer as ``uid`` **778** in the 2nd terminal:
@@ -199,7 +199,7 @@ Now start the service-provider application as ``uid`` **777** in the 1st termina
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_10/opt/HelloWorldClient
-   sudo -u consumer778 bin/consumer --service_instance_manifest ./etc/consumer_config.json
+   sudo -u consumer778 bin/consumer_app --service_instance_manifest ./etc/consumer_config.json
 
 
 With this **matching** setup everything works exactly as in chapter 2: the provider grants ``uid`` 778 access to its

--- a/score/mw/com/doc/tutorial/chapter_11/BUILD
+++ b/score/mw/com/doc/tutorial/chapter_11/BUILD
@@ -27,7 +27,7 @@ cc_library(
 )
 
 cc_binary(
-    name = "provider",
+    name = "provider_app",
     srcs = [
         "provider/provider.cpp",
         "provider/provider.h",
@@ -43,7 +43,7 @@ cc_binary(
 )
 
 cc_binary(
-    name = "consumer",
+    name = "consumer_app",
     srcs = [
         "consumer/consumer.cpp",
         "consumer/consumer.h",
@@ -61,7 +61,7 @@ cc_binary(
 pkg_application(
     name = "provider-pkg",
     app_name = "LongRunningServer",
-    bin = [":provider"],
+    bin = [":provider_app"],
     etc = [
         "provider/logging.json",
         "provider/mw_com_config.json",
@@ -82,7 +82,7 @@ pkg_tar(
 pkg_application(
     name = "consumer-pkg",
     app_name = "LongRunningClient",
-    bin = [":consumer"],
+    bin = [":consumer_app"],
     etc = [
         "consumer/logging.json",
         "consumer/mw_com_config.json",

--- a/score/mw/com/doc/tutorial/chapter_11/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_11/README.rst
@@ -334,7 +334,7 @@ Start the service-provider application in the 1st terminal:
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_11/opt/LongRunningServer
-   bin/provider
+   bin/provider_app
 
 
 ... and the service-consumer in the 2nd terminal:
@@ -342,7 +342,7 @@ Start the service-provider application in the 1st terminal:
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_11/opt/LongRunningClient
-   bin/consumer
+   bin/consumer_app
 
 
 You will observe the consumer posting jobs every 500 ms (each getting ``queued at provider: true``), and – after a random

--- a/score/mw/com/doc/tutorial/chapter_12/BUILD
+++ b/score/mw/com/doc/tutorial/chapter_12/BUILD
@@ -28,7 +28,7 @@ cc_library(
 )
 
 cc_binary(
-    name = "provider",
+    name = "provider_app",
     srcs = [
         "provider/provider.cpp",
         "provider/provider.h",
@@ -75,7 +75,7 @@ cc_library(
 )
 
 cc_binary(
-    name = "consumer",
+    name = "consumer_app",
     srcs = [
         "consumer/consumer.cpp",
         "consumer/consumer.h",
@@ -94,7 +94,7 @@ cc_binary(
 pkg_application(
     name = "provider-pkg",
     app_name = "HelloWorldServer",
-    bin = [":provider"],
+    bin = [":provider_app"],
     etc = [
         "provider/logging.json",
         "provider/mw_com_config.json",
@@ -115,7 +115,7 @@ pkg_tar(
 pkg_application(
     name = "consumer-pkg",
     app_name = "HelloWorldClient",
-    bin = [":consumer"],
+    bin = [":consumer_app"],
     etc = [
         "consumer/logging.json",
         "consumer/mw_com_config.json",

--- a/score/mw/com/doc/tutorial/chapter_2/BUILD
+++ b/score/mw/com/doc/tutorial/chapter_2/BUILD
@@ -27,7 +27,7 @@ cc_library(
 )
 
 cc_binary(
-    name = "provider",
+    name = "provider_app",
     srcs = [
         "provider/provider.cpp",
         "provider/provider.h",
@@ -43,7 +43,7 @@ cc_binary(
 )
 
 cc_binary(
-    name = "consumer",
+    name = "consumer_app",
     srcs = [
         "consumer/consumer.cpp",
         "consumer/consumer.h",
@@ -61,7 +61,7 @@ cc_binary(
 pkg_application(
     name = "provider-pkg",
     app_name = "HelloWorldServer",
-    bin = [":provider"],
+    bin = [":provider_app"],
     etc = [
         "provider/logging.json",
         "provider/mw_com_config.json",
@@ -82,7 +82,7 @@ pkg_tar(
 pkg_application(
     name = "consumer-pkg",
     app_name = "HelloWorldClient",
-    bin = [":consumer"],
+    bin = [":consumer_app"],
     etc = [
         "consumer/logging.json",
         "consumer/consumer_config.json",

--- a/score/mw/com/doc/tutorial/chapter_2/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_2/README.rst
@@ -79,7 +79,7 @@ To run provider/consumer apps, extract both archives (e.g. in a tmp-directory):
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_2/opt/HelloWorldServer
-   bin/provider
+   bin/provider_app
 
 
 and the service-consumer in the 2nd terminal (this is notably different to chapter 1, because we now provide a specific
@@ -88,7 +88,7 @@ configuration for the consumer app, which is loaded via the `--service_instance_
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_2/opt/HelloWorldClient
-   bin/consumer --service_instance_manifest ./etc/consumer_config.json 
+   bin/consumer_app --service_instance_manifest ./etc/consumer_config.json 
 
 
 Provider application
@@ -146,7 +146,7 @@ run into an error like this, when starting the consumer app:
 
 .. code-block:: text
 
-   q240165@cmucw1079481:/tmp/tutorial/chapter_2/opt/HelloWorldClient$ bin/consumer --service_instance_manifest ./etc/consumer_config.json 
+   q240165@cmucw1079481:/tmp/tutorial/chapter_2/opt/HelloWorldClient$ bin/consumer_app --service_instance_manifest ./etc/consumer_config.json 
    2026/07/02 10:43:53.1833727 39169650 000 ECU1 EXP1 lola log fatal verbose 7 Parsing config file ./etc/mw_com_config.json failed with error: An error occurred during parsing. :  Failed to open file  . Terminating. 
    Aborted (core dumped)
 

--- a/score/mw/com/doc/tutorial/chapter_3/BUILD
+++ b/score/mw/com/doc/tutorial/chapter_3/BUILD
@@ -27,7 +27,7 @@ cc_library(
 )
 
 cc_binary(
-    name = "provider",
+    name = "provider_app",
     srcs = [
         "provider/provider.cpp",
         "provider/provider.h",
@@ -43,7 +43,7 @@ cc_binary(
 )
 
 cc_binary(
-    name = "consumer",
+    name = "consumer_app",
     srcs = [
         "consumer/consumer.cpp",
         "consumer/consumer.h",
@@ -62,7 +62,7 @@ cc_binary(
 pkg_application(
     name = "provider-pkg",
     app_name = "HelloWorldServer",
-    bin = [":provider"],
+    bin = [":provider_app"],
     etc = [
         "provider/logging.json",
         "provider/mw_com_config.json",
@@ -83,7 +83,7 @@ pkg_tar(
 pkg_application(
     name = "consumer-pkg",
     app_name = "HelloWorldClient",
-    bin = [":consumer"],
+    bin = [":consumer_app"],
     etc = [
         "consumer/logging.json",
         "consumer/mw_com_config.json",

--- a/score/mw/com/doc/tutorial/chapter_3/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_3/README.rst
@@ -85,7 +85,7 @@ Extract both archives (e.g. in a tmp-directory):
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_3/opt/HelloWorldServer
-   bin/provider
+   bin/provider_app
 
 
 and the service-consumer in the 2nd terminal. Note that we do **not** pass a `--service_instance_manifest` argument
@@ -95,7 +95,7 @@ here: the consumer uses the **implicit** configuration loading, which expects th
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_3/opt/HelloWorldClient
-   bin/consumer
+   bin/consumer_app
 
 
 When both run, you will observe how the provider brings up its 3 instances one after the other:

--- a/score/mw/com/doc/tutorial/chapter_4/BUILD
+++ b/score/mw/com/doc/tutorial/chapter_4/BUILD
@@ -27,7 +27,7 @@ cc_library(
 )
 
 cc_binary(
-    name = "provider",
+    name = "provider_app",
     srcs = [
         "provider/provider.cpp",
         "provider/provider.h",
@@ -43,7 +43,7 @@ cc_binary(
 )
 
 cc_binary(
-    name = "consumer",
+    name = "consumer_app",
     srcs = [
         "consumer/consumer.cpp",
         "consumer/consumer.h",
@@ -62,7 +62,7 @@ cc_binary(
 pkg_application(
     name = "provider-pkg",
     app_name = "HelloWorldServer",
-    bin = [":provider"],
+    bin = [":provider_app"],
     etc = [
         "provider/logging.json",
         "provider/mw_com_config.json",
@@ -83,7 +83,7 @@ pkg_tar(
 pkg_application(
     name = "consumer-pkg",
     app_name = "HelloWorldClient",
-    bin = [":consumer"],
+    bin = [":consumer_app"],
     etc = [
         "consumer/logging.json",
         "consumer/mw_com_config.json",

--- a/score/mw/com/doc/tutorial/chapter_4/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_4/README.rst
@@ -114,7 +114,7 @@ Extract both archives (e.g. in a tmp-directory):
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_4/opt/HelloWorldServer
-   bin/provider
+   bin/provider_app
 
 
 and the service-consumer in the 2nd terminal:
@@ -122,7 +122,7 @@ and the service-consumer in the 2nd terminal:
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_4/opt/HelloWorldClient
-   bin/consumer
+   bin/consumer_app
 
 
 When both run, you will observe how the provider alternates between offering and stopping to offer the service:

--- a/score/mw/com/doc/tutorial/chapter_5/BUILD
+++ b/score/mw/com/doc/tutorial/chapter_5/BUILD
@@ -27,7 +27,7 @@ cc_library(
 )
 
 cc_binary(
-    name = "provider",
+    name = "provider_app",
     srcs = [
         "provider/provider.cpp",
         "provider/provider.h",
@@ -43,7 +43,7 @@ cc_binary(
 )
 
 cc_binary(
-    name = "consumer",
+    name = "consumer_app",
     srcs = [
         "consumer/consumer.cpp",
         "consumer/consumer.h",
@@ -62,7 +62,7 @@ cc_binary(
 pkg_application(
     name = "provider-pkg",
     app_name = "HelloWorldServer",
-    bin = [":provider"],
+    bin = [":provider_app"],
     etc = [
         "provider/logging.json",
         "provider/mw_com_config.json",
@@ -83,7 +83,7 @@ pkg_tar(
 pkg_application(
     name = "consumer-pkg",
     app_name = "HelloWorldClient",
-    bin = [":consumer"],
+    bin = [":consumer_app"],
     etc = [
         "consumer/logging.json",
         "consumer/mw_com_config.json",

--- a/score/mw/com/doc/tutorial/chapter_5/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_5/README.rst
@@ -95,7 +95,7 @@ Extract both archives (e.g. in a tmp-directory):
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_5/opt/HelloWorldServer
-   bin/provider
+   bin/provider_app
 
 
 and the service-consumer in the 2nd terminal:
@@ -103,7 +103,7 @@ and the service-consumer in the 2nd terminal:
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_5/opt/HelloWorldClient
-   bin/consumer
+   bin/consumer_app
 
 
 You will observe how the provider announces and sends its event updates at randomized intervals:

--- a/score/mw/com/doc/tutorial/chapter_6/BUILD
+++ b/score/mw/com/doc/tutorial/chapter_6/BUILD
@@ -27,7 +27,7 @@ cc_library(
 )
 
 cc_binary(
-    name = "provider",
+    name = "provider_app",
     srcs = [
         "provider/provider.cpp",
         "provider/provider.h",
@@ -43,7 +43,7 @@ cc_binary(
 )
 
 cc_binary(
-    name = "consumer",
+    name = "consumer_app",
     srcs = [
         "consumer/consumer.cpp",
         "consumer/consumer.h",
@@ -60,7 +60,7 @@ cc_binary(
 pkg_application(
     name = "provider-pkg",
     app_name = "HelloWorldServer",
-    bin = [":provider"],
+    bin = [":provider_app"],
     etc = [
         "provider/logging.json",
         "provider/mw_com_config.json",
@@ -83,7 +83,7 @@ pkg_tar(
 pkg_application(
     name = "consumer1-pkg",
     app_name = "HelloWorldClient1",
-    bin = [":consumer"],
+    bin = [":consumer_app"],
     etc = [
         "consumer/logging.json",
         "consumer/client_1/mw_com_config.json",
@@ -104,7 +104,7 @@ pkg_tar(
 pkg_application(
     name = "consumer2-pkg",
     app_name = "HelloWorldClient2",
-    bin = [":consumer"],
+    bin = [":consumer_app"],
     etc = [
         "consumer/logging.json",
         "consumer/client_2/mw_com_config.json",

--- a/score/mw/com/doc/tutorial/chapter_6/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_6/README.rst
@@ -180,7 +180,7 @@ Start the provider in the 1st terminal:
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_6/opt/HelloWorldServer
-   bin/provider
+   bin/provider_app
 
 
 ... and the two consumers (each with its own `max_sample_count`) in a 2nd and 3rd terminal, e.g.:
@@ -188,13 +188,13 @@ Start the provider in the 1st terminal:
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_6/opt/HelloWorldClient1
-   bin/consumer 4
+   bin/consumer_app 4
 
 
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_6/opt/HelloWorldClient2
-   bin/consumer 5
+   bin/consumer_app 5
 
 
 Playing with the sizing

--- a/score/mw/com/doc/tutorial/chapter_7/BUILD
+++ b/score/mw/com/doc/tutorial/chapter_7/BUILD
@@ -27,7 +27,7 @@ cc_library(
 )
 
 cc_binary(
-    name = "provider",
+    name = "provider_app",
     srcs = [
         "provider/provider.cpp",
         "provider/provider.h",
@@ -43,7 +43,7 @@ cc_binary(
 )
 
 cc_binary(
-    name = "consumer",
+    name = "consumer_app",
     srcs = [
         "consumer/consumer.cpp",
         "consumer/consumer.h",
@@ -62,7 +62,7 @@ cc_binary(
 pkg_application(
     name = "provider-pkg",
     app_name = "TirePressureServer",
-    bin = [":provider"],
+    bin = [":provider_app"],
     etc = [
         "provider/logging.json",
         "provider/mw_com_config.json",
@@ -83,7 +83,7 @@ pkg_tar(
 pkg_application(
     name = "consumer-pkg",
     app_name = "TirePressureClient",
-    bin = [":consumer"],
+    bin = [":consumer_app"],
     etc = [
         "consumer/logging.json",
         "consumer/mw_com_config.json",

--- a/score/mw/com/doc/tutorial/chapter_7/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_7/README.rst
@@ -108,7 +108,7 @@ Extract both archives (e.g. in a tmp-directory):
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_7/opt/TirePressureServer
-   bin/provider
+   bin/provider_app
 
 
 and the service-consumer in the 2nd terminal:
@@ -116,7 +116,7 @@ and the service-consumer in the 2nd terminal:
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_7/opt/TirePressureClient
-   bin/consumer
+   bin/consumer_app
 
 
 The provider first sets the **initial value** (`2.0` bar) of each field, offers the service and then waits 20 s

--- a/score/mw/com/doc/tutorial/chapter_8/BUILD
+++ b/score/mw/com/doc/tutorial/chapter_8/BUILD
@@ -27,7 +27,7 @@ cc_library(
 )
 
 cc_binary(
-    name = "provider",
+    name = "provider_app",
     srcs = [
         "provider/provider.cpp",
         "provider/provider.h",
@@ -43,7 +43,7 @@ cc_binary(
 )
 
 cc_binary(
-    name = "consumer",
+    name = "consumer_app",
     srcs = [
         "consumer/consumer.cpp",
         "consumer/consumer.h",
@@ -62,7 +62,7 @@ cc_binary(
 pkg_application(
     name = "provider-pkg",
     app_name = "CalculatorServer",
-    bin = [":provider"],
+    bin = [":provider_app"],
     etc = [
         "provider/logging.json",
         "provider/mw_com_config.json",
@@ -83,7 +83,7 @@ pkg_tar(
 pkg_application(
     name = "consumer-pkg",
     app_name = "CalculatorClient",
-    bin = [":consumer"],
+    bin = [":consumer_app"],
     etc = [
         "consumer/logging.json",
         "consumer/mw_com_config.json",

--- a/score/mw/com/doc/tutorial/chapter_8/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_8/README.rst
@@ -239,7 +239,7 @@ Extract both archives (e.g. in a tmp-directory):
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_8/opt/CalculatorServer
-   bin/provider
+   bin/provider_app
 
 
 and the service-consumer in the 2nd terminal:
@@ -247,7 +247,7 @@ and the service-consumer in the 2nd terminal:
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_8/opt/CalculatorClient
-   bin/consumer
+   bin/consumer_app
 
 
 The consumer finds the service, creates the proxy, performs both method calls and then terminates on its own:

--- a/score/mw/com/doc/tutorial/chapter_9/BUILD
+++ b/score/mw/com/doc/tutorial/chapter_9/BUILD
@@ -27,7 +27,7 @@ cc_library(
 )
 
 cc_binary(
-    name = "provider",
+    name = "provider_app",
     srcs = [
         "provider/provider.cpp",
         "provider/provider.h",
@@ -43,7 +43,7 @@ cc_binary(
 )
 
 cc_binary(
-    name = "consumer",
+    name = "consumer_app",
     srcs = [
         "consumer/consumer.cpp",
         "consumer/consumer.h",
@@ -62,7 +62,7 @@ cc_binary(
 pkg_application(
     name = "provider-pkg",
     app_name = "TirePressureExtendedServer",
-    bin = [":provider"],
+    bin = [":provider_app"],
     etc = [
         "provider/logging.json",
         "provider/mw_com_config.json",
@@ -83,7 +83,7 @@ pkg_tar(
 pkg_application(
     name = "consumer-pkg",
     app_name = "TirePressureExtendedClient",
-    bin = [":consumer"],
+    bin = [":consumer_app"],
     etc = [
         "consumer/logging.json",
         "consumer/mw_com_config.json",

--- a/score/mw/com/doc/tutorial/chapter_9/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_9/README.rst
@@ -299,7 +299,7 @@ Extract both archives (e.g. in a tmp-directory):
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_9/opt/TirePressureExtendedServer
-   bin/provider
+   bin/provider_app
 
 
 and the service-consumer in the 2nd terminal:
@@ -307,7 +307,7 @@ and the service-consumer in the 2nd terminal:
 .. code-block:: bash
 
    cd /tmp/tutorial/chapter_9/opt/TirePressureExtendedClient
-   bin/consumer
+   bin/consumer_app
 
 
 Summary


### PR DESCRIPTION
In the tutorials the bin names (provider/consumer) did shadow directory names in symlinks.
Renamed the binaries throughout the tutorial:
provider -> provider_app
consumer -> consumer_app