### PR TITLE
    quality/coverage: enable Rust coverage in the LLVM pipeline

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -343,9 +343,9 @@ gcc_ferrocene = use_extension(
 )
 gcc_ferrocene.toolchain(
     name = "ferrocene_x86_64_unknown_linux_gnu_llvm",
-    coverage_tools_sha256 = "497958e925bc94833ea226d68f6d5ba38bd890f571c73e230141d2923e30dd94",
+    coverage_tools_sha256 = "f4b1cdcaf644b3dac429dfc50c674cde8f9620e1a563e3dcdfb313a7ce68c888",
     coverage_tools_strip_prefix = "779fbed05ae9e9fe2a04137929d99cc9b3d516fd/x86_64-unknown-linux-gnu",
-    coverage_tools_url = "https://github.com/eclipse-score/ferrocene_toolchain_builder/releases/download/1.0.1/coverage-tools-779fbed05ae9e9fe2a04137929d99cc9b3d516fd-x86_64-unknown-linux-gnu.tar.gz",
+    coverage_tools_url = "https://github.com/eclipse-score/ferrocene_toolchain_builder/releases/download/1.3.0/coverage-tools-779fbed05ae9e9fe2a04137929d99cc9b3d516fd-x86_64-unknown-linux-gnu.tar.gz",
     exec_triple = "x86_64-unknown-linux-gnu",
     extra_rustc_flags = [
         "-Clink-arg=-Wl,--no-as-needed",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -15927,7 +15927,7 @@
     "@@score_toolchains_rust+//extensions:ferrocene_toolchain_ext.bzl%ferrocene_toolchain_ext": {
       "general": {
         "bzlTransitiveDigest": "9k8SLwP4ec9xXjFivq0Kn0FradTQhcEA+j/WsLxfVPM=",
-        "usagesDigest": "WyB+Pzv/vJHKmPatla/aGL4HfPuTK2OrtJSJL+O1D20=",
+        "usagesDigest": "m8DKpEPkV7AfK9cGQnHaEcjojk4T1HTFtgsbLpPXueE=",
         "recordedFileInputs": {},
         "recordedDirentsInputs": {},
         "envVariables": {},
@@ -15962,8 +15962,8 @@
                 "@platforms//cpu:x86_64",
                 "@platforms//os:linux"
               ],
-              "coverage_tools_url": "https://github.com/eclipse-score/ferrocene_toolchain_builder/releases/download/1.0.1/coverage-tools-779fbed05ae9e9fe2a04137929d99cc9b3d516fd-x86_64-unknown-linux-gnu.tar.gz",
-              "coverage_tools_sha256": "497958e925bc94833ea226d68f6d5ba38bd890f571c73e230141d2923e30dd94",
+              "coverage_tools_url": "https://github.com/eclipse-score/ferrocene_toolchain_builder/releases/download/1.3.0/coverage-tools-779fbed05ae9e9fe2a04137929d99cc9b3d516fd-x86_64-unknown-linux-gnu.tar.gz",
+              "coverage_tools_sha256": "f4b1cdcaf644b3dac429dfc50c674cde8f9620e1a563e3dcdfb313a7ce68c888",
               "coverage_tools_strip_prefix": "779fbed05ae9e9fe2a04137929d99cc9b3d516fd/x86_64-unknown-linux-gnu",
               "miri_sysroot_url": "",
               "miri_sysroot_sha256": "",

--- a/quality/coverage/BUILD
+++ b/quality/coverage/BUILD
@@ -73,5 +73,10 @@ coverage_scope(
     deps = [
         "//score/message_passing",
         "//score/mw/com",
+        # Public Rust API crate. Not reachable through the dependable_element
+        # indices above (those traverse C++ components only). The scope aspect
+        # walks its transitive deps, which cover all Rust production crates
+        # (score_com_concept, runtime-lola, ffi-lola, plumbing).
+        "//score/mw/com/rust:score_com",
     ],
 )

--- a/quality/coverage/coverage.bazelrc
+++ b/quality/coverage/coverage.bazelrc
@@ -60,6 +60,26 @@ coverage --test_env=COVERAGE_GCOV_PATH=/usr/bin/true
 coverage --test_env=LLVM_PROFILE_CONTINUOUS_MODE=1
 coverage --features=enable_llvm_coverage_for_death_tests
 
+# Rust coverage instrumentation (LLVM pipeline only; reset for QNX below).
+# Requires score_toolchains_rust >= 0.9.2 + ferrocene_toolchain_builder >=
+# 1.3.0 coverage-tools: the extension then declares llvm_cov/llvm_profdata on
+# the rust_toolchain, which makes rules_rust add -Cinstrument-coverage under
+# `bazel coverage`.
+#
+# The list-typed extra_rustc_flags setting is used (not the repeatable
+# extra_rustc_flag) so the QNX section can reset it to empty.
+#   -Cllvm-args=-runtime-counter-relocation: Rust equivalent of the
+#     enable_llvm_coverage_for_death_tests cc_feature — continuous-mode
+#     profiling (%c in LLVM_PROFILE_FILE) requires runtime counter relocation,
+#     otherwise the profile runtime errors out and writes no .profraw.
+#   -Clink-dead-code: keep unlinked functions in the coverage map so
+#     unreferenced code shows as uncovered instead of vanishing.
+#   -Zcoverage-options=branch: branch coverage instrumentation. NOTE: -Z flags
+#     are unstable rustc options; this works because the Ferrocene toolchain
+#     in use is a rolling (nightly-based) build. If a stable-channel Ferrocene
+#     is ever pinned, drop this flag (Rust branch columns revert to "-").
+coverage --@rules_rust//rust/settings:extra_rustc_flags=-Cllvm-args=-runtime-counter-relocation,-Clink-dead-code,-Zcoverage-options=branch
+
 # ============================================================================
 # QNX x86_64 coverage configuration (gcov-based)
 # ============================================================================
@@ -82,6 +102,9 @@ coverage:qnx_x86_64 --coverage_report_generator=@bazel_tools//tools/test:coverag
 coverage:qnx_x86_64 --test_env=GENERATE_LLVM_LCOV
 coverage:qnx_x86_64 --test_env=COVERAGE_GCOV_PATH
 coverage:qnx_x86_64 --test_env=LLVM_PROFILE_CONTINUOUS_MODE
+# Reset the Rust LLVM-coverage rustc flags: the QNX pipeline is gcov-based
+# and must not carry llvm covmap instrumentation options.
+coverage:qnx_x86_64 --@rules_rust//rust/settings:extra_rustc_flags=
 
 # Shorthand: --config=qnx uses qnx_x86_64 (consistent with .bazelrc).
 coverage:qnx --config=qnx_x86_64

--- a/quality/coverage/coverage_justifications.yaml
+++ b/quality/coverage/coverage_justifications.yaml
@@ -74,17 +74,20 @@ justifications:
         line_end: 29
 
   - id: gateway-clear-nonblock-on-accepted-socket
+    platforms: [linux, qnx]
     category: defensive_programming
     reason: >
        Defensive programming: Posix system call can only go wrong if the socket file descriptor is invalid,
        but socket has just been accepted in an earlier step.
 
   - id: gateway-handle-response-only-ack-response
+    platforms: [linux, qnx]
     category: defensive_programming
     reason: >
        Defensive programming: Type has already been checked before this function has been called.
 
   - id: gateway-dispatch-loop-calls-handler
+    platforms: [linux, qnx]
     category: tool_false_positive
     reason: >
        Coverage tool incorrectly marks this line as not covered. Lines immediately before and after are covered.

--- a/quality/coverage/coverage_scope.bzl
+++ b/quality/coverage/coverage_scope.bzl
@@ -22,7 +22,14 @@ cc_library, it collects the actual source files (srcs + hdrs).
 The resulting allowlist contains one source file path per line (relative to the
 workspace root). The coverage reporter uses this to restrict reports to exactly
 the files that are part of a dependable_element's implementation.
+
+Rust support: rust_library targets provide CcInfo (their rlib is exposed as a
+.a symlink) and their .rs files come from the srcs attribute, so the CcInfo
+branch covers them. rust_binary targets provide no CcInfo; a dedicated
+CrateInfo branch collects their sources and the coverage-built executable.
 """
+
+load("@rules_rust//rust:rust_common.bzl", "CrateInfo")
 
 visibility(["//..."])
 
@@ -67,6 +74,15 @@ def _coverage_scope_aspect_impl(target, ctx):
                         if archive and "/external/" not in archive.path and not archive.path.startswith("external/"):
                             direct_archives.append(archive)
                             break
+    elif CrateInfo in target:
+        # rust_binary: no CcInfo, collect .rs sources from CrateInfo and use the
+        # coverage-built executable as the baseline object.
+        for f in target[CrateInfo].srcs.to_list():
+            if not f.path.startswith("external/") and f.is_source:
+                direct_files.append(f.short_path)
+        out = target[CrateInfo].output
+        if out and "/external/" not in out.path and not out.path.startswith("external/"):
+            direct_archives.append(out)
 
     # Propagate from children traversed by the aspect
     for attr_name in ["components", "implementation", "deps", "implementation_deps", "exported_deps"]:
@@ -92,8 +108,6 @@ _coverage_scope_aspect = aspect(
 # =============================================================================
 
 def _coverage_scope_impl(ctx):
-    print(ctx.configuration.short_id)
-    print(ctx.configuration.coverage_enabled)
     """Aggregates source file paths from all deps and writes allowlist + baseline objects."""
     all_files = {}
     all_objects = []

--- a/quality/coverage/justify.py
+++ b/quality/coverage/justify.py
@@ -246,10 +246,16 @@ def scan_file_for_markers(
 
 def collect_source_files(source_root: Path, file_filter: str) -> List[Path]:
     """Collect source files to scan for markers."""
-    extensions = file_filter.split(",") if file_filter else ["cpp", "h", "hpp", "cc"]
+    extensions = file_filter.split(",") if file_filter else ["cpp", "h", "hpp", "cc", "rs"]
     files = []
     for ext in extensions:
-        files.extend(source_root.rglob(f"*.{ext.strip()}"))
+        for path in source_root.rglob(f"*.{ext.strip()}"):
+            # Skip Bazel convenience symlinks (bazel-bin, bazel-out, bazel-<repo>, ...)
+            # so the marker scan does not descend into build outputs.
+            rel_parts = path.relative_to(source_root).parts
+            if rel_parts and rel_parts[0].startswith("bazel-"):
+                continue
+            files.append(path)
     return sorted(files)
 
 
@@ -436,8 +442,8 @@ def parse_args() -> argparse.Namespace:
     parser.add_argument(
         "--file-filter",
         type=str,
-        default="cpp,h,hpp,cc",
-        help="Comma-separated file extensions to scan (default: cpp,h,hpp,cc)",
+        default="cpp,h,hpp,cc,rs",
+        help="Comma-separated file extensions to scan (default: cpp,h,hpp,cc,rs)",
     )
     parser.add_argument(
         "--platform",

--- a/quality/coverage/llvm_cov/BUILD
+++ b/quality/coverage/llvm_cov/BUILD
@@ -27,6 +27,8 @@ py_binary(
         "//:MODULE.bazel",
         "@llvm_toolchain//:llvm-cov",
         "@llvm_toolchain//:llvm-profdata",
+        # Demangler for C++ (Itanium) and Rust (v0/legacy) symbol names.
+        "@llvm_toolchain_llvm//:bin/llvm-cxxfilt",
     ],
     deps = ["@rules_python//python/runfiles"],
 )

--- a/quality/coverage/llvm_cov/merger.py
+++ b/quality/coverage/llvm_cov/merger.py
@@ -53,13 +53,15 @@ def main() -> None:
         cleanup_dangling_symlinks(args.coverage_dir)
         sys.exit(0)
 
+    llvm_profdata = find_llvm_profdata()
+
     # Merge profraw → profdata.
     profdata_dir = args.coverage_dir / "profdata"
     profdata_dir.mkdir(exist_ok=True)
     profdata_file = profdata_dir / "target.profdata"
 
     run_command([
-        str(os.environ.get("LLVM_PROFDATA")), "merge",
+        llvm_profdata, "merge",
         "--sparse",
         "--output", str(profdata_file),
     ] + [str(f) for f in profraw_files])
@@ -87,6 +89,37 @@ def main() -> None:
 
     target = os.environ.get("TEST_TARGET", "unknown")
     print(f"INFO: Coverage merger completed for '{target}'", file=sys.stderr)
+
+
+def find_llvm_profdata() -> str:
+    """Locate the llvm-profdata binary, terminating with an error when absent.
+
+    C++ tests: Bazel exports LLVM_PROFDATA from the cc toolchain.
+    Rust tests: rules_rust exports RUST_LLVM_PROFDATA (an execroot-relative
+    path to the rust_toolchain's llvm_profdata) instead; resolve it against
+    the current directory, ROOT and the runfiles dir.
+    """
+    direct = os.environ.get("LLVM_PROFDATA")
+    if direct and Path(direct).exists():
+        return direct
+
+    rust = os.environ.get("RUST_LLVM_PROFDATA")
+    if rust:
+        exec_root = Path(os.environ.get("ROOT", "."))
+        runfiles_dir = Path(os.environ.get("RUNFILES_DIR", "")) / os.environ.get("TEST_WORKSPACE", "_main")
+        for candidate in [Path(rust), exec_root / rust, runfiles_dir / rust]:
+            if candidate.exists():
+                return str(candidate)
+
+    print(
+        "ERROR: llvm-profdata not found. Checked LLVM_PROFDATA "
+        f"({direct or 'unset'}) and RUST_LLVM_PROFDATA ({rust or 'unset'}). "
+        "For C++ tests the cc toolchain must export LLVM_PROFDATA; for Rust "
+        "tests the rust_toolchain must declare llvm_profdata "
+        "(score_toolchains_rust >= 0.9.2 with coverage-tools >= 1.3.0).",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 
 def cleanup_dangling_symlinks(directory: Path) -> None:
@@ -131,8 +164,30 @@ def get_object_files_from_manifest(source_file_manifest: Path) -> Set[str]:
                         object_files.add(str(candidate))
                     else:
                         object_files.add(str(exec_root / obj_path))
+        else:
+            # Rust tests: rules_rust lists the instrumented test executable
+            # itself in the manifest (via coverage metadata_files) instead of
+            # an objects_list.txt. Pick up manifest entries that are ELF
+            # binaries directly. Skip external/ entries: the rust_toolchain
+            # also lists its llvm-cov/llvm-profdata binaries as metadata
+            # files, and those are not instrumented objects.
+            if manifest.startswith("external/") or "/external/" in manifest:
+                continue
+            for candidate in [runfiles_dir / manifest, exec_root / manifest, Path(manifest)]:
+                if candidate.is_file() and is_elf(candidate):
+                    object_files.add(str(candidate))
+                    break
 
     return object_files
+
+
+def is_elf(path: Path) -> bool:
+    """Return True if the file at path is an ELF binary."""
+    try:
+        with open(path, "rb") as f:
+            return f.read(4) == b"\x7fELF"
+    except OSError:
+        return False
 
 
 def run_command(cmd: List[str]) -> subprocess.CompletedProcess:

--- a/quality/coverage/llvm_cov/reporter.py
+++ b/quality/coverage/llvm_cov/reporter.py
@@ -69,6 +69,13 @@ def main() -> None:
     baseline_objects = load_baseline_objects(
         r, args.baseline_objects, args.workspace_root)
 
+    # Rust rlib archives (exposed as .a symlinks by rules_rust) start with a
+    # lib.rmeta member, which makes llvm-cov reject the whole archive with
+    # "no coverage data found" even though the .o members carry the covmap.
+    # Expand such archives into their object members.
+    baseline_objects = expand_rlib_archives(
+        baseline_objects, Path.cwd() / "rlib_baseline_objects")
+
     # Determine filter regexes: prefer allowlist-based filtering, fall back to manual regexes.
     workspace_root = args.workspace_root
     allowlist_files = []
@@ -273,9 +280,14 @@ def get_covered_files(
         match = re.match(r"^(.+?)\s{2,}\d+", line)
         if match:
             filename = match.group(1).strip()
-            # Strip workspace_root prefix if present
-            if filename.startswith(workspace_root):
-                filename = filename[len(workspace_root):]
+            # Normalize to workspace-relative form. llvm-cov report prints the
+            # raw covmap path: for C++ that is the recorded compilation dir
+            # /proc/self/cwd/<rel>, --path-equivalence does not rewrite the
+            # DISPLAYED path. Rust covmap paths are already exec-root relative.
+            for prefix in (workspace_root, "/proc/self/cwd/"):
+                if filename.startswith(prefix):
+                    filename = filename[len(prefix):]
+                    break
             files.add(filename)
 
     return files
@@ -304,8 +316,8 @@ def run_llvm_cov_show(
         "--show-region-summary=0",
     ]
 
-    cxxfilt = llvm_bin_path.parent / "llvm-cxxfilt"
-    if cxxfilt.exists():
+    cxxfilt = find_cxxfilt(llvm_bin_path)
+    if cxxfilt:
         cmd.append(f"--Xdemangler={cxxfilt}")
 
     for regex in filter_regexes:
@@ -436,6 +448,100 @@ def read_reports_file(reports_file: Path) -> List[str]:
     """Read the reports file listing all per-test coverage outputs."""
     with open(reports_file, encoding="utf-8") as f:
         return [line.strip() for line in f if line.strip()]
+
+
+def _read_ar_members(path: str) -> List[tuple]:
+    """Parse a Unix ar archive, returning (name, data_offset, size) tuples.
+
+    Handles the GNU long-name table ("//" member with "/<offset>" references).
+    Returns an empty list when the file is not an ar archive.
+    """
+    members = []
+    longnames = b""
+    with open(path, "rb") as f:
+        if f.read(8) != b"!<arch>\n":
+            return []
+        while True:
+            header = f.read(60)
+            if len(header) < 60:
+                break
+            name = header[0:16].decode(errors="replace").rstrip()
+            try:
+                size = int(header[48:58].decode().strip() or "0")
+            except ValueError:
+                break
+            data_offset = f.tell()
+            if name == "//":
+                longnames = f.read(size)
+            else:
+                if name.startswith("/") and name[1:].isdigit():
+                    start = int(name[1:])
+                    end = longnames.find(b"\n", start)
+                    name = longnames[start:end].decode(errors="replace").rstrip("/")
+                elif name.endswith("/"):
+                    name = name[:-1]
+                members.append((name, data_offset, size))
+                f.seek(size, 1)
+            if size % 2 == 1:
+                f.seek(1, 1)
+    return members
+
+
+def expand_rlib_archives(objects: List[str], workdir: Path) -> List[str]:
+    """Replace Rust rlib archives with their extracted object members.
+
+    llvm-cov rejects rlib archives ("no coverage data found") because of the
+    leading lib.rmeta member, even though the .o members carry the coverage
+    mapping. Non-rlib entries (C++ .a archives, executables) pass through
+    unchanged.
+    """
+    result = []
+    extracted = 0
+    for obj in objects:
+        members = _read_ar_members(obj) if obj.endswith((".a", ".rlib")) else []
+        if not any(name == "lib.rmeta" for name, _, _ in members):
+            result.append(obj)
+            continue
+        workdir.mkdir(parents=True, exist_ok=True)
+        with open(obj, "rb") as f:
+            for index, (name, offset, size) in enumerate(members):
+                if not name.endswith(".o"):
+                    continue
+                f.seek(offset)
+                out_path = workdir / f"{Path(obj).stem}.{index}.o"
+                out_path.write_bytes(f.read(size))
+                result.append(str(out_path))
+                extracted += 1
+    if extracted:
+        print(f"INFO: Expanded {extracted} object(s) from Rust rlib baseline archives.",
+              file=sys.stderr)
+    return result
+
+
+def find_cxxfilt(llvm_bin_path: Path) -> str:
+    """Locate llvm-cxxfilt for demangling (C++ Itanium and Rust v0/legacy symbols).
+
+    Tries the directory of llvm-cov first, then the @llvm_toolchain_llvm
+    distribution via runfiles (toolchains_llvm declares no alias for
+    llvm-cxxfilt, so it is wired as a direct data dependency).
+    Terminates with an error when unavailable: the binary is a declared data
+    dependency of the reporter, so its absence indicates a broken setup.
+    """
+    sibling = llvm_bin_path.parent / "llvm-cxxfilt"
+    if sibling.exists():
+        return str(sibling)
+    r = Runfiles.Create()
+    if r:
+        location = r.Rlocation("llvm_toolchain_llvm/bin/llvm-cxxfilt")
+        if location and Path(location).exists():
+            return location
+    print(
+        "ERROR: llvm-cxxfilt not found (checked next to llvm-cov and in the "
+        "@llvm_toolchain_llvm runfiles). It is a declared data dependency of "
+        "the reporter; check //quality/coverage/llvm_cov:reporter.",
+        file=sys.stderr,
+    )
+    sys.exit(1)
 
 
 def load_coverage_allowlist(runfiles: Runfiles, rlocation_path: str) -> List[str]:


### PR DESCRIPTION
    Until now the unified llvm-cov pipeline reported C++ only: the Ferrocene
    toolchain registered for coverage runs did not declare llvm_cov, so
    rules_rust never instrumented Rust crates, no .rs file was in the scope
    allowlist, and justify.py did not scan Rust sources.

    Toolchain:
    - bump score_toolchains_rust to 0.9.2: its ferrocene extension now wires
      llvm-cov/llvm-profdata from the coverage-tools tarball into the
      generated rust_toolchain, which activates -Cinstrument-coverage under
      'bazel coverage'
    - bump ferrocene_toolchain_builder coverage-tools to 1.3.0 (ships
      llvm-cov/llvm-profdata/llvm-cxxfilt built from the same LLVM as rustc)

    coverage.bazelrc:
    - -Cllvm-args=-runtime-counter-relocation: continuous-mode profiling
      (LLVM_PROFILE_CONTINUOUS_MODE) otherwise writes no .profraw for Rust
    - -Clink-dead-code: keep unreferenced functions visible as uncovered
    - -Zcoverage-options=branch: branch coverage instrumentation (unstable
      flag; works because Ferrocene is a nightly-based rolling build)

    Pipeline:
    - coverage_scope.bzl: CrateInfo branch collects rust_binary sources and
      executables; rust_library was already handled via CcInfo; remove
      leftover debug prints
    - merger.py: resolve RUST_LLVM_PROFDATA (Bazel only sets LLVM_PROFDATA
      via the cc toolchain); pick up the Rust test binary from the coverage
      manifest (ELF detection), skipping external/ toolchain binaries
    - reporter.py: normalize /proc/self/cwd/ covmap paths so the allowlist
      subtraction works with mixed C++ (absolute) and Rust (relative) paths;
      expand Rust rlib baseline archives into their .o members (llvm-cov
      rejects rlibs due to the leading lib.rmeta member); resolve
      llvm-cxxfilt via runfiles (demangles Rust v0/legacy and C++ symbols)
    - justify.py: scan .rs files for COV_JUSTIFIED markers; skip bazel-*
      convenience symlinks
    - quality/coverage/BUILD: add the Rust production crates to
      coverage_scope (mocks/test_support excluded); crate visibilities
      widened by //quality/coverage:__pkg__ only

    Known limitations:
    - com-api-concept-test and com-api-runtime-lola-tests are tagged
      'manual' and are skipped by wildcard coverage runs; their crates
      report as 0% baseline unless the tests are invoked explicitly
    - lib.rs/error.rs/reloc.rs-style files without executable code carry no
      coverage regions and do not appear in reports (same as C++ headers)