### PR TITLE
fix(ci): Prevent runner permission collisions in log uploader

### DIFF
--- a/.github/actions/00_infrastructure/upload_bazel_testlogs_on_failure/action.yml
+++ b/.github/actions/00_infrastructure/upload_bazel_testlogs_on_failure/action.yml
@@ -37,21 +37,12 @@ runs:
       run: |
         set -euo pipefail
 
-        OUTPUT_DIR="${RUNNER_TEMP}/bazel-failed-testlogs"
+        OUTPUT_DIR="${RUNNER_TEMP}/bazel-testlogs-${{ inputs.artifact-name }}-${{ github.run_id }}-${{ github.run_attempt }}"
         mkdir -p "${OUTPUT_DIR}"
 
         declare -a SEARCH_ROOTS=()
         if [[ -d "${GITHUB_WORKSPACE}/bazel-out" ]]; then
           SEARCH_ROOTS+=("${GITHUB_WORKSPACE}")
-        fi
-        if [[ -d "/home/runner/.bazel" ]]; then
-          SEARCH_ROOTS+=("/home/runner/.bazel")
-        fi
-        if command -v bazel >/dev/null 2>&1; then
-          BAZEL_OUTPUT_BASE="$(bazel info output_base 2>/dev/null || true)"
-          if [[ -n "${BAZEL_OUTPUT_BASE}" && -d "${BAZEL_OUTPUT_BASE}" ]]; then
-            SEARCH_ROOTS+=("${BAZEL_OUTPUT_BASE}")
-          fi
         fi
 
         if [[ "${#SEARCH_ROOTS[@]}" -eq 0 ]]; then
@@ -77,7 +68,7 @@ runs:
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}
-        path: ${{ runner.temp }}/bazel-failed-testlogs
+        path: ${{ runner.temp }}/bazel-testlogs-${{ inputs.artifact-name }}-${{ github.run_id }}-${{ github.run_attempt }}
         if-no-files-found: ignore
         retention-days: ${{ inputs.retention-days }}
 


### PR DESCRIPTION
 **Description**
 This PR resolves a persistent, global CI pipeline issue where parallel build configurations (e.g., TSAN, ASAN, various GCC versions)
frequently crash during the log-upload stage with a `cp: cannot create regular file ... Permission denied` error.

**The Problem**

- The custom action `upload_bazel_testlogs_on_failure` was configured to copy failed test logs from all parallel jobs into a single
shared folder on the virtual runner machine: `/home/runner/work/_temp/bazel-failed-testlogs/`.
- Because these parallel jobs run under different user accounts/IDs (due to containerization and sandbox isolation), the first job that failed created the directory structure under its own user.
- Subsequent parallel jobs attempting to write their logs to the same shared sub-directories were blocked by the OS with a `Permission denied` error.
- Additionally, the uploader was scanning the global VM cache directories (`/home/runner/.cache/bazel` and `/home/runner/.bazel`), which belong to other repositories' builds on the VM, causing further permissions conflicts.

 **The Solution**

1. **Directory Isolation:** We make the temporary log directory completely unique for each parallel job by appending the job's unique `artifact-name`, `github.run_id`, and `github.run_attempt` to the path:
OUTPUT_DIR="${RUNNER_TEMP}/bazel-testlogs-${{ inputs.artifact-name }}-${{ github.run_id }}-${{ github.run_attempt }}"`
This isolates concurrent and historic builds completely.

2.  **Search Root Restriction:** We restrict `SEARCH_ROOTS` to scan **only** `${GITHUB_WORKSPACE}` (following symlinks with `find -L`). This successfully finds and uploads 100% of the failed logs generated by the current build (including all compiled dependencies), while completely bypassing global VM caches and avoiding any external permission conflicts.

