### PR TITLE
fix(ci): grant security-events permission to build-linters

### DIFF
--- a/.github/workflows/nightly_cache_recreation.yml
+++ b/.github/workflows/nightly_cache_recreation.yml
@@ -174,6 +174,7 @@ jobs:
     permissions:
       contents: read
       actions: write
+      security-events: write
     secrets:
       UBUNTU_SNAPSHOT_MIRROR_URL: ${{ secrets.UBUNTU_SNAPSHOT_MIRROR_URL }}
 


### PR DESCRIPTION
The reusable linter workflow uploads SARIF via github/codeql-action, so the caller must explicitly allow security-events: write. Add that permission to build-linters in nightly_cache_recreation.yml.