### PR TITLE
Amsh fix fortify source coverage separation

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -298,6 +298,7 @@ llvm.toolchain(
     extra_enabled_features = [
         "//quality/compiler_warnings/clang:default_flags",
         "//quality/compiler_warnings/clang:minimal_warnings",
+        "//quality/compiler_warnings:fortify_source",
     ],
     extra_known_features = [
         "@score_cpp_policies//sanitizers/features:debug_symbols",

--- a/quality/compiler_warnings/BUILD
+++ b/quality/compiler_warnings/BUILD
@@ -27,9 +27,6 @@ cc_args(
         "-fPIC",
         "-fstack-protector-strong",
         "-fdiagnostics-color=always",
-        # Fortify libc calls (buffer-overflow checks) used by message (de)serialization.
-        # NOTE: effective only at -O1+; requires the non-executable stack link hardening below.
-        "-D_FORTIFY_SOURCE=2",
         # Bounds/precondition checks on libstdc++ containers (ABI-safe; not _GLIBCXX_DEBUG).
         "-D_GLIBCXX_ASSERTIONS",
         # Per-page stack probing so a large VLA/alloca in deep IPC dispatch cannot skip the guard page.
@@ -47,6 +44,26 @@ cc_args(
 )
 
 cc_args(
+    name = "fortify_source_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    args = [
+        "-D_FORTIFY_SOURCE=2",
+    ],
+    visibility = ["//quality/compiler_warnings:__subpackages__"],
+)
+
+cc_feature(
+    name = "fortify_source",
+    args = [
+        ":fortify_source_args",
+    ],
+    feature_name = "score_communication_fortify_source",
+    visibility = ["//visibility:public"],
+)
+
+cc_args(
     name = "default_link_args",
     actions = [
         "@rules_cc//cc/toolchains/actions:link_actions",
@@ -61,7 +78,6 @@ cc_args(
         "-Wl,-as-needed",
         "-ldl",
         "-Wl,--pop-state",
-        "-fuse-ld=gold",
         "-Wl,-no-as-needed",
         "-lc",
         "-lm",

--- a/quality/coverage/coverage.bazelrc
+++ b/quality/coverage/coverage.bazelrc
@@ -88,3 +88,7 @@ coverage:qnx --config=qnx_x86_64
 
 # Disable treat_warnings_as_errors for coverage builds to avoid build failures from instrumentation-related warnings
 coverage --features=-score_communication_treat_warnings_as_errors
+
+# Disable clang default hardening flags for coverage: -fuse-ld=gold breaks linking the LLVM coverage runtime (undefined reference to 'atexit') and _FORTIFY_SOURCE conflicts with the -O0 coverage build.
+coverage --features=-score_communication_clang_default_flags
+coverage --host_features=-score_communication_clang_default_flags

--- a/quality/coverage/coverage.bazelrc
+++ b/quality/coverage/coverage.bazelrc
@@ -88,7 +88,3 @@ coverage:qnx --config=qnx_x86_64
 
 # Disable treat_warnings_as_errors for coverage builds to avoid build failures from instrumentation-related warnings
 coverage --features=-score_communication_treat_warnings_as_errors
-
-# Disable clang default hardening flags for coverage: -fuse-ld=gold breaks linking the LLVM coverage runtime (undefined reference to 'atexit') and _FORTIFY_SOURCE conflicts with the -O0 coverage build.
-coverage --features=-score_communication_clang_default_flags
-coverage --host_features=-score_communication_clang_default_flags

--- a/quality/coverage/coverage.bazelrc
+++ b/quality/coverage/coverage.bazelrc
@@ -88,3 +88,6 @@ coverage:qnx --config=qnx_x86_64
 
 # Disable treat_warnings_as_errors for coverage builds to avoid build failures from instrumentation-related warnings
 coverage --features=-score_communication_treat_warnings_as_errors
+
+# Disable fortify_source for coverage builds to avoid linking failures with LLVM coverage runtime.
+coverage --features=-score_communication_fortify_source

--- a/quality/visibility_guard/public_targets.golden
+++ b/quality/visibility_guard/public_targets.golden
@@ -10,6 +10,7 @@
 //quality/compiler_warnings/gcc:strict_warnings
 //quality/compiler_warnings/gcc:strict_warnings_no_error
 //quality/compiler_warnings/gcc:third_party_warnings
+//quality/compiler_warnings:fortify_source
 //quality/compiler_warnings:minimal_warnings
 //quality/compiler_warnings:strict_warnings
 //quality/compiler_warnings:treat_warnings_as_errors


### PR DESCRIPTION
Fix: Separate fortify_source feature and resolve coverage build failures

Extract -D_FORTIFY_SOURCE=2 into its own cc_feature to enable selective
disabling during coverage builds without affecting other hardening flags.