### PR TITLE
mw/com/impl: Internally use memory::DataTypeSizeInfo

### DIFF
--- a/score/mw/com/gateway/gateway_application/BUILD
+++ b/score/mw/com/gateway/gateway_application/BUILD
@@ -112,6 +112,7 @@ cc_unit_test(
         "//score/mw/com/impl/test:dummy_instance_identifier_builder",
         "//score/mw/com/impl/test:runtime_mock_guard",
         "@googletest//:gtest",
+        "@score_baselibs//score/memory:data_type_size_info",
         "@score_baselibs//score/result",
     ],
 )

--- a/score/mw/com/gateway/gateway_application/gateway_application_test.cpp
+++ b/score/mw/com/gateway/gateway_application/gateway_application_test.cpp
@@ -12,6 +12,7 @@
  *******************************************************************************/
 #include "score/mw/com/gateway/gateway_application/gateway_application.h"
 
+#include "score/memory/data_type_size_info.h"
 #include "score/mw/com/gateway/gateway_application/configuration/gateway_configuration.h"
 #include "score/mw/com/gateway/gateway_application/gateway_error.h"
 #include "score/mw/com/gateway/transport_layer/transport_mock.h"
@@ -701,7 +702,7 @@ class GatewayApplicationFlowTest : public ::testing::Test
         // --- Generic skeleton event binding factory: yields a fresh mock per event --------------
         ON_CALL(generic_skeleton_event_binding_factory_mock_, Create(::testing::_, ::testing::_, ::testing::_))
             .WillByDefault(::testing::Invoke(
-                [this](impl::SkeletonBase&, std::string_view event_name, const impl::DataTypeMetaInfo&)
+                [this](impl::SkeletonBase&, std::string_view event_name, const score::memory::DataTypeSizeInfo&)
                     -> score::Result<std::unique_ptr<impl::GenericSkeletonEventBinding>> {
                     auto mock = std::make_unique<::testing::NiceMock<impl::mock_binding::GenericSkeletonEvent>>();
                     ON_CALL(*mock, SetReceiveHandlerRegistrationChangedHandler(::testing::_))
@@ -1065,9 +1066,9 @@ TEST_F(GatewayApplicationFlowTest, ProvideServiceCreatesSkeletonRegistersCallbac
     // Given a whitelisted ("svc/a") provide request with one event whose binding expects exactly one
     // subscription-callback registration.
     ON_CALL(generic_skeleton_event_binding_factory_mock_, Create(::testing::_, ::testing::_, ::testing::_))
-        .WillByDefault(
-            ::testing::Invoke([this](impl::SkeletonBase&, std::string_view event_name, const impl::DataTypeMetaInfo&)
-                                  -> score::Result<std::unique_ptr<impl::GenericSkeletonEventBinding>> {
+        .WillByDefault(::testing::Invoke(
+            [this](impl::SkeletonBase&, std::string_view event_name, const score::memory::DataTypeSizeInfo&)
+                -> score::Result<std::unique_ptr<impl::GenericSkeletonEventBinding>> {
                 auto mock = std::make_unique<::testing::NiceMock<impl::mock_binding::GenericSkeletonEvent>>();
                 EXPECT_CALL(*mock, SetReceiveHandlerRegistrationChangedHandler(::testing::_))
                     .WillOnce(::testing::Return(score::Result<void>{}));
@@ -1203,9 +1204,9 @@ TEST_F(GatewayApplicationFlowTest, ProvideServiceSetReceiveHandlerRegistrationFa
 {
     // Given the skeleton event rejects the receive-handler-registration-changed handler
     ON_CALL(generic_skeleton_event_binding_factory_mock_, Create(::testing::_, ::testing::_, ::testing::_))
-        .WillByDefault(
-            ::testing::Invoke([this](impl::SkeletonBase&, std::string_view event_name, const impl::DataTypeMetaInfo&)
-                                  -> score::Result<std::unique_ptr<impl::GenericSkeletonEventBinding>> {
+        .WillByDefault(::testing::Invoke(
+            [this](impl::SkeletonBase&, std::string_view event_name, const score::memory::DataTypeSizeInfo&)
+                -> score::Result<std::unique_ptr<impl::GenericSkeletonEventBinding>> {
                 auto mock = std::make_unique<::testing::NiceMock<impl::mock_binding::GenericSkeletonEvent>>();
                 ON_CALL(*mock, SetReceiveHandlerRegistrationChangedHandler(::testing::_))
                     .WillByDefault(

--- a/score/mw/com/impl/BUILD
+++ b/score/mw/com/impl/BUILD
@@ -912,20 +912,6 @@ cc_library(
 )
 
 cc_library(
-    name = "i_generic_skeleton_event_binding_factory",
-    hdrs = ["i_generic_skeleton_event_binding_factory.h"],
-    features = COMPILER_WARNING_FEATURES,
-    tags = ["FFI"],
-    visibility = [
-        "//score/mw/com/impl:__subpackages__",
-    ],
-    deps = [
-        ":generic_skeleton_event_binding",
-        ":skeleton_base",
-    ],
-)
-
-cc_library(
     name = "event_receive_handler",
     srcs = ["event_receive_handler.cpp"],
     hdrs = ["event_receive_handler.h"],

--- a/score/mw/com/impl/BUILD
+++ b/score/mw/com/impl/BUILD
@@ -164,6 +164,7 @@ cc_library(
         "//score/mw/com/impl/plumbing",
         "//score/mw/com/impl/plumbing:generic_skeleton_event_binding_factory",
         "@score_baselibs//score/language/futurecpp",
+        "@score_baselibs//score/memory:data_type_size_info",
     ],
     tags = ["FFI"],
     visibility = [
@@ -236,6 +237,11 @@ cc_library(
     visibility = [
         "//score/mw/com:__pkg__",
         "//score/mw/com/impl:__subpackages__",
+    ],
+    deps = [
+        ":error",
+        "@score_baselibs//score/memory:data_type_size_info",
+        "@score_baselibs//score/result",
     ],
 )
 
@@ -1241,6 +1247,16 @@ cc_unit_test(
     srcs = ["method_type_test.cpp"],
     features = COMPILER_WARNING_FEATURES,
     deps = [":method_type"],
+)
+
+cc_unit_test(
+    name = "data_type_meta_info_test",
+    srcs = ["data_type_meta_info_test.cpp"],
+    deps = [
+        ":data_type_meta_info",
+        ":error",
+        "@score_baselibs//score/result",
+    ],
 )
 
 cc_unit_test(

--- a/score/mw/com/impl/bindings/lola/BUILD
+++ b/score/mw/com/impl/bindings/lola/BUILD
@@ -241,7 +241,7 @@ cc_library(
     ],
     deps = [
         "//score/memory/shared",
-        "//score/mw/com/impl:data_type_meta_info",
+        "@score_baselibs//score/memory:data_type_size_info",
     ],
 )
 

--- a/score/mw/com/impl/bindings/lola/event_meta_info.h
+++ b/score/mw/com/impl/bindings/lola/event_meta_info.h
@@ -13,8 +13,8 @@
 #ifndef SCORE_MW_COM_IMPL_BINDINGS_LOLA_EVENT_META_INFO_H
 #define SCORE_MW_COM_IMPL_BINDINGS_LOLA_EVENT_META_INFO_H
 
+#include "score/memory/data_type_size_info.h"
 #include "score/memory/shared/offset_ptr.h"
-#include "score/mw/com/impl/data_type_meta_info.h"
 
 namespace score::mw::com::impl::lola
 {
@@ -26,7 +26,7 @@ namespace score::mw::com::impl::lola
 class EventMetaInfo
 {
   public:
-    EventMetaInfo(const impl::DataTypeMetaInfo data_type_info,
+    EventMetaInfo(const memory::DataTypeSizeInfo data_type_info,
                   const memory::shared::OffsetPtr<void> event_slots_raw_array)
         : data_type_info_(data_type_info), event_slots_raw_array_(event_slots_raw_array)
     {
@@ -36,7 +36,7 @@ class EventMetaInfo
     // be private.". There are no class invariants to maintain which could be violated by directly accessing member
     // variables.
     // coverity[autosar_cpp14_m11_0_1_violation]
-    impl::DataTypeMetaInfo data_type_info_;
+    memory::DataTypeSizeInfo data_type_info_;
     // coverity[autosar_cpp14_m11_0_1_violation]
     memory::shared::OffsetPtr<void> event_slots_raw_array_;
 };

--- a/score/mw/com/impl/bindings/lola/generic_proxy_event.cpp
+++ b/score/mw/com/impl/bindings/lola/generic_proxy_event.cpp
@@ -79,7 +79,7 @@ inline Result<std::size_t> GenericProxyEvent::GetNewSamples(Callback&& receiver,
 
 std::size_t GenericProxyEvent::GetSampleSize() const noexcept
 {
-    return meta_info_.data_type_info_.size;
+    return meta_info_.data_type_info_.Size();
 }
 
 bool GenericProxyEvent::HasSerializedFormat() const noexcept
@@ -140,8 +140,8 @@ Result<std::size_t> GenericProxyEvent::GetNewSamplesImpl(Callback&& receiver, Tr
 
     auto& event_data_control_local = proxy_event_common_.GetConsumerEventDataControlLocal();
 
-    const std::size_t sample_size = meta_info_.data_type_info_.size;
-    const std::size_t sample_alignment = meta_info_.data_type_info_.alignment;
+    const std::size_t sample_size = meta_info_.data_type_info_.Size();
+    const std::size_t sample_alignment = meta_info_.data_type_info_.Alignment();
     const std::size_t aligned_size =
         memory::shared::CalculateAlignedSize(sample_size, static_cast<std::size_t>(sample_alignment));
 

--- a/score/mw/com/impl/bindings/lola/generic_proxy_event_test.cpp
+++ b/score/mw/com/impl/bindings/lola/generic_proxy_event_test.cpp
@@ -127,11 +127,12 @@ TEST_F(LolaGenericProxyEventDeathTest, OverflowWhenCalculatingRawEventsSlotsArra
 
     // Given a mocked SkeletonEvent whose metainfo stores a size which will lead to an overflow when calculating the raw
     // event slot array size
-    const auto align_of = fake_data_->data_storage->events_metainfo_.at(element_fq_id_).data_type_info_.alignment;
+    const auto align_of = fake_data_->data_storage->events_metainfo_.at(element_fq_id_).data_type_info_.Alignment();
 
-    // Subtract the align of from the max size to prevent an overflow when calculating the aligned size
-    fake_data_->data_storage->events_metainfo_.at(element_fq_id_).data_type_info_.size =
-        std::numeric_limits<std::size_t>::max() - align_of;
+    // Subtract the align of from the max size to prevent an overflow when calculating the aligned size.
+    // Keep the size a multiple of the alignment to satisfy the DataTypeSizeInfo invariant.
+    fake_data_->data_storage->events_metainfo_.at(element_fq_id_).data_type_info_ =
+        score::memory::DataTypeSizeInfo{(std::numeric_limits<std::size_t>::max() / align_of) * align_of, align_of};
 
     // and given a GenericProxyEvent which has subscribed
     WithAGenericProxyEvent(element_fq_id_, event_name_);

--- a/score/mw/com/impl/bindings/lola/generic_skeleton_event.cpp
+++ b/score/mw/com/impl/bindings/lola/generic_skeleton_event.cpp
@@ -11,13 +11,13 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 #include "score/mw/com/impl/bindings/lola/generic_skeleton_event.h"
-#include "score/memory/shared/pointer_arithmetic_util.h"
 #include "score/mw/com/impl/bindings/lola/skeleton.h"
 #include "score/mw/com/impl/bindings/lola/skeleton_event.h"
 #include "score/mw/com/impl/bindings/lola/skeleton_event_properties.h"
 #include "score/mw/com/impl/runtime.h"
 #include "score/mw/com/impl/sample_allocatee_guard.h"
-#include "score/mw/com/impl/skeleton_event_binding.h"
+
+#include "score/memory/shared/pointer_arithmetic_util.h"
 
 namespace score::mw::com::impl::lola
 {
@@ -25,7 +25,7 @@ GenericSkeletonEvent::GenericSkeletonEvent(Skeleton& parent,
                                            const std::string_view event_name,
                                            const SkeletonEventProperties& event_properties,
                                            const ElementFqId& element_fq_id,
-                                           const DataTypeMetaInfo& size_info,
+                                           const memory::DataTypeSizeInfo& size_info,
                                            impl::tracing::SkeletonEventTracingData tracing_data)
     : size_info_{size_info},
       event_data_storage_{nullptr},
@@ -38,8 +38,8 @@ Result<void> GenericSkeletonEvent::PrepareOffer() noexcept
     const auto registration_result =
         skeleton_event_common_.GetParent().RegisterGeneric(skeleton_event_common_.GetElementFQId(),
                                                            skeleton_event_common_.GetEventProperties(),
-                                                           size_info_.size,
-                                                           size_info_.alignment);
+                                                           size_info_.Size(),
+                                                           size_info_.Alignment());
 
     event_data_storage_ = static_cast<std::uint8_t*>(registration_result.type_erased_event_data_storage_ptr);
 
@@ -66,14 +66,14 @@ Result<score::mw::com::impl::SampleAllocateePtr<void>> GenericSkeletonEvent::All
     const auto slot_index = allocated_slot_result.value();
 
     // Calculate the exact slot spacing based on alignment padding
-    const auto aligned_size = memory::shared::CalculateAlignedSize(size_info_.size, size_info_.alignment);
+    const auto aligned_size = memory::shared::CalculateAlignedSize(size_info_.Size(), size_info_.Alignment());
     std::size_t offset = static_cast<std::size_t>(slot_index) * aligned_size;
     void* data_ptr = static_cast<void*>(memory::shared::AddOffsetToPointer(event_data_storage_, offset));
 
     // The ConsumerEventDataControlLocalView stored inside SampleAllocateePtr is only used by the send-tracing path.
-    //  Tracing is a diagnostic/monitoring feature with no safety requirement, so QM is sufficient.
-    //  GetConsumerEventDataControlLocalView(kASIL_B) is a separate code path introduced specifically for
-    //  GetLatestSample().
+    // Tracing is a diagnostic/monitoring feature with no safety requirement, so QM is sufficient.
+    // GetConsumerEventDataControlLocalView(kASIL_B) is a separate code path introduced specifically for
+    // GetLatestSample().
     auto lola_ptr = lola::SampleAllocateePtr<void>(
         data_ptr,
         skeleton_event_common_.GetEventDataControlComposite(),
@@ -89,7 +89,7 @@ Result<void> GenericSkeletonEvent::Notify() noexcept
 
 std::pair<size_t, size_t> GenericSkeletonEvent::GetSizeInfo() const noexcept
 {
-    return {size_info_.size, size_info_.alignment};
+    return {size_info_.Size(), size_info_.Alignment()};
 }
 
 void GenericSkeletonEvent::PrepareStopOffer() noexcept

--- a/score/mw/com/impl/bindings/lola/generic_skeleton_event.h
+++ b/score/mw/com/impl/bindings/lola/generic_skeleton_event.h
@@ -18,9 +18,10 @@
 #include "score/mw/com/impl/bindings/lola/event_data_storage.h"
 #include "score/mw/com/impl/bindings/lola/skeleton_event_common.h"
 #include "score/mw/com/impl/bindings/lola/skeleton_event_properties.h"
-#include "score/mw/com/impl/data_type_meta_info.h"
 #include "score/mw/com/impl/generic_skeleton_event_binding.h"
 #include "score/mw/com/impl/sample_allocatee_guard.h"
+
+#include "score/memory/data_type_size_info.h"
 
 #include <optional>
 
@@ -38,7 +39,7 @@ class GenericSkeletonEvent : public GenericSkeletonEventBinding
                          const std::string_view event_name,
                          const SkeletonEventProperties& event_properties,
                          const ElementFqId& element_fq_id,
-                         const DataTypeMetaInfo& size_info,
+                         const memory::DataTypeSizeInfo& size_info,
                          impl::tracing::SkeletonEventTracingData tracing_data = {});
 
     Result<void> Send(score::mw::com::impl::SampleAllocateePtr<void> sample) noexcept override;
@@ -59,7 +60,7 @@ class GenericSkeletonEvent : public GenericSkeletonEventBinding
 
     std::size_t GetMaxSize() const noexcept override
     {
-        return size_info_.size;
+        return size_info_.Size();
     }
 
     /// \brief Set callback, to get notified, when either the 1st event-notification has been registered or the last
@@ -80,7 +81,7 @@ class GenericSkeletonEvent : public GenericSkeletonEventBinding
     }
 
   private:
-    DataTypeMetaInfo size_info_;
+    memory::DataTypeSizeInfo size_info_;
     std::uint8_t* event_data_storage_;
     SkeletonEventCommon<void> skeleton_event_common_;
 };

--- a/score/mw/com/impl/bindings/lola/generic_skeleton_event_test.cpp
+++ b/score/mw/com/impl/bindings/lola/generic_skeleton_event_test.cpp
@@ -54,7 +54,7 @@ class GenericSkeletonEventFixture : public SkeletonEventFixture
     }
 
     std::unique_ptr<GenericSkeletonEvent> generic_skeleton_event_;
-    const DataTypeMetaInfo size_info_{10U, 8U};
+    const memory::DataTypeSizeInfo size_info_{16U, 8U};
 };
 
 // TODO: Fix requirement linkage as soon as requirements are matured in S-CORE.
@@ -123,8 +123,8 @@ TEST_F(GenericSkeletonEventFixture, GetSizeInfo)
     auto size_info = generic_skeleton_event_->GetSizeInfo();
 
     // Then we get the correct size and alignment
-    EXPECT_EQ(size_info.first, size_info_.size);
-    EXPECT_EQ(size_info.second, size_info_.alignment);
+    EXPECT_EQ(size_info.first, size_info_.Size());
+    EXPECT_EQ(size_info.second, size_info_.Alignment());
 }
 
 // Test: GetMaxSize
@@ -148,7 +148,7 @@ TEST_F(GenericSkeletonEventFixture, GetMaxSize)
     auto max_size = generic_skeleton_event_->GetMaxSize();
 
     // Then we get the correct size
-    EXPECT_EQ(max_size, size_info_.size);
+    EXPECT_EQ(max_size, size_info_.Size());
 }
 
 // Test: PrepareOffer

--- a/score/mw/com/impl/bindings/lola/proxy_event.h
+++ b/score/mw/com/impl/bindings/lola/proxy_event.h
@@ -160,9 +160,9 @@ inline const std::uint8_t* ProxyEvent<SampleType>::InitialiseEventSlotsRawArray(
     const void* const event_slots_raw_array = meta_info_.event_slots_raw_array_.get(event_slots_raw_array_size);
 
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(nullptr != event_slots_raw_array, "Null event slot array");
-    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(meta_info_.data_type_info_.size == sizeof(SampleType),
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(meta_info_.data_type_info_.Size() == sizeof(SampleType),
                                                       "Event sample size mismatch");
-    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(meta_info_.data_type_info_.alignment == alignof(SampleType),
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(meta_info_.data_type_info_.Alignment() == alignof(SampleType),
                                                       "Event sample alignment mismatch");
 
     return static_cast<const std::uint8_t*>(event_slots_raw_array);

--- a/score/mw/com/impl/bindings/lola/proxy_test.cpp
+++ b/score/mw/com/impl/bindings/lola/proxy_test.cpp
@@ -661,8 +661,8 @@ TEST_F(ProxyGetEventMetaInfoFixture, GetEventMetaInfoWillReturnDataForEventThatW
     const auto event_meta_info = proxy_->GetEventMetaInfo(kDummyElementFqId);
 
     // Then the EventMetaInfo will contain the meta info of the SkeletonEvent type
-    EXPECT_EQ(event_meta_info.data_type_info_.size, sizeof(ProxyMockedMemoryFixture::SampleType));
-    EXPECT_EQ(event_meta_info.data_type_info_.alignment, alignof(ProxyMockedMemoryFixture::SampleType));
+    EXPECT_EQ(event_meta_info.data_type_info_.Size(), sizeof(ProxyMockedMemoryFixture::SampleType));
+    EXPECT_EQ(event_meta_info.data_type_info_.Alignment(), alignof(ProxyMockedMemoryFixture::SampleType));
 }
 
 using ProxyGetEventMetaInfoDeathTest = ProxyGetEventMetaInfoFixture;

--- a/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
@@ -224,7 +224,7 @@ void* SkeletonMemoryManager::CreateGenericEventDataInCreatedSharedMemory(
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(inserted_data_slots.second,
                                                 "Couldn't register/emplace event-storage in data-section.");
 
-    const DataTypeMetaInfo sample_meta_info{sample_size, static_cast<std::uint8_t>(sample_alignment)};
+    const memory::DataTypeSizeInfo sample_meta_info{sample_size, sample_alignment};
     void* const event_data_raw_array = data_storage->data();
 
     auto inserted_meta_info =
@@ -247,8 +247,8 @@ void* SkeletonMemoryManager::RetrieveGenericEventDataFromOpenedSharedMemory(
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(event_meta_info_it != storage_->events_metainfo_.cend(),
                                                 "Could not find element fq id in meta info map");
 
-    const auto sample_size = event_meta_info_it->second.data_type_info_.size;
-    const auto sample_alignment = event_meta_info_it->second.data_type_info_.alignment;
+    const auto sample_size = event_meta_info_it->second.data_type_info_.Size();
+    const auto sample_alignment = event_meta_info_it->second.data_type_info_.Alignment();
     const auto aligned_sample_size =
         memory::shared::CalculateAlignedSize(sample_size, static_cast<std::size_t>(sample_alignment));
     const auto total_event_slots_size = safe_math::Multiply<safe_math::ReturnMode::kAbortOnError>(
@@ -743,7 +743,7 @@ EventControl& SkeletonMemoryManager::EmplaceEventControl(const QualityType asil_
 }
 
 EventMetaInfo& SkeletonMemoryManager::EmplaceEventMetaInfo(const ElementFqId element_fq_id,
-                                                           const DataTypeMetaInfo& sample_meta_info,
+                                                           const memory::DataTypeSizeInfo& sample_meta_info,
                                                            void* type_erased_event_data_storage)
 {
     auto inserted_meta_info =

--- a/score/mw/com/impl/bindings/lola/skeleton_memory_manager.h
+++ b/score/mw/com/impl/bindings/lola/skeleton_memory_manager.h
@@ -23,6 +23,7 @@
 #include "score/mw/com/impl/configuration/quality_type.h"
 #include "score/mw/com/impl/skeleton_binding.h"
 
+#include "score/memory/data_type_size_info.h"
 #include "score/memory/shared/polymorphic_offset_ptr_allocator.h"
 
 #include <score/assert.hpp>
@@ -206,7 +207,7 @@ class SkeletonMemoryManager final
                                                           const SkeletonEventProperties& element_properties);
 
     EventMetaInfo& EmplaceEventMetaInfo(const ElementFqId element_fq_id,
-                                        const DataTypeMetaInfo& sample_meta_info,
+                                        const memory::DataTypeSizeInfo& sample_meta_info,
                                         void* type_erased_event_data_storage);
 
     QualityType quality_type_;
@@ -243,7 +244,7 @@ auto SkeletonMemoryManager::CreateEventDataInCreatedSharedMemory(const ElementFq
 {
     auto& event_data_storage = EmplaceEventDataStorage<SampleType>(element_fq_id, element_properties);
 
-    constexpr DataTypeMetaInfo sample_meta_info{sizeof(SampleType), static_cast<std::uint8_t>(alignof(SampleType))};
+    constexpr memory::DataTypeSizeInfo sample_meta_info{sizeof(SampleType), alignof(SampleType)};
     auto* const event_data_raw_array = event_data_storage.data();
     score::cpp::ignore = EmplaceEventMetaInfo(element_fq_id, sample_meta_info, event_data_raw_array);
 

--- a/score/mw/com/impl/bindings/lola/skeleton_test.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_test.cpp
@@ -1360,11 +1360,11 @@ TEST_P(SkeletonRegisterParamaterisedFixture, ValidEventMetaInfoExistAfterEventIs
     ASSERT_TRUE(event_foo_meta_info_ptr.has_value());
     ASSERT_TRUE(event_dumb_meta_info_ptr.has_value());
     // and they have the expected properties
-    ASSERT_EQ(event_foo_meta_info_ptr->data_type_info_.size, sizeof(std::uint8_t));
-    ASSERT_EQ(event_foo_meta_info_ptr->data_type_info_.alignment, alignof(std::uint8_t));
+    ASSERT_EQ(event_foo_meta_info_ptr->data_type_info_.Size(), sizeof(std::uint8_t));
+    ASSERT_EQ(event_foo_meta_info_ptr->data_type_info_.Alignment(), alignof(std::uint8_t));
 
-    ASSERT_EQ(event_dumb_meta_info_ptr->data_type_info_.size, sizeof(VeryComplexType));
-    ASSERT_EQ(event_dumb_meta_info_ptr->data_type_info_.alignment, alignof(VeryComplexType));
+    ASSERT_EQ(event_dumb_meta_info_ptr->data_type_info_.Size(), sizeof(VeryComplexType));
+    ASSERT_EQ(event_dumb_meta_info_ptr->data_type_info_.Alignment(), alignof(VeryComplexType));
 
     const auto GetEventSlotsArraySize = [](const std::size_t sample_size,
                                            const std::size_t sample_alignment,
@@ -1374,13 +1374,13 @@ TEST_P(SkeletonRegisterParamaterisedFixture, ValidEventMetaInfoExistAfterEventIs
         return aligned_size * number_of_sample_slots;
     };
 
-    const auto foo_event_slots_size = GetEventSlotsArraySize(event_foo_meta_info_ptr->data_type_info_.size,
-                                                             event_foo_meta_info_ptr->data_type_info_.alignment,
+    const auto foo_event_slots_size = GetEventSlotsArraySize(event_foo_meta_info_ptr->data_type_info_.Size(),
+                                                             event_foo_meta_info_ptr->data_type_info_.Alignment(),
                                                              test::kDefaultEventProperties.GetTotalNumberOfSlots());
     ASSERT_EQ(event_foo_meta_info_ptr->event_slots_raw_array_.get(foo_event_slots_size), foo_event_data_storage);
 
-    const auto dumb_event_slots_size = GetEventSlotsArraySize(event_foo_meta_info_ptr->data_type_info_.size,
-                                                              event_foo_meta_info_ptr->data_type_info_.alignment,
+    const auto dumb_event_slots_size = GetEventSlotsArraySize(event_foo_meta_info_ptr->data_type_info_.Size(),
+                                                              event_foo_meta_info_ptr->data_type_info_.Alignment(),
                                                               test::kDefaultEventProperties.GetTotalNumberOfSlots());
     ASSERT_EQ(event_dumb_meta_info_ptr->event_slots_raw_array_.get(dumb_event_slots_size), dumb_event_data_storage);
 

--- a/score/mw/com/impl/bindings/lola/test/skeleton_event_component_test.cpp
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_event_component_test.cpp
@@ -331,8 +331,8 @@ TEST_F(SkeletonEventComponentTestFixture, SkeletonWillCalculateEventMetaInfoFrom
 
     // Then the event meta info should correspond to the type of the skeleton event
     ASSERT_TRUE(event_meta_info.has_value());
-    EXPECT_EQ(event_meta_info.value().data_type_info_.alignment, alignof(SkeletonEventSampleType));
-    EXPECT_EQ(event_meta_info.value().data_type_info_.size, sizeof(SkeletonEventSampleType));
+    EXPECT_EQ(event_meta_info.value().data_type_info_.Alignment(), alignof(SkeletonEventSampleType));
+    EXPECT_EQ(event_meta_info.value().data_type_info_.Size(), sizeof(SkeletonEventSampleType));
 }
 
 using SkeletonEventComponentDeathTest = SkeletonEventComponentTestFixture;

--- a/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h
@@ -479,7 +479,7 @@ class SkeletonMockedMemoryFixture : public ::testing::Test
             std::piecewise_construct, std::forward_as_tuple(element_fq_id), std::forward_as_tuple(event_data_storage));
         EXPECT_TRUE(inserted_data_slots.second);
 
-        const DataTypeMetaInfo sample_meta_info{10U, 16U};
+        const score::memory::DataTypeSizeInfo sample_meta_info{16U, 16U};
         auto* event_data_raw_array = event_data_storage->data();
         auto inserted_meta_info = service_data_storage.events_metainfo_.emplace(
             std::piecewise_construct,

--- a/score/mw/com/impl/bindings/lola/test_doubles/fake_mocked_service_data.h
+++ b/score/mw/com/impl/bindings/lola/test_doubles/fake_mocked_service_data.h
@@ -77,7 +77,7 @@ inline std::tuple<EventControl*, EventDataStorage<SampleType>*> FakeMockedServic
     const memory::shared::OffsetPtr<void> rel_event_data_buffer{static_cast<void*>(event_data_slots)};
     data_storage->events_.emplace(id, rel_event_data_buffer);
 
-    const DataTypeMetaInfo sample_meta_info{sizeof(SampleType), alignof(SampleType)};
+    const score::memory::DataTypeSizeInfo sample_meta_info{sizeof(SampleType), alignof(SampleType)};
     auto* event_data_raw_array = event_data_slots->data();
     const auto inserted_meta_info =
         data_storage->events_metainfo_.emplace(std::piecewise_construct,

--- a/score/mw/com/impl/bindings/lola/test_doubles/fake_service_data.h
+++ b/score/mw/com/impl/bindings/lola/test_doubles/fake_service_data.h
@@ -105,7 +105,7 @@ inline std::tuple<EventControl*, EventDataStorage<SampleType>*> FakeServiceData:
     const memory::shared::OffsetPtr<void> rel_event_data_buffer{static_cast<void*>(event_data_slots)};
     data_storage->events_.emplace(id, rel_event_data_buffer);
 
-    const DataTypeMetaInfo sample_meta_info{sizeof(SampleType), alignof(SampleType)};
+    const score::memory::DataTypeSizeInfo sample_meta_info{sizeof(SampleType), alignof(SampleType)};
     auto* event_data_raw_array = event_data_slots->data();
     const auto inserted_meta_info =
         data_storage->events_metainfo_.emplace(std::piecewise_construct,

--- a/score/mw/com/impl/data_type_meta_info.cpp
+++ b/score/mw/com/impl/data_type_meta_info.cpp
@@ -11,3 +11,30 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 #include "score/mw/com/impl/data_type_meta_info.h"
+
+#include "score/mw/com/impl/com_error.h"
+
+namespace score::mw::com::impl
+{
+
+score::Result<score::memory::DataTypeSizeInfo> MakeDataTypeSizeInfo(const DataTypeMetaInfo& meta_info)
+{
+    const bool is_alignment_power_of_two =
+        ((meta_info.alignment != 0U) && ((meta_info.alignment & (meta_info.alignment - 1U)) == 0U));
+    if (!is_alignment_power_of_two)
+    {
+        return MakeUnexpected(ComErrc::kInvalidConfiguration,
+                              "DataTypeMetaInfo alignment must be a non-zero power of two.");
+    }
+
+    const bool is_size_multiple_of_alignment = ((meta_info.size % meta_info.alignment) == 0U);
+    if (!is_size_multiple_of_alignment)
+    {
+        return MakeUnexpected(ComErrc::kInvalidConfiguration,
+                              "DataTypeMetaInfo size must be an integer multiple of its alignment.");
+    }
+
+    return score::memory::DataTypeSizeInfo{meta_info.size, meta_info.alignment};
+}
+
+}  // namespace score::mw::com::impl

--- a/score/mw/com/impl/data_type_meta_info.h
+++ b/score/mw/com/impl/data_type_meta_info.h
@@ -13,6 +13,9 @@
 #ifndef SCORE_MW_COM_IMPL_BINDINGS_LOLA_DATA_TYPE_META_INFO_H
 #define SCORE_MW_COM_IMPL_BINDINGS_LOLA_DATA_TYPE_META_INFO_H
 
+#include "score/memory/data_type_size_info.h"
+#include "score/result/result.h"
+
 #include <cstddef>
 #include <cstdint>
 
@@ -27,6 +30,17 @@ struct DataTypeMetaInfo
     std::size_t size;
     std::size_t alignment;
 };
+
+/// \brief Validates the given public DataTypeMetaInfo and converts it into the internal
+/// score::memory::DataTypeSizeInfo.
+///
+/// DataTypeSizeInfo enforces (via assertions) that the alignment is a non-zero power of two and that the size is an
+/// integer multiple of the alignment. This function checks these invariants up-front so that invalid meta-info handed
+/// over via the public API results in an error Result instead of a contract violation/abort.
+///
+/// \param meta_info The (public) meta-info to validate and convert.
+/// \return The converted DataTypeSizeInfo on success, or a ComErrc error if the invariants are violated.
+score::Result<memory::DataTypeSizeInfo> MakeDataTypeSizeInfo(const DataTypeMetaInfo& meta_info);
 
 }  // namespace score::mw::com::impl
 

--- a/score/mw/com/impl/data_type_meta_info_test.cpp
+++ b/score/mw/com/impl/data_type_meta_info_test.cpp
@@ -1,0 +1,92 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/impl/data_type_meta_info.h"
+
+#include "score/mw/com/impl/com_error.h"
+
+#include <gtest/gtest.h>
+
+namespace score::mw::com::impl
+{
+namespace
+{
+
+TEST(MakeDataTypeSizeInfoTest, ConvertsSizeMultipleOfAlignment)
+{
+    // Given a valid meta-info (size multiple of a power-of-two alignment)
+    const DataTypeMetaInfo meta_info{16U, 8U};
+
+    // When converting it
+    const auto result = MakeDataTypeSizeInfo(meta_info);
+
+    // Then the conversion succeeds and preserves size and alignment
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value().Size(), 16U);
+    EXPECT_EQ(result.value().Alignment(), 8U);
+}
+
+TEST(MakeDataTypeSizeInfoTest, ConvertsSizeEqualToAlignment)
+{
+    // Given a meta-info where size equals alignment
+    const DataTypeMetaInfo meta_info{8U, 8U};
+
+    // When converting it
+    const auto result = MakeDataTypeSizeInfo(meta_info);
+
+    // Then the conversion succeeds and preserves size and alignment
+    ASSERT_TRUE(result.has_value());
+    EXPECT_EQ(result.value().Size(), 8U);
+    EXPECT_EQ(result.value().Alignment(), 8U);
+}
+
+TEST(MakeDataTypeSizeInfoTest, RejectsZeroAlignment)
+{
+    // Given a meta-info with zero alignment
+    const DataTypeMetaInfo meta_info{16U, 0U};
+
+    // When converting it
+    const auto result = MakeDataTypeSizeInfo(meta_info);
+
+    // Then the conversion fails with kInvalidConfiguration
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ComErrc::kInvalidConfiguration);
+}
+
+TEST(MakeDataTypeSizeInfoTest, RejectsNonPowerOfTwoAlignment)
+{
+    // Given a meta-info with a non-power-of-two alignment
+    const DataTypeMetaInfo meta_info{24U, 6U};
+
+    // When converting it
+    const auto result = MakeDataTypeSizeInfo(meta_info);
+
+    // Then the conversion fails with kInvalidConfiguration
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ComErrc::kInvalidConfiguration);
+}
+
+TEST(MakeDataTypeSizeInfoTest, RejectsSizeNotMultipleOfAlignment)
+{
+    // Given a meta-info whose size is not a multiple of its power-of-two alignment
+    const DataTypeMetaInfo meta_info{10U, 8U};
+
+    // When converting it
+    const auto result = MakeDataTypeSizeInfo(meta_info);
+
+    // Then the conversion fails with kInvalidConfiguration
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ComErrc::kInvalidConfiguration);
+}
+
+}  // namespace
+}  // namespace score::mw::com::impl

--- a/score/mw/com/impl/generic_skeleton.cpp
+++ b/score/mw/com/impl/generic_skeleton.cpp
@@ -14,6 +14,7 @@
 
 #include "score/mw/com/impl/com_error.h"
 #include "score/mw/com/impl/configuration/lola_service_type_deployment.h"
+#include "score/mw/com/impl/data_type_meta_info.h"
 #include "score/mw/com/impl/plumbing/generic_skeleton_event_binding_factory.h"
 #include "score/mw/com/impl/plumbing/skeleton_binding_factory.h"
 #include "score/mw/com/impl/runtime.h"
@@ -100,8 +101,21 @@ Result<GenericSkeleton> GenericSkeleton::Create(const InstanceIdentifier& identi
             return MakeUnexpected(ComErrc::kBindingFailure);
         }
 
+        // Validate & convert the public DataTypeMetaInfo into the internal DataTypeSizeInfo. Invalid meta-info (e.g.
+        // alignment not a power of two, or size not a multiple of alignment) results in an error instead of a later
+        // contract violation. Unfortunately our public interface DataTypeMetaInfo does not enforce these invariants,
+        // so we have to check them here. @ToDo: At some point we should already enforce this on DataTypeMetaInfo,
+        // but this would require a break in the public API!
+        auto data_type_size_info_result = MakeDataTypeSizeInfo(info.data_type_meta_info);
+        if (!data_type_size_info_result.has_value())
+        {
+            score::mw::log::LogError("GenericSkeleton")
+                << "Invalid data type meta-info provided for event: " << info.name;
+            return MakeUnexpected(ComErrc::kInvalidConfiguration);
+        }
+
         auto event_binding_result =
-            GenericSkeletonEventBindingFactory::Create(skeleton, info.name, info.data_type_meta_info);
+            GenericSkeletonEventBindingFactory::Create(skeleton, info.name, data_type_size_info_result.value());
 
         if (!event_binding_result.has_value())
         {

--- a/score/mw/com/impl/generic_skeleton_test.cpp
+++ b/score/mw/com/impl/generic_skeleton_test.cpp
@@ -43,6 +43,7 @@ using ::testing::ByMove;
 using ::testing::Field;
 using ::testing::Invoke;
 using ::testing::NiceMock;
+using ::testing::Property;
 using ::testing::Return;
 using ::testing::ReturnRef;
 
@@ -188,8 +189,8 @@ TEST_F(GenericSkeletonTest, CreateWithEventsInitializesEventBindings)
     params.events = event_storage;
 
     // Expect the Event Factory to be called
-    auto MetaMatcher =
-        AllOf(Field(&DataTypeMetaInfo::size, meta_info.size), Field(&DataTypeMetaInfo::alignment, meta_info.alignment));
+    auto MetaMatcher = AllOf(Property(&score::memory::DataTypeSizeInfo::Size, meta_info.size),
+                             Property(&score::memory::DataTypeSizeInfo::Alignment, meta_info.alignment));
 
     EXPECT_CALL(generic_skeleton_event_binding_factory_mock_, Create(_, event_name, MetaMatcher))
         .WillOnce(Return(ByMove(std::make_unique<NiceMock<mock_binding::GenericSkeletonEvent>>())));
@@ -203,6 +204,54 @@ TEST_F(GenericSkeletonTest, CreateWithEventsInitializesEventBindings)
     ASSERT_EQ(events.size(), 1);
 
     EXPECT_NE(events.find(event_name), events.cend());
+}
+
+TEST_F(GenericSkeletonTest, CreateWithInvalidDataTypeMetaInfoAlignmentFails)
+{
+    // Given configuration for one event whose meta-info has an alignment that is not a power of two
+    auto identifier = dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithEvent();
+    const std::string event_name = "test_event";
+    const DataTypeMetaInfo meta_info{16, 6};
+
+    std::vector<EventInfo> event_storage;
+    event_storage.push_back({event_name, meta_info});
+
+    GenericSkeletonServiceElementInfo params;
+    params.events = event_storage;
+
+    // Expecting that the event factory is never be called for invalid meta-info
+    EXPECT_CALL(generic_skeleton_event_binding_factory_mock_, Create(_, _, _)).Times(0);
+
+    // When creating the skeleton
+    auto result = GenericSkeleton::Create(identifier, params);
+
+    // Then creation fails with kInvalidConfiguration
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ComErrc::kInvalidConfiguration);
+}
+
+TEST_F(GenericSkeletonTest, CreateWithInvalidDataTypeMetaInfoSizeFails)
+{
+    // Given configuration for one event whose size is not a multiple of its (valid) alignment
+    auto identifier = dummy_instance_identifier_builder_.CreateValidLolaInstanceIdentifierWithEvent();
+    const std::string event_name = "test_event";
+    const DataTypeMetaInfo meta_info{10, 8};
+
+    std::vector<EventInfo> event_storage;
+    event_storage.push_back({event_name, meta_info});
+
+    GenericSkeletonServiceElementInfo params;
+    params.events = event_storage;
+
+    // Expecting that the event factory is never be called for invalid meta-info
+    EXPECT_CALL(generic_skeleton_event_binding_factory_mock_, Create(_, _, _)).Times(0);
+
+    // When creating the skeleton
+    auto result = GenericSkeleton::Create(identifier, params);
+
+    // Then creation fails with kInvalidConfiguration
+    ASSERT_FALSE(result.has_value());
+    EXPECT_EQ(result.error(), ComErrc::kInvalidConfiguration);
 }
 
 TEST_F(GenericSkeletonTest, CreateWithDuplicateEventNamesFails)

--- a/score/mw/com/impl/i_generic_skeleton_event_binding_factory.h
+++ b/score/mw/com/impl/i_generic_skeleton_event_binding_factory.h
@@ -13,7 +13,7 @@
 #ifndef SCORE_MW_COM_IMPL_I_GENERIC_SKELETON_EVENT_BINDING_FACTORY_H
 #define SCORE_MW_COM_IMPL_I_GENERIC_SKELETON_EVENT_BINDING_FACTORY_H
 
-#include "score/mw/com/impl/data_type_meta_info.h"
+#include "score/memory/data_type_size_info.h"
 #include "score/mw/com/impl/generic_skeleton_event_binding.h"
 #include "score/mw/com/impl/skeleton_base.h"
 #include <memory>
@@ -27,10 +27,8 @@ class IGenericSkeletonEventBindingFactory
   public:
     virtual ~IGenericSkeletonEventBindingFactory() noexcept = default;
 
-    // Changed SizeInfo -> DataTypeMetaInfo
-    virtual score::Result<std::unique_ptr<GenericSkeletonEventBinding>> Create(SkeletonBase&,
-                                                                               std::string_view,
-                                                                               const DataTypeMetaInfo&) noexcept = 0;
+    virtual score::Result<std::unique_ptr<GenericSkeletonEventBinding>>
+    Create(SkeletonBase&, std::string_view, const memory::DataTypeSizeInfo&) noexcept = 0;
 };
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/BUILD
+++ b/score/mw/com/impl/plumbing/BUILD
@@ -79,6 +79,21 @@ cc_library(
 )
 
 cc_library(
+    name = "i_generic_skeleton_event_binding_factory",
+    srcs = ["i_generic_skeleton_event_binding_factory.cpp"],
+    hdrs = ["i_generic_skeleton_event_binding_factory.h"],
+    features = COMPILER_WARNING_FEATURES,
+    tags = ["FFI"],
+    visibility = [
+        "//score/mw/com/impl/plumbing:__subpackages__",
+    ],
+    deps = [
+        "//score/mw/com/impl:generic_skeleton_event_binding",
+        "//score/mw/com/impl:skeleton_base",
+    ],
+)
+
+cc_library(
     name = "skeleton_method_binding_factory_impl",
     srcs = ["skeleton_method_binding_factory_impl.cpp"],
     hdrs = ["skeleton_method_binding_factory_impl.h"],
@@ -636,8 +651,8 @@ cc_library(
         "//score/mw/com/impl:__subpackages__",
     ],
     deps = [
+        ":i_generic_skeleton_event_binding_factory",
         ":skeleton_service_element_binding_factory_impl",
-        "//score/mw/com/impl:i_generic_skeleton_event_binding_factory",
         "//score/mw/com/impl/bindings/lola:generic_skeleton_event",
     ],
 )
@@ -658,8 +673,8 @@ cc_library(
         "//score/mw/com/impl:__subpackages__",
     ],
     deps = [
+        ":i_generic_skeleton_event_binding_factory",
         ":skeleton_service_element_binding_factory_impl",
-        "//score/mw/com/impl:i_generic_skeleton_event_binding_factory",
         "//score/mw/com/impl/bindings/lola:generic_skeleton_event",
     ],
 )
@@ -675,7 +690,7 @@ cc_library(
         "//score/mw/com/impl:__subpackages__",
     ],
     deps = [
-        "//score/mw/com/impl:i_generic_skeleton_event_binding_factory",
+        ":i_generic_skeleton_event_binding_factory",
         "@googletest//:gtest",
     ],
 )

--- a/score/mw/com/impl/plumbing/generic_skeleton_event_binding_factory.h
+++ b/score/mw/com/impl/plumbing/generic_skeleton_event_binding_factory.h
@@ -13,8 +13,8 @@
 #ifndef SCORE_MW_COM_IMPL_PLUMBING_GENERIC_SKELETON_EVENT_BINDING_FACTORY_H
 #define SCORE_MW_COM_IMPL_PLUMBING_GENERIC_SKELETON_EVENT_BINDING_FACTORY_H
 
+#include "score/memory/data_type_size_info.h"
 #include "score/mw/com/impl/bindings/lola/generic_skeleton_event.h"
-#include "score/mw/com/impl/data_type_meta_info.h"
 #include "score/mw/com/impl/generic_skeleton_event_binding.h"
 #include "score/mw/com/impl/i_generic_skeleton_event_binding_factory.h"
 #include "score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_impl.h"
@@ -38,15 +38,16 @@ class GenericSkeletonEventBindingFactory
 
     // This static method allows your Source Code (generic_skeleton.cpp)
     // to call GenericSkeletonEventBindingFactory::Create(...) directly.
-    static Result<std::unique_ptr<GenericSkeletonEventBinding>> Create(SkeletonBase& skeleton_base,
-                                                                       std::string_view event_name,
-                                                                       const DataTypeMetaInfo& meta_info) noexcept
+    static Result<std::unique_ptr<GenericSkeletonEventBinding>> Create(
+        SkeletonBase& skeleton_base,
+        std::string_view event_name,
+        const score::memory::DataTypeSizeInfo& size_info) noexcept
     {
         // A. If a Mock is registered (during Unit Tests), use it.
         if (mock_ != nullptr)
         {
-            //  Pass meta_info to mock
-            return mock_->Create(skeleton_base, event_name, meta_info);
+            //  Pass size_info to mock
+            return mock_->Create(skeleton_base, event_name, size_info);
         }
 
         // B. Otherwise (in Production), use the Real Implementation.
@@ -55,7 +56,7 @@ class GenericSkeletonEventBindingFactory
         return CreateGenericSkeletonEventOrField<GenericSkeletonEventBinding,
                                                  lola::GenericSkeletonEvent,
                                                  ServiceElementType::EVENT>(
-            instance_identifier, skeleton_base, event_name, meta_info);
+            instance_identifier, skeleton_base, event_name, size_info);
     }
 };
 

--- a/score/mw/com/impl/plumbing/generic_skeleton_event_binding_factory.h
+++ b/score/mw/com/impl/plumbing/generic_skeleton_event_binding_factory.h
@@ -13,14 +13,14 @@
 #ifndef SCORE_MW_COM_IMPL_PLUMBING_GENERIC_SKELETON_EVENT_BINDING_FACTORY_H
 #define SCORE_MW_COM_IMPL_PLUMBING_GENERIC_SKELETON_EVENT_BINDING_FACTORY_H
 
-#include "score/memory/data_type_size_info.h"
 #include "score/mw/com/impl/bindings/lola/generic_skeleton_event.h"
 #include "score/mw/com/impl/generic_skeleton_event_binding.h"
-#include "score/mw/com/impl/i_generic_skeleton_event_binding_factory.h"
+#include "score/mw/com/impl/plumbing/i_generic_skeleton_event_binding_factory.h"
 #include "score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_impl.h"
 #include "score/mw/com/impl/service_element_type.h"
 #include "score/mw/com/impl/skeleton_base.h"
 
+#include "score/memory/data_type_size_info.h"
 #include "score/result/result.h"
 
 #include <memory>

--- a/score/mw/com/impl/plumbing/generic_skeleton_event_binding_factory_impl.cpp
+++ b/score/mw/com/impl/plumbing/generic_skeleton_event_binding_factory_impl.cpp
@@ -16,16 +16,16 @@
 #include "score/mw/com/impl/service_element_type.h"
 #include "score/mw/com/impl/skeleton_base.h"
 
-// Updated signature to use DataTypeMetaInfo
+// Updated signature to use score::memory::DataTypeSizeInfo
 score::Result<std::unique_ptr<score::mw::com::impl::GenericSkeletonEventBinding>>
 score::mw::com::impl::GenericSkeletonEventBindingFactoryImpl::Create(SkeletonBase& parent,
                                                                      std::string_view event_name,
-                                                                     const DataTypeMetaInfo& meta_info) noexcept
+                                                                     const memory::DataTypeSizeInfo& size_info) noexcept
 {
     const auto& instance_identifier = SkeletonBaseView{parent}.GetAssociatedInstanceIdentifier();
 
     return CreateGenericSkeletonEventOrField<GenericSkeletonEventBinding,
                                              lola::GenericSkeletonEvent,
                                              ServiceElementType::EVENT>(
-        instance_identifier, parent, event_name, meta_info);
+        instance_identifier, parent, event_name, size_info);
 }

--- a/score/mw/com/impl/plumbing/generic_skeleton_event_binding_factory_impl.h
+++ b/score/mw/com/impl/plumbing/generic_skeleton_event_binding_factory_impl.h
@@ -13,8 +13,9 @@
 #ifndef SCORE_MW_COM_IMPL_PLUMBING_GENERIC_SKELETON_EVENT_BINDING_FACTORY_IMPL_H
 #define SCORE_MW_COM_IMPL_PLUMBING_GENERIC_SKELETON_EVENT_BINDING_FACTORY_IMPL_H
 
-#include "score/mw/com/impl/data_type_meta_info.h"
 #include "score/mw/com/impl/i_generic_skeleton_event_binding_factory.h"
+
+#include "score/memory/data_type_size_info.h"
 
 namespace score::mw::com::impl
 {
@@ -22,9 +23,8 @@ namespace score::mw::com::impl
 class GenericSkeletonEventBindingFactoryImpl : public IGenericSkeletonEventBindingFactory
 {
   public:
-    score::Result<std::unique_ptr<GenericSkeletonEventBinding>> Create(SkeletonBase&,
-                                                                       std::string_view,
-                                                                       const DataTypeMetaInfo&) noexcept override;
+    score::Result<std::unique_ptr<GenericSkeletonEventBinding>>
+    Create(SkeletonBase&, std::string_view, const memory::DataTypeSizeInfo&) noexcept override;
 };
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/generic_skeleton_event_binding_factory_mock.h
+++ b/score/mw/com/impl/plumbing/generic_skeleton_event_binding_factory_mock.h
@@ -13,10 +13,12 @@
 #ifndef SCORE_MW_COM_IMPL_PLUMBING_GENERIC_SKELETON_EVENT_BINDING_FACTORY_MOCK_H
 #define SCORE_MW_COM_IMPL_PLUMBING_GENERIC_SKELETON_EVENT_BINDING_FACTORY_MOCK_H
 
-#include "score/mw/com/impl/data_type_meta_info.h"
 #include "score/mw/com/impl/i_generic_skeleton_event_binding_factory.h"
 
+#include "score/memory/data_type_size_info.h"
+
 #include <gmock/gmock.h>
+#include <memory>
 
 namespace score::mw::com::impl
 {
@@ -26,7 +28,7 @@ class GenericSkeletonEventBindingFactoryMock : public IGenericSkeletonEventBindi
   public:
     MOCK_METHOD(score::Result<std::unique_ptr<GenericSkeletonEventBinding>>,
                 Create,
-                (SkeletonBase&, std::string_view, const DataTypeMetaInfo&),
+                (SkeletonBase&, std::string_view, const memory::DataTypeSizeInfo&),
                 (noexcept, override));
 };
 

--- a/score/mw/com/impl/plumbing/generic_skeleton_event_binding_factory_mock.h
+++ b/score/mw/com/impl/plumbing/generic_skeleton_event_binding_factory_mock.h
@@ -13,7 +13,7 @@
 #ifndef SCORE_MW_COM_IMPL_PLUMBING_GENERIC_SKELETON_EVENT_BINDING_FACTORY_MOCK_H
 #define SCORE_MW_COM_IMPL_PLUMBING_GENERIC_SKELETON_EVENT_BINDING_FACTORY_MOCK_H
 
-#include "score/mw/com/impl/i_generic_skeleton_event_binding_factory.h"
+#include "score/mw/com/impl/plumbing/i_generic_skeleton_event_binding_factory.h"
 
 #include "score/memory/data_type_size_info.h"
 

--- a/score/mw/com/impl/plumbing/i_generic_skeleton_event_binding_factory.cpp
+++ b/score/mw/com/impl/plumbing/i_generic_skeleton_event_binding_factory.cpp
@@ -10,23 +10,4 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-#ifndef SCORE_MW_COM_IMPL_PLUMBING_GENERIC_SKELETON_EVENT_BINDING_FACTORY_IMPL_H
-#define SCORE_MW_COM_IMPL_PLUMBING_GENERIC_SKELETON_EVENT_BINDING_FACTORY_IMPL_H
-
 #include "score/mw/com/impl/plumbing/i_generic_skeleton_event_binding_factory.h"
-
-#include "score/memory/data_type_size_info.h"
-
-namespace score::mw::com::impl
-{
-
-class GenericSkeletonEventBindingFactoryImpl : public IGenericSkeletonEventBindingFactory
-{
-  public:
-    score::Result<std::unique_ptr<GenericSkeletonEventBinding>>
-    Create(SkeletonBase&, std::string_view, const memory::DataTypeSizeInfo&) noexcept override;
-};
-
-}  // namespace score::mw::com::impl
-
-#endif  // SCORE_MW_COM_IMPL_PLUMBING_GENERIC_SKELETON_EVENT_BINDING_FACTORY_IMPL_H

--- a/score/mw/com/impl/plumbing/i_generic_skeleton_event_binding_factory.h
+++ b/score/mw/com/impl/plumbing/i_generic_skeleton_event_binding_factory.h
@@ -10,12 +10,14 @@
  *
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
-#ifndef SCORE_MW_COM_IMPL_I_GENERIC_SKELETON_EVENT_BINDING_FACTORY_H
-#define SCORE_MW_COM_IMPL_I_GENERIC_SKELETON_EVENT_BINDING_FACTORY_H
+#ifndef SCORE_MW_COM_IMPL_PLUMBING_I_GENERIC_SKELETON_EVENT_BINDING_FACTORY_H
+#define SCORE_MW_COM_IMPL_PLUMBING_I_GENERIC_SKELETON_EVENT_BINDING_FACTORY_H
 
-#include "score/memory/data_type_size_info.h"
 #include "score/mw/com/impl/generic_skeleton_event_binding.h"
 #include "score/mw/com/impl/skeleton_base.h"
+
+#include "score/memory/data_type_size_info.h"
+
 #include <memory>
 #include <string_view>
 
@@ -33,4 +35,4 @@ class IGenericSkeletonEventBindingFactory
 
 }  // namespace score::mw::com::impl
 
-#endif  // SCORE_MW_COM_IMPL_I_GENERIC_SKELETON_EVENT_BINDING_FACTORY_H
+#endif  // SCORE_MW_COM_IMPL_PLUMBING_I_GENERIC_SKELETON_EVENT_BINDING_FACTORY_H

--- a/score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_impl.h
+++ b/score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_impl.h
@@ -20,11 +20,11 @@
 #include "score/mw/com/impl/configuration/binding_service_type_deployment.h"
 #include "score/mw/com/impl/configuration/lola_service_instance_deployment.h"
 #include "score/mw/com/impl/configuration/service_instance_deployment.h"
-#include "score/mw/com/impl/data_type_meta_info.h"
 #include "score/mw/com/impl/field_tags_store.h"
 #include "score/mw/com/impl/skeleton_base.h"
 #include "score/mw/com/impl/tracing/skeleton_event_tracing_data.h"
 
+#include "score/memory/data_type_size_info.h"
 #include "score/mw/log/logging.h"
 
 #include <score/assert.hpp>
@@ -188,13 +188,13 @@ auto CreateSkeletonEventOrField(const InstanceIdentifier& identifier,
     return std::visit(visitor, identifier_view.GetServiceTypeDeployment().binding_info_);
 }
 
-/// @brief Overload for typed skeletons (which do not have a DataTypeMetaInfo).
+/// @brief Overload for typed skeletons (which do not have a score::memory::DataTypeSizeInfo).
 template <typename SkeletonServiceElementBinding, typename SkeletonServiceElement, ServiceElementType element_type>
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
 auto CreateGenericSkeletonEventOrField(const InstanceIdentifier& identifier,
                                        SkeletonBase& parent,
                                        const std::string_view service_element_name,
-                                       const DataTypeMetaInfo& meta_info)
+                                       const memory::DataTypeSizeInfo& size_info) noexcept
     -> std::unique_ptr<SkeletonServiceElementBinding>
 {
     static_assert((element_type == ServiceElementType::EVENT) || (element_type == ServiceElementType::FIELD));
@@ -203,7 +203,7 @@ auto CreateGenericSkeletonEventOrField(const InstanceIdentifier& identifier,
 
     using ReturnType = std::unique_ptr<SkeletonServiceElementBinding>;
     auto visitor = score::cpp::overload(
-        [identifier_view, &parent, &service_element_name, &meta_info](
+        [identifier_view, &parent, &service_element_name, &size_info](
             const LolaServiceTypeDeployment& lola_service_type_deployment) -> ReturnType {
             auto* const lola_parent = dynamic_cast<lola::Skeleton*>(&SkeletonBaseView{parent}.GetBinding());
             if (lola_parent == nullptr)
@@ -235,7 +235,7 @@ auto CreateGenericSkeletonEventOrField(const InstanceIdentifier& identifier,
                                                             service_element_name,
                                                             skeleton_event_properties,
                                                             element_fq_id,
-                                                            meta_info,
+                                                            size_info,
                                                             tracing::SkeletonEventTracingData{});
         },
         [](const score::cpp::blank&) noexcept -> ReturnType {


### PR DESCRIPTION
The type DataTypeMetaInfo, which we use on our
public interface is too weak! It doesn't assure
invariants on size/alignment, which C++ demands:
size has to be always a power of two and be an
integer multiple of tzhe alignment.

This commit switches to internal use of memory::DataTypeSizeInfo which forces this. On the public interface we keep the weak DataTypeMetaInfo for now to avoid a breaking change! In the public layer we transform DataTypeMetaInfo to DataTypeSizeInfo. In case this isn't possible because DataTypeMetaInfo is invalid, we return an error in the public API.