### PR TITLE
Remove unused CheckForValidDataControls declaration (RULE-0-2-4)

### DIFF
--- a/score/mw/com/impl/bindings/lola/event_data_control_composite.h
+++ b/score/mw/com/impl/bindings/lola/event_data_control_composite.h
@@ -134,7 +134,6 @@ class EventDataControlComposite
         const noexcept;
 
     std::optional<SlotIndexType> AllocateNextMultiSlot() noexcept;
-    void CheckForValidDataControls() const noexcept;
 };
 
 }  // namespace score::mw::com::impl::lola


### PR DESCRIPTION
The private member function CheckForValidDataControls was declared in EventDataControlComposite but never defined or called anywhere in the codebase. Removing the dead declaration fixes the one valid RULE-0-2-4 finding for this class.