### PR TITLE
## Fix: Separate fortify_source feature and resolve coverage build failures

### DIFF
--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -297,6 +297,7 @@ llvm.toolchain(
     cxx_standard = {"": "c++17"},
     extra_enabled_features = [
         "//quality/compiler_warnings/clang:default_flags",
+        "//quality/compiler_warnings:fortify_source",
         "//quality/compiler_warnings/clang:minimal_warnings",
     ],
     extra_known_features = [

--- a/quality/compiler_warnings/BUILD
+++ b/quality/compiler_warnings/BUILD
@@ -27,9 +27,6 @@ cc_args(
         "-fPIC",
         "-fstack-protector-strong",
         "-fdiagnostics-color=always",
-        # Fortify libc calls (buffer-overflow checks) used by message (de)serialization.
-        # NOTE: effective only at -O1+; requires the non-executable stack link hardening below.
-        "-D_FORTIFY_SOURCE=2",
         # Bounds/precondition checks on libstdc++ containers (ABI-safe; not _GLIBCXX_DEBUG).
         "-D_GLIBCXX_ASSERTIONS",
         # Per-page stack probing so a large VLA/alloca in deep IPC dispatch cannot skip the guard page.
@@ -47,6 +44,27 @@ cc_args(
 )
 
 cc_args(
+    name = "fortify_source_args",
+    actions = [
+        "@rules_cc//cc/toolchains/actions:compile_actions",
+    ],
+    args = [
+        "-U_FORTIFY_SOURCE",
+        "-D_FORTIFY_SOURCE=2",
+    ],
+    visibility = ["//quality/compiler_warnings:__subpackages__"],
+)
+
+cc_feature(
+    name = "fortify_source",
+    args = [
+        ":fortify_source_args",
+    ],
+    feature_name = "score_communication_fortify_source",
+    visibility = ["//visibility:public"],
+)
+
+cc_args(
     name = "default_link_args",
     actions = [
         "@rules_cc//cc/toolchains/actions:link_actions",
@@ -61,7 +79,6 @@ cc_args(
         "-Wl,-as-needed",
         "-ldl",
         "-Wl,--pop-state",
-        "-fuse-ld=gold",
         "-Wl,-no-as-needed",
         "-lc",
         "-lm",

--- a/quality/coverage/coverage.bazelrc
+++ b/quality/coverage/coverage.bazelrc
@@ -111,3 +111,7 @@ coverage:qnx --config=qnx_x86_64
 
 # Disable treat_warnings_as_errors for coverage builds to avoid build failures from instrumentation-related warnings
 coverage --features=-score_communication_treat_warnings_as_errors
+
+# Disable fortify_source for coverage builds to avoid linking failures with LLVM coverage runtime.
+coverage --features=-score_communication_fortify_source
+coverage --host_features=-score_communication_fortify_source

--- a/quality/visibility_guard/public_targets.golden
+++ b/quality/visibility_guard/public_targets.golden
@@ -10,6 +10,7 @@
 //quality/compiler_warnings/gcc:strict_warnings
 //quality/compiler_warnings/gcc:strict_warnings_no_error
 //quality/compiler_warnings/gcc:third_party_warnings
+//quality/compiler_warnings:fortify_source
 //quality/compiler_warnings:minimal_warnings
 //quality/compiler_warnings:strict_warnings
 //quality/compiler_warnings:treat_warnings_as_errors


### PR DESCRIPTION


Extract -D_FORTIFY_SOURCE=2 into its own cc_feature to enable selective disabling during coverage builds without affecting other hardening flags.