### PR TITLE
fix(codeql): include .codeql/** in compiled pack filegroup

### DIFF
--- a/third_party/codeql/codeql_release_pack.bzl
+++ b/third_party/codeql/codeql_release_pack.bzl
@@ -50,7 +50,10 @@ def _codeql_release_pack_impl(repository_ctx):
         "BUILD.bazel",
         "filegroup(\n" +
         "    name = \"pack\",\n" +
-        "    srcs = glob([\"pack/**\"], allow_empty = False),\n" +
+        "    srcs = glob([\n" +
+        "        \"pack/**\",\n" +
+        "        \"pack/.codeql/**\",\n" +
+        "    ], allow_empty = False),\n" +
         "    visibility = [\"//visibility:public\"],\n" +
         ")\n",
     )


### PR DESCRIPTION
Bazel's glob() skips hidden paths (starting with '.') by default, so glob(["pack/**"]) silently omitted pack/.codeql/libraries/** from @codeql_coding_standards_compiled//:pack.

The .codeql/libraries/ directory bundles all vendored library dependencies of the pre-compiled MISRA C++ pack (including advanced-security/qtil, codeql/mad, codeql/cpp-all, etc.). Without these, 'database analyze' cannot resolve extensional predicates such as allocationFunctionModel, deallocationFunctionModel, throwingFunctionModel, and unicodeHasBooleanProperty, causing 33 of 218 queries to fail with exit code 34.

Fix: add 'pack/.codeql/**' as an explicit second glob pattern so hidden sub-trees are included.