### PR TITLE
mw/com: Rename skeleton_method lambda params to avoid shadowing

### DIFF
--- a/score/mw/com/impl/methods/skeleton_method.h
+++ b/score/mw/com/impl/methods/skeleton_method.h
@@ -159,8 +159,8 @@ Result<void> SkeletonMethod<ReturnType(ArgTypes...)>::RegisterHandler(Callable&&
             // Call the callable with the typed_return_ptr and the typed_in_arg_ptrs which are unpacked from the
             // tuple into individual arguments.
             std::apply(
-                [&actual_callback, typed_return_ptr](ArgTypes*... typed_in_arg_ptrs) {
-                    std::invoke(actual_callback, *typed_return_ptr, *typed_in_arg_ptrs...);
+                [&actual_callback, typed_return_ptr](ArgTypes*... in_arg_ptrs) {
+                    std::invoke(actual_callback, *typed_return_ptr, *in_arg_ptrs...);
                 },
                 typed_in_arg_ptrs);
         }
@@ -169,8 +169,8 @@ Result<void> SkeletonMethod<ReturnType(ArgTypes...)>::RegisterHandler(Callable&&
             // Call the callable with the typed_in_arg_ptrs which are unpacked from the tuple into individual
             // arguments.
             std::apply(
-                [&actual_callback](ArgTypes*... typed_in_arg_ptrs) {
-                    std::invoke(actual_callback, *typed_in_arg_ptrs...);
+                [&actual_callback](ArgTypes*... in_arg_ptrs) {
+                    std::invoke(actual_callback, *in_arg_ptrs...);
                 },
                 typed_in_arg_ptrs);
         }


### PR DESCRIPTION
The two std::apply lambdas in SkeletonMethod::RegisterHandler declared a parameter pack named typed_in_arg_ptrs, which shadows the outer local InArgPtrTuple typed_in_arg_ptrs. Compilers configured with -Werror=shadow (e.g. downstream integrators) fail to build any translation unit that pulls in score/mw/com/impl/traits.h:

  error: declaration of 'typed_in_arg_ptrs' shadows a previous local

Rename the lambda parameter packs to in_arg_ptrs. The trailing std::apply argument still refers to the outer local and is left unchanged, so behaviour is identical.