### PR TITLE
fix(misra): add precedence-clarifying parentheses (RULE-8-0-1)

### DIFF
--- a/score/memory/shared/new_delete_delegate_resource.cpp
+++ b/score/memory/shared/new_delete_delegate_resource.cpp
@@ -33,7 +33,7 @@ namespace  // anonymous
 
 // coverity[autosar_cpp14_a0_1_1_violation] false-positive: used in alignment check
 constexpr std::uintptr_t PAGE_SIZE{4096U};
-static_assert((PAGE_SIZE % alignof(std::max_align_t) == 0), "allocation_buffer_start_address_ is not max aligned!");
+static_assert(((PAGE_SIZE % alignof(std::max_align_t)) == 0), "allocation_buffer_start_address_ is not max aligned!");
 
 }  // namespace
 

--- a/score/memory/shared/pointer_arithmetic_util.cpp
+++ b/score/memory/shared/pointer_arithmetic_util.cpp
@@ -153,7 +153,7 @@ std::ptrdiff_t SubtractPointersBytes(const void* const first, const void* const 
     // Since we need to cast positive_result_as_integer to a std::ptrdiff_t, we have to handle the special case in which
     // the actual result is equal to ptr_diff_min. In such a case, the absolute value of the result will be ptr_diff_max
     // + 1U which cannot fit inside a std::ptrdiff_t. So we directly return ptr_diff_min in such a case.
-    if (absolute_value_result_as_integer == static_cast<std::uintptr_t>(ptr_diff_max) + 1U)
+    if (absolute_value_result_as_integer == (static_cast<std::uintptr_t>(ptr_diff_max) + 1U))
     {
         return std::numeric_limits<std::ptrdiff_t>::min();
     }

--- a/score/memory/shared/shared_memory_resource.cpp
+++ b/score/memory/shared/shared_memory_resource.cpp
@@ -999,7 +999,7 @@ auto SharedMemoryResource::acquireLockFile() const noexcept -> std::optional<Loc
         {
             const auto* const path = std::get_if<std::string>(&shared_memory_resource_identifier_);
             ::score::mw::log::LogFatal("shm")
-                << __func__ << __LINE__ << "Shared Memory Resource: " << (path != nullptr ? *path : "<unknown>")
+                << __func__ << __LINE__ << "Shared Memory Resource: " << ((path != nullptr) ? *path : "<unknown>")
                 << " Lock file still present after timeout. Cannot open shared memory. Terminating";
             std::terminate();
         }

--- a/score/mw/com/impl/bindings/lola/proxy.cpp
+++ b/score/mw/com/impl/bindings/lola/proxy.cpp
@@ -300,7 +300,7 @@ void AppendEnabledFieldIdsAndQueueSizes(
             {
                 continue;
             }
-            const bool is_enabled_in_deployment = method_type == MethodType::kGet
+            const bool is_enabled_in_deployment = (method_type == MethodType::kGet)
                                                       ? method_deployment.use_get_if_available_
                                                       : method_deployment.use_set_if_available_;
             if (!is_enabled_in_deployment)

--- a/score/mw/com/impl/configuration/lola_method_instance_deployment.h
+++ b/score/mw/com/impl/configuration/lola_method_instance_deployment.h
@@ -78,7 +78,7 @@ class LolaMethodInstanceDeployment
 
 inline bool operator==(const LolaMethodInstanceDeployment& lhs, const LolaMethodInstanceDeployment& rhs) noexcept
 {
-    return lhs.queue_size_ == rhs.queue_size_ && lhs.enabled_ == rhs.enabled_;
+    return (lhs.queue_size_ == rhs.queue_size_) && (lhs.enabled_ == rhs.enabled_);
 }
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/field_tags_store.cpp
+++ b/score/mw/com/impl/field_tags_store.cpp
@@ -17,8 +17,8 @@ namespace score::mw::com::impl
 
 bool operator==(const FieldTagsStore& lhs, const FieldTagsStore& rhs)
 {
-    return lhs.HasGetter() == rhs.HasGetter() && lhs.HasSetter() == rhs.HasSetter() &&
-           lhs.HasNotifier() == rhs.HasNotifier();
+    return (lhs.HasGetter() == rhs.HasGetter()) && (lhs.HasSetter() == rhs.HasSetter()) &&
+           (lhs.HasNotifier() == rhs.HasNotifier());
 }
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/plumbing/proxy_event_binding_factory_impl.cpp
+++ b/score/mw/com/impl/plumbing/proxy_event_binding_factory_impl.cpp
@@ -38,8 +38,8 @@ Result<std::unique_ptr<GenericProxyEventBinding>> GenericProxyEventBindingFactor
     const std::string_view event_name,
     const ServiceElementType service_element_type)
 {
-    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(service_element_type == ServiceElementType::EVENT ||
-                                              service_element_type == ServiceElementType::FIELD);
+    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD((service_element_type == ServiceElementType::EVENT) ||
+                                              (service_element_type == ServiceElementType::FIELD));
 
     using ReturnType = Result<std::unique_ptr<lola::GenericProxyEvent>>;
     auto deployment_info_visitor = score::cpp::overload(

--- a/score/mw/com/impl/proxy_field_base.h
+++ b/score/mw/com/impl/proxy_field_base.h
@@ -162,7 +162,7 @@ class ProxyFieldBaseView
     {
         // If the WithNotifier tag is not set, proxy_event_base_dispatch_ will be nullptr. In that case, we never had to
         // create the event binding so we report that there were no construction errors.
-        return proxy_field_base_.proxy_event_base_dispatch_ != nullptr
+        return (proxy_field_base_.proxy_event_base_dispatch_ != nullptr)
                    ? ProxyEventBaseView{*proxy_field_base_.proxy_event_base_dispatch_}.GetBindingConstructionResult()
                    : Result<void>{};
     }
@@ -171,7 +171,7 @@ class ProxyFieldBaseView
     {
         // If the WithSetter tag is not set, proxy_set_method_dispatch_ will be nullptr. In that case, we never had to
         // create the setter method binding so we report that there were no construction errors.
-        return proxy_field_base_.proxy_set_method_dispatch_ != nullptr
+        return (proxy_field_base_.proxy_set_method_dispatch_ != nullptr)
                    ? ProxyMethodBaseView{*proxy_field_base_.proxy_set_method_dispatch_}.GetBindingConstructionResult()
                    : Result<void>{};
     }
@@ -180,7 +180,7 @@ class ProxyFieldBaseView
     {
         // If the WithGetter tag is not set, proxy_get_method_dispatch_ will be nullptr. In that case, we never had to
         // create the getter method binding so we report that there were no construction errors.
-        return proxy_field_base_.proxy_get_method_dispatch_ != nullptr
+        return (proxy_field_base_.proxy_get_method_dispatch_ != nullptr)
                    ? ProxyMethodBaseView{*proxy_field_base_.proxy_get_method_dispatch_}.GetBindingConstructionResult()
                    : Result<void>{};
     }


### PR DESCRIPTION
Add explicit parentheses around sub-expressions in mixed-operator contexts to satisfy MISRA C++ RULE-8-0-1 (missing-precedence- clarifying-parenthesis). Fixes 13 code scanning alerts.