### PR TITLE
mw/com: Pass the GetNewSamplesCallback to WaitForSamples

### DIFF
--- a/score/mw/com/test/common_test_resources/proxy_event_receiver.h
+++ b/score/mw/com/test/common_test_resources/proxy_event_receiver.h
@@ -15,25 +15,24 @@
 
 #include "score/concurrency/notification.h"
 #include "score/mw/com/test/common_test_resources/fail_test.h"
-#include "score/mw/com/types.h"
 
 #include <score/stop_token.hpp>
 
-#include <cstdint>
+#include <functional>
 #include <iostream>
-#include <optional>
+#include <utility>
 
 namespace score::mw::com::test
 {
 
 /// \brief Helper class which registers a receiveHandler on construction and allows waiting for a
 /// certain number of samples to be received. It also checks that the received samples are in the expected order.
-template <typename ProxyEventType, typename GetNewSamplesCallback>
+template <typename ProxyEventType>
 class ProxyEventReceiver
 {
   public:
-    explicit ProxyEventReceiver(ProxyEventType& proxy_event, GetNewSamplesCallback get_new_samples_callback)
-        : proxy_event_{proxy_event}, get_new_samples_callback_{std::move(get_new_samples_callback)}
+    explicit ProxyEventReceiver(ProxyEventType& proxy_event)
+        : received_sample_notification_{}, proxy_event_{proxy_event}
     {
         auto receive_handler = [&received_sample_notification = received_sample_notification_]() {
             std::cout << "ProxyEventReceiver: Received event notification" << std::endl;
@@ -56,15 +55,17 @@ class ProxyEventReceiver
     ///
     /// \return true if the expected number of samples was received, false if the wait was interrupted by the
     /// stop_token.
+    template <typename GetNewSamplesCallback>
     [[nodiscard]] bool WaitForSamples(const score::cpp::stop_token& stop_token,
-                                      const std::size_t num_samples_to_receive)
+                                      const std::size_t num_samples_to_receive,
+                                      GetNewSamplesCallback&& get_new_samples_callback)
     {
         std::size_t received_count{0U};
         while (!stop_token.stop_requested())
         {
             auto get_samples_result = proxy_event_.GetNewSamples(
-                [this](auto sample) {
-                    std::invoke(get_new_samples_callback_, std::move(sample));
+                [&get_new_samples_callback](auto sample) {
+                    std::invoke(get_new_samples_callback, std::move(sample));
                 },
                 num_samples_to_receive);
             if (!get_samples_result.has_value())
@@ -104,10 +105,8 @@ class ProxyEventReceiver
     }
 
   private:
-    score::concurrency::Notification received_sample_notification_{};
-    std::optional<std::uint32_t> latest_value_{};
+    score::concurrency::Notification received_sample_notification_;
     ProxyEventType& proxy_event_;
-    GetNewSamplesCallback get_new_samples_callback_;
 };
 
 }  // namespace score::mw::com::test

--- a/score/mw/com/test/fields/set_and_notifier/consumer.cpp
+++ b/score/mw/com/test/fields/set_and_notifier/consumer.cpp
@@ -69,19 +69,7 @@ void run_notifier_consumer(const score::cpp::stop_token& stop_token)
     // Step 2. Register unified receive handler that verifies samples arrive in the expected order
     std::cout << "\nConsumer: Step 2 - Register unified receive handler" << std::endl;
     constexpr auto kMaxNumSamples{2U};
-    std::size_t sample_index{0U};
-    auto value_callback = [&sample_index](const auto& sample_ptr) noexcept {
-        if (sample_index == 0U && *sample_ptr != kInitialValue)
-        {
-            FailTest("Consumer: Did not receive expected initial value ", kInitialValue, " in notifier scenario");
-        }
-        else if (sample_index == 1U && *sample_ptr != kUpdatedValue)
-        {
-            FailTest("Consumer: Did not receive expected updated value ", kUpdatedValue, " in notifier scenario");
-        }
-        ++sample_index;
-    };
-    ProxyEventReceiver field_receiver{proxy.initial_only_field, std::move(value_callback)};
+    ProxyEventReceiver field_receiver{proxy.initial_only_field};
 
     // Step 3. Register state change handler
     std::cout << "\nConsumer: Step 3 - Register state change handler" << std::endl;
@@ -100,7 +88,19 @@ void run_notifier_consumer(const score::cpp::stop_token& stop_token)
 
     // Step 6. Wait for all expected samples
     std::cout << "\nConsumer: Step 6 - Wait for all expected samples" << std::endl;
-    if (!field_receiver.WaitForSamples(stop_token, kMaxNumSamples))
+    std::size_t sample_index{0U};
+    auto value_callback = [&sample_index](const auto& sample_ptr) noexcept {
+        if (sample_index == 0U && *sample_ptr != kInitialValue)
+        {
+            FailTest("Consumer: Did not receive expected initial value ", kInitialValue, " in notifier scenario");
+        }
+        else if (sample_index == 1U && *sample_ptr != kUpdatedValue)
+        {
+            FailTest("Consumer: Did not receive expected updated value ", kUpdatedValue, " in notifier scenario");
+        }
+        ++sample_index;
+    };
+    if (!field_receiver.WaitForSamples(stop_token, kMaxNumSamples, std::move(value_callback)))
     {
         FailTest("Consumer: Did not receive all expected samples in notifier scenario");
     }
@@ -128,19 +128,7 @@ void run_set_and_notifier_consumer(const score::cpp::stop_token& stop_token)
     // Step 2. Register unified receive handler that verifies samples arrive in the expected order
     std::cout << "\nConsumer: Step 2 - Register unified receive handler" << std::endl;
     constexpr auto kMaxNumSamples{1U};
-    std::size_t sample_index{0U};
-    auto value_callback = [&sample_index](const auto& sample_ptr) noexcept {
-        if (sample_index == 0U && *sample_ptr != kInitialValue)
-        {
-            FailTest("Consumer: Did not receive initial value ", kInitialValue, " in set scenario");
-        }
-        else if (sample_index == 1U && *sample_ptr != kSetRequestValue * 2 + 1)
-        {
-            FailTest("Consumer: Did not receive transformed value ", kSetRequestValue * 2 + 1, " after Set call");
-        }
-        ++sample_index;
-    };
-    ProxyEventReceiver field_receiver{proxy.set_and_notifier_enabled_field, std::move(value_callback)};
+    ProxyEventReceiver field_receiver{proxy.set_and_notifier_enabled_field};
 
     // Step 3. Register state change handler
     std::cout << "\nConsumer: Step 3 - Register state change handler" << std::endl;
@@ -156,7 +144,20 @@ void run_set_and_notifier_consumer(const score::cpp::stop_token& stop_token)
     {
         FailTest("Consumer: Subscription failed in set scenario");
     }
-    if (!field_receiver.WaitForSamples(stop_token, 1U))
+
+    std::size_t sample_index{0U};
+    auto value_callback = [&sample_index](const auto& sample_ptr) noexcept {
+        if (sample_index == 0U && *sample_ptr != kInitialValue)
+        {
+            FailTest("Consumer: Did not receive initial value ", kInitialValue, " in set scenario");
+        }
+        else if (sample_index == 1U && *sample_ptr != kSetRequestValue * 2 + 1)
+        {
+            FailTest("Consumer: Did not receive transformed value ", kSetRequestValue * 2 + 1, " after Set call");
+        }
+        ++sample_index;
+    };
+    if (!field_receiver.WaitForSamples(stop_token, 1U, std::move(value_callback)))
     {
         FailTest("Consumer: Did not receive initial value ", kInitialValue, " in set scenario");
     }
@@ -178,7 +179,7 @@ void run_set_and_notifier_consumer(const score::cpp::stop_token& stop_token)
 
     // Step 7. Verify transformed value received via field notification
     std::cout << "\nConsumer: Step 7 - Verify transformed value via field notification" << std::endl;
-    if (!field_receiver.WaitForSamples(stop_token, 1U))
+    if (!field_receiver.WaitForSamples(stop_token, 1U, value_callback))
     {
         FailTest("Consumer: Did not receive transformed value ", kSetRequestValue * 2 + 1, " after Set call");
     }

--- a/score/mw/com/test/move_semantics/skeleton_event/consumer.cpp
+++ b/score/mw/com/test/move_semantics/skeleton_event/consumer.cpp
@@ -57,6 +57,23 @@ void RunConsumer(const InstanceSpecifier& instance_specifier,
     auto& proxy = proxy_container.GetProxy();
 
     // Step 2. Register receive handler
+    std::cout << "\nConsumer: Step 2 - Register receive handler" << std::endl;
+    ProxyEventReceiver proxy_event_receiver{proxy.moved_event_};
+
+    // Step 3. Register state change handler
+    std::cout << "\nConsumer: Step 3 - Register state change handler" << std::endl;
+    ProxyEventStateChangeNotifier proxy_event_state_change_notifier{proxy.moved_event_};
+
+    // Step 4. Subscribe
+    std::cout << "\nConsumer: Step 4 - Subscribe" << std::endl;
+    auto subscribe_result = proxy.moved_event_.Subscribe(num_samples_to_receive);
+    if (!subscribe_result.has_value())
+    {
+        FailTest("skeleton_event_move_semantics consumer failed: Subscribe failed: ", subscribe_result.error());
+    }
+
+    // Step 5. Wait for provider to send values and notify
+    std::cout << "\nConsumer: Step 5 - Wait for provider to send values and notify" << std::endl;
     std::optional<std::uint32_t> latest_value{0U};
     auto get_new_samples_callback = [&latest_value](SamplePtr<std::uint32_t> sample) {
         if (sample == nullptr)
@@ -73,23 +90,6 @@ void RunConsumer(const InstanceSpecifier& instance_specifier,
         }
         latest_value = *sample;
     };
-    std::cout << "\nConsumer: Step 2 - Register receive handler" << std::endl;
-    ProxyEventReceiver proxy_event_receiver{proxy.moved_event_, std::move(get_new_samples_callback)};
-
-    // Step 3. Register state change handler
-    std::cout << "\nConsumer: Step 3 - Register state change handler" << std::endl;
-    ProxyEventStateChangeNotifier proxy_event_state_change_notifier{proxy.moved_event_};
-
-    // Step 4. Subscribe
-    std::cout << "\nConsumer: Step 4 - Subscribe" << std::endl;
-    auto subscribe_result = proxy.moved_event_.Subscribe(num_samples_to_receive);
-    if (!subscribe_result.has_value())
-    {
-        FailTest("skeleton_event_move_semantics consumer failed: Subscribe failed: ", subscribe_result.error());
-    }
-
-    // Step 5. Wait for provider to send values and notify
-    std::cout << "\nConsumer: Step 5 - Wait for provider to send values and notify" << std::endl;
     for (std::size_t iteration = 0U; iteration < num_send_iterations; ++iteration)
     {
         std::cout << "\nConsumer: Iteration " << (iteration + 1) << " of " << num_send_iterations << std::endl;
@@ -100,7 +100,8 @@ void RunConsumer(const InstanceSpecifier& instance_specifier,
             FailTest("skeleton_event_move_semantics consumer failed: WaitForStateChange was interrupted by stop_token");
         }
 
-        const auto wait_for_samples_result = proxy_event_receiver.WaitForSamples(stop_token, num_samples_to_receive);
+        const auto wait_for_samples_result =
+            proxy_event_receiver.WaitForSamples(stop_token, num_samples_to_receive, get_new_samples_callback);
         if (!wait_for_samples_result)
         {
             FailTest("skeleton_event_move_semantics consumer failed: WaitForSamples was interrupted by stop_token");


### PR DESCRIPTION
This change allows the ProxyEventReceiver to be used with different callbacks called each time WaitForSamples is called.