### PR TITLE
fix(mw/com): remove noexcept from functions that can propagate except…

### DIFF
--- a/score/message_passing/unix_domain/unix_domain_server.cpp
+++ b/score/message_passing/unix_domain/unix_domain_server.cpp
@@ -102,7 +102,7 @@ void UnixDomainServer::ServerConnection::RequestDisconnect() noexcept
     server_.engine_->UnregisterPosixEndpoint(endpoint_);
 }
 
-bool UnixDomainServer::ServerConnection::ProcessInput() noexcept
+bool UnixDomainServer::ServerConnection::ProcessInput()
 {
     std::uint8_t code;
     auto& user_data = *user_data_;
@@ -134,7 +134,7 @@ bool UnixDomainServer::ServerConnection::ProcessInput() noexcept
     return true;
 }
 
-UnixDomainServer::ServerConnection::~ServerConnection() noexcept
+UnixDomainServer::ServerConnection::~ServerConnection() noexcept(false)
 {
     if (user_data_.has_value())
     {

--- a/score/message_passing/unix_domain/unix_domain_server.h
+++ b/score/message_passing/unix_domain/unix_domain_server.h
@@ -50,9 +50,9 @@ class UnixDomainServer final : public IServer
 
         // Server methods
         void AcceptConnection(UserData&& data, score::cpp::pmr::unique_ptr<ServerConnection>&& self) noexcept;
-        bool ProcessInput() noexcept;
+        bool ProcessInput();
 
-        ~ServerConnection() noexcept;
+        ~ServerConnection() noexcept(false);
 
       private:
         UnixDomainServer& server_;

--- a/score/mw/com/api_surface.lock.json
+++ b/score/mw/com/api_surface.lock.json
@@ -71,7 +71,7 @@
       "name": "Create",
       "qualified_name": "score::mw::com::InstanceIdentifier::Create",
       "kind": "method",
-      "signature": "static Create : score::Result<InstanceIdentifier> (std::string &&) noexcept"
+      "signature": "static Create : score::Result<InstanceIdentifier> (std::string &&)"
     },
     {
       "name": "InstanceIdentifier",
@@ -227,7 +227,7 @@
       "name": "Create",
       "qualified_name": "score::mw::com::GenericProxy::Create",
       "kind": "method",
-      "signature": "static Create : Result<GenericProxy> (HandleType) noexcept"
+      "signature": "static Create : Result<GenericProxy> (HandleType)"
     },
     {
       "name": "FindService",
@@ -311,7 +311,7 @@
       "name": "Subscribe",
       "qualified_name": "score::mw::com::GenericProxyEvent::Subscribe",
       "kind": "method",
-      "signature": "Subscribe : Result<void> (const std::size_t) noexcept"
+      "signature": "Subscribe : Result<void> (const std::size_t)"
     },
     {
       "name": "UnsetReceiveHandler",
@@ -799,7 +799,7 @@
       "name": "ProxyEventBase",
       "qualified_name": "score::mw::com::GenericProxyEvent::ProxyEventBase",
       "kind": "constructor",
-      "signature": "ProxyEventBase : void (std::string_view, Result<std::unique_ptr<ProxyEventBindingBase>>) noexcept"
+      "signature": "ProxyEventBase : void (std::string_view, Result<std::unique_ptr<ProxyEventBindingBase>>)"
     },
     {
       "name": "ProxyEventBase",
@@ -841,13 +841,13 @@
       "name": "Create",
       "qualified_name": "score::mw::com::GenericSkeleton::Create",
       "kind": "method",
-      "signature": "static Create : Result<GenericSkeleton> (const InstanceIdentifier &, const GenericSkeletonServiceElementInfo &) noexcept [[nodiscard]]"
+      "signature": "static Create : Result<GenericSkeleton> (const InstanceIdentifier &, const GenericSkeletonServiceElementInfo &) [[nodiscard]]"
     },
     {
       "name": "Create",
       "qualified_name": "score::mw::com::GenericSkeleton::Create",
       "kind": "method",
-      "signature": "static Create : Result<GenericSkeleton> (const InstanceSpecifier &, const GenericSkeletonServiceElementInfo &) noexcept [[nodiscard]]"
+      "signature": "static Create : Result<GenericSkeleton> (const InstanceSpecifier &, const GenericSkeletonServiceElementInfo &) [[nodiscard]]"
     },
     {
       "name": "GetEvents",

--- a/score/mw/com/impl/bindings/lola/consumer_event_data_control_local_view.cpp
+++ b/score/mw/com/impl/bindings/lola/consumer_event_data_control_local_view.cpp
@@ -33,7 +33,7 @@ constexpr auto MAX_REFERENCE_RETRIES = 100U;
 
 template <template <class> class AtomicIndirectorType>
 ConsumerEventDataControlLocalView<AtomicIndirectorType>::ConsumerEventDataControlLocalView(
-    EventDataControl& event_data_control_shared) noexcept
+    EventDataControl& event_data_control_shared)
     : state_slots_{event_data_control_shared.state_slots_.begin(), event_data_control_shared.state_slots_.size()}
 {
 }
@@ -41,7 +41,7 @@ ConsumerEventDataControlLocalView<AtomicIndirectorType>::ConsumerEventDataContro
 template <template <class> class AtomicIndirectorType>
 ConsumerEventDataControlLocalView<AtomicIndirectorType>::ConsumerEventDataControlLocalView(
     EventDataControl& event_data_control_shared,
-    TransactionLogLocalView transaction_log_local_view) noexcept
+    TransactionLogLocalView transaction_log_local_view)
     : ConsumerEventDataControlLocalView{event_data_control_shared}
 {
     SetTransactionLogLocalView(transaction_log_local_view);
@@ -55,7 +55,7 @@ template <template <class> class AtomicIndirectorType>
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
 auto ConsumerEventDataControlLocalView<AtomicIndirectorType>::ReferenceNextEvent(
     const EventSlotStatus::EventTimeStamp last_search_time,
-    const EventSlotStatus::EventTimeStamp upper_limit) noexcept -> std::optional<SlotIndexType>
+    const EventSlotStatus::EventTimeStamp upper_limit) -> std::optional<SlotIndexType>
 {
     // function can only finish with result, if use count was able to be increased
     std::optional<SlotIndexType> possible_index{};

--- a/score/mw/com/impl/bindings/lola/consumer_event_data_control_local_view.h
+++ b/score/mw/com/impl/bindings/lola/consumer_event_data_control_local_view.h
@@ -54,7 +54,7 @@ class ConsumerEventDataControlLocalView final
   public:
     using LocalEventControlSlots = score::cpp::span<ControlSlotType>;
 
-    ConsumerEventDataControlLocalView(EventDataControl& event_data_control_shared) noexcept;
+    ConsumerEventDataControlLocalView(EventDataControl& event_data_control_shared);
 
     /// Test-only constructor which allows to directly set the TransactionLogLocalView. This avoids having to
     /// inject the TransactionLogLocalView via the production code path which would require creating a
@@ -63,7 +63,7 @@ class ConsumerEventDataControlLocalView final
     /// In production, this cannot be used since the ConsumerEventDataControlLocalView is created before the
     /// TransactionLog is created, so it must be injected later.
     ConsumerEventDataControlLocalView(EventDataControl& event_data_control_shared,
-                                      TransactionLogLocalView transaction_log_local_view) noexcept;
+                                      TransactionLogLocalView transaction_log_local_view);
 
     ~ConsumerEventDataControlLocalView() noexcept = default;
 
@@ -85,7 +85,7 @@ class ConsumerEventDataControlLocalView final
     /// \post DereferenceEvent() is invoked to withdraw read-ownership
     std::optional<SlotIndexType> ReferenceNextEvent(
         const EventSlotStatus::EventTimeStamp last_search_time,
-        const EventSlotStatus::EventTimeStamp upper_limit = EventSlotStatus::TIMESTAMP_MAX) noexcept;
+        const EventSlotStatus::EventTimeStamp upper_limit = EventSlotStatus::TIMESTAMP_MAX);
 
     /// \brief Increments refcount of given slot by one (given it is in the correct state i.e. being accessible/
     ///        readable)

--- a/score/mw/com/impl/bindings/lola/event_control.cpp
+++ b/score/mw/com/impl/bindings/lola/event_control.cpp
@@ -18,7 +18,7 @@ namespace score::mw::com::impl::lola
 EventControl::EventControl(const SlotIndexType number_of_slots,
                            const SubscriberCountType max_subscribers,
                            const bool enforce_max_samples,
-                           score::memory::shared::ManagedMemoryResource& resource) noexcept
+                           score::memory::shared::ManagedMemoryResource& resource)
     : data_control{number_of_slots, resource},
       subscription_control{number_of_slots, max_subscribers, enforce_max_samples},
       transaction_log_set_{max_subscribers, number_of_slots, resource}

--- a/score/mw/com/impl/bindings/lola/event_control.h
+++ b/score/mw/com/impl/bindings/lola/event_control.h
@@ -28,7 +28,7 @@ class EventControl
     EventControl(const SlotIndexType number_of_slots,
                  const SubscriberCountType max_subscribers,
                  const bool enforce_max_samples,
-                 score::memory::shared::ManagedMemoryResource& resource) noexcept;
+                 score::memory::shared::ManagedMemoryResource& resource);
 
     // Suppress "AUTOSAR C++14 M11-0-1" rule findings. This rule states: "Member data in non-POD class types shall
     // be private.". There are no class invariants to maintain which could be violated by directly accessing member

--- a/score/mw/com/impl/bindings/lola/event_data_control.h
+++ b/score/mw/com/impl/bindings/lola/event_data_control.h
@@ -41,7 +41,7 @@ class EventDataControl
     using EventControlSlots =
         containers::DynamicArray<ControlSlotType, memory::shared::PolymorphicOffsetPtrAllocator<ControlSlotType>>;
 
-    EventDataControl(const SlotIndexType max_slots, score::memory::shared::ManagedMemoryResource& resource) noexcept
+    EventDataControl(const SlotIndexType max_slots, score::memory::shared::ManagedMemoryResource& resource)
         : state_slots_{max_slots, resource}
     {
     }

--- a/score/mw/com/impl/bindings/lola/generic_proxy_event.cpp
+++ b/score/mw/com/impl/bindings/lola/generic_proxy_event.cpp
@@ -132,7 +132,7 @@ Result<std::size_t> GenericProxyEvent::GetNumNewSamplesAvailableImpl() const noe
 // implicitly". std::terminate() is implicitly called from '.value()' in case it doesn't have a value but as we check
 // before with 'has_value()' so no way for throwing std::bad_optional_access which leds to std::terminate().
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-Result<std::size_t> GenericProxyEvent::GetNewSamplesImpl(Callback&& receiver, TrackerGuardFactory& tracker) noexcept
+Result<std::size_t> GenericProxyEvent::GetNewSamplesImpl(Callback&& receiver, TrackerGuardFactory& tracker)
 {
     const auto max_sample_count = tracker.GetNumAvailableGuards();
 

--- a/score/mw/com/impl/bindings/lola/generic_proxy_event.h
+++ b/score/mw/com/impl/bindings/lola/generic_proxy_event.h
@@ -81,7 +81,7 @@ class GenericProxyEvent final : public GenericProxyEventBinding
     void NotifyServiceInstanceChangedAvailability(bool is_available, pid_t new_event_source_pid) noexcept override;
 
   private:
-    Result<std::size_t> GetNewSamplesImpl(Callback&& receiver, TrackerGuardFactory& tracker) noexcept;
+    Result<std::size_t> GetNewSamplesImpl(Callback&& receiver, TrackerGuardFactory& tracker);
     Result<std::size_t> GetNumNewSamplesAvailableImpl() const noexcept;
 
     ProxyEventCommon proxy_event_common_;

--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service.cpp
@@ -48,7 +48,7 @@ MessagePassingService::MessagePassingService(
     const AsilSpecificCfg& config_asil_qm,
     const std::optional<AsilSpecificCfg>& config_asil_b,
     // coverity[autosar_cpp14_a8_4_12_violation] Function only uses the object without affecting ownership
-    const std::unique_ptr<IMessagePassingServiceInstanceFactory>& factory) noexcept
+    const std::unique_ptr<IMessagePassingServiceInstanceFactory>& factory)
     : IMessagePassingService{},
       client_factory_{score::cpp::pmr::make_shared<Engine>(score::cpp::pmr::get_default_resource(),
                                                            score::cpp::pmr::get_default_resource(),

--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service.h
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service.h
@@ -66,7 +66,7 @@ class MessagePassingService final : public IMessagePassingService
     /// \param factory optional factory used to create MessagePassingServiceInstances
     MessagePassingService(const AsilSpecificCfg& config_asil_qm,
                           const std::optional<AsilSpecificCfg>& config_asil_b,
-                          const std::unique_ptr<IMessagePassingServiceInstanceFactory>& factory) noexcept;
+                          const std::unique_ptr<IMessagePassingServiceInstanceFactory>& factory);
 
     MessagePassingService(const MessagePassingService&) = delete;
     MessagePassingService(MessagePassingService&&) = delete;

--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance.cpp
@@ -251,10 +251,9 @@ MessagePassingServiceInstance::MessagePassingServiceInstance(
     // Suppress autosar_cpp14_a15_5_3_violation: False Positive
     // Rationale: Passing an argument by reference cannot throw
     // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-    auto received_send_message_callback =
-        [scoped_function = message_callback_scoped_function](
-            score::message_passing::IServerConnection& connection,
-            const score::cpp::span<const std::uint8_t> message) noexcept -> score::cpp::blank {
+    auto received_send_message_callback = [scoped_function = message_callback_scoped_function](
+                                              score::message_passing::IServerConnection& connection,
+                                              const score::cpp::span<const std::uint8_t> message) -> score::cpp::blank {
         SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(std::holds_alternative<std::uintptr_t>(connection.GetUserData()),
                                                     "Message Passing: UserData does not contain a uintptr_t");
         // Suppress "AUTOSAR C++14 A15-5-3" The rule states: "Implicit call of std::terminate()"
@@ -296,15 +295,13 @@ MessagePassingServiceInstance::MessagePassingServiceInstance(
 
 message_passing::MessageCallback MessagePassingServiceInstance::CreateSendMessageWithReplyCallback()
 {
-    auto message_callback_with_reply_scoped_function =
-        std::make_shared<score::safecpp::MoveOnlyScopedFunction<score::Result<void>(
-            uid_t, pid_t, score::cpp::span<const std::uint8_t>)>>(
-            message_callback_scope_,
-            [this](uid_t sender_uid,
-                   pid_t sender_pid,
-                   score::cpp::span<const std::uint8_t> message) noexcept -> score::Result<void> {
-                return this->MessageCallbackWithReply(sender_uid, sender_pid, message);
-            });
+    auto message_callback_with_reply_scoped_function = std::make_shared<score::safecpp::MoveOnlyScopedFunction<
+        score::Result<void>(uid_t, pid_t, score::cpp::span<const std::uint8_t>)>>(
+        message_callback_scope_,
+        [this](
+            uid_t sender_uid, pid_t sender_pid, score::cpp::span<const std::uint8_t> message) -> score::Result<void> {
+            return this->MessageCallbackWithReply(sender_uid, sender_pid, message);
+        });
 
     // Note. When received_send_message_with_reply_callback returns an error, the message passing connection with the
     // client will be disconnected. Therefore, we only return an error from the callback when the error is unrecoverable
@@ -313,7 +310,7 @@ message_passing::MessageCallback MessagePassingServiceInstance::CreateSendMessag
     auto received_send_message_with_reply_callback =
         [message_callback_with_reply_scoped_function = std::move(message_callback_with_reply_scoped_function)](
             score::message_passing::IServerConnection& connection,
-            score::cpp::span<const std::uint8_t> message) noexcept -> score::cpp::expected_blank<score::os::Error> {
+            score::cpp::span<const std::uint8_t> message) -> score::cpp::expected_blank<score::os::Error> {
         const auto client_identity = connection.GetClientIdentity();
         const pid_t client_pid = client_identity.pid;
         const auto client_uid = client_identity.uid;

--- a/score/mw/com/impl/bindings/lola/methods/type_erased_call_queue.cpp
+++ b/score/mw/com/impl/bindings/lola/methods/type_erased_call_queue.cpp
@@ -90,7 +90,7 @@ TypeErasedCallQueue::TypeErasedCallQueue(memory::shared::ManagedMemoryResource& 
     std::tie(in_args_queue_start_address_, return_queue_start_address_) = AllocateQueue();
 }
 
-TypeErasedCallQueue::~TypeErasedCallQueue()
+TypeErasedCallQueue::~TypeErasedCallQueue() noexcept(false)
 {
     if (in_args_queue_start_address_.data != nullptr)
     {

--- a/score/mw/com/impl/bindings/lola/methods/type_erased_call_queue.h
+++ b/score/mw/com/impl/bindings/lola/methods/type_erased_call_queue.h
@@ -42,7 +42,7 @@ class TypeErasedCallQueue final
     TypeErasedCallQueue(memory::shared::ManagedMemoryResource& resource,
                         const TypeErasedElementInfo& type_erased_element_info);
 
-    ~TypeErasedCallQueue();
+    ~TypeErasedCallQueue() noexcept(false);
 
     TypeErasedCallQueue(const TypeErasedCallQueue&) = delete;
     TypeErasedCallQueue& operator=(const TypeErasedCallQueue&) = delete;

--- a/score/mw/com/impl/bindings/lola/provider_event_data_control_local_view.cpp
+++ b/score/mw/com/impl/bindings/lola/provider_event_data_control_local_view.cpp
@@ -32,7 +32,7 @@ constexpr auto MAX_ALLOCATE_RETRIES = 100U;
 
 template <template <class> class AtomicIndirectorType>
 ProviderEventDataControlLocalView<AtomicIndirectorType>::ProviderEventDataControlLocalView(
-    EventDataControl& event_data_control) noexcept
+    EventDataControl& event_data_control)
     : state_slots_{event_data_control.state_slots_.begin(), event_data_control.state_slots_.size()}
 {
 }

--- a/score/mw/com/impl/bindings/lola/provider_event_data_control_local_view.h
+++ b/score/mw/com/impl/bindings/lola/provider_event_data_control_local_view.h
@@ -59,7 +59,7 @@ class ProviderEventDataControlLocalView final
 
     using LocalEventControlSlots = score::cpp::span<ControlSlotType>;
 
-    ProviderEventDataControlLocalView(EventDataControl& event_data_control) noexcept;
+    ProviderEventDataControlLocalView(EventDataControl& event_data_control);
 
     ~ProviderEventDataControlLocalView() noexcept = default;
 

--- a/score/mw/com/impl/bindings/lola/proxy.cpp
+++ b/score/mw/com/impl/bindings/lola/proxy.cpp
@@ -350,7 +350,7 @@ ElementFqId Proxy::EventNameToElementFqIdConverter::Convert(const std::string_vi
 // in case 'service_instance_usage_marker_file' doesn't have value but as we check before with 'has_value()'
 // so no way for throwing std::bad_optional_access which leds to std::terminate().
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-std::unique_ptr<Proxy> Proxy::Create(const HandleType handle) noexcept
+std::unique_ptr<Proxy> Proxy::Create(const HandleType handle)
 {
     const auto& instance_deployment = GetLoLaInstanceDeployment(handle);
     const auto& lola_service_deployment = GetLoLaServiceTypeDeployment(handle);
@@ -435,7 +435,7 @@ Proxy::Proxy(std::shared_ptr<memory::shared::ManagedMemoryResource> control,
              std::unique_ptr<score::memory::shared::FlockMutexAndLock<score::memory::shared::SharedFlockMutex>>
                  service_instance_usage_flock_mutex_and_lock,
              score::filesystem::Filesystem filesystem,
-             ProxyInstanceIdentifier::ProxyInstanceCounter proxy_instance_counter) noexcept
+             ProxyInstanceIdentifier::ProxyInstanceCounter proxy_instance_counter)
     : ProxyBinding{},
       control_{std::move(control)},
       data_{std::move(data)},
@@ -559,8 +559,7 @@ void Proxy::ServiceAvailabilityChangeHandler(const bool is_service_available)
 // value is not comparable and in our case the key is comparable. so no way for 'event_controls_.find()' to throw an
 // exception.
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-ConsumerEventDataControlLocalView<> Proxy::GetConsumerEventDataControlLocalView(
-    const ElementFqId element_fq_id) noexcept
+ConsumerEventDataControlLocalView<> Proxy::GetConsumerEventDataControlLocalView(const ElementFqId element_fq_id)
 {
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(control_ != nullptr,
                                                       "Proxy::GetEventControl: Managed memory control pointer is Null");
@@ -590,7 +589,7 @@ ConsumerEventDataControlLocalView<> Proxy::GetConsumerEventDataControlLocalView(
 // value is not comparable and in our case the key is comparable. so no way for 'event_controls_.find()' to throw an
 // exception.
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-EventSubscriptionControl<>& Proxy::GetEventSubscriptionControl(const ElementFqId element_fq_id) noexcept
+EventSubscriptionControl<>& Proxy::GetEventSubscriptionControl(const ElementFqId element_fq_id)
 {
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(control_ != nullptr,
                                                       "Proxy::GetEventControl: Managed memory control pointer is Null");
@@ -610,7 +609,7 @@ EventSubscriptionControl<>& Proxy::GetEventSubscriptionControl(const ElementFqId
 // value is not comparable and in our case the key is comparable. so no way for 'event_controls_.find()' to throw an
 // exception.
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-TransactionLogSet& Proxy::GetTransactionLogSet(const ElementFqId element_fq_id) noexcept
+TransactionLogSet& Proxy::GetTransactionLogSet(const ElementFqId element_fq_id)
 {
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(control_ != nullptr,
                                                       "Proxy::GetEventControl: Managed memory control pointer is Null");
@@ -630,7 +629,7 @@ TransactionLogSet& Proxy::GetTransactionLogSet(const ElementFqId element_fq_id) 
 // value is not comparable and in our case the key is comparable. so no way for 'event_controls_.find()' to throw an
 // exception.
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-const EventMetaInfo& Proxy::GetEventMetaInfo(const ElementFqId element_fq_id) const noexcept
+const EventMetaInfo& Proxy::GetEventMetaInfo(const ElementFqId element_fq_id) const
 {
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(data_ != nullptr,
                                                       "Proxy::GetEventMetaInfo: Managed memory data pointer is Null");
@@ -658,7 +657,7 @@ const EventMetaInfo& Proxy::GetEventMetaInfo(const ElementFqId element_fq_id) co
 // value is not comparable and in our case the key is comparable. so no way for 'event_controls_.find()' to throw an
 // exception.
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-bool Proxy::IsEventProvided(const std::string_view event_name) const noexcept
+bool Proxy::IsEventProvided(const std::string_view event_name) const
 {
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(control_ != nullptr,
                                                       "IsEventProvided: Managed memory control pointer is Null");
@@ -745,7 +744,7 @@ score::Result<void> Proxy::SetupMethods(const std::size_t additional_shm_size_by
     return subscription_result;
 }
 
-void Proxy::CleanupMethods() noexcept
+void Proxy::CleanupMethods()
 {
     // Skip teardown if method SHM was never created (method_shm_resource_ is null, nothing to clean up).
     if (!are_proxy_methods_setup_.load())

--- a/score/mw/com/impl/bindings/lola/proxy.h
+++ b/score/mw/com/impl/bindings/lola/proxy.h
@@ -115,7 +115,7 @@ class Proxy : public ProxyBinding
     // coverity[autosar_cpp14_m3_2_4_violation]
     ~Proxy() override;
 
-    static std::unique_ptr<Proxy> Create(const HandleType handle) noexcept;
+    static std::unique_ptr<Proxy> Create(const HandleType handle);
 
     Proxy(std::shared_ptr<memory::shared::ManagedMemoryResource> control,
           std::shared_ptr<memory::shared::ManagedMemoryResource> data,
@@ -126,22 +126,22 @@ class Proxy : public ProxyBinding
           std::unique_ptr<score::memory::shared::FlockMutexAndLock<score::memory::shared::SharedFlockMutex>>
               service_instance_usage_flock_mutex_and_lock,
           score::filesystem::Filesystem filesystem,
-          ProxyInstanceIdentifier::ProxyInstanceCounter proxy_instance_counter) noexcept;
+          ProxyInstanceIdentifier::ProxyInstanceCounter proxy_instance_counter);
 
     /// Returns the address of the control structure, for the given event ID.
     ///
     /// Terminates if the event control structure cannot be found.
-    ConsumerEventDataControlLocalView<> GetConsumerEventDataControlLocalView(const ElementFqId element_fq_id) noexcept;
+    ConsumerEventDataControlLocalView<> GetConsumerEventDataControlLocalView(const ElementFqId element_fq_id);
 
     /// Returns the EventSubscriptionControl for the given event ID.
     ///
     /// Terminates if the event control structure cannot be found.
-    EventSubscriptionControl<>& GetEventSubscriptionControl(const ElementFqId element_fq_id) noexcept;
+    EventSubscriptionControl<>& GetEventSubscriptionControl(const ElementFqId element_fq_id);
 
     /// Returns the TransactionLogSet for the given event ID.
     ///
     /// Terminates if the event control structure cannot be found.
-    TransactionLogSet& GetTransactionLogSet(const ElementFqId element_fq_id) noexcept;
+    TransactionLogSet& GetTransactionLogSet(const ElementFqId element_fq_id);
 
     /// Retrieves a reference to the event data storage area for a given ElementFqId.
     ///
@@ -158,14 +158,14 @@ class Proxy : public ProxyBinding
     ///
     /// \param element_fq_id The Event ID.
     /// \return An event data meta info.
-    const EventMetaInfo& GetEventMetaInfo(const ElementFqId element_fq_id) const noexcept;
+    const EventMetaInfo& GetEventMetaInfo(const ElementFqId element_fq_id) const;
 
     /// Checks whether the event corresponding to event_name is provided
     ///
     /// It does this by checking whether the event corresponding to event_name exists in shared memory.
     /// \param event_name The event name to check.
     /// \return True if the event name exists, otherwise, false
-    bool IsEventProvided(const std::string_view event_name) const noexcept override;
+    bool IsEventProvided(const std::string_view event_name) const override;
 
     /// \brief Sets up the shared memory for all the methods of the proxy, notifies the skeleton to open the shared
     /// memory and perform any setup on skeleton side.
@@ -216,7 +216,7 @@ class Proxy : public ProxyBinding
     void StopProxyAutoReconnect();
 
     void ServiceAvailabilityChangeHandler(const bool is_service_available);
-    void CleanupMethods() noexcept;
+    void CleanupMethods();
     void InitializeSharedMemoryForMethods(
         memory::shared::ManagedMemoryResource& memory_resource,
         const std::vector<std::pair<UniqueMethodIdentifier, LolaMethodInstanceDeployment::QueueSize>>& method_data,

--- a/score/mw/com/impl/bindings/lola/proxy_event_common.cpp
+++ b/score/mw/com/impl/bindings/lola/proxy_event_common.cpp
@@ -62,7 +62,7 @@ SubscriptionState ProxyEventCommon::GetSubscriptionState() const noexcept
     return SubscriptionStateMachineStateToSubscriptionState(current_state);
 }
 
-Result<std::size_t> ProxyEventCommon::GetNumNewSamplesAvailable() const noexcept
+Result<std::size_t> ProxyEventCommon::GetNumNewSamplesAvailable() const
 {
     const auto& slot_collector = test_slot_collector_.has_value()
                                      ? test_slot_collector_
@@ -73,7 +73,7 @@ Result<std::size_t> ProxyEventCommon::GetNumNewSamplesAvailable() const noexcept
     return slot_collector.value().GetNumNewSamplesAvailable();
 }
 
-SlotCollector::SlotIndices ProxyEventCommon::GetNewSamplesSlotIndices(const std::size_t max_count) noexcept
+SlotCollector::SlotIndices ProxyEventCommon::GetNewSamplesSlotIndices(const std::size_t max_count)
 {
     auto& slot_collector = test_slot_collector_.has_value()
                                ? test_slot_collector_

--- a/score/mw/com/impl/bindings/lola/proxy_event_common.h
+++ b/score/mw/com/impl/bindings/lola/proxy_event_common.h
@@ -71,7 +71,7 @@ class ProxyEventCommon final
     ///
     /// The call is dispatched to SlotCollector. It is the responsibility of the calling code to ensure that
     /// GetNumNewSamplesAvailable() is only called when the event is in the subscribed state.
-    Result<std::size_t> GetNumNewSamplesAvailable() const noexcept;
+    Result<std::size_t> GetNumNewSamplesAvailable() const;
 
     /// \brief Get the indicators of the slots containing samples that are pending for reception in ascending order.
     ///        I.e. returned SlotIndices begin with the oldest slots/events (lowest timestamp) first and end at the
@@ -79,7 +79,7 @@ class ProxyEventCommon final
     ///
     /// The call is dispatched to SlotCollector. It is the responsibility of the calling code to ensure that
     /// GetNewSamplesSlotIndices() is only called when the event is in the subscribed state.
-    SlotCollector::SlotIndices GetNewSamplesSlotIndices(const std::size_t max_count) noexcept;
+    SlotCollector::SlotIndices GetNewSamplesSlotIndices(const std::size_t max_count);
 
     Result<void> SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler);
     Result<void> UnsetReceiveHandler();

--- a/score/mw/com/impl/bindings/lola/runtime.cpp
+++ b/score/mw/com/impl/bindings/lola/runtime.cpp
@@ -36,7 +36,7 @@ namespace score::mw::com::impl::lola
 /// \param config The application's configuration object.
 /// \return The determined application identifier (either the configured ID or the process UID).
 
-std::uint32_t Runtime::DetermineApplicationIdentifier(const Configuration& config) const noexcept
+std::uint32_t Runtime::DetermineApplicationIdentifier(const Configuration& config) const
 {
     const auto& global_config = config.GetGlobalConfiguration();
     const auto application_id = global_config.GetApplicationId();

--- a/score/mw/com/impl/bindings/lola/runtime.h
+++ b/score/mw/com/impl/bindings/lola/runtime.h
@@ -105,7 +105,7 @@ class Runtime final : public IRuntime
     pid_t pid_;
     std::uint32_t application_id_;
 
-    std::uint32_t DetermineApplicationIdentifier(const Configuration& config) const noexcept;
+    std::uint32_t DetermineApplicationIdentifier(const Configuration& config) const;
 };
 
 }  // namespace score::mw::com::impl::lola

--- a/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client.cpp
+++ b/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client.cpp
@@ -144,7 +144,7 @@ ServiceDiscoveryClient::~ServiceDiscoveryClient() noexcept
 // implicitly". std::terminate() is implicitly called from '.value()' in case it doesn't have value but as we check
 // before with 'has_value()' so no way for throwing std::bad_optional_access which leds to std::terminate().
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-auto ServiceDiscoveryClient::OfferService(const InstanceIdentifier instance_identifier) noexcept -> Result<void>
+auto ServiceDiscoveryClient::OfferService(const InstanceIdentifier instance_identifier) -> Result<void>
 {
     const EnrichedInstanceIdentifier enriched_instance_identifier{instance_identifier};
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(
@@ -705,10 +705,9 @@ auto ServiceDiscoveryClient::UnlinkWatchWithSearchRequest(
 // implicitly". std::terminate() is implicitly called from '.value()' in case it doesn't have value but as we check
 // before with 'has_value()' so no way for throwing std::bad_optional_access which leds to std::terminate().
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-Result<void> ServiceDiscoveryClient::StartFindService(
-    const FindServiceHandle find_service_handle,
-    FindServiceHandler<HandleType> handler,
-    const EnrichedInstanceIdentifier enriched_instance_identifier) noexcept
+Result<void> ServiceDiscoveryClient::StartFindService(const FindServiceHandle find_service_handle,
+                                                      FindServiceHandler<HandleType> handler,
+                                                      const EnrichedInstanceIdentifier enriched_instance_identifier)
 {
     // Suppress Autosar C++14 A8-5-3 states that auto variables shall not be initialized using braced initialization.
     // This is a false positive, we don't use auto here
@@ -784,7 +783,7 @@ Result<void> ServiceDiscoveryClient::StartFindService(
 // before with 'has_value()' so no way for throwing std::bad_optional_access which leds to std::terminate().
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
 auto ServiceDiscoveryClient::OnInstanceDirectoryCreated(const WatchesContainer::iterator& watch_iterator,
-                                                        std::string_view name) noexcept -> void
+                                                        std::string_view name) -> void
 {
     const auto& [enriched_instance_identifier, search_keys] = watch_iterator->second;
 
@@ -912,7 +911,7 @@ void ServiceDiscoveryClient::OnInstanceFlagFileRemoved(const WatchesContainer::i
 // before with 'has_value()' so no way for throwing std::bad_optional_access which leds to std::terminate().
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
 Result<ServiceHandleContainer<HandleType>> ServiceDiscoveryClient::FindService(
-    const EnrichedInstanceIdentifier enriched_instance_identifier) noexcept
+    const EnrichedInstanceIdentifier enriched_instance_identifier)
 {
     // Suppress Autosar C++14 A8-5-3 states that auto variables shall not be initialized using braced initialization.
     // This is a false positive, we don't use auto here

--- a/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client.h
+++ b/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client.h
@@ -54,20 +54,19 @@ class ServiceDiscoveryClient final : public IServiceDiscoveryClient
 
     ~ServiceDiscoveryClient() noexcept override;
 
-    [[nodiscard]] Result<void> OfferService(const InstanceIdentifier instance_identifier) noexcept override;
+    [[nodiscard]] Result<void> OfferService(const InstanceIdentifier instance_identifier) override;
 
     [[nodiscard]] Result<void> StopOfferService(
         const InstanceIdentifier instance_identifier,
         const IServiceDiscovery::QualityTypeSelector quality_type_selector) noexcept override;
 
-    [[nodiscard]] Result<void> StartFindService(
-        const FindServiceHandle find_service_handle,
-        FindServiceHandler<HandleType> handler,
-        const EnrichedInstanceIdentifier enriched_instance_identifier) noexcept override;
+    [[nodiscard]] Result<void> StartFindService(const FindServiceHandle find_service_handle,
+                                                FindServiceHandler<HandleType> handler,
+                                                const EnrichedInstanceIdentifier enriched_instance_identifier) override;
 
     [[nodiscard]] Result<void> StopFindService(const FindServiceHandle find_service_handle) noexcept override;
     [[nodiscard]] Result<ServiceHandleContainer<HandleType>> FindService(
-        const EnrichedInstanceIdentifier enriched_instance_identifier) noexcept override;
+        const EnrichedInstanceIdentifier enriched_instance_identifier) override;
 
   private:
     class SearchRequest
@@ -147,7 +146,7 @@ class ServiceDiscoveryClient final : public IServiceDiscoveryClient
     void UnlinkWatchWithSearchRequest(const WatchesContainer::iterator& watch_iterator,
                                       const SearchRequestsContainer::iterator& search_iterator) noexcept;
 
-    void OnInstanceDirectoryCreated(const WatchesContainer::iterator& watch_iterator, std::string_view name) noexcept;
+    void OnInstanceDirectoryCreated(const WatchesContainer::iterator& watch_iterator, std::string_view name);
 
     void OnInstanceFlagFileCreated(const WatchesContainer::iterator& watch_iterator,
                                    const std::string_view name) noexcept;

--- a/score/mw/com/impl/bindings/lola/service_discovery/flag_file.cpp
+++ b/score/mw/com/impl/bindings/lola/service_discovery/flag_file.cpp
@@ -147,8 +147,7 @@ auto GetQualityTypeString(QualityType quality_type) noexcept -> std::string_view
     return result;
 }
 
-auto GetSearchPathForIdentifier(const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept
-    -> filesystem::Path
+auto GetSearchPathForIdentifier(const EnrichedInstanceIdentifier& enriched_instance_identifier) -> filesystem::Path
 {
     const auto service_id =
         enriched_instance_identifier.GetBindingSpecificServiceId<LolaServiceTypeDeployment>().value();
@@ -243,7 +242,7 @@ auto FlagFile::Exists(const EnrichedInstanceIdentifier& enriched_instance_identi
 // This suppression should be removed after fixing [Ticket-173043](broken_link_j/Ticket-173043)
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
 auto FlagFile::CreateSearchPath(const EnrichedInstanceIdentifier& enriched_instance_identifier,
-                                const filesystem::Filesystem& filesystem) noexcept -> Result<filesystem::Path>
+                                const filesystem::Filesystem& filesystem) -> Result<filesystem::Path>
 {
     auto path = GetSearchPathForIdentifier(enriched_instance_identifier);
 

--- a/score/mw/com/impl/bindings/lola/service_discovery/flag_file.h
+++ b/score/mw/com/impl/bindings/lola/service_discovery/flag_file.h
@@ -31,8 +31,7 @@ auto GetQualityTypeString(QualityType quality_type) noexcept -> std::string_view
 /// contains an Instance ID.
 ///
 /// The service discovery path is: `<sd>/mw_com_lola/<service_id>/<instance_id>.
-auto GetSearchPathForIdentifier(const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept
-    -> filesystem::Path;
+auto GetSearchPathForIdentifier(const EnrichedInstanceIdentifier& enriched_instance_identifier) -> filesystem::Path;
 
 class FlagFile
 {
@@ -66,7 +65,7 @@ class FlagFile
     /// InstanceIdentifier in the filesystem.
     static auto CreateSearchPath(
         const EnrichedInstanceIdentifier& enriched_instance_identifier,
-        const filesystem::Filesystem& filesystem = filesystem::FilesystemFactory{}.CreateInstance()) noexcept
+        const filesystem::Filesystem& filesystem = filesystem::FilesystemFactory{}.CreateInstance())
         -> score::Result<filesystem::Path>;
 
   private:

--- a/score/mw/com/impl/bindings/lola/service_discovery/flag_file_crawler.cpp
+++ b/score/mw/com/impl/bindings/lola/service_discovery/flag_file_crawler.cpp
@@ -115,7 +115,7 @@ FlagFileCrawler::FlagFileCrawler(os::InotifyInstance& inotify_instance, filesyst
 // which leds to std::terminate().
 // This suppression should be removed after fixing [Ticket-173043](broken_link_j/Ticket-173043)
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-auto FlagFileCrawler::Crawl(const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept
+auto FlagFileCrawler::Crawl(const EnrichedInstanceIdentifier& enriched_instance_identifier)
     -> score::Result<QualityAwareContainer<KnownInstancesContainer>>
 {
     constexpr auto kAddWatch = false;
@@ -142,7 +142,7 @@ auto FlagFileCrawler::CrawlAndWatch(const EnrichedInstanceIdentifier& enriched_i
 // This suppression should be removed after fixing[Ticket-173043](broken_link_j/Ticket-173043)
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
 auto FlagFileCrawler::CrawlAndWatchImpl(const EnrichedInstanceIdentifier& enriched_instance_identifier,
-                                        const bool add_watch) noexcept
+                                        const bool add_watch)
     -> score::Result<std::tuple<std::unordered_map<os::InotifyWatchDescriptor, EnrichedInstanceIdentifier>,
                                 QualityAwareContainer<KnownInstancesContainer>>>
 {
@@ -212,7 +212,7 @@ auto FlagFileCrawler::CrawlAndWatchImpl(const EnrichedInstanceIdentifier& enrich
 // [Ticket-173043](broken_link_j/Ticket-173043)
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
 auto FlagFileCrawler::CrawlAndWatchWithRetry(const EnrichedInstanceIdentifier& enriched_instance_identifier,
-                                             const std::uint8_t max_number_of_retries) noexcept
+                                             const std::uint8_t max_number_of_retries)
     -> score::Result<std::tuple<std::unordered_map<os::InotifyWatchDescriptor, EnrichedInstanceIdentifier>,
                                 QualityAwareContainer<KnownInstancesContainer>>>
 {
@@ -276,8 +276,7 @@ auto FlagFileCrawler::ParseQualityTypeFromString(const std::string_view filename
 // std::bad_optional_access which leds to std::terminate().
 // This suppression should be removed after fixing [Ticket-173043](broken_link_j/Ticket-173043)
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-auto FlagFileCrawler::GatherExistingInstanceDirectories(
-    const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept
+auto FlagFileCrawler::GatherExistingInstanceDirectories(const EnrichedInstanceIdentifier& enriched_instance_identifier)
     -> score::Result<std::vector<EnrichedInstanceIdentifier>>
 {
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(
@@ -323,7 +322,7 @@ auto FlagFileCrawler::GatherExistingInstanceDirectories(
 // throwing std::bad_optional_access which leds to std::terminate().
 // This suppression should be removed after fixing [Ticket-173043](broken_link_j/Ticket-173043)
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-auto FlagFileCrawler::AddWatchToInotifyInstance(const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept
+auto FlagFileCrawler::AddWatchToInotifyInstance(const EnrichedInstanceIdentifier& enriched_instance_identifier)
     -> Result<os::InotifyWatchDescriptor>
 {
 

--- a/score/mw/com/impl/bindings/lola/service_discovery/flag_file_crawler.h
+++ b/score/mw/com/impl/bindings/lola/service_discovery/flag_file_crawler.h
@@ -36,7 +36,7 @@ class FlagFileCrawler
     explicit FlagFileCrawler(os::InotifyInstance& inotify_instance,
                              filesystem::Filesystem filesystem = filesystem::FilesystemFactory{}.CreateInstance());
 
-    auto Crawl(const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept
+    auto Crawl(const EnrichedInstanceIdentifier& enriched_instance_identifier)
         -> score::Result<QualityAwareContainer<KnownInstancesContainer>>;
 
     auto CrawlAndWatch(const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept
@@ -44,7 +44,7 @@ class FlagFileCrawler
                                     QualityAwareContainer<KnownInstancesContainer>>>;
 
     auto CrawlAndWatchWithRetry(const EnrichedInstanceIdentifier& enriched_instance_identifier,
-                                const std::uint8_t max_number_of_retries) noexcept
+                                const std::uint8_t max_number_of_retries)
         -> score::Result<std::tuple<std::unordered_map<os::InotifyWatchDescriptor, EnrichedInstanceIdentifier>,
                                     QualityAwareContainer<KnownInstancesContainer>>>;
 
@@ -52,16 +52,14 @@ class FlagFileCrawler
     static auto ParseQualityTypeFromString(const std::string_view filename) noexcept -> QualityType;
 
   private:
-    auto CrawlAndWatchImpl(const EnrichedInstanceIdentifier& enriched_instance_identifier,
-                           const bool add_watch) noexcept
+    auto CrawlAndWatchImpl(const EnrichedInstanceIdentifier& enriched_instance_identifier, const bool add_watch)
         -> score::Result<std::tuple<std::unordered_map<os::InotifyWatchDescriptor, EnrichedInstanceIdentifier>,
                                     QualityAwareContainer<KnownInstancesContainer>>>;
 
-    static auto GatherExistingInstanceDirectories(
-        const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept
+    static auto GatherExistingInstanceDirectories(const EnrichedInstanceIdentifier& enriched_instance_identifier)
         -> score::Result<std::vector<EnrichedInstanceIdentifier>>;
 
-    auto AddWatchToInotifyInstance(const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept
+    auto AddWatchToInotifyInstance(const EnrichedInstanceIdentifier& enriched_instance_identifier)
         -> Result<os::InotifyWatchDescriptor>;
 
     os::InotifyInstance& inotify_instance_;

--- a/score/mw/com/impl/bindings/lola/service_discovery/known_instances_container.cpp
+++ b/score/mw/com/impl/bindings/lola/service_discovery/known_instances_container.cpp
@@ -17,7 +17,7 @@
 namespace score::mw::com::impl::lola
 {
 
-auto KnownInstancesContainer::Insert(const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept -> bool
+auto KnownInstancesContainer::Insert(const EnrichedInstanceIdentifier& enriched_instance_identifier) -> bool
 {
     const auto instance_id = enriched_instance_identifier.GetBindingSpecificInstanceId<LolaServiceInstanceId>();
     if (instance_id.has_value())
@@ -41,7 +41,7 @@ auto KnownInstancesContainer::Insert(const EnrichedInstanceIdentifier& enriched_
     return false;
 }
 
-auto KnownInstancesContainer::Remove(const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept -> void
+auto KnownInstancesContainer::Remove(const EnrichedInstanceIdentifier& enriched_instance_identifier) -> void
 {
     const auto instance_id = enriched_instance_identifier.GetBindingSpecificInstanceId<LolaServiceInstanceId>();
     if (instance_id.has_value())
@@ -55,8 +55,8 @@ auto KnownInstancesContainer::Remove(const EnrichedInstanceIdentifier& enriched_
     }
 }
 
-auto KnownInstancesContainer::GetKnownHandles(
-    const EnrichedInstanceIdentifier& enriched_instance_identifier) const noexcept -> std::vector<HandleType>
+auto KnownInstancesContainer::GetKnownHandles(const EnrichedInstanceIdentifier& enriched_instance_identifier) const
+    -> std::vector<HandleType>
 {
     std::vector<HandleType> handles{};
 

--- a/score/mw/com/impl/bindings/lola/service_discovery/known_instances_container.h
+++ b/score/mw/com/impl/bindings/lola/service_discovery/known_instances_container.h
@@ -29,9 +29,9 @@ namespace score::mw::com::impl::lola
 class KnownInstancesContainer final
 {
   public:
-    auto Insert(const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept -> bool;
-    auto Remove(const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept -> void;
-    auto GetKnownHandles(const EnrichedInstanceIdentifier& enriched_instance_identifier) const noexcept
+    auto Insert(const EnrichedInstanceIdentifier& enriched_instance_identifier) -> bool;
+    auto Remove(const EnrichedInstanceIdentifier& enriched_instance_identifier) -> void;
+    auto GetKnownHandles(const EnrichedInstanceIdentifier& enriched_instance_identifier) const
         -> std::vector<HandleType>;
 
     auto Merge(KnownInstancesContainer&& container_to_be_merged) noexcept -> void;

--- a/score/mw/com/impl/bindings/lola/service_discovery/lola_service_instance_identifier.cpp
+++ b/score/mw/com/impl/bindings/lola/service_discovery/lola_service_instance_identifier.cpp
@@ -26,7 +26,7 @@ LolaServiceInstanceIdentifier::LolaServiceInstanceIdentifier(LolaServiceId servi
 // This is false positive, all data members are initialized using member initializers in the delegation constructor.
 // coverity[autosar_cpp14_a12_6_1_violation]
 LolaServiceInstanceIdentifier::LolaServiceInstanceIdentifier(
-    const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept
+    const EnrichedInstanceIdentifier& enriched_instance_identifier)
     : LolaServiceInstanceIdentifier{
           enriched_instance_identifier.GetBindingSpecificServiceId<LolaServiceTypeDeployment>().value()}
 {
@@ -61,7 +61,7 @@ bool operator==(const LolaServiceInstanceIdentifier& lhs, const LolaServiceInsta
 // doesn't have value but as we check before with 'has_value()' so no way for calling std::terminate().
 // coverity[autosar_cpp14_a15_5_3_violation]
 std::size_t std::hash<score::mw::com::impl::lola::LolaServiceInstanceIdentifier>::operator()(
-    const score::mw::com::impl::lola::LolaServiceInstanceIdentifier& identifier) const noexcept
+    const score::mw::com::impl::lola::LolaServiceInstanceIdentifier& identifier) const
 {
     static_assert(sizeof(score::mw::com::impl::LolaServiceId) <= 4U);
     static_assert(sizeof(score::mw::com::impl::LolaServiceInstanceId::InstanceId) <= 2U);

--- a/score/mw/com/impl/bindings/lola/service_discovery/lola_service_instance_identifier.h
+++ b/score/mw/com/impl/bindings/lola/service_discovery/lola_service_instance_identifier.h
@@ -27,7 +27,7 @@ class LolaServiceInstanceIdentifier
 {
   public:
     explicit LolaServiceInstanceIdentifier(LolaServiceId service_id) noexcept;
-    explicit LolaServiceInstanceIdentifier(const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept;
+    explicit LolaServiceInstanceIdentifier(const EnrichedInstanceIdentifier& enriched_instance_identifier);
 
     LolaServiceId GetServiceId() const noexcept;
     std::optional<LolaServiceInstanceId::InstanceId> GetInstanceId() const noexcept;
@@ -47,7 +47,7 @@ template <>
 class hash<score::mw::com::impl::lola::LolaServiceInstanceIdentifier>
 {
   public:
-    std::size_t operator()(const score::mw::com::impl::lola::LolaServiceInstanceIdentifier& identifier) const noexcept;
+    std::size_t operator()(const score::mw::com::impl::lola::LolaServiceInstanceIdentifier& identifier) const;
 };
 
 }  // namespace std

--- a/score/mw/com/impl/bindings/lola/skeleton.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton.cpp
@@ -425,8 +425,7 @@ auto Skeleton::PrepareOffer(SkeletonEventBindings& events,
 // so no way for throwing std::bad_optional_access which leds to std::terminate(). This suppression should be
 // removed after fixing [Ticket-173043](broken_link_j/Ticket-173043) coverity[autosar_cpp14_a15_5_3_violation :
 // FALSE]
-auto Skeleton::PrepareStopOffer(std::optional<UnregisterShmObjectTraceCallback> unregister_shm_object_callback) noexcept
-    -> void
+auto Skeleton::PrepareStopOffer(std::optional<UnregisterShmObjectTraceCallback> unregister_shm_object_callback) -> void
 {
     prepare_stop_offer_called_ = true;
 
@@ -575,7 +574,7 @@ bool Skeleton::VerifyAllMethodHandlersRegistered() const
 auto Skeleton::RegisterGeneric(const ElementFqId element_fq_id,
                                const SkeletonEventProperties& element_properties,
                                const size_t sample_size,
-                               const size_t sample_alignment) noexcept -> GenericRegistrationResult
+                               const size_t sample_alignment) -> GenericRegistrationResult
 {
     if (use_gateway_forwarded_shm_ || was_old_shm_region_reopened_)
     {

--- a/score/mw/com/impl/bindings/lola/skeleton.h
+++ b/score/mw/com/impl/bindings/lola/skeleton.h
@@ -115,8 +115,7 @@ class Skeleton final : public SkeletonBinding
         SkeletonFieldBindings& fields,
         std::optional<RegisterShmObjectTraceCallback> register_shm_object_trace_callback) override;
 
-    void PrepareStopOffer(
-        std::optional<UnregisterShmObjectTraceCallback> unregister_shm_object_callback) noexcept override;
+    void PrepareStopOffer(std::optional<UnregisterShmObjectTraceCallback> unregister_shm_object_callback) override;
 
     BindingType GetBindingType() const noexcept override
     {
@@ -134,7 +133,7 @@ class Skeleton final : public SkeletonBinding
     auto RegisterGeneric(const ElementFqId element_fq_id,
                          const SkeletonEventProperties& element_properties,
                          const size_t sample_size,
-                         const size_t sample_alignment) noexcept -> GenericRegistrationResult;
+                         const size_t sample_alignment) -> GenericRegistrationResult;
 
     /// \brief Enables dynamic registration of Events at the Skeleton.
     /// \tparam SampleType The type of the event

--- a/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
@@ -195,7 +195,7 @@ void* SkeletonMemoryManager::CreateGenericEventDataInCreatedSharedMemory(
     const ElementFqId element_fq_id,
     const SkeletonEventProperties& element_properties,
     size_t sample_size,
-    size_t sample_alignment) noexcept
+    size_t sample_alignment)
 {
     // Guard against over-aligned types (Short-term solution protection)
     if (sample_alignment > alignof(std::max_align_t))
@@ -239,7 +239,7 @@ void* SkeletonMemoryManager::CreateGenericEventDataInCreatedSharedMemory(
 
 void* SkeletonMemoryManager::RetrieveGenericEventDataFromOpenedSharedMemory(
     const ElementFqId element_fq_id,
-    const SkeletonEventProperties& element_properties) noexcept
+    const SkeletonEventProperties& element_properties)
 {
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(storage_ != nullptr, "Service data storage is not available.");
 

--- a/score/mw/com/impl/bindings/lola/skeleton_memory_manager.h
+++ b/score/mw/com/impl/bindings/lola/skeleton_memory_manager.h
@@ -111,7 +111,7 @@ class SkeletonMemoryManager final
     auto CreateGenericEventDataInCreatedSharedMemory(const ElementFqId element_fq_id,
                                                      const SkeletonEventProperties& element_properties,
                                                      size_t sample_size,
-                                                     size_t sample_alignment) noexcept -> void*;
+                                                     size_t sample_alignment) -> void*;
 
     /// \brief Opens an EventControl for QM and optionally for ASIL-B (if the Skeleton is ASIL-B) for a specific
     /// event that were created by a previous skeleton.
@@ -133,8 +133,7 @@ class SkeletonMemoryManager final
     /// Generic events use EventMetaInfo as the stable type-erased contract. No interpretation to a
     /// DynamicArray<SampleType> takes place in this case.
     auto RetrieveGenericEventDataFromOpenedSharedMemory(const ElementFqId element_fq_id,
-                                                        const SkeletonEventProperties& element_properties) noexcept
-        -> void*;
+                                                        const SkeletonEventProperties& element_properties) -> void*;
 
     /// \brief Rolls back any existing operations in the TransactionLog corresponding to a SkeletonEvent
     ///

--- a/score/mw/com/impl/bindings/lola/subscription_helpers.cpp
+++ b/score/mw/com/impl/bindings/lola/subscription_helpers.cpp
@@ -47,7 +47,7 @@ void EventReceiveHandlerManager::Reregister(
     }
 }
 
-void EventReceiveHandlerManager::Unregister() noexcept
+void EventReceiveHandlerManager::Unregister()
 {
     if (registration_number_.has_value())
     {

--- a/score/mw/com/impl/bindings/lola/subscription_helpers.h
+++ b/score/mw/com/impl/bindings/lola/subscription_helpers.h
@@ -50,7 +50,7 @@ class EventReceiveHandlerManager
 
     void Register(std::weak_ptr<ScopedEventReceiveHandler> handler);
     void Reregister(std::optional<std::weak_ptr<ScopedEventReceiveHandler>> new_event_receiver_handler);
-    void Unregister() noexcept;
+    void Unregister();
 
     void UpdatePid(pid_t new_event_source_pid) noexcept
     {

--- a/score/mw/com/impl/bindings/lola/subscription_not_subscribed_states.cpp
+++ b/score/mw/com/impl/bindings/lola/subscription_not_subscribed_states.cpp
@@ -35,7 +35,7 @@ namespace score::mw::com::impl::lola
 // implicitly". std::terminate() is implicitly called from '.value()' in case it doesn't have value but as we check
 // before with 'has_value()' so no way for throwing std::bad_optional_access which leds to std::terminate().
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-Result<void> NotSubscribedState::SubscribeEvent(const std::size_t max_sample_count) noexcept
+Result<void> NotSubscribedState::SubscribeEvent(const std::size_t max_sample_count)
 {
     auto transaction_log_registration_guard_result = state_machine_.transaction_log_set_.RegisterProxyElement(
         state_machine_.transaction_log_id_, state_machine_.event_data_control_local_);
@@ -154,7 +154,7 @@ const std::optional<SlotCollector>& NotSubscribedState::GetSlotCollector() const
     return state_machine_.subscription_data_.slot_collector_;
 }
 
-void NotSubscribedState::OnEntry() noexcept
+void NotSubscribedState::OnEntry()
 {
     const auto transaction_log_index = state_machine_.transaction_log_registration_guard_->GetTransactionLogIndex();
     auto& transaction_log = state_machine_.transaction_log_set_.GetTransactionLog(transaction_log_index);

--- a/score/mw/com/impl/bindings/lola/subscription_not_subscribed_states.h
+++ b/score/mw/com/impl/bindings/lola/subscription_not_subscribed_states.h
@@ -35,7 +35,7 @@ class NotSubscribedState final : public SubscriptionStateBase
 
     ~NotSubscribedState() noexcept override = default;
 
-    Result<void> SubscribeEvent(const std::size_t max_sample_count) noexcept override;
+    Result<void> SubscribeEvent(const std::size_t max_sample_count) override;
     void UnsubscribeEvent() noexcept override;
     void StopOfferEvent() noexcept override;
     void ReOfferEvent(const pid_t new_event_source_pid) noexcept override;
@@ -46,7 +46,7 @@ class NotSubscribedState final : public SubscriptionStateBase
     std::optional<SlotCollector>& GetSlotCollector() & noexcept override;
     const std::optional<SlotCollector>& GetSlotCollector() const& noexcept override;
 
-    void OnEntry() noexcept override;
+    void OnEntry() override;
 };
 
 }  // namespace score::mw::com::impl::lola

--- a/score/mw/com/impl/bindings/lola/subscription_state_base.h
+++ b/score/mw/com/impl/bindings/lola/subscription_state_base.h
@@ -40,18 +40,18 @@ class SubscriptionStateBase
     SubscriptionStateBase(SubscriptionStateBase&&) noexcept = delete;
     SubscriptionStateBase& operator=(SubscriptionStateBase&&) & noexcept = delete;
 
-    virtual Result<void> SubscribeEvent(const std::size_t max_sample_count) noexcept = 0;
+    virtual Result<void> SubscribeEvent(const std::size_t max_sample_count) = 0;
     virtual void UnsubscribeEvent() noexcept = 0;
     virtual void StopOfferEvent() noexcept = 0;
-    virtual void ReOfferEvent(const pid_t new_event_source_pid) noexcept = 0;
+    virtual void ReOfferEvent(const pid_t new_event_source_pid) = 0;
 
     virtual void SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) noexcept = 0;
     virtual void UnsetReceiveHandler() noexcept = 0;
-    virtual std::optional<std::uint16_t> GetMaxSampleCount() const noexcept = 0;
+    virtual std::optional<std::uint16_t> GetMaxSampleCount() const = 0;
     virtual std::optional<SlotCollector>& GetSlotCollector() & noexcept = 0;
     virtual const std::optional<SlotCollector>& GetSlotCollector() const& noexcept = 0;
 
-    virtual void OnEntry() noexcept {};
+    virtual void OnEntry() {};
     virtual void OnExit() noexcept {};
 
   protected:

--- a/score/mw/com/impl/bindings/lola/subscription_state_machine.cpp
+++ b/score/mw/com/impl/bindings/lola/subscription_state_machine.cpp
@@ -147,7 +147,7 @@ const ElementFqId& SubscriptionStateMachine::GetElementFqId() const& noexcept
 // implicitly". std::terminate() is implicitly called from '.value()' in case it doesn't have a value but as we check
 // before with 'has_value()' so no way for throwing std::bad_optional_access which leds to std::terminate().
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-void SubscriptionStateMachine::TransitionToState(const SubscriptionStateMachineState newState) noexcept
+void SubscriptionStateMachine::TransitionToState(const SubscriptionStateMachineState newState)
 {
     GetCurrentEventState().OnExit();
     current_state_idx_.store(newState);

--- a/score/mw/com/impl/bindings/lola/subscription_state_machine.h
+++ b/score/mw/com/impl/bindings/lola/subscription_state_machine.h
@@ -139,7 +139,7 @@ class SubscriptionStateMachine : public std::enable_shared_from_this<Subscriptio
     // Private member methods should be called under lock
     SubscriptionStateBase& GetCurrentEventState() noexcept;
     const SubscriptionStateBase& GetCurrentEventState() const noexcept;
-    void TransitionToState(const SubscriptionStateMachineState newState) noexcept;
+    void TransitionToState(const SubscriptionStateMachineState newState);
 
     // State machine variables
     mutable std::mutex state_mutex_;

--- a/score/mw/com/impl/bindings/lola/subscription_subscribed_states.cpp
+++ b/score/mw/com/impl/bindings/lola/subscription_subscribed_states.cpp
@@ -26,7 +26,7 @@
 namespace score::mw::com::impl::lola
 {
 
-Result<void> SubscribedState::SubscribeEvent(const std::size_t max_sample_count) noexcept
+Result<void> SubscribedState::SubscribeEvent(const std::size_t max_sample_count)
 {
     // Suppress "AUTOSAR C++14 A4-7-1" rule finding. This rule states: "An integer expression shall
     // not lead to data loss.".
@@ -83,7 +83,7 @@ void SubscribedState::UnsetReceiveHandler() noexcept
     state_machine_.event_receive_handler_manager_.Unregister();
 }
 
-std::optional<std::uint16_t> SubscribedState::GetMaxSampleCount() const noexcept
+std::optional<std::uint16_t> SubscribedState::GetMaxSampleCount() const
 {
     SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(
         state_machine_.subscription_data_.max_sample_count_.value() > 0U,

--- a/score/mw/com/impl/bindings/lola/subscription_subscribed_states.h
+++ b/score/mw/com/impl/bindings/lola/subscription_subscribed_states.h
@@ -37,14 +37,14 @@ class SubscribedState final : public SubscriptionStateBase
 
     ~SubscribedState() noexcept override = default;
 
-    Result<void> SubscribeEvent(const std::size_t) noexcept override;
+    Result<void> SubscribeEvent(const std::size_t) override;
     void UnsubscribeEvent() noexcept override;
     void StopOfferEvent() noexcept override;
     void ReOfferEvent(const pid_t) noexcept override;
 
     void SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) noexcept override;
     void UnsetReceiveHandler() noexcept override;
-    std::optional<std::uint16_t> GetMaxSampleCount() const noexcept override;
+    std::optional<std::uint16_t> GetMaxSampleCount() const override;
     std::optional<SlotCollector>& GetSlotCollector() & noexcept override;
     const std::optional<SlotCollector>& GetSlotCollector() const& noexcept override;
 };

--- a/score/mw/com/impl/bindings/lola/subscription_subscription_pending_states.cpp
+++ b/score/mw/com/impl/bindings/lola/subscription_subscription_pending_states.cpp
@@ -28,7 +28,7 @@
 namespace score::mw::com::impl::lola
 {
 
-Result<void> SubscriptionPendingState::SubscribeEvent(const std::size_t max_sample_count) noexcept
+Result<void> SubscriptionPendingState::SubscribeEvent(const std::size_t max_sample_count)
 {
     // Suppress "AUTOSAR C++14 A4-7-1" rule finding. This rule states: "An integer expression shall
     // not lead to data loss.".
@@ -71,7 +71,7 @@ void SubscriptionPendingState::StopOfferEvent() noexcept
     std::terminate();
 }
 
-void SubscriptionPendingState::ReOfferEvent(const pid_t new_event_source_pid) noexcept
+void SubscriptionPendingState::ReOfferEvent(const pid_t new_event_source_pid)
 {
     state_machine_.provider_service_instance_is_available_ = true;
     state_machine_.event_receive_handler_manager_.UpdatePid(new_event_source_pid);
@@ -90,7 +90,7 @@ void SubscriptionPendingState::UnsetReceiveHandler() noexcept
     state_machine_.event_receiver_handler_ = std::nullopt;
 }
 
-std::optional<std::uint16_t> SubscriptionPendingState::GetMaxSampleCount() const noexcept
+std::optional<std::uint16_t> SubscriptionPendingState::GetMaxSampleCount() const
 {
     SCORE_LANGUAGE_FUTURECPP_ASSERT_MESSAGE(
         state_machine_.subscription_data_.max_sample_count_.has_value(),

--- a/score/mw/com/impl/bindings/lola/subscription_subscription_pending_states.h
+++ b/score/mw/com/impl/bindings/lola/subscription_subscription_pending_states.h
@@ -37,14 +37,14 @@ class SubscriptionPendingState final : public SubscriptionStateBase
 
     ~SubscriptionPendingState() noexcept override = default;
 
-    Result<void> SubscribeEvent(const std::size_t max_sample_count) noexcept override;
+    Result<void> SubscribeEvent(const std::size_t max_sample_count) override;
     void UnsubscribeEvent() noexcept override;
     void StopOfferEvent() noexcept override;
-    void ReOfferEvent(const pid_t new_event_source_pid) noexcept override;
+    void ReOfferEvent(const pid_t new_event_source_pid) override;
 
     void SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) noexcept override;
     void UnsetReceiveHandler() noexcept override;
-    std::optional<std::uint16_t> GetMaxSampleCount() const noexcept override;
+    std::optional<std::uint16_t> GetMaxSampleCount() const override;
     std::optional<SlotCollector>& GetSlotCollector() & noexcept override;
     const std::optional<SlotCollector>& GetSlotCollector() const& noexcept override;
 };

--- a/score/mw/com/impl/bindings/lola/tracing/tracing_runtime.cpp
+++ b/score/mw/com/impl/bindings/lola/tracing/tracing_runtime.cpp
@@ -256,7 +256,7 @@ void TracingRuntime::ClearCachedFileDescriptorForReregisteringShmObject(
 // The instance specifier is loaded into the configuration during the initialization.
 // coverity[autosar_cpp14_a15_5_3_violation]
 analysis::tracing::ServiceInstanceElement TracingRuntime::ConvertToTracingServiceInstanceElement(
-    const impl::tracing::ServiceElementInstanceIdentifierView service_element_instance_identifier_view) const noexcept
+    const impl::tracing::ServiceElementInstanceIdentifierView service_element_instance_identifier_view) const
 {
     const auto& service_instance_deployments = configuration_.GetServiceInstances();
     const auto& service_type_deployments = configuration_.GetServiceTypes();
@@ -404,9 +404,8 @@ auto TracingRuntime::GetTraceContextId(
 // implicitly". std::terminate() is implicitly called from '.value()' in case it doesn't have value but as we check
 // before with 'has_value()' so no way for throwing std::bad_optional_access which leds to std::terminate().
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-TracingRuntime::EmplaceTypeErasedSamplePtr(
-    impl::tracing::TypeErasedSamplePtr type_erased_sample_ptr,
-    const impl::tracing::ServiceElementTracingData service_element_tracing_data) noexcept
+TracingRuntime::EmplaceTypeErasedSamplePtr(impl::tracing::TypeErasedSamplePtr type_erased_sample_ptr,
+                                           const impl::tracing::ServiceElementTracingData service_element_tracing_data)
 {
     if (service_element_tracing_data.service_element_range_start >=
         next_available_position_for_new_service_element_range_start_)

--- a/score/mw/com/impl/bindings/lola/tracing/tracing_runtime.h
+++ b/score/mw/com/impl/bindings/lola/tracing/tracing_runtime.h
@@ -77,7 +77,7 @@ class TracingRuntime : public impl::tracing::IBindingTracingRuntime
 
     bool RegisterWithGenericTraceApi() noexcept override;
 
-    analysis::tracing::TraceClientId GetTraceClientId() const noexcept override
+    analysis::tracing::TraceClientId GetTraceClientId() const override
     {
         return trace_client_id_.value();
     }
@@ -123,7 +123,7 @@ class TracingRuntime : public impl::tracing::IBindingTracingRuntime
 
     analysis::tracing::ServiceInstanceElement ConvertToTracingServiceInstanceElement(
         const impl::tracing::ServiceElementInstanceIdentifierView service_element_instance_identifier_view)
-        const noexcept override;
+        const override;
 
     /// \brief EmplaceTypeErasedSamplePtr takes a ServiceElementTracingData and returns a TraceContextId, which allows
     /// to correctly retrieve the sample ptr again. Discarding this value will make it impossible to free the sample
@@ -131,7 +131,7 @@ class TracingRuntime : public impl::tracing::IBindingTracingRuntime
     /// function returns an empty optional.
     [[nodiscard]] std::optional<TraceContextId> EmplaceTypeErasedSamplePtr(
         impl::tracing::TypeErasedSamplePtr type_erased_sample_ptr,
-        const impl::tracing::ServiceElementTracingData service_element_tracing_data) noexcept override;
+        const impl::tracing::ServiceElementTracingData service_element_tracing_data) override;
 
     void ClearTypeErasedSamplePtr(const TraceContextId trace_context_id) noexcept override;
     void ClearTypeErasedSamplePtrs(

--- a/score/mw/com/impl/bindings/lola/transaction_log.cpp
+++ b/score/mw/com/impl/bindings/lola/transaction_log.cpp
@@ -15,8 +15,7 @@
 namespace score::mw::com::impl::lola
 {
 
-TransactionLog::TransactionLog(const std::size_t number_of_slots,
-                               memory::shared::ManagedMemoryResource& resource) noexcept
+TransactionLog::TransactionLog(const std::size_t number_of_slots, memory::shared::ManagedMemoryResource& resource)
     : reference_count_slots_(number_of_slots, resource), subscribe_transactions_{}, subscription_max_sample_count_{}
 {
 }

--- a/score/mw/com/impl/bindings/lola/transaction_log.h
+++ b/score/mw/com/impl/bindings/lola/transaction_log.h
@@ -43,7 +43,7 @@ class TransactionLog
         score::containers::DynamicArray<TransactionLogSlot,
                                         memory::shared::PolymorphicOffsetPtrAllocator<TransactionLogSlot>>;
 
-    TransactionLog(const std::size_t number_of_slots, memory::shared::ManagedMemoryResource& resource) noexcept;
+    TransactionLog(const std::size_t number_of_slots, memory::shared::ManagedMemoryResource& resource);
 
     /// \brief Vector containing one TransactionLogSlot for each slot in the corresponding control vector.
     TransactionLogSlots reference_count_slots_;

--- a/score/mw/com/impl/bindings/lola/transaction_log_local_view.cpp
+++ b/score/mw/com/impl/bindings/lola/transaction_log_local_view.cpp
@@ -62,7 +62,7 @@ bool DoesLogContainIncrementOrDecrementTransactions(
 
 }  // namespace
 
-TransactionLogLocalView::TransactionLogLocalView(TransactionLog& transaction_log) noexcept
+TransactionLogLocalView::TransactionLogLocalView(TransactionLog& transaction_log)
     : reference_count_slots_local_{transaction_log.reference_count_slots_.data(),
                                    transaction_log.reference_count_slots_.size()},
       subscribe_transactions_{transaction_log.subscribe_transactions_},
@@ -240,8 +240,7 @@ Result<void> TransactionLogLocalView::RollbackIncrementTransactions(
     return {};
 }
 
-Result<void> TransactionLogLocalView::RollbackSubscribeTransactions(
-    const UnsubscribeCallback& unsubscribe_callback) noexcept
+Result<void> TransactionLogLocalView::RollbackSubscribeTransactions(const UnsubscribeCallback& unsubscribe_callback)
 {
     const bool was_subscribe_succesfully_recorded{subscribe_transactions_.get().GetTransactionBegin() &&
                                                   subscribe_transactions_.get().GetTransactionEnd()};

--- a/score/mw/com/impl/bindings/lola/transaction_log_local_view.h
+++ b/score/mw/com/impl/bindings/lola/transaction_log_local_view.h
@@ -45,7 +45,7 @@ class TransactionLogLocalView
     using UnsubscribeCallback =
         score::cpp::callback<void(TransactionLog::MaxSampleCountType subscription_max_sample_count)>;
 
-    TransactionLogLocalView(TransactionLog& transaction_log) noexcept;
+    TransactionLogLocalView(TransactionLog& transaction_log);
 
     /// \brief Record Subscription / Unsubscription transactions
     ///
@@ -100,7 +100,7 @@ class TransactionLogLocalView
 
   private:
     Result<void> RollbackIncrementTransactions(const DereferenceSlotCallback& dereference_slot_callback) noexcept;
-    Result<void> RollbackSubscribeTransactions(const UnsubscribeCallback& unsubscribe_callback) noexcept;
+    Result<void> RollbackSubscribeTransactions(const UnsubscribeCallback& unsubscribe_callback);
 
     /// \brief View pointing to DynamicArray containing one TransactionLogSlot for each slot in the corresponding
     /// control vector.

--- a/score/mw/com/impl/bindings/mock_binding/proxy.h
+++ b/score/mw/com/impl/bindings/mock_binding/proxy.h
@@ -41,7 +41,7 @@ class ProxyFacade : public ProxyBinding
     ProxyFacade(Proxy& proxy) : ProxyBinding{}, proxy_{proxy} {}
     ~ProxyFacade() override = default;
 
-    bool IsEventProvided(const std::string_view event_name) const noexcept override
+    bool IsEventProvided(const std::string_view event_name) const override
     {
         return proxy_.IsEventProvided(event_name);
     }

--- a/score/mw/com/impl/bindings/mock_binding/skeleton.h
+++ b/score/mw/com/impl/bindings/mock_binding/skeleton.h
@@ -50,7 +50,7 @@ class SkeletonFacade : public SkeletonBinding
         return skeleton_.PrepareOffer(skeleton_event_binding, skeleton_field_binding, std::move(callback));
     }
 
-    void PrepareStopOffer(std::optional<UnregisterShmObjectTraceCallback> callback) noexcept override final
+    void PrepareStopOffer(std::optional<UnregisterShmObjectTraceCallback> callback) override final
     {
         return skeleton_.PrepareStopOffer(std::move(callback));
     }

--- a/score/mw/com/impl/bindings/mock_binding/tracing/tracing_runtime.h
+++ b/score/mw/com/impl/bindings/mock_binding/tracing/tracing_runtime.h
@@ -25,7 +25,7 @@ class TracingRuntime : public IBindingTracingRuntime
   public:
     MOCK_METHOD(ServiceElementTracingData, RegisterServiceElement, (std::uint8_t), (noexcept, override));
     MOCK_METHOD(bool, RegisterWithGenericTraceApi, (), (noexcept, override));
-    MOCK_METHOD(analysis::tracing::TraceClientId, GetTraceClientId, (), (const, noexcept, override));
+    MOCK_METHOD(analysis::tracing::TraceClientId, GetTraceClientId, (), (const, override));
     MOCK_METHOD(void, SetDataLossFlag, (const bool new_value), (noexcept, override));
     MOCK_METHOD(bool, GetDataLossFlag, (), (const, noexcept, override));
     MOCK_METHOD(void,
@@ -65,7 +65,7 @@ class TracingRuntime : public IBindingTracingRuntime
     MOCK_METHOD(std::optional<TraceContextId>,
                 EmplaceTypeErasedSamplePtr,
                 (TypeErasedSamplePtr, const impl::tracing::ServiceElementTracingData),
-                (noexcept, override));
+                (override));
     MOCK_METHOD(void, ClearTypeErasedSamplePtr, (TraceContextId), (noexcept, override));
     MOCK_METHOD(void,
                 ClearTypeErasedSamplePtrs,

--- a/score/mw/com/impl/configuration/binding_service_type_deployment.h
+++ b/score/mw/com/impl/configuration/binding_service_type_deployment.h
@@ -33,7 +33,7 @@ class BindingServiceTypeDeployment
     using MethodIdMapping = std::unordered_map<std::string, MethodIdType>;
     using ServiceId = ServiceIdType;
 
-    explicit BindingServiceTypeDeployment(const score::json::Object& json_object) noexcept;
+    explicit BindingServiceTypeDeployment(const score::json::Object& json_object);
 
     explicit BindingServiceTypeDeployment(const ServiceIdType service_id,
                                           EventIdMapping events = {},

--- a/score/mw/com/impl/configuration/binding_service_type_deployment_impl.h
+++ b/score/mw/com/impl/configuration/binding_service_type_deployment_impl.h
@@ -66,7 +66,7 @@ template <typename ServiceElementIdType>
 // ToDo: implement a runtime validation check for json, after parsing when the first json object is created, s.t. we can
 // be sure json.As<T> call will return a value. See Ticket-177855.
 // coverity[autosar_cpp14_a15_5_3_violation]
-auto ConvertJsonToServiceElementIdMap(const json::Object& json_object, const std::string_view key) noexcept
+auto ConvertJsonToServiceElementIdMap(const json::Object& json_object, const std::string_view key)
     -> std::unordered_map<std::string, ServiceElementIdType>
 {
     const auto& service_element_json = GetValueFromJson<json::Object>(json_object, key);
@@ -116,7 +116,7 @@ BindingServiceTypeDeployment<EventIdType, FieldIdType, MethodIdType, ServiceIdTy
 
 template <typename EventIdType, typename FieldIdType, typename MethodIdType, typename ServiceIdType>
 BindingServiceTypeDeployment<EventIdType, FieldIdType, MethodIdType, ServiceIdType>::BindingServiceTypeDeployment(
-    const score::json::Object& json_object) noexcept
+    const score::json::Object& json_object)
     : BindingServiceTypeDeployment<EventIdType, FieldIdType, MethodIdType, ServiceIdType>::BindingServiceTypeDeployment(
           GetValueFromJson<ServiceIdType>(json_object, detail::kServiceIdKey),
           detail::ConvertJsonToServiceElementIdMap<EventIdType>(json_object, detail::kEventsKey),

--- a/score/mw/com/impl/configuration/configuration_common_resources.cpp
+++ b/score/mw/com/impl/configuration/configuration_common_resources.cpp
@@ -37,7 +37,7 @@ std::string ToHashStringImpl(const std::uint16_t instance_id, const std::size_t 
 // The .value() call will only throw if the ToBuffer returns an error. In this case we are in an unrecoverable state and
 // a terminate callfunction didn't succeed in parsing the json. In this case termination is the intended behaviour.
 // coverity[autosar_cpp14_a15_5_3_violation]
-std::string ToStringImpl(const json::Object& serialized_json_object) noexcept
+std::string ToStringImpl(const json::Object& serialized_json_object)
 {
     score::json::JsonWriter writer{};
     const std::string serialized_form = writer.ToBuffer(serialized_json_object).value();

--- a/score/mw/com/impl/configuration/configuration_common_resources.h
+++ b/score/mw/com/impl/configuration/configuration_common_resources.h
@@ -36,7 +36,7 @@ constexpr auto kBindingInfoIndexKey = "bindingInfoIndex";
 // There is a template-method in service_type_deployment.cpp with the same signature, but different due to template use
 // coverity[autosar_cpp14_a2_10_4_violation] False positive, see above
 std::string ToHashStringImpl(const std::uint16_t instance_id, const std::size_t hash_string_size) noexcept;
-std::string ToStringImpl(const json::Object& serialized_json_object) noexcept;
+std::string ToStringImpl(const json::Object& serialized_json_object);
 
 /// \brief Helper function to get a value from a json object.
 ///
@@ -115,7 +115,7 @@ template <typename VariantHeldType>
 class DoConstructVariant
 {
   public:
-    static VariantHeldType Do(const score::json::Object& json_object, std::string_view json_variant_key) noexcept
+    static VariantHeldType Do(const score::json::Object& json_object, std::string_view json_variant_key)
     {
         const auto& binding_info_json_object = GetValueFromJson<json::Object>(json_object, json_variant_key);
         return VariantHeldType{binding_info_json_object};

--- a/score/mw/com/impl/configuration/lola_event_instance_deployment.cpp
+++ b/score/mw/com/impl/configuration/lola_event_instance_deployment.cpp
@@ -52,7 +52,7 @@ LolaEventInstanceDeployment::LolaEventInstanceDeployment(const score::json::Obje
 {
 }
 
-LolaEventInstanceDeployment LolaEventInstanceDeployment::CreateFromJson(const score::json::Object& json_object) noexcept
+LolaEventInstanceDeployment LolaEventInstanceDeployment::CreateFromJson(const score::json::Object& json_object)
 {
 
     const auto serialization_version = GetValueFromJson<std::uint32_t>(json_object, kSerializationVersionKey);
@@ -83,7 +83,7 @@ LolaEventInstanceDeployment LolaEventInstanceDeployment::CreateFromJson(const sc
 //                                                                   implicitly"
 // false positive std::bad_optional_access. We check and early exit in case the optional is empty.
 // coverity[autosar_cpp14_a15_5_3_violation]
-score::json::Object LolaEventInstanceDeployment::Serialize() const noexcept
+score::json::Object LolaEventInstanceDeployment::Serialize() const
 {
     score::json::Object json_object{};
     if (number_of_sample_slots_.has_value())
@@ -113,7 +113,7 @@ score::json::Object LolaEventInstanceDeployment::Serialize() const noexcept
 //                                                                   implicitly"
 // false positive std::bad_optional_access. We check and early exit in case the optional is empty.
 // coverity[autosar_cpp14_a15_5_3_violation]
-auto LolaEventInstanceDeployment::GetNumberOfSampleSlots() const noexcept -> std::optional<SampleSlotCountType>
+auto LolaEventInstanceDeployment::GetNumberOfSampleSlots() const -> std::optional<SampleSlotCountType>
 {
     if (!number_of_sample_slots_.has_value())
     {

--- a/score/mw/com/impl/configuration/lola_event_instance_deployment.h
+++ b/score/mw/com/impl/configuration/lola_event_instance_deployment.h
@@ -37,13 +37,13 @@ class LolaEventInstanceDeployment
 
     explicit LolaEventInstanceDeployment(const score::json::Object& json_object) noexcept;
 
-    static LolaEventInstanceDeployment CreateFromJson(const score::json::Object& json_object) noexcept;
+    static LolaEventInstanceDeployment CreateFromJson(const score::json::Object& json_object);
 
-    score::json::Object Serialize() const noexcept;
+    score::json::Object Serialize() const;
 
     void SetNumberOfSampleSlots(SampleSlotCountType number_of_sample_slots) noexcept;
 
-    [[nodiscard]] std::optional<SampleSlotCountType> GetNumberOfSampleSlots() const noexcept;
+    [[nodiscard]] std::optional<SampleSlotCountType> GetNumberOfSampleSlots() const;
     [[nodiscard]] std::optional<SampleSlotCountType> GetNumberOfSampleSlotsExcludingTracingSlot() const noexcept;
 
     [[nodiscard]] TracingSlotSizeType GetNumberOfTracingSlots() const noexcept;

--- a/score/mw/com/impl/configuration/lola_field_instance_deployment.cpp
+++ b/score/mw/com/impl/configuration/lola_field_instance_deployment.cpp
@@ -43,7 +43,7 @@ LolaFieldInstanceDeployment::LolaFieldInstanceDeployment(const score::json::Obje
 {
 }
 
-LolaFieldInstanceDeployment LolaFieldInstanceDeployment::CreateFromJson(const score::json::Object& json_object) noexcept
+LolaFieldInstanceDeployment LolaFieldInstanceDeployment::CreateFromJson(const score::json::Object& json_object)
 {
     // Delegate event-specific parsing to LolaEventInstanceDeployment (which also checks serialization version).
     auto event_deployment = LolaEventInstanceDeployment::CreateFromJson(json_object);

--- a/score/mw/com/impl/configuration/lola_field_instance_deployment.h
+++ b/score/mw/com/impl/configuration/lola_field_instance_deployment.h
@@ -33,7 +33,7 @@ class LolaFieldInstanceDeployment
 
     explicit LolaFieldInstanceDeployment(const score::json::Object& json_object) noexcept;
 
-    static LolaFieldInstanceDeployment CreateFromJson(const score::json::Object& json_object) noexcept;
+    static LolaFieldInstanceDeployment CreateFromJson(const score::json::Object& json_object);
 
     score::json::Object Serialize() const noexcept;
 

--- a/score/mw/com/impl/configuration/lola_service_instance_deployment.cpp
+++ b/score/mw/com/impl/configuration/lola_service_instance_deployment.cpp
@@ -48,7 +48,7 @@ constexpr auto kInterVmForwarded = "interVmForwarded";
 // be sure json.As<T> call will return a value. See Ticket-177855.
 // coverity[autosar_cpp14_a15_5_3_violation]
 std::unordered_map<QualityType, std::vector<uid_t>> ConvertJsonToUidMap(const json::Object& json_object,
-                                                                        std::string_view key) noexcept
+                                                                        std::string_view key)
 {
     const auto& uid_map_json = GetValueFromJson<json::Object>(json_object, key);
 
@@ -143,7 +143,7 @@ bool operator<(const LolaServiceInstanceDeployment& lhs, const LolaServiceInstan
 // See Note 1 for autosar_cpp14_a15_5_3_violation.
 // coverity[autosar_cpp14_a12_1_5_violation]
 // coverity[autosar_cpp14_a15_5_3_violation]
-LolaServiceInstanceDeployment::LolaServiceInstanceDeployment(const score::json::Object& json_object) noexcept
+LolaServiceInstanceDeployment::LolaServiceInstanceDeployment(const score::json::Object& json_object)
     : LolaServiceInstanceDeployment{
           {},
           ConvertJsonToServiceElementMap<EventInstanceMapping>(json_object, kEventsKeyInstDepl),
@@ -215,7 +215,7 @@ LolaServiceInstanceDeployment::LolaServiceInstanceDeployment(
 {
 }
 
-score::json::Object LolaServiceInstanceDeployment::Serialize() const noexcept
+score::json::Object LolaServiceInstanceDeployment::Serialize() const
 {
     json::Object json_object{};
     json_object[kSerializationVersionKeyInstDepl] = score::json::Any{serializationVersion};

--- a/score/mw/com/impl/configuration/lola_service_instance_deployment.h
+++ b/score/mw/com/impl/configuration/lola_service_instance_deployment.h
@@ -43,7 +43,7 @@ class LolaServiceInstanceDeployment
     using MethodInstanceMapping = std::unordered_map<std::string, LolaMethodInstanceDeployment>;
 
     LolaServiceInstanceDeployment() = default;
-    explicit LolaServiceInstanceDeployment(const score::json::Object& json_object) noexcept;
+    explicit LolaServiceInstanceDeployment(const score::json::Object& json_object);
     explicit LolaServiceInstanceDeployment(const std::optional<LolaServiceInstanceId> instance_id,
                                            EventInstanceMapping events = {},
                                            FieldInstanceMapping fields = {},
@@ -85,7 +85,7 @@ class LolaServiceInstanceDeployment
     bool inter_vm_support_{false};
     bool inter_vm_forwarded_{false};
 
-    score::json::Object Serialize() const noexcept;
+    score::json::Object Serialize() const;
     bool ContainsEvent(const std::string& event_name) const noexcept;
     bool ContainsField(const std::string& field_name) const noexcept;
     bool ContainsMethod(const std::string& method_name) const noexcept;

--- a/score/mw/com/impl/configuration/lola_service_instance_id.cpp
+++ b/score/mw/com/impl/configuration/lola_service_instance_id.cpp
@@ -44,7 +44,7 @@ LolaServiceInstanceId::LolaServiceInstanceId(InstanceId instance_id) noexcept
 // This rule states: Common class initialization for non-constant members shall be done by a delegating constructor.
 // Justification: Delegating constructor is used.
 // coverity[autosar_cpp14_a12_1_5_violation]
-LolaServiceInstanceId::LolaServiceInstanceId(const score::json::Object& json_object) noexcept
+LolaServiceInstanceId::LolaServiceInstanceId(const score::json::Object& json_object)
     : LolaServiceInstanceId{GetValueFromJson<InstanceId>(json_object, kInstanceIdKeyLolaSerInstID)}
 {
     const auto serialization_version =

--- a/score/mw/com/impl/configuration/lola_service_instance_id.h
+++ b/score/mw/com/impl/configuration/lola_service_instance_id.h
@@ -31,7 +31,7 @@ class LolaServiceInstanceId
   public:
     using InstanceId = std::uint16_t;
 
-    explicit LolaServiceInstanceId(const score::json::Object& json_object) noexcept;
+    explicit LolaServiceInstanceId(const score::json::Object& json_object);
     explicit LolaServiceInstanceId(InstanceId instance_id) noexcept;
 
     score::json::Object Serialize() const noexcept;

--- a/score/mw/com/impl/configuration/service_identifier_type.cpp
+++ b/score/mw/com/impl/configuration/service_identifier_type.cpp
@@ -44,7 +44,7 @@ ServiceIdentifierType::ServiceIdentifierType(std::string serviceTypeName,
 {
 }
 
-ServiceIdentifierType::ServiceIdentifierType(const score::json::Object& json_object) noexcept
+ServiceIdentifierType::ServiceIdentifierType(const score::json::Object& json_object)
     : ServiceIdentifierType(
           std::string{GetValueFromJson<std::string_view>(json_object, kServiceTypeKeyServIdentType)},
           static_cast<ServiceVersionType>(GetValueFromJson<json::Object>(json_object, kVersionKeyServIdentType)))

--- a/score/mw/com/impl/configuration/service_identifier_type.h
+++ b/score/mw/com/impl/configuration/service_identifier_type.h
@@ -43,7 +43,7 @@ ServiceIdentifierType make_ServiceIdentifierType(std::string, const std::uint32_
 class ServiceIdentifierType final
 {
   public:
-    explicit ServiceIdentifierType(const score::json::Object& json_object) noexcept;
+    explicit ServiceIdentifierType(const score::json::Object& json_object);
 
     ServiceIdentifierType() = delete;
     ~ServiceIdentifierType() noexcept = default;

--- a/score/mw/com/impl/configuration/service_instance_deployment.cpp
+++ b/score/mw/com/impl/configuration/service_instance_deployment.cpp
@@ -40,7 +40,7 @@ constexpr auto kServiceKey = "service";
 // False positive, we first check if json_result has value before we call value() on it. I.e. no throw through
 // bad_variant_access can occur.
 // coverity[autosar_cpp14_a15_5_3_violation]
-QualityType GetQualityTypeFromJson(const score::json::Object& json_object, std::string_view key) noexcept
+QualityType GetQualityTypeFromJson(const score::json::Object& json_object, std::string_view key)
 {
     const auto it = json_object.find(key);
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(it != json_object.end());
@@ -55,7 +55,7 @@ QualityType GetQualityTypeFromJson(const score::json::Object& json_object, std::
 }
 
 // coverity[autosar_cpp14_a2_10_4_violation] False positive, function is in anonymous namespace
-ServiceInstanceDeployment::BindingInformation GetBindingInfoFromJson(const score::json::Object& json_object) noexcept
+ServiceInstanceDeployment::BindingInformation GetBindingInfoFromJson(const score::json::Object& json_object)
 {
     const auto variant_index = GetValueFromJson<std::ptrdiff_t>(json_object, kBindingInfoIndexKey);
 
@@ -67,12 +67,12 @@ ServiceInstanceDeployment::BindingInformation GetBindingInfoFromJson(const score
 
 }  // namespace
 
-auto operator==(const ServiceInstanceDeployment& lhs, const ServiceInstanceDeployment& rhs) noexcept -> bool
+auto operator==(const ServiceInstanceDeployment& lhs, const ServiceInstanceDeployment& rhs) -> bool
 {
     return (((lhs.asilLevel_ == rhs.asilLevel_) && (lhs.bindingInfo_ == rhs.bindingInfo_)));
 }
 
-auto operator<(const ServiceInstanceDeployment& lhs, const ServiceInstanceDeployment& rhs) noexcept -> bool
+auto operator<(const ServiceInstanceDeployment& lhs, const ServiceInstanceDeployment& rhs) -> bool
 {
     if (lhs.bindingInfo_ == rhs.bindingInfo_)
     {
@@ -94,7 +94,7 @@ auto areCompatible(const ServiceInstanceDeployment& lhs, const ServiceInstanceDe
 }
 
 // coverity[autosar_cpp14_a15_5_3_violation] False positive, none of the fucntions throw.
-ServiceInstanceDeployment::ServiceInstanceDeployment(const score::json::Object& json_object) noexcept
+ServiceInstanceDeployment::ServiceInstanceDeployment(const score::json::Object& json_object)
     : ServiceInstanceDeployment(
           ServiceIdentifierType{GetValueFromJson<json::Object>(json_object, kServiceKey)},
           GetBindingInfoFromJson(json_object),
@@ -120,7 +120,7 @@ ServiceInstanceDeployment::ServiceInstanceDeployment(const score::json::Object& 
 // exceptions, a variant can never be in this state, i.e. std::visit can never throw std::bad_variant_access.
 //
 // coverity[autosar_cpp14_a15_5_3_violation] Note 1
-score::json::Object ServiceInstanceDeployment::Serialize() const noexcept
+score::json::Object ServiceInstanceDeployment::Serialize() const
 {
     score::json::Object json_object{};
     json_object[kBindingInfoIndexKey] = score::json::Any{bindingInfo_.index()};
@@ -144,7 +144,7 @@ score::json::Object ServiceInstanceDeployment::Serialize() const noexcept
 }
 
 // coverity[autosar_cpp14_a15_5_3_violation] see Note 1
-BindingType ServiceInstanceDeployment::GetBindingType() const noexcept
+BindingType ServiceInstanceDeployment::GetBindingType() const
 {
     // FP: only one statement in this line
     // coverity[autosar_cpp14_a7_1_7_violation]

--- a/score/mw/com/impl/configuration/service_instance_deployment.h
+++ b/score/mw/com/impl/configuration/service_instance_deployment.h
@@ -39,7 +39,7 @@ class ServiceInstanceDeployment
   public:
     using BindingInformation = std::variant<LolaServiceInstanceDeployment, score::cpp::blank>;
 
-    explicit ServiceInstanceDeployment(const score::json::Object& json_object) noexcept;
+    explicit ServiceInstanceDeployment(const score::json::Object& json_object);
     ServiceInstanceDeployment(const ServiceIdentifierType service,
                               BindingInformation binding,
                               const QualityType asil_level,
@@ -58,9 +58,9 @@ class ServiceInstanceDeployment
     ServiceInstanceDeployment(ServiceInstanceDeployment&& other) noexcept = default;
     ServiceInstanceDeployment& operator=(ServiceInstanceDeployment&& other) noexcept = default;
 
-    score::json::Object Serialize() const noexcept;
+    score::json::Object Serialize() const;
 
-    BindingType GetBindingType() const noexcept;
+    BindingType GetBindingType() const;
 
     // Note the struct is not compliant to POD type containing non-POD member.
     // The struct is used as a config storage obtained by performing the parsing json object.
@@ -76,8 +76,8 @@ class ServiceInstanceDeployment
     constexpr static std::uint32_t serializationVersion = 1U;
 };
 
-bool operator==(const ServiceInstanceDeployment& lhs, const ServiceInstanceDeployment& rhs) noexcept;
-bool operator<(const ServiceInstanceDeployment& lhs, const ServiceInstanceDeployment& rhs) noexcept;
+bool operator==(const ServiceInstanceDeployment& lhs, const ServiceInstanceDeployment& rhs);
+bool operator<(const ServiceInstanceDeployment& lhs, const ServiceInstanceDeployment& rhs);
 bool areCompatible(const ServiceInstanceDeployment& lhs, const ServiceInstanceDeployment& rhs);
 
 template <typename ServiceInstanceDeploymentBinding>

--- a/score/mw/com/impl/configuration/service_instance_id.cpp
+++ b/score/mw/com/impl/configuration/service_instance_id.cpp
@@ -34,7 +34,7 @@ constexpr auto kSerializationVersionKeySerInstID = "serializationVersion";
 
 // This function with this signature is only defined here. And is in  anonymous namespace.
 // coverity[autosar_cpp14_a2_10_4_violation : FALSE]
-ServiceInstanceId::BindingInformation GetBindingInfoFromJson(const score::json::Object& json_object) noexcept
+ServiceInstanceId::BindingInformation GetBindingInfoFromJson(const score::json::Object& json_object)
 {
     const auto variant_index = GetValueFromJson<std::ptrdiff_t>(json_object, kBindingInfoIndexKeySerInstID);
 
@@ -60,7 +60,7 @@ ServiceInstanceId::BindingInformation GetBindingInfoFromJson(const score::json::
 // coverity[autosar_cpp14_a2_10_1_violation]
 // coverity[autosar_cpp14_a15_5_3_violation] Note 1
 // coverity[autosar_cpp14_a2_10_4_violation : FALSE]
-std::string ToHashStringImpl(const ServiceInstanceId::BindingInformation& binding_info) noexcept
+std::string ToHashStringImpl(const ServiceInstanceId::BindingInformation& binding_info)
 {
 
     // The conversion to hex string below does not work with a std::uint8_t, so we cast it to an int. However, we
@@ -110,7 +110,7 @@ ServiceInstanceId::ServiceInstanceId(BindingInformation binding_info) noexcept
 // This rule states: Common class initialization for non-constant members shall be done by a delegating constructor.
 // Justification: Delegating constructor is used.
 // coverity[autosar_cpp14_a12_1_5_violation]
-ServiceInstanceId::ServiceInstanceId(const score::json::Object& json_object) noexcept
+ServiceInstanceId::ServiceInstanceId(const score::json::Object& json_object)
     : ServiceInstanceId{GetBindingInfoFromJson(json_object)}
 {
     const auto serialization_version = GetValueFromJson<std::uint32_t>(json_object, kSerializationVersionKeySerInstID);
@@ -122,7 +122,7 @@ ServiceInstanceId::ServiceInstanceId(const score::json::Object& json_object) noe
 
 // See Note 1
 // coverity[autosar_cpp14_a15_5_3_violation]
-score::json::Object ServiceInstanceId::Serialize() const noexcept
+score::json::Object ServiceInstanceId::Serialize() const
 {
     score::json::Object json_object{};
     json_object[kBindingInfoIndexKeySerInstID] = score::json::Any{binding_info_.index()};
@@ -144,7 +144,7 @@ std::string_view ServiceInstanceId::ToHashString() const noexcept
 
 // See Note 1
 // coverity[autosar_cpp14_a15_5_3_violation]
-bool operator==(const ServiceInstanceId& lhs, const ServiceInstanceId& rhs) noexcept
+bool operator==(const ServiceInstanceId& lhs, const ServiceInstanceId& rhs)
 {
     auto visitor = score::cpp::overload(
         [&rhs](const LolaServiceInstanceId& lhs_lola) noexcept -> bool {
@@ -163,7 +163,7 @@ bool operator==(const ServiceInstanceId& lhs, const ServiceInstanceId& rhs) noex
 
 // See Note 1
 // coverity[autosar_cpp14_a15_5_3_violation]
-bool operator<(const ServiceInstanceId& lhs, const ServiceInstanceId& rhs) noexcept
+bool operator<(const ServiceInstanceId& lhs, const ServiceInstanceId& rhs)
 {
     auto visitor = score::cpp::overload(
         [&rhs](const LolaServiceInstanceId& lhs_lola) noexcept -> bool {

--- a/score/mw/com/impl/configuration/service_instance_id.h
+++ b/score/mw/com/impl/configuration/service_instance_id.h
@@ -32,10 +32,10 @@ class ServiceInstanceId
   public:
     using BindingInformation = std::variant<LolaServiceInstanceId, score::cpp::blank>;
 
-    explicit ServiceInstanceId(const score::json::Object& json_object) noexcept;
+    explicit ServiceInstanceId(const score::json::Object& json_object);
     explicit ServiceInstanceId(BindingInformation binding_info) noexcept;
 
-    score::json::Object Serialize() const noexcept;
+    score::json::Object Serialize() const;
     std::string_view ToHashString() const noexcept;
 
     // This variable has no invariance that needs to be conserved and is needed to be both accessed and set by the user
@@ -64,8 +64,8 @@ class ServiceInstanceId
     std::string hash_string_;
 };
 
-bool operator==(const ServiceInstanceId& lhs, const ServiceInstanceId& rhs) noexcept;
-bool operator<(const ServiceInstanceId& lhs, const ServiceInstanceId& rhs) noexcept;
+bool operator==(const ServiceInstanceId& lhs, const ServiceInstanceId& rhs);
+bool operator<(const ServiceInstanceId& lhs, const ServiceInstanceId& rhs);
 
 template <typename ServiceInstanceIdBinding>
 const ServiceInstanceIdBinding& GetServiceInstanceIdBinding(const ServiceInstanceId& service_instance_id)

--- a/score/mw/com/impl/configuration/service_type_deployment.cpp
+++ b/score/mw/com/impl/configuration/service_type_deployment.cpp
@@ -27,7 +27,7 @@ namespace
 {
 
 // coverity[autosar_cpp14_a2_10_4_violation] False positive, function is in anonymous namespace
-ServiceTypeDeployment::BindingInformation GetBindingInfoFromJson(const score::json::Object& json_object) noexcept
+ServiceTypeDeployment::BindingInformation GetBindingInfoFromJson(const score::json::Object& json_object)
 {
     const auto variant_index = GetValueFromJson<std::ptrdiff_t>(json_object, kBindingInfoIndexKey);
 
@@ -50,7 +50,7 @@ ServiceTypeDeployment::BindingInformation GetBindingInfoFromJson(const score::js
 // coverity[autosar_cpp14_a2_10_4_violation] False positive, function is in anonymous namespace
 // coverity[autosar_cpp14_a2_10_1_violation] See above
 // coverity[autosar_cpp14_a15_5_3_violation]
-std::string ToHashStringImpl(const ServiceTypeDeployment::BindingInformation& binding_info) noexcept
+std::string ToHashStringImpl(const ServiceTypeDeployment::BindingInformation& binding_info)
 {
     // The conversion to hex string below does not work with a std::uint8_t, so we cast it to an int. However, we
     // ensure that the value is less than 16 to ensure it will fit with a single char in the string representation.
@@ -98,7 +98,7 @@ ServiceTypeDeployment::ServiceTypeDeployment(const BindingInformation binding) n
 // This rule states: Common class initialization for non-constant members shall be done by a delegating constructor.
 // Justification: Delegating constructor is used.
 // coverity[autosar_cpp14_a12_1_5_violation]
-ServiceTypeDeployment::ServiceTypeDeployment(const score::json::Object& json_object) noexcept
+ServiceTypeDeployment::ServiceTypeDeployment(const score::json::Object& json_object)
     : ServiceTypeDeployment{GetBindingInfoFromJson(json_object)}
 {
     const auto serialization_version = GetValueFromJson<std::uint32_t>(json_object, kSerializationVersionKey);
@@ -115,7 +115,7 @@ ServiceTypeDeployment::ServiceTypeDeployment(const score::json::Object& json_obj
 // std::visit will only throw std::bad_variant_access if the variant is empty by exception. Since we do not use
 // exceptions, a variant can never be in this state, i.e. std::visit can never throw std::bad_variant_access.
 // coverity[autosar_cpp14_a15_5_3_violation]
-score::json::Object ServiceTypeDeployment::Serialize() const noexcept
+score::json::Object ServiceTypeDeployment::Serialize() const
 {
     score::json::Object json_object{};
     json_object[kBindingInfoIndexKey] = score::json::Any{binding_info_.index()};
@@ -136,7 +136,7 @@ std::string_view ServiceTypeDeployment::ToHashString() const noexcept
     return hash_string_;
 }
 
-bool operator==(const ServiceTypeDeployment& lhs, const ServiceTypeDeployment& rhs) noexcept
+bool operator==(const ServiceTypeDeployment& lhs, const ServiceTypeDeployment& rhs)
 {
     return lhs.binding_info_ == rhs.binding_info_;
 }

--- a/score/mw/com/impl/configuration/service_type_deployment.h
+++ b/score/mw/com/impl/configuration/service_type_deployment.h
@@ -32,11 +32,11 @@ class ServiceTypeDeployment
   public:
     using BindingInformation = std::variant<LolaServiceTypeDeployment, score::cpp::blank>;
 
-    explicit ServiceTypeDeployment(const score::json::Object& json_object) noexcept;
+    explicit ServiceTypeDeployment(const score::json::Object& json_object);
 
     explicit ServiceTypeDeployment(const BindingInformation binding) noexcept;
 
-    score::json::Object Serialize() const noexcept;
+    score::json::Object Serialize() const;
     std::string_view ToHashString() const noexcept;
 
     // This variable has no invariance that needs to be conserved and is needed to be both accessed and set by the user
@@ -65,7 +65,7 @@ class ServiceTypeDeployment
     std::string hash_string_;
 };
 
-bool operator==(const ServiceTypeDeployment& lhs, const ServiceTypeDeployment& rhs) noexcept;
+bool operator==(const ServiceTypeDeployment& lhs, const ServiceTypeDeployment& rhs);
 
 template <typename ServiceTypeDeploymentBinding>
 const ServiceTypeDeploymentBinding& GetServiceTypeDeploymentBinding(

--- a/score/mw/com/impl/configuration/service_version_type.cpp
+++ b/score/mw/com/impl/configuration/service_version_type.cpp
@@ -42,7 +42,7 @@ ServiceVersionType::ServiceVersionType(const std::uint32_t major_version_number,
 // initialized by the constructor shall be initialized using member initializers".
 // This is false positive, all data members are initialized using member initializers in the delegation constructor.
 // coverity[autosar_cpp14_a12_6_1_violation]
-ServiceVersionType::ServiceVersionType(const score::json::Object& json_object) noexcept
+ServiceVersionType::ServiceVersionType(const score::json::Object& json_object)
     : ServiceVersionType{GetValueFromJson<std::uint32_t>(json_object, kMajorVersionKeySerVerType),
                          GetValueFromJson<std::uint32_t>(json_object, kMinorVersionKeySerVerType)}
 {

--- a/score/mw/com/impl/configuration/service_version_type.h
+++ b/score/mw/com/impl/configuration/service_version_type.h
@@ -45,7 +45,7 @@ ServiceVersionType make_ServiceVersionType(const std::uint32_t major_version_num
 class ServiceVersionType final
 {
   public:
-    explicit ServiceVersionType(const score::json::Object& json_object) noexcept;
+    explicit ServiceVersionType(const score::json::Object& json_object);
 
     ServiceVersionType() = delete;
     ~ServiceVersionType() noexcept = default;

--- a/score/mw/com/impl/configuration/tracing_configuration.cpp
+++ b/score/mw/com/impl/configuration/tracing_configuration.cpp
@@ -101,7 +101,7 @@ void TracingConfiguration::SetServiceElementTracingEnabled(tracing::ServiceEleme
 // coverity[autosar_cpp14_a15_5_3_violation]
 bool TracingConfiguration::IsServiceElementTracingEnabled(
     tracing::ServiceElementIdentifierView service_element_identifier_view,
-    std::string_view instance_specifier_view) const noexcept
+    std::string_view instance_specifier_view) const
 {
     const auto find_result = service_element_tracing_enabled_map_.find(service_element_identifier_view);
     if (find_result == service_element_tracing_enabled_map_.end())

--- a/score/mw/com/impl/configuration/tracing_configuration.h
+++ b/score/mw/com/impl/configuration/tracing_configuration.h
@@ -77,7 +77,7 @@ class TracingConfiguration final
     void SetServiceElementTracingEnabled(tracing::ServiceElementIdentifier service_element_identifier,
                                          InstanceSpecifier instance_specifier) noexcept;
     bool IsServiceElementTracingEnabled(tracing::ServiceElementIdentifierView service_element_identifier_view,
-                                        std::string_view instance_specifier_view) const noexcept;
+                                        std::string_view instance_specifier_view) const;
 
   private:
     std::map<tracing::ServiceElementIdentifier,

--- a/score/mw/com/impl/generic_proxy.cpp
+++ b/score/mw/com/impl/generic_proxy.cpp
@@ -39,7 +39,7 @@ namespace
 // an exception.
 // This suppression should be removed after fixing [Ticket-173043](broken_link_j/Ticket-173043)
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-std::vector<std::string_view> GetEventNameList(const InstanceIdentifier& identifier) noexcept
+std::vector<std::string_view> GetEventNameList(const InstanceIdentifier& identifier)
 {
     using ReturnType = std::vector<std::string_view>;
 
@@ -61,7 +61,7 @@ std::vector<std::string_view> GetEventNameList(const InstanceIdentifier& identif
 
 }  // namespace
 
-Result<GenericProxy> GenericProxy::Create(HandleType instance_handle) noexcept
+Result<GenericProxy> GenericProxy::Create(HandleType instance_handle)
 {
     auto proxy_binding_result = ProxyBindingFactory::Create(instance_handle);
     if (!proxy_binding_result.has_value())

--- a/score/mw/com/impl/generic_proxy.h
+++ b/score/mw/com/impl/generic_proxy.h
@@ -65,7 +65,7 @@ class GenericProxy : public ProxyBase
      * \param instance_handle Handle to the instance
      * \return Result containing the created GenericProxy instance or an error code.
      */
-    static Result<GenericProxy> Create(HandleType instance_handle) noexcept;
+    static Result<GenericProxy> Create(HandleType instance_handle);
 
     ~GenericProxy() noexcept;
 

--- a/score/mw/com/impl/generic_skeleton.cpp
+++ b/score/mw/com/impl/generic_skeleton.cpp
@@ -54,7 +54,7 @@ std::string_view GetEventName(const InstanceIdentifier& identifier, std::string_
 }  // namespace
 
 Result<GenericSkeleton> GenericSkeleton::Create(const InstanceSpecifier& specifier,
-                                                const GenericSkeletonServiceElementInfo& in) noexcept
+                                                const GenericSkeletonServiceElementInfo& in)
 {
     const auto instance_identifier_result = GetInstanceIdentifier(specifier);
 
@@ -68,7 +68,7 @@ Result<GenericSkeleton> GenericSkeleton::Create(const InstanceSpecifier& specifi
 }
 
 Result<GenericSkeleton> GenericSkeleton::Create(const InstanceIdentifier& identifier,
-                                                const GenericSkeletonServiceElementInfo& in) noexcept
+                                                const GenericSkeletonServiceElementInfo& in)
 {
     auto binding = SkeletonBindingFactory::Create(identifier);
     if (!binding)

--- a/score/mw/com/impl/generic_skeleton.h
+++ b/score/mw/com/impl/generic_skeleton.h
@@ -59,14 +59,14 @@ class GenericSkeleton : public SkeletonBase
     ///   `initial_value_bytes.size()` must be <= `size_info.size`.
     /// - On error, no partially-created elements are left behind.
     [[nodiscard]] static Result<GenericSkeleton> Create(const InstanceIdentifier& identifier,
-                                                        const GenericSkeletonServiceElementInfo& in) noexcept;
+                                                        const GenericSkeletonServiceElementInfo& in);
 
     /// \brief Same as Create(InstanceIdentifier, ...) but resolves the specifier first.
     /// \param specifier The instance specifier.
     /// \param in Input parameters for creation.
     /// \return A GenericSkeleton or an error.
     [[nodiscard]] static Result<GenericSkeleton> Create(const InstanceSpecifier& specifier,
-                                                        const GenericSkeletonServiceElementInfo& in) noexcept;
+                                                        const GenericSkeletonServiceElementInfo& in);
 
     /// \brief Returns a read-only view to the name-keyed map of events.
     /// \note The returned view is valid as long as the GenericSkeleton lives.

--- a/score/mw/com/impl/handle_type.cpp
+++ b/score/mw/com/impl/handle_type.cpp
@@ -26,8 +26,7 @@ namespace score::mw::com::impl
 namespace
 {
 
-ServiceInstanceId ExtractInstanceId(std::optional<ServiceInstanceId> instance_id,
-                                    const InstanceIdentifier& identifier) noexcept
+ServiceInstanceId ExtractInstanceId(std::optional<ServiceInstanceId> instance_id, const InstanceIdentifier& identifier)
 {
     if (instance_id.has_value())
     {

--- a/score/mw/com/impl/i_runtime.h
+++ b/score/mw/com/impl/i_runtime.h
@@ -52,7 +52,7 @@ class IRuntime
 
     /// \brief Returns TracingFilterConfig that is parsed from a json config file.
     /// \return TracingFilterConfig pointer or nullptr in case the config file could not be found or parsed.
-    virtual const tracing::ITracingFilterConfig* GetTracingFilterConfig() const noexcept = 0;
+    virtual const tracing::ITracingFilterConfig* GetTracingFilterConfig() const = 0;
 
   protected:
     IRuntime(const IRuntime&) = default;

--- a/score/mw/com/impl/i_service_discovery.h
+++ b/score/mw/com/impl/i_service_discovery.h
@@ -50,7 +50,7 @@ class IServiceDiscovery
     [[nodiscard]] virtual Result<ServiceHandleContainer<HandleType>> FindService(
         InstanceIdentifier instance_identifier) noexcept = 0;
     [[nodiscard]] virtual Result<ServiceHandleContainer<HandleType>> FindService(
-        InstanceSpecifier instance_specifier) noexcept = 0;
+        InstanceSpecifier instance_specifier) = 0;
 
   protected:
     IServiceDiscovery(const IServiceDiscovery&) = default;

--- a/score/mw/com/impl/i_service_discovery_client.h
+++ b/score/mw/com/impl/i_service_discovery_client.h
@@ -31,17 +31,17 @@ class IServiceDiscoveryClient
     virtual ~IServiceDiscoveryClient() noexcept = default;
     IServiceDiscoveryClient() = default;
 
-    [[nodiscard]] virtual Result<void> OfferService(const InstanceIdentifier instance_identifier) noexcept = 0;
+    [[nodiscard]] virtual Result<void> OfferService(const InstanceIdentifier instance_identifier) = 0;
     [[nodiscard]] virtual Result<void> StopOfferService(
         const InstanceIdentifier instance_identifier,
         const IServiceDiscovery::QualityTypeSelector quality_type_selector) noexcept = 0;
     [[nodiscard]] virtual Result<void> StartFindService(
         const FindServiceHandle find_service_handle,
         FindServiceHandler<HandleType> handler,
-        const EnrichedInstanceIdentifier enriched_instance_identifier) noexcept = 0;
+        const EnrichedInstanceIdentifier enriched_instance_identifier) = 0;
     [[nodiscard]] virtual Result<void> StopFindService(const FindServiceHandle find_service_handle) noexcept = 0;
     [[nodiscard]] virtual Result<ServiceHandleContainer<HandleType>> FindService(
-        const EnrichedInstanceIdentifier enriched_instance_identifier) noexcept = 0;
+        const EnrichedInstanceIdentifier enriched_instance_identifier) = 0;
 
   protected:
     IServiceDiscoveryClient(const IServiceDiscoveryClient&) = default;

--- a/score/mw/com/impl/instance_identifier.cpp
+++ b/score/mw/com/impl/instance_identifier.cpp
@@ -44,7 +44,7 @@ Configuration* InstanceIdentifier::configuration_{nullptr};
 // std::bad_optional_access which leds to std::terminate().
 // This suppression should be removed after fixing [Ticket-173043](broken_link_j/Ticket-173043)
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-score::Result<InstanceIdentifier> InstanceIdentifier::Create(std::string&& serialized_format) noexcept
+score::Result<InstanceIdentifier> InstanceIdentifier::Create(std::string&& serialized_format)
 {
     if (configuration_ == nullptr)
     {
@@ -80,7 +80,7 @@ score::Result<InstanceIdentifier> InstanceIdentifier::Create(std::string&& seria
 // Rationale: Delegation to a separate constructor complexifies the code significantly.
 // This adds more risk than doing the initialization of the members in each constructor.
 // coverity[autosar_cpp14_a12_1_5_violation : FALSE]
-InstanceIdentifier::InstanceIdentifier(const json::Object& json_object, std::string&& serialized_string) noexcept
+InstanceIdentifier::InstanceIdentifier(const json::Object& json_object, std::string&& serialized_string)
     : instance_deployment_{nullptr}, type_deployment_{nullptr}, serialized_string_{std::move(serialized_string)}
 {
     const auto serialization_version = GetValueFromJson<std::uint32_t>(json_object, kSerializationVersionKey);
@@ -161,7 +161,7 @@ InstanceIdentifierView::InstanceIdentifierView(const InstanceIdentifier& identif
 // an exception.
 // This suppression should be removed after fixing [Ticket-173043](broken_link_j/Ticket-173043)
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-auto InstanceIdentifierView::GetServiceInstanceId() const noexcept -> std::optional<ServiceInstanceId>
+auto InstanceIdentifierView::GetServiceInstanceId() const -> std::optional<ServiceInstanceId>
 {
     auto visitor = score::cpp::overload(
         [](const LolaServiceInstanceDeployment& deployment) -> std::optional<ServiceInstanceId> {

--- a/score/mw/com/impl/instance_identifier.h
+++ b/score/mw/com/impl/instance_identifier.h
@@ -55,7 +55,7 @@ class InstanceIdentifier final
      * called with a dummy InstanceSpecifier) triggers this.
      * If the configuration has not been set, kInvalidConfiguration is returned.
      */
-    static score::Result<InstanceIdentifier> Create(std::string&& serialized_format) noexcept;
+    static score::Result<InstanceIdentifier> Create(std::string&& serialized_format);
 
     InstanceIdentifier() = delete;
     ~InstanceIdentifier() noexcept = default;
@@ -141,7 +141,7 @@ class InstanceIdentifier final
      * @param json_object Used to construct the InstanceIdentifier (no copies of json_object are made internally).
      * @param serialized_string Serialized string which the json_object is derived from. Used to set serialized_string_.
      */
-    explicit InstanceIdentifier(const json::Object& json_object, std::string&& serialized_string) noexcept;
+    explicit InstanceIdentifier(const json::Object& json_object, std::string&& serialized_string);
 
     /**
      * @brief internal impl. specific ctor.
@@ -241,7 +241,7 @@ class InstanceIdentifierView final
         return identifier_.Serialize();
     };
 
-    std::optional<ServiceInstanceId> GetServiceInstanceId() const noexcept;
+    std::optional<ServiceInstanceId> GetServiceInstanceId() const;
     const ServiceInstanceDeployment& GetServiceInstanceDeployment() const noexcept;
     const ServiceTypeDeployment& GetServiceTypeDeployment() const;
     bool isCompatibleWith(const InstanceIdentifier&) const;

--- a/score/mw/com/impl/methods/proxy_method_base.h
+++ b/score/mw/com/impl/methods/proxy_method_base.h
@@ -40,7 +40,7 @@ class ProxyMethodBase : public EnableReferenceToMoveableFromThis<ProxyMethodBase
   public:
     ProxyMethodBase(std::string_view method_name,
                     Result<std::unique_ptr<ProxyMethodBinding>> proxy_method_binding,
-                    MethodType method_type) noexcept
+                    MethodType method_type)
         : EnableReferenceToMoveableFromThis<ProxyMethodBase>(),
           method_name_{method_name},
           method_type_{method_type},

--- a/score/mw/com/impl/plumbing/i_proxy_event_binding_factory.h
+++ b/score/mw/com/impl/plumbing/i_proxy_event_binding_factory.h
@@ -71,11 +71,10 @@ class IGenericProxyEventBindingFactory
     /// \param handle The handle containing the binding information.
     /// \param event_name The binding unspecific name of the event inside the proxy denoted by handle.
     /// \return An instance of ProxyEventBinding or an error in case of binding construction failure.
-    virtual Result<std::unique_ptr<GenericProxyEventBinding>> Create(
-        HandleType parent_handle,
-        ProxyBinding& parent_binding,
-        const std::string_view event_name,
-        const ServiceElementType service_element_type) noexcept = 0;
+    virtual Result<std::unique_ptr<GenericProxyEventBinding>> Create(HandleType parent_handle,
+                                                                     ProxyBinding& parent_binding,
+                                                                     const std::string_view event_name,
+                                                                     const ServiceElementType service_element_type) = 0;
 };
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/i_proxy_method_binding_factory.h
+++ b/score/mw/com/impl/plumbing/i_proxy_method_binding_factory.h
@@ -49,7 +49,7 @@ class IProxyMethodBindingFactory
     virtual auto Create(HandleType parent_handle,
                         ProxyBinding& parent_binding,
                         const std::string_view method_name,
-                        MethodType method_type) noexcept -> Result<std::unique_ptr<ProxyMethodBinding>> = 0;
+                        MethodType method_type) -> Result<std::unique_ptr<ProxyMethodBinding>> = 0;
 };
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/proxy_event_binding_factory_impl.cpp
+++ b/score/mw/com/impl/plumbing/proxy_event_binding_factory_impl.cpp
@@ -36,7 +36,7 @@ Result<std::unique_ptr<GenericProxyEventBinding>> GenericProxyEventBindingFactor
     HandleType parent_handle,
     ProxyBinding& parent_binding,
     const std::string_view event_name,
-    const ServiceElementType service_element_type) noexcept
+    const ServiceElementType service_element_type)
 {
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(service_element_type == ServiceElementType::EVENT ||
                                               service_element_type == ServiceElementType::FIELD);

--- a/score/mw/com/impl/plumbing/proxy_event_binding_factory_impl.h
+++ b/score/mw/com/impl/plumbing/proxy_event_binding_factory_impl.h
@@ -59,11 +59,10 @@ class GenericProxyEventBindingFactoryImpl : public IGenericProxyEventBindingFact
     /// \param handle The handle containing the binding information.
     /// \param event_name The binding unspecific name of the event inside the proxy denoted by handle.
     /// \return An instance of ProxyEventBinding or an error in case binding creation fails.
-    Result<std::unique_ptr<GenericProxyEventBinding>> Create(
-        HandleType parent_handle,
-        ProxyBinding& parent_binding,
-        const std::string_view event_name,
-        const ServiceElementType service_element_type) noexcept override;
+    Result<std::unique_ptr<GenericProxyEventBinding>> Create(HandleType parent_handle,
+                                                             ProxyBinding& parent_binding,
+                                                             const std::string_view event_name,
+                                                             const ServiceElementType service_element_type) override;
 };
 
 template <typename SampleType>

--- a/score/mw/com/impl/plumbing/proxy_event_binding_factory_mock.h
+++ b/score/mw/com/impl/plumbing/proxy_event_binding_factory_mock.h
@@ -38,7 +38,7 @@ class GenericProxyEventBindingFactoryMock : public IGenericProxyEventBindingFact
         Result<std::unique_ptr<GenericProxyEventBinding>>,
         Create,
         (HandleType, ProxyBinding&, const std::string_view event_name, const ServiceElementType service_element_type),
-        (noexcept, override));
+        (override));
 };
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/proxy_method_binding_factory_impl.h
+++ b/score/mw/com/impl/plumbing/proxy_method_binding_factory_impl.h
@@ -98,7 +98,7 @@ class ProxyMethodBindingFactoryImpl<ReturnType(ArgTypes...)> : public IProxyMeth
     Result<std::unique_ptr<ProxyMethodBinding>> Create(HandleType parent_handle,
                                                        ProxyBinding& parent_binding,
                                                        const std::string_view method_name,
-                                                       MethodType method_type) noexcept override;
+                                                       MethodType method_type) override;
 };
 
 template <typename ReturnType, typename... ArgTypes>
@@ -106,7 +106,7 @@ Result<std::unique_ptr<ProxyMethodBinding>> ProxyMethodBindingFactoryImpl<Return
     HandleType parent_handle,
     ProxyBinding& parent_binding,
     const std::string_view method_name,
-    MethodType method_type) noexcept
+    MethodType method_type)
 {
     auto method_name_str = std::string{method_name};
 

--- a/score/mw/com/impl/plumbing/proxy_method_binding_factory_mock.h
+++ b/score/mw/com/impl/plumbing/proxy_method_binding_factory_mock.h
@@ -31,7 +31,7 @@ class ProxyMethodBindingFactoryMock : public IProxyMethodBindingFactory
                  ProxyBinding& parent_binding,
                  const std::string_view method_name,
                  MethodType method_type),
-                (noexcept, override));
+                (override));
 };
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_impl.h
+++ b/score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_impl.h
@@ -194,7 +194,7 @@ template <typename SkeletonServiceElementBinding, typename SkeletonServiceElemen
 auto CreateGenericSkeletonEventOrField(const InstanceIdentifier& identifier,
                                        SkeletonBase& parent,
                                        const std::string_view service_element_name,
-                                       const DataTypeMetaInfo& meta_info) noexcept
+                                       const DataTypeMetaInfo& meta_info)
     -> std::unique_ptr<SkeletonServiceElementBinding>
 {
     static_assert((element_type == ServiceElementType::EVENT) || (element_type == ServiceElementType::FIELD));

--- a/score/mw/com/impl/proxy_binding.h
+++ b/score/mw/com/impl/proxy_binding.h
@@ -53,7 +53,7 @@ class ProxyBinding
     ///
     /// \param event_name The event name to check.
     /// \return True if the event name exists, otherwise, false
-    virtual bool IsEventProvided(const std::string_view event_name) const noexcept = 0;
+    virtual bool IsEventProvided(const std::string_view event_name) const = 0;
 
     /// \brief Performs any binding specific setup required.
     ///

--- a/score/mw/com/impl/proxy_binding_test.cpp
+++ b/score/mw/com/impl/proxy_binding_test.cpp
@@ -26,7 +26,7 @@ namespace
 class MyProxy final : public ProxyBinding
 {
   public:
-    bool IsEventProvided(const std::string_view) const noexcept override
+    bool IsEventProvided(const std::string_view) const override
     {
         return true;
     }

--- a/score/mw/com/impl/proxy_event_base.cpp
+++ b/score/mw/com/impl/proxy_event_base.cpp
@@ -35,7 +35,7 @@ namespace score::mw::com::impl
 thread_local bool ProxyEventBase::is_in_receive_handler_context = false;
 
 ProxyEventBase::ProxyEventBase(std::string_view event_name,
-                               Result<std::unique_ptr<ProxyEventBindingBase>> proxy_event_binding) noexcept
+                               Result<std::unique_ptr<ProxyEventBindingBase>> proxy_event_binding)
     : EnableReferenceToMoveableFromThis<ProxyEventBase>(),
       binding_construction_result_{},
       binding_base_{std::move(proxy_event_binding)
@@ -73,7 +73,7 @@ ProxyEventBase& ProxyEventBase::operator=(ProxyEventBase&&) noexcept = default;
 // which leds to std::terminate().
 // This suppression should be removed after fixing [Ticket-173043](broken_link_j/Ticket-173043)
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-Result<void> ProxyEventBase::Subscribe(const std::size_t max_sample_count) noexcept
+Result<void> ProxyEventBase::Subscribe(const std::size_t max_sample_count)
 {
     if (proxy_event_base_mock_ != nullptr)
     {

--- a/score/mw/com/impl/proxy_event_base.h
+++ b/score/mw/com/impl/proxy_event_base.h
@@ -59,8 +59,7 @@ class ProxyEventBase : public EnableReferenceToMoveableFromThis<ProxyEventBase>
     /// \brief Constructs a ProxyEventBase with the given proxy event binding.
     /// \param event_name Event name of the event.
     /// \param proxy_event_binding The binding that shall be associated with this proxy event.
-    ProxyEventBase(std::string_view event_name,
-                   Result<std::unique_ptr<ProxyEventBindingBase>> proxy_event_binding) noexcept;
+    ProxyEventBase(std::string_view event_name, Result<std::unique_ptr<ProxyEventBindingBase>> proxy_event_binding);
 
     /// \brief A ProxyEventBase shall not be copyable
     ProxyEventBase(const ProxyEventBase&) = delete;
@@ -80,7 +79,7 @@ class ProxyEventBase : public EnableReferenceToMoveableFromThis<ProxyEventBase>
      *                          be able to offer to the using application.
      * \return On failure, returns an error code.
      */
-    Result<void> Subscribe(const std::size_t max_sample_count) noexcept;
+    Result<void> Subscribe(const std::size_t max_sample_count);
 
     /**
      * \api

--- a/score/mw/com/impl/runtime.cpp
+++ b/score/mw/com/impl/runtime.cpp
@@ -144,7 +144,7 @@ auto Runtime::getInstance() noexcept -> IRuntime&
 // std::bad_optional_access which leds to std::terminate(). This suppression should be removed after fixing
 // [Ticket-173043](broken_link_j/Ticket-173043)
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-Runtime& Runtime::getInstanceInternal() noexcept
+Runtime& Runtime::getInstanceInternal()
 {
     TouchStaticDependencies();
     // Suppress "AUTOSAR C++14 A3-3-2" rule finding. This rule states: "Static and thread-local objects shall be
@@ -261,7 +261,7 @@ auto Runtime::GetServiceDiscovery() & noexcept -> IServiceDiscovery&
     return service_discovery_;
 }
 
-auto Runtime::GetTracingFilterConfig() const noexcept -> const tracing::ITracingFilterConfig*
+auto Runtime::GetTracingFilterConfig() const -> const tracing::ITracingFilterConfig*
 {
     if (!tracing_filter_configuration_.has_value())
     {

--- a/score/mw/com/impl/runtime.h
+++ b/score/mw/com/impl/runtime.h
@@ -119,7 +119,7 @@ class Runtime final : public IRuntime
 
     /// \brief see IRuntime::GetTracingFilterConfig
     // coverity[autosar_cpp14_a10_3_1_violation]
-    const tracing::ITracingFilterConfig* GetTracingFilterConfig() const noexcept override final;
+    const tracing::ITracingFilterConfig* GetTracingFilterConfig() const override final;
 
     /// \brief see IRuntime::GetTracingRuntime
     // coverity[autosar_cpp14_a10_3_1_violation]
@@ -129,7 +129,7 @@ class Runtime final : public IRuntime
     /// \return static Runtime (the real one - not a mock!) configured based on the configuration set by one of the
     ///         static Initialize() overloads.
     /// \pre the internal static initialization_config_ has to be initialized with a Configuration.
-    static Runtime& getInstanceInternal() noexcept;
+    static Runtime& getInstanceInternal();
 
     /// \brief pointer to a mock to be used (set via InjectMock())
     static score::mw::com::impl::IRuntime* mock_;

--- a/score/mw/com/impl/runtime_mock.h
+++ b/score/mw/com/impl/runtime_mock.h
@@ -30,7 +30,7 @@ class RuntimeMock : public IRuntime
     MOCK_METHOD(IBindingRuntime*, GetBindingRuntime, (BindingType), (const, noexcept, override));
     MOCK_METHOD(std::vector<InstanceIdentifier>, resolve, (const InstanceSpecifier&), (const, override));
     MOCK_METHOD(IServiceDiscovery&, GetServiceDiscovery, (), (ref(&), noexcept, override));
-    MOCK_METHOD(const tracing::ITracingFilterConfig*, GetTracingFilterConfig, (), (const, noexcept, override));
+    MOCK_METHOD(const tracing::ITracingFilterConfig*, GetTracingFilterConfig, (), (const, override));
     MOCK_METHOD(tracing::ITracingRuntime*, GetTracingRuntime, (), (const, noexcept, override));
 };
 

--- a/score/mw/com/impl/service_discovery.cpp
+++ b/score/mw/com/impl/service_discovery.cpp
@@ -344,7 +344,7 @@ Result<ServiceHandleContainer<HandleType>> ServiceDiscovery::FindService(
 // which leds to std::terminate().
 // This suppression should be removed after fixing [Ticket-173043](broken_link_j/Ticket-173043)
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-Result<ServiceHandleContainer<HandleType>> ServiceDiscovery::FindService(InstanceSpecifier instance_specifier) noexcept
+Result<ServiceHandleContainer<HandleType>> ServiceDiscovery::FindService(InstanceSpecifier instance_specifier)
 {
     ServiceHandleContainer<HandleType> handles;
     const auto instance_identifiers = runtime_.resolve(instance_specifier);

--- a/score/mw/com/impl/service_discovery.h
+++ b/score/mw/com/impl/service_discovery.h
@@ -55,8 +55,7 @@ class ServiceDiscovery final : public IServiceDiscovery
     [[nodiscard]] Result<void> StopFindService(const FindServiceHandle) noexcept override;
     [[nodiscard]] Result<ServiceHandleContainer<HandleType>> FindService(
         InstanceIdentifier instance_identifier) noexcept override;
-    [[nodiscard]] Result<ServiceHandleContainer<HandleType>> FindService(
-        InstanceSpecifier instance_specifier) noexcept override;
+    [[nodiscard]] Result<ServiceHandleContainer<HandleType>> FindService(InstanceSpecifier instance_specifier) override;
 
   private:
     /// \brief Dispatches to BindingSpecificStartFindService and processes a binding error if returned

--- a/score/mw/com/impl/service_discovery_client_mock.h
+++ b/score/mw/com/impl/service_discovery_client_mock.h
@@ -23,7 +23,7 @@ namespace score::mw::com::impl
 class ServiceDiscoveryClientMock : public IServiceDiscoveryClient
 {
   public:
-    MOCK_METHOD(Result<void>, OfferService, (InstanceIdentifier), (noexcept, override));
+    MOCK_METHOD(Result<void>, OfferService, (InstanceIdentifier), (override));
     MOCK_METHOD(Result<void>,
                 StopOfferService,
                 (InstanceIdentifier, IServiceDiscovery::QualityTypeSelector),
@@ -31,12 +31,9 @@ class ServiceDiscoveryClientMock : public IServiceDiscoveryClient
     MOCK_METHOD(Result<void>,
                 StartFindService,
                 (FindServiceHandle, (FindServiceHandler<HandleType>), EnrichedInstanceIdentifier),
-                (noexcept, override));
+                (override));
     MOCK_METHOD(Result<void>, StopFindService, (FindServiceHandle), (noexcept, override));
-    MOCK_METHOD(Result<ServiceHandleContainer<HandleType>>,
-                FindService,
-                (EnrichedInstanceIdentifier),
-                (noexcept, override));
+    MOCK_METHOD(Result<ServiceHandleContainer<HandleType>>, FindService, (EnrichedInstanceIdentifier), (override));
 };
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/service_discovery_mock.h
+++ b/score/mw/com/impl/service_discovery_mock.h
@@ -51,7 +51,7 @@ class ServiceDiscoveryMock : public IServiceDiscovery
                 (noexcept, override));
     MOCK_METHOD(Result<void>, StopFindService, (FindServiceHandle), (noexcept, override));
     MOCK_METHOD(Result<ServiceHandleContainer<HandleType>>, FindService, (InstanceIdentifier), (noexcept, override));
-    MOCK_METHOD(Result<ServiceHandleContainer<HandleType>>, FindService, (InstanceSpecifier), (noexcept, override));
+    MOCK_METHOD(Result<ServiceHandleContainer<HandleType>>, FindService, (InstanceSpecifier), (override));
 };
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/skeleton_binding.h
+++ b/score/mw/com/impl/skeleton_binding.h
@@ -92,7 +92,7 @@ class SkeletonBinding
      *
      * \return void
      */
-    virtual void PrepareStopOffer(std::optional<UnregisterShmObjectTraceCallback>) noexcept = 0;
+    virtual void PrepareStopOffer(std::optional<UnregisterShmObjectTraceCallback>) = 0;
 
     /// \brief Gets the binding type of the binding
     virtual BindingType GetBindingType() const noexcept = 0;

--- a/score/mw/com/impl/skeleton_binding_test.cpp
+++ b/score/mw/com/impl/skeleton_binding_test.cpp
@@ -29,7 +29,7 @@ class MySkeleton final : public SkeletonBinding
     {
         return {};
     }
-    void PrepareStopOffer(std::optional<UnregisterShmObjectTraceCallback>) noexcept override {}
+    void PrepareStopOffer(std::optional<UnregisterShmObjectTraceCallback>) override {}
     BindingType GetBindingType() const noexcept override
     {
         return BindingType::kFake;

--- a/score/mw/com/impl/tracing/configuration/tracing_filter_config.cpp
+++ b/score/mw/com/impl/tracing/configuration/tracing_filter_config.cpp
@@ -172,7 +172,7 @@ std::size_t FindNumberOfTracingSlots(
     const std::unordered_map<TracePointKey, std::set<InstanceSpecifierView>>& trace_point_map,
     std::unordered_set<ServiceElementIdentifierView>& service_element_identifier_view_set,
     const score::mw::com::impl::Configuration& configuration,
-    ServiceElementType service_element_type) noexcept
+    ServiceElementType service_element_type)
 {
     std::size_t number_of_needed_traceing_slots{0U};
     // Suppress "AUTOSAR C++14 A0-1-1", The rule states: "A project shall not contain instances of non-volatile

--- a/score/mw/com/impl/tracing/i_binding_tracing_runtime.h
+++ b/score/mw/com/impl/tracing/i_binding_tracing_runtime.h
@@ -62,7 +62,7 @@ class IBindingTracingRuntime
     /// \brief Return trace client id this binding specific tracing runtime got assigned in
     ///        RegisterWithGenericTraceApi()
     /// \return trace client id
-    virtual analysis::tracing::TraceClientId GetTraceClientId() const noexcept = 0;
+    virtual analysis::tracing::TraceClientId GetTraceClientId() const = 0;
 
     /// \brief Set data loss flag for the specific binding.
     /// \param new_value
@@ -107,7 +107,7 @@ class IBindingTracingRuntime
 
     virtual std::optional<TraceContextId> EmplaceTypeErasedSamplePtr(
         TypeErasedSamplePtr type_erased_sample_ptr,
-        const ServiceElementTracingData service_element_tracing_data) noexcept = 0;
+        const ServiceElementTracingData service_element_tracing_data) = 0;
     virtual void ClearTypeErasedSamplePtr(const TraceContextId trace_context_id) noexcept = 0;
     virtual void ClearTypeErasedSamplePtrs(
         const impl::tracing::ServiceElementTracingData& service_element_tracing_data) noexcept = 0;

--- a/score/mw/com/impl/tracing/i_tracing_runtime.h
+++ b/score/mw/com/impl/tracing/i_tracing_runtime.h
@@ -56,10 +56,9 @@ class ITracingRuntime
     virtual void RegisterShmObject(const BindingType binding_type,
                                    const ServiceElementInstanceIdentifierView service_element_instance_identifier_view,
                                    const memory::shared::ISharedMemoryResource::FileDescriptor shm_object_fd,
-                                   void* const shm_memory_start_address) noexcept = 0;
-    virtual void UnregisterShmObject(
-        BindingType binding_type,
-        ServiceElementInstanceIdentifierView service_element_instance_identifier_view) noexcept = 0;
+                                   void* const shm_memory_start_address) = 0;
+    virtual void UnregisterShmObject(BindingType binding_type,
+                                     ServiceElementInstanceIdentifierView service_element_instance_identifier_view) = 0;
 
     virtual Result<void> Trace(const BindingType binding_type,
                                const ServiceElementTracingData service_element_tracing_data,
@@ -68,14 +67,14 @@ class ITracingRuntime
                                const TracePointDataId trace_point_data_id,
                                TypeErasedSamplePtr sample_ptr,
                                const void* const shm_data_ptr,
-                               const std::size_t shm_data_size) noexcept = 0;
+                               const std::size_t shm_data_size) = 0;
 
     virtual Result<void> Trace(const BindingType binding_type,
                                const ServiceElementInstanceIdentifierView service_element_instance_identifier,
                                const TracePointType trace_point_type,
                                const std::optional<TracePointDataId> trace_point_data_id,
                                const void* const local_data_ptr,
-                               const std::size_t local_data_size) noexcept = 0;
+                               const std::size_t local_data_size) = 0;
 
     virtual IBindingTracingRuntime& GetBindingTracingRuntime(const BindingType binding_type) const noexcept = 0;
 

--- a/score/mw/com/impl/tracing/tracing_runtime.cpp
+++ b/score/mw/com/impl/tracing/tracing_runtime.cpp
@@ -132,7 +132,7 @@ const std::unordered_map<SkeletonFieldTracePointType, analysis::tracing::TracePo
 // This suppression should be removed after fixing [Ticket-173043](broken_link_j/Ticket-173043)
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
 analysis::tracing::TracePointType InternalToExternalTracePointType(
-    const TracingRuntime::TracePointType& internal_trace_point_type) noexcept
+    const TracingRuntime::TracePointType& internal_trace_point_type)
 {
     auto visitor = score::cpp::overload(
         [](const ProxyEventTracePointType& proxy_event_trace_point) -> analysis::tracing::TracePointType {
@@ -341,7 +341,7 @@ void TracingRuntime::RegisterShmObject(
     const BindingType binding_type,
     const ServiceElementInstanceIdentifierView service_element_instance_identifier_view,
     const memory::shared::ISharedMemoryResource::FileDescriptor shm_object_fd,
-    void* const shm_memory_start_address) noexcept
+    void* const shm_memory_start_address)
 {
     if (!atomic_state_.is_tracing_enabled)
     {
@@ -397,9 +397,8 @@ void TracingRuntime::RegisterShmObject(
 // In this case, we want the program to terminate and do not rely on any stack unwinding in case of an implicit
 // terminate.
 // coverity[autosar_cpp14_a15_5_3_violation]
-void TracingRuntime::UnregisterShmObject(
-    BindingType binding_type,
-    ServiceElementInstanceIdentifierView service_element_instance_identifier_view) noexcept
+void TracingRuntime::UnregisterShmObject(BindingType binding_type,
+                                         ServiceElementInstanceIdentifierView service_element_instance_identifier_view)
 {
     if (!atomic_state_.is_tracing_enabled)
     {
@@ -452,7 +451,7 @@ void TracingRuntime::UnregisterShmObject(
 // coverity[autosar_cpp14_a15_5_3_violation: FALSE] see justification of autosar_cpp14_a15_5_3_violation for Trace()
 Result<analysis::tracing::ShmObjectHandle> TracingRuntime::GetRegisteredShmObject(
     IBindingTracingRuntime& binding_runtime,
-    const ServiceElementInstanceIdentifierView service_element_instance_identifier) noexcept
+    const ServiceElementInstanceIdentifierView service_element_instance_identifier)
 {
     auto shm_object_handle = binding_runtime.GetShmObjectHandle(service_element_instance_identifier);
     if (shm_object_handle.has_value())
@@ -515,7 +514,7 @@ Result<void> TracingRuntime::Trace(const BindingType binding_type,
                                    const TracePointDataId trace_point_data_id,
                                    TypeErasedSamplePtr sample_ptr,
                                    const void* const shm_data_ptr,
-                                   const std::size_t shm_data_size) noexcept
+                                   const std::size_t shm_data_size)
 {
     if (!atomic_state_.is_tracing_enabled)
     {
@@ -608,7 +607,7 @@ Result<void> TracingRuntime::Trace(const BindingType binding_type,
                                    const TracePointType trace_point_type,
                                    const std::optional<TracePointDataId> trace_point_data_id,
                                    const void* const local_data_ptr,
-                                   const std::size_t local_data_size) noexcept
+                                   const std::size_t local_data_size)
 {
     if (!atomic_state_.is_tracing_enabled)
     {

--- a/score/mw/com/impl/tracing/tracing_runtime.h
+++ b/score/mw/com/impl/tracing/tracing_runtime.h
@@ -102,11 +102,10 @@ class TracingRuntime : public ITracingRuntime
     void RegisterShmObject(const BindingType binding_type,
                            const ServiceElementInstanceIdentifierView service_element_instance_identifier_view,
                            const memory::shared::ISharedMemoryResource::FileDescriptor shm_object_fd,
-                           void* const shm_memory_start_address) noexcept override;
+                           void* const shm_memory_start_address) override;
 
-    void UnregisterShmObject(
-        BindingType binding_type,
-        ServiceElementInstanceIdentifierView service_element_instance_identifier_view) noexcept override;
+    void UnregisterShmObject(BindingType binding_type,
+                             ServiceElementInstanceIdentifierView service_element_instance_identifier_view) override;
 
     /// \brief Trace call for data residing in shared-memory being handled async via TraceDoneCallback. So this API
     ///        is only called by SkeletonEvents/Fields emitting data (send/update).
@@ -138,7 +137,7 @@ class TracingRuntime : public ITracingRuntime
                        const TracePointDataId trace_point_data_id,
                        TypeErasedSamplePtr sample_ptr,
                        const void* const shm_data_ptr,
-                       const std::size_t shm_data_size) noexcept override;
+                       const std::size_t shm_data_size) override;
 
     /// \brief Trace call for data residing locally (not in shared-memory) being synchronously copied for tracing.
     /// \param binding_type identification of binding, which does the call.
@@ -156,7 +155,7 @@ class TracingRuntime : public ITracingRuntime
                        const TracePointType trace_point_type,
                        const std::optional<TracePointDataId> trace_point_data_id,
                        const void* const local_data_ptr,
-                       const std::size_t local_data_size) noexcept override;
+                       const std::size_t local_data_size) override;
 
     IBindingTracingRuntime& GetBindingTracingRuntime(const BindingType binding_type) const noexcept override;
 
@@ -173,7 +172,7 @@ class TracingRuntime : public ITracingRuntime
 
     Result<analysis::tracing::ShmObjectHandle> GetRegisteredShmObject(
         IBindingTracingRuntime& binding_runtime,
-        const ServiceElementInstanceIdentifierView service_element_instance_identifier) noexcept;
+        const ServiceElementInstanceIdentifierView service_element_instance_identifier);
 
     std::unordered_map<BindingType, IBindingTracingRuntime*> binding_tracing_runtimes_;
 

--- a/score/mw/com/impl/tracing/tracing_runtime_mock.h
+++ b/score/mw/com/impl/tracing/tracing_runtime_mock.h
@@ -30,8 +30,8 @@ class TracingRuntimeMock : public ITracingRuntime
     MOCK_METHOD(void,
                 RegisterShmObject,
                 (BindingType, ServiceElementInstanceIdentifierView, analysis::tracing::ShmObjectHandle, void*),
-                (noexcept, override));
-    MOCK_METHOD(void, UnregisterShmObject, (BindingType, ServiceElementInstanceIdentifierView), (noexcept, override));
+                (override));
+    MOCK_METHOD(void, UnregisterShmObject, (BindingType, ServiceElementInstanceIdentifierView), (override));
 
     MOCK_METHOD(Result<void>,
                 Trace,
@@ -43,7 +43,7 @@ class TracingRuntimeMock : public ITracingRuntime
                  TypeErasedSamplePtr sample_ptr,
                  const void*,
                  std::size_t),
-                (noexcept, override));
+                (override));
     MOCK_METHOD(Result<void>,
                 Trace,
                 (BindingType,
@@ -52,7 +52,7 @@ class TracingRuntimeMock : public ITracingRuntime
                  std::optional<TracePointDataId>,
                  const void*,
                  std::size_t),
-                (noexcept, override));
+                (override));
     MOCK_METHOD(IBindingTracingRuntime&, GetBindingTracingRuntime, (BindingType), (const, noexcept, override));
 };
 


### PR DESCRIPTION
…ions

Resolves all 122 open CodeQL/MISRA findings for rule cpp/misra/noexcept-function-should-not-propagate-to-the-caller on main.

The flagged functions were declared noexcept(true) but the analyzer can prove they may propagate std::bad_variant_access, std::bad_optional_access or std::system_error (from std::visit / std::optional access / inotify). None of them are swap or move operations, so the fix is to drop the noexcept specifier. Declarations and definitions are kept in sync, and for flagged virtual functions the noexcept was also removed from the interface base declaration and sibling overrides (subscription state machine, IServiceDiscovery(Client), ITracingRuntime, IBindingTracingRuntime, IRuntime, proxy/skeleton bindings, binding factories) plus their mocks.

Destructors (~ServerConnection, ~TypeErasedCallQueue) are implicitly noexcept(true); they are marked noexcept(false) so the finding clears.