### PR TITLE
mw/com: Add single source of truth for getter / setter signatures

### DIFF
--- a/score/mw/com/impl/BUILD
+++ b/score/mw/com/impl/BUILD
@@ -276,6 +276,7 @@ cc_library(
     ],
     deps = [
         ":error",
+        ":field_getter_setter_signatures",
         ":field_tags",
         ":method_type",
         ":skeleton_event",
@@ -343,6 +344,7 @@ cc_library(
         "//score/mw/com:__subpackages__",
     ],
     deps = [
+        ":field_getter_setter_signatures",
         ":field_tags",
         ":method_type",
         ":proxy_event",
@@ -781,6 +783,18 @@ cc_library(
     visibility = ["//score/mw/com:__subpackages__"],
     deps = [
         ":field_tags",
+    ],
+)
+
+cc_library(
+    name = "field_getter_setter_signatures",
+    srcs = ["field_getter_setter_signatures.cpp"],
+    hdrs = ["field_getter_setter_signatures.h"],
+    features = COMPILER_WARNING_FEATURES,
+    tags = ["FFI"],
+    visibility = ["//score/mw/com:__subpackages__"],
+    deps = [
+        "@score_baselibs//score/result",
     ],
 )
 

--- a/score/mw/com/impl/field_getter_setter_signatures.cpp
+++ b/score/mw/com/impl/field_getter_setter_signatures.cpp
@@ -1,0 +1,13 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/impl/field_getter_setter_signatures.h"

--- a/score/mw/com/impl/field_getter_setter_signatures.h
+++ b/score/mw/com/impl/field_getter_setter_signatures.h
@@ -1,0 +1,33 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_IMPL_FIELD_GETTER_SETTER_SIGNATURES_H
+#define SCORE_MW_COM_IMPL_FIELD_GETTER_SETTER_SIGNATURES_H
+
+#include "score/result/result.h"
+
+namespace score::mw::com::impl
+{
+
+/// \brief Provides the method signatures for field getter and setter methods.
+///
+/// Since the setter / getter functions can fail within the middleware code (e.g. when trying to update the field
+/// value fails), we need to return a result from the setter and getter.
+template <typename FieldType>
+using SetMethodSignature = score::Result<FieldType>(FieldType);
+
+template <typename FieldType>
+using GetMethodSignature = FieldType();
+
+}  // namespace score::mw::com::impl
+
+#endif  // SCORE_MW_COM_IMPL_FIELD_GETTER_SETTER_SIGNATURES_H

--- a/score/mw/com/impl/plumbing/BUILD
+++ b/score/mw/com/impl/plumbing/BUILD
@@ -330,6 +330,7 @@ cc_library(
         ":lola_proxy_element_building_blocks",
         ":proxy_event_binding_factory",
         ":proxy_method_binding_factory",
+        "//score/mw/com/impl:field_getter_setter_signatures",
         "//score/mw/com/impl:method_type",
         "@score_baselibs//score/language/futurecpp",
     ],

--- a/score/mw/com/impl/plumbing/proxy_field_binding_factory_impl.h
+++ b/score/mw/com/impl/plumbing/proxy_field_binding_factory_impl.h
@@ -15,6 +15,7 @@
 
 #include "score/mw/com/impl/bindings/lola/element_fq_id.h"
 #include "score/mw/com/impl/bindings/lola/proxy_event.h"
+#include "score/mw/com/impl/field_getter_setter_signatures.h"
 #include "score/mw/com/impl/method_type.h"
 #include "score/mw/com/impl/plumbing/i_proxy_field_binding_factory.h"
 #include "score/mw/com/impl/plumbing/lola_proxy_element_building_blocks.h"
@@ -83,7 +84,7 @@ inline Result<std::unique_ptr<ProxyMethodBinding>> ProxyFieldBindingFactoryImpl<
     ProxyBinding& parent_binding,
     const std::string_view field_name) noexcept
 {
-    return ProxyMethodBindingFactory<SampleType()>::Create(
+    return ProxyMethodBindingFactory<GetMethodSignature<SampleType>>::Create(
         std::move(parent_handle), parent_binding, field_name, MethodType::kGet);
 }
 
@@ -93,7 +94,7 @@ inline Result<std::unique_ptr<ProxyMethodBinding>> ProxyFieldBindingFactoryImpl<
     ProxyBinding& parent_binding,
     const std::string_view field_name) noexcept
 {
-    return ProxyMethodBindingFactory<SampleType(SampleType)>::Create(
+    return ProxyMethodBindingFactory<SetMethodSignature<SampleType>>::Create(
         std::move(parent_handle), parent_binding, field_name, MethodType::kSet);
 }
 

--- a/score/mw/com/impl/proxy_field.h
+++ b/score/mw/com/impl/proxy_field.h
@@ -13,6 +13,7 @@
 #ifndef SCORE_MW_COM_IMPL_PROXY_FIELD_H
 #define SCORE_MW_COM_IMPL_PROXY_FIELD_H
 
+#include "score/mw/com/impl/field_getter_setter_signatures.h"
 #include "score/mw/com/impl/field_tags.h"
 #include "score/mw/com/impl/methods/method_signature_element_ptr.h"
 #include "score/mw/com/impl/methods/proxy_method_with_in_args_and_return.h"
@@ -89,20 +90,21 @@ class ProxyFieldImpl : public ProxyFieldBase
                    std::unique_ptr<ProxyEventBinding<FieldType>> event_binding,
                    std::unique_ptr<ProxyMethodBinding> set_method_binding = nullptr,
                    std::unique_ptr<ProxyMethodBinding> get_method_binding = nullptr)
-        : ProxyFieldImpl{field_name,
-                         std::make_unique<ProxyEvent<FieldType>>(field_name, std::move(event_binding)),
-                         set_method_binding == nullptr
-                             ? nullptr
-                             : std::make_unique<ProxyMethod<SetMethodSignature>>(
-                                   field_name,
-                                   std::move(set_method_binding),
-                                   typename ProxyMethod<SetMethodSignature>::FieldSetterConstructorEnabler{}),
-                         get_method_binding == nullptr
-                             ? nullptr
-                             : std::make_unique<ProxyMethod<GetMethodSignature>>(
-                                   field_name,
-                                   std::move(get_method_binding),
-                                   typename ProxyMethod<GetMethodSignature>::FieldGetterConstructorEnabler{})}
+        : ProxyFieldImpl{
+              field_name,
+              std::make_unique<ProxyEvent<FieldType>>(field_name, std::move(event_binding)),
+              set_method_binding == nullptr
+                  ? nullptr
+                  : std::make_unique<ProxyMethod<SetMethodSignature<FieldType>>>(
+                        field_name,
+                        std::move(set_method_binding),
+                        typename ProxyMethod<SetMethodSignature<FieldType>>::FieldSetterConstructorEnabler{}),
+              get_method_binding == nullptr
+                  ? nullptr
+                  : std::make_unique<ProxyMethod<GetMethodSignature<FieldType>>>(
+                        field_name,
+                        std::move(get_method_binding),
+                        typename ProxyMethod<GetMethodSignature<FieldType>>::FieldGetterConstructorEnabler{})}
     {
     }
 
@@ -351,13 +353,6 @@ class ProxyFieldImpl : public ProxyFieldBase
     }
 
   private:
-    /// \brief Signatures of the internal Set and Get methods.
-    ///
-    /// Since the setter / getter functions can fail within the middleware code (e.g. when trying to update the field
-    /// value fails), we need to return a result from the setter and getter.
-    using SetMethodSignature = score::Result<FieldType>(FieldType);
-    using GetMethodSignature = FieldType();
-
     static constexpr bool kHasNotifier = contains_type<WithNotifier, Tags...>::value;
     static constexpr bool kHasSetter = contains_type<WithSetter, Tags...>::value;
     static constexpr bool kHasGetter = contains_type<WithGetter, Tags...>::value;
@@ -386,17 +381,17 @@ class ProxyFieldImpl : public ProxyFieldBase
 
     /// \brief Builds the Set-method dispatch via the binding factory when WithSetter is enabled.
     /// \return A valid ProxyMethod dispatch when WithSetter is in the tag pack, nullptr otherwise.
-    static std::unique_ptr<ProxyMethod<SetMethodSignature>> MakeSetMethodDispatchIfEnabled(
+    static std::unique_ptr<ProxyMethod<SetMethodSignature<FieldType>>> MakeSetMethodDispatchIfEnabled(
         ProxyBase& proxy_base,
         const std::string_view field_name)
     {
         if constexpr (kHasSetter)
         {
-            return std::make_unique<ProxyMethod<SetMethodSignature>>(
+            return std::make_unique<ProxyMethod<SetMethodSignature<FieldType>>>(
                 field_name,
                 ProxyFieldBindingFactory<FieldType>::CreateSetMethodBinding(
                     proxy_base.GetHandle(), ProxyBaseView{proxy_base}.GetBinding(), field_name),
-                typename ProxyMethod<SetMethodSignature>::FieldSetterConstructorEnabler{});
+                typename ProxyMethod<SetMethodSignature<FieldType>>::FieldSetterConstructorEnabler{});
         }
         else
         {
@@ -408,17 +403,17 @@ class ProxyFieldImpl : public ProxyFieldBase
 
     /// \brief Builds the Get-method dispatch via the binding factory when WithGetter is enabled.
     /// \return A valid ProxyMethod dispatch when WithGetter is in the tag pack, nullptr otherwise.
-    static std::unique_ptr<ProxyMethod<GetMethodSignature>> MakeGetMethodDispatchIfEnabled(
+    static std::unique_ptr<ProxyMethod<GetMethodSignature<FieldType>>> MakeGetMethodDispatchIfEnabled(
         ProxyBase& proxy_base,
         const std::string_view field_name)
     {
         if constexpr (kHasGetter)
         {
-            return std::make_unique<ProxyMethod<GetMethodSignature>>(
+            return std::make_unique<ProxyMethod<GetMethodSignature<FieldType>>>(
                 field_name,
                 ProxyFieldBindingFactory<FieldType>::CreateGetMethodBinding(
                     proxy_base.GetHandle(), ProxyBaseView{proxy_base}.GetBinding(), field_name),
-                typename ProxyMethod<GetMethodSignature>::FieldGetterConstructorEnabler{});
+                typename ProxyMethod<GetMethodSignature<FieldType>>::FieldGetterConstructorEnabler{});
         }
         else
         {
@@ -430,8 +425,8 @@ class ProxyFieldImpl : public ProxyFieldBase
 
     ProxyFieldImpl(const std::string_view field_name,
                    std::unique_ptr<ProxyEvent<FieldType>> proxy_event_dispatch,
-                   std::unique_ptr<ProxyMethod<SetMethodSignature>> proxy_method_set_dispatch,
-                   std::unique_ptr<ProxyMethod<GetMethodSignature>> proxy_method_get_dispatch)
+                   std::unique_ptr<ProxyMethod<SetMethodSignature<FieldType>>> proxy_method_set_dispatch,
+                   std::unique_ptr<ProxyMethod<GetMethodSignature<FieldType>>> proxy_method_get_dispatch)
         : ProxyFieldBase{field_name,
                          proxy_event_dispatch.get(),
                          proxy_method_set_dispatch.get(),
@@ -444,8 +439,8 @@ class ProxyFieldImpl : public ProxyFieldBase
 
     std::unique_ptr<ProxyEvent<FieldType>> proxy_event_dispatch_;
 
-    std::unique_ptr<ProxyMethod<SetMethodSignature>> proxy_method_set_dispatch_;
-    std::unique_ptr<ProxyMethod<GetMethodSignature>> proxy_method_get_dispatch_;
+    std::unique_ptr<ProxyMethod<SetMethodSignature<FieldType>>> proxy_method_set_dispatch_;
+    std::unique_ptr<ProxyMethod<GetMethodSignature<FieldType>>> proxy_method_get_dispatch_;
 
     static_assert(
         std::is_same_v<decltype(proxy_event_dispatch_), std::unique_ptr<ProxyEvent<FieldType>>>,

--- a/score/mw/com/impl/skeleton_field.h
+++ b/score/mw/com/impl/skeleton_field.h
@@ -13,6 +13,7 @@
 #ifndef SCORE_MW_COM_IMPL_SKELETON_FIELD_H
 #define SCORE_MW_COM_IMPL_SKELETON_FIELD_H
 
+#include "score/mw/com/impl/field_getter_setter_signatures.h"
 #include "score/mw/com/impl/field_tags.h"
 #include "score/mw/com/impl/method_type.h"
 #include "score/mw/com/impl/methods/skeleton_method.h"
@@ -205,13 +206,6 @@ class SkeletonFieldImpl : public SkeletonFieldBase
     }
 
   private:
-    /// \brief Signatures of the internal Set and Get methods.
-    ///
-    /// Since the setter / getter functions can fail within the middleware code (e.g. when trying to update the field
-    /// value fails), we need to return a result from the setter and getter.
-    using SetMethodSignature = score::Result<FieldType>(FieldType);
-    using GetMethodSignature = FieldType();
-
     [[nodiscard]] bool IsInitialValueSaved() const noexcept override
     {
         return initial_field_value_ != nullptr;
@@ -253,16 +247,17 @@ class SkeletonFieldImpl : public SkeletonFieldBase
 
     /// \brief Builds the Get-method dispatch when WithGetter is enabled.
     /// \return A valid SkeletonMethod dispatch when WithGetter is in the tag pack, nullptr otherwise.
-    static std::unique_ptr<SkeletonMethod<GetMethodSignature>> MakeGetMethodIfEnabled(SkeletonBase& parent,
-                                                                                      const std::string_view field_name)
+    static std::unique_ptr<SkeletonMethod<GetMethodSignature<FieldType>>> MakeGetMethodIfEnabled(
+        SkeletonBase& parent,
+        const std::string_view field_name)
     {
         if constexpr (kHasGetter)
         {
-            return std::make_unique<SkeletonMethod<GetMethodSignature>>(
+            return std::make_unique<SkeletonMethod<GetMethodSignature<FieldType>>>(
                 parent,
                 field_name,
                 ::score::mw::com::impl::MethodType::kGet,
-                typename SkeletonMethod<GetMethodSignature>::FieldOnlyConstructorEnabler{});
+                typename SkeletonMethod<GetMethodSignature<FieldType>>::FieldOnlyConstructorEnabler{});
         }
         else
         {
@@ -274,16 +269,17 @@ class SkeletonFieldImpl : public SkeletonFieldBase
 
     /// \brief Builds the Set-method dispatch when WithSetter is enabled.
     /// \return A valid SkeletonMethod dispatch when WithSetter is in the tag pack, nullptr otherwise.
-    static std::unique_ptr<SkeletonMethod<SetMethodSignature>> MakeSetMethodIfEnabled(SkeletonBase& parent,
-                                                                                      const std::string_view field_name)
+    static std::unique_ptr<SkeletonMethod<SetMethodSignature<FieldType>>> MakeSetMethodIfEnabled(
+        SkeletonBase& parent,
+        const std::string_view field_name)
     {
         if constexpr (kHasSetter)
         {
-            return std::make_unique<SkeletonMethod<SetMethodSignature>>(
+            return std::make_unique<SkeletonMethod<SetMethodSignature<FieldType>>>(
                 parent,
                 field_name,
                 ::score::mw::com::impl::MethodType::kSet,
-                typename SkeletonMethod<SetMethodSignature>::FieldOnlyConstructorEnabler{});
+                typename SkeletonMethod<SetMethodSignature<FieldType>>::FieldOnlyConstructorEnabler{});
         }
         else
         {
@@ -298,8 +294,8 @@ class SkeletonFieldImpl : public SkeletonFieldBase
     SkeletonFieldImpl(SkeletonBase& parent,
                       const std::string_view field_name,
                       std::unique_ptr<SkeletonEvent<FieldType>> skeleton_event_dispatch,
-                      std::unique_ptr<SkeletonMethod<SetMethodSignature>> skeleton_set_method_dispatch,
-                      std::unique_ptr<SkeletonMethod<GetMethodSignature>> skeleton_get_method_dispatch);
+                      std::unique_ptr<SkeletonMethod<SetMethodSignature<FieldType>>> skeleton_set_method_dispatch,
+                      std::unique_ptr<SkeletonMethod<GetMethodSignature<FieldType>>> skeleton_get_method_dispatch);
 
     std::unique_ptr<FieldType> initial_field_value_;
     ISkeletonField<FieldType>* skeleton_field_mock_;
@@ -317,8 +313,8 @@ class SkeletonFieldImpl : public SkeletonFieldBase
     /// moveable).
     std::unique_ptr<std::mutex> set_handler_mutex_{};
 
-    std::unique_ptr<SkeletonMethod<SetMethodSignature>> set_method_;
-    std::unique_ptr<SkeletonMethod<GetMethodSignature>> get_method_;
+    std::unique_ptr<SkeletonMethod<SetMethodSignature<FieldType>>> set_method_;
+    std::unique_ptr<SkeletonMethod<GetMethodSignature<FieldType>>> get_method_;
 };
 
 template <typename SampleDataType, typename... Tags>
@@ -326,8 +322,8 @@ SkeletonFieldImpl<SampleDataType, Tags...>::SkeletonFieldImpl(
     SkeletonBase& parent,
     const std::string_view field_name,
     std::unique_ptr<SkeletonEvent<FieldType>> skeleton_event_dispatch,
-    std::unique_ptr<SkeletonMethod<SetMethodSignature>> skeleton_set_method_dispatch,
-    std::unique_ptr<SkeletonMethod<GetMethodSignature>> skeleton_get_method_dispatch)
+    std::unique_ptr<SkeletonMethod<SetMethodSignature<FieldType>>> skeleton_set_method_dispatch,
+    std::unique_ptr<SkeletonMethod<GetMethodSignature<FieldType>>> skeleton_get_method_dispatch)
     : SkeletonFieldBase{field_name, std::move(skeleton_event_dispatch)},
       initial_field_value_{nullptr},
       skeleton_field_mock_{nullptr},


### PR DESCRIPTION
Also use the correct signature in the binding factories to address the bug ticket: SWP-275041.