### PR TITLE
[Flaky test fix] mw/com: Call StopFindService at the end of test

### DIFF
--- a/score/mw/com/test/partial_restart/provider_restart_max_subscribers/consumer.cpp
+++ b/score/mw/com/test/partial_restart/provider_restart_max_subscribers/consumer.cpp
@@ -46,7 +46,8 @@ ConsumerActions::ConsumerActions(CheckPointControl& check_point_control,
       test_stop_token_{std::move(test_stop_token)},
       consumer_parameters_{consumer_parameters},
       proxies_{},
-      handle_notification_data_{}
+      handle_notification_data_{},
+      find_service_handle_{std::nullopt}
 {
     // Initialize mw::com runtime explicitly, if we were called with cmd-line args from main/parent
     if (argc > 0 && argv != nullptr)
@@ -104,6 +105,26 @@ void ConsumerActions::DoConsumerActions() noexcept
         return;
     }
 
+    // ********************************************************************************
+    // Step (C.21) - Stop async FindService
+    // ********************************************************************************
+    std::cout << "Consumer Step (C.21): Stop async FindService" << std::endl;
+    if (!find_service_handle_.has_value())
+    {
+        std::cerr << "Consumer Step (C.21): Missing FindService handle!" << std::endl;
+        check_point_control_.ErrorOccurred();
+        return;
+    }
+
+    auto stop_find_service_result = TestServiceProxy::StopFindService(find_service_handle_.value());
+    if (!stop_find_service_result.has_value())
+    {
+        std::cerr << "Consumer Step (C.21): Stop async FindService failed with error: "
+                  << stop_find_service_result.error() << std::endl;
+        check_point_control_.ErrorOccurred();
+        return;
+    }
+
     std::cout << "Consumer: Finishing actions!" << std::endl;
 }
 
@@ -123,9 +144,10 @@ void ConsumerActions::DoConsumerActionsBeforeRestart() noexcept
     {
         return;
     }
+    find_service_handle_ = find_service_handle_result.value();
 
     // ********************************************************************************
-    // Step (C.2) - Wait for FindServiceHandler to be called. Call StopFindService in handler
+    // Step (C.2) - Wait for FindServiceHandler to be called
     // ********************************************************************************
     std::cout << "Consumer Step (C.2): Wait for FindServiceHandler to be called" << std::endl;
     if (!WaitTillServiceAppears(handle_notification_data_, kMaxHandleNotificationWaitTime))
@@ -229,7 +251,7 @@ void ConsumerActions::DoConsumerActionsAfterRestart() noexcept
     WaitTillServiceDisappears(handle_notification_data_);
 
     // ********************************************************************************
-    // Step (C.12) - Wait for FindServiceHandler to be called. Call StopFindService in handler
+    // Step (C.12) - Wait for FindServiceHandler to be called
     // ********************************************************************************
     std::cout << "Consumer Step (C.12): Wait for FindServiceHandler to be called." << std::endl;
     if (!WaitTillServiceAppears(handle_notification_data_, kMaxHandleNotificationWaitTime))

--- a/score/mw/com/test/partial_restart/provider_restart_max_subscribers/consumer.h
+++ b/score/mw/com/test/partial_restart/provider_restart_max_subscribers/consumer.h
@@ -18,6 +18,7 @@
 #include "score/mw/com/test/partial_restart/consumer_handle_notification_data.h"
 #include "score/mw/com/test/partial_restart/test_datatype.h"
 
+#include <optional>
 #include <vector>
 
 namespace score::mw::com::test
@@ -48,6 +49,7 @@ class ConsumerActions
     ConsumerParameters consumer_parameters_;
     std::vector<TestServiceProxy> proxies_;
     HandleNotificationData handle_notification_data_;
+    std::optional<FindServiceHandle> find_service_handle_;
 };
 
 }  // namespace score::mw::com::test


### PR DESCRIPTION
Previously, the find service handler was occassionally called after the ConsumerActions was destroyed. The handler held references to objects in ConsumerActions (such as a mutex) which were accessed in the handler after they'd already been destroyed. Calling StopFindService prevents this issue.