### PR TITLE
mw/com: Mark CompileOrRuntimeAssert message param as maybe_unused

### DIFF
--- a/score/mw/com/impl/methods/method_traits_checker.h
+++ b/score/mw/com/impl/methods/method_traits_checker.h
@@ -71,7 +71,7 @@ enum class FailureMode
 // runtime since we don't currently have infrastructure for compile time testing. When compile time testing is enabled
 // in SWP-46885, we can remove FailureMode and the runtime tests and replace them with compile time tests.
 template <bool condition, FailureMode failure_mode>
-void CompileOrRuntimeAssert(const char* message)
+void CompileOrRuntimeAssert([[maybe_unused]] const char* message)
 {
     if constexpr (failure_mode == FailureMode::COMPILE_TIME)
     {


### PR DESCRIPTION
CompileOrRuntimeAssert only uses its 'message' parameter in the RUNTIME FailureMode branch. When the template is instantiated with FailureMode::COMPILE_TIME (the default for the method-handler signature checks in AssertMethodHandlerSupportsMethodSignature and friends), 'message' is unused. Compilers configured with -Werror=unused-but-set-parameter (e.g. downstream integrators) then fail to build any translation unit that instantiates SkeletonMethod::RegisterHandler:

  error: parameter 'message' set but not used

The warning is emitted at the header definition site, so it cannot be suppressed at the instantiation site. Mark the parameter [[maybe_unused]].