### PR TITLE
fix(ci): grant security-events: write to fetch-linters job

### DIFF
--- a/.github/workflows/nightly_cache_recreation.yml
+++ b/.github/workflows/nightly_cache_recreation.yml
@@ -84,6 +84,7 @@ jobs:
     permissions:
       contents: read
       actions: write
+      security-events: write
     secrets:
       UBUNTU_SNAPSHOT_MIRROR_URL: ${{ secrets.UBUNTU_SNAPSHOT_MIRROR_URL }}
 


### PR DESCRIPTION
The reusable workflow _linter.yml requests 'security-events: write' in its nested job to upload SARIF reports via the CodeQL action. The calling job in nightly_cache_recreation.yml must explicitly grant at least the same permission level; omitting it defaults to 'none', causing the workflow validation error at line 78.