### PR TITLE
Fix flaky gateway integration test

### DIFF
--- a/score/mw/com/gateway/transport_layer/sample/test/app1_main.cpp
+++ b/score/mw/com/gateway/transport_layer/sample/test/app1_main.cpp
@@ -85,10 +85,8 @@ int ExecuteWithReconnect()
 {
     // App1 will receive one message, will disconnect and after the reconnect receive one more message and respond with
     // a notification.
-    constexpr int kMessagesBeforeDisconnect = 1;
-    constexpr int kMessagesAfterReconnect = 1;
     constexpr int kExpectedSendMessages = 1;
-    constexpr int kTotalExpectedMessages = kMessagesBeforeDisconnect + kMessagesAfterReconnect;
+    constexpr int kTotalExpectedMessages = 2;
 
     auto config = CreateConfiguration();
     BidirectionalTransport transport{std::move(config)};
@@ -101,7 +99,6 @@ int ExecuteWithReconnect()
 
     std::atomic<int> received_message_count{0};
     std::atomic<int> sent_message_count{0};
-    std::atomic<bool> disconnect_detected{false};
 
     transport.SetMessageHandler([&](std::unique_ptr<score::mw::com::gateway::TransportMessage> message) {
         const int count = ++received_message_count;
@@ -118,54 +115,11 @@ int ExecuteWithReconnect()
         }
     });
 
-    // Wait for the first message before disconnect
+    // Wait for all expected messages to be sent. Between receiving message 1 and message 2 there will be a
+    // disconnect application's transport layer should reconnect automatically.
     constexpr int kTimeoutMs = 15000;
     constexpr int kSleepIntervalMs = 50;
     int elapsed = 0;
-    while (received_message_count < kMessagesBeforeDisconnect && elapsed < kTimeoutMs)
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(kSleepIntervalMs));
-        elapsed += kSleepIntervalMs;
-    }
-    if (received_message_count < kMessagesBeforeDisconnect)
-    {
-        std::cerr << "App1: Timed out waiting for messages before disconnect. Received "
-                  << received_message_count.load() << std::endl;
-        return 1;
-    }
-    std::cout << "App1: Received pre-disconnect messages, waiting for disconnect and reconnect..." << std::endl;
-
-    // Wait for disconnect to be detected (App2 has been shut down)
-    elapsed = 0;
-    while (transport.IsConnected() && elapsed < kTimeoutMs)
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(kSleepIntervalMs));
-        elapsed += kSleepIntervalMs;
-    }
-    if (transport.IsConnected())
-    {
-        std::cout << "App1: Warning - No disconnected detected, but might have reconnected to quickly." << std::endl;
-    }
-    else
-    {
-        std::cout << "App1: Disconnect detected, waiting for reconnect" << std::endl;
-    }
-
-    // Wait for reconnect
-    elapsed = 0;
-    while (!transport.IsConnected() && elapsed < kTimeoutMs)
-    {
-        std::this_thread::sleep_for(std::chrono::milliseconds(kSleepIntervalMs));
-        elapsed += kSleepIntervalMs;
-    }
-    if (!transport.IsConnected())
-    {
-        std::cerr << "App1: Timed out waiting for reconnect." << std::endl;
-        return 1;
-    }
-
-    // Wait for the remaining message after reconnect
-    elapsed = 0;
     while (received_message_count < kTotalExpectedMessages && elapsed < kTimeoutMs)
     {
         std::this_thread::sleep_for(std::chrono::milliseconds(kSleepIntervalMs));

--- a/score/mw/com/gateway/transport_layer/sample/test/app2_main.cpp
+++ b/score/mw/com/gateway/transport_layer/sample/test/app2_main.cpp
@@ -124,7 +124,7 @@ int ExecuteWithReconnect()
         transport.Shutdown();
     }
 
-    // Pause in order to let app1 detect the disconnect
+    // Pause in order to let app1 handle the disconnect
     std::this_thread::sleep_for(std::chrono::seconds(2));
 
     // Reconnect and send message

--- a/score/mw/com/gateway/transport_layer/sample/test/integration_test/BUILD
+++ b/score/mw/com/gateway/transport_layer/sample/test/integration_test/BUILD
@@ -29,8 +29,4 @@ integration_test(
         "test_bidirectional_transport_reconnect.py",
     ],
     filesystem = "//score/mw/com/gateway/transport_layer/sample/test:application-pkg",
-    # Flaky: In rare cases the reconnect seems to happen too early so that App1 does not detect it and times out waiting,
-    # while App2 finishes successfully. Test will be replaced with complete integration test (not just covering
-    # socket side channel communication) in the near future.
-    flaky = True,
 )


### PR DESCRIPTION
Problem with this test was that we checked for connection state in App1 and did this within a loop. If App2 reconnected, sent and received messages and terminate within one loop cycle, the state would again be disconnected. Instead of checking if state 'disconnected' has been identified by transport layer, just check if after reconnect messages will still be sent and received. Connection handling should be done by BidirectionalTransportLayer in the background anyways.