### PR TITLE
feat(memory): Inter vm custom typemem provider

### DIFF
--- a/score/memory/shared/BUILD
+++ b/score/memory/shared/BUILD
@@ -114,8 +114,6 @@ cc_library(
         "@score_baselibs//score/os:stat",
         "@score_baselibs//score/os:unistd",
         "@score_baselibs//score/os/utils/acl",
-        # TODO Hacky
-        "@score_baselibs//score/os/utils/interprocess:interprocess_notification",
     ],
 )
 

--- a/score/memory/shared/i_shared_memory_factory.h
+++ b/score/memory/shared/i_shared_memory_factory.h
@@ -60,6 +60,8 @@ class ISharedMemoryFactory
 
     virtual void SetTypedMemoryProvider(std::shared_ptr<score::memory::shared::TypedMemory>) noexcept = 0;
 
+    virtual void SetInterVMMemoryProvider(std::shared_ptr<score::memory::shared::TypedMemory>) noexcept = 0;
+
     virtual std::size_t GetControlBlockSize() noexcept = 0;
 
     virtual void Clear() noexcept = 0;

--- a/score/memory/shared/shared_memory_factory.cpp
+++ b/score/memory/shared/shared_memory_factory.cpp
@@ -83,7 +83,12 @@ auto SharedMemoryFactory::RemoveStaleArtefacts(const std::string& path) noexcept
 
 auto SharedMemoryFactory::SetTypedMemoryProvider(std::shared_ptr<TypedMemory> typed_memory_ptr) noexcept -> void
 {
-    instance().SetTypedMemoryProvider(typed_memory_ptr);
+    instance().SetTypedMemoryProvider(std::move(typed_memory_ptr));
+}
+
+auto SharedMemoryFactory::SetInterVMMemoryProvider(std::shared_ptr<TypedMemory> intervm_memory_ptr) noexcept -> void
+{
+    instance().SetInterVMMemoryProvider(std::move(intervm_memory_ptr));
 }
 
 auto SharedMemoryFactory::instance() noexcept -> ISharedMemoryFactory&

--- a/score/memory/shared/shared_memory_factory.h
+++ b/score/memory/shared/shared_memory_factory.h
@@ -160,6 +160,9 @@ class SharedMemoryFactory
 
     static void SetTypedMemoryProvider(std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr) noexcept;
 
+    static void SetInterVMMemoryProvider(
+        std::shared_ptr<score::memory::shared::TypedMemory> intervm_memory_ptr) noexcept;
+
     static std::size_t GetControlBlockSize() noexcept
     {
         return instance().GetControlBlockSize();

--- a/score/memory/shared/shared_memory_factory_impl.cpp
+++ b/score/memory/shared/shared_memory_factory_impl.cpp
@@ -11,6 +11,7 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 #include "score/memory/shared/shared_memory_factory_impl.h"
+#include "score/memory/shared/typedshm/typedshm_wrapper/typed_memory.h"
 #include "score/memory/shared/typedshm/utils/typed_memory_utils.h"
 #include "score/mw/log/logging.h"
 #include "score/os/errno_logging.h"
@@ -140,18 +141,22 @@ auto SharedMemoryFactoryImpl::Open(const std::string& path,
 {
     if (IsInterVmShmPath(path))
     {
-        score::mw::log::LogError("shm")
-            << "Opening inter-VM shared memory (path prefix '" << kInterVmSharedShmPrefix
-            << "') is not supported. No portable implementation exists yet. Rejecting path: " << path;
-        return nullptr;
+        if (intervm_memory_ptr_ == nullptr)
+        {
+            score::mw::log::LogError("shm")
+                << "Opening inter-VM shared memory (path prefix '" << kInterVmSharedShmPrefix
+                << "') requires an InterVM memory provider set via SetInterVMMemoryProvider(). Rejecting path: "
+                << path;
+            return nullptr;
+        }
     }
 
     std::lock_guard<std::mutex> lock{mutex_};
     auto resource = GetResourceIfAlreadyOpened(path, resources_);
     if (resource == nullptr)
     {
-        const auto result =
-            SharedMemoryResource::Open(path, is_read_write, &CreateAccessControlList, typed_memory_ptr_);
+        const auto effective_ptr = IsInterVmShmPath(path) ? intervm_memory_ptr_ : typed_memory_ptr_;
+        const auto result = SharedMemoryResource::Open(path, is_read_write, &CreateAccessControlList, effective_ptr);
         if (!result.has_value())
         {
             score::mw::log::LogWarn("shm") << "Could not open Shared Memory " << path << ":" << result.error();
@@ -185,10 +190,14 @@ auto score::memory::shared::SharedMemoryFactoryImpl::Create(std::string path,
 {
     if (IsInterVmShmPath(path))
     {
-        score::mw::log::LogError("shm")
-            << "Creating inter-VM shared memory (path prefix '" << kInterVmSharedShmPrefix
-            << "') is not supported. No portable implementation exists yet. Rejecting path: " << path;
-        return nullptr;
+        if (intervm_memory_ptr_ == nullptr)
+        {
+            score::mw::log::LogError("shm")
+                << "Creating inter-VM shared memory (path prefix '" << kInterVmSharedShmPrefix
+                << "') requires an InterVM memory provider set via SetInterVMMemoryProvider(). Rejecting path: "
+                << path;
+            return nullptr;
+        }
     }
 
     std::lock_guard<std::mutex> lock{mutex_};
@@ -198,17 +207,25 @@ auto score::memory::shared::SharedMemoryFactoryImpl::Create(std::string path,
         return nullptr;
     }
 
-    if (prefer_typed_memory && (typed_memory_ptr_ == nullptr))
+    std::shared_ptr<TypedMemory> effective_provider = nullptr;
+    if (IsInterVmShmPath(path))
     {
-        score::mw::log::LogError("shm")
-            << "Shared memory has to be created in typed memory but no typed memory instance has "
-               "been provided using the public interface SetTypedMemoryProvider ";
-        return nullptr;
+        effective_provider = intervm_memory_ptr_;
+    }
+    else if (prefer_typed_memory)
+    {
+        if (typed_memory_ptr_ == nullptr)
+        {
+            score::mw::log::LogError("shm")
+                << "Shared memory has to be created in typed memory but no typed memory instance has "
+                   "been provided using the public interface SetTypedMemoryProvider ";
+            return nullptr;
+        }
+        effective_provider = typed_memory_ptr_;
     }
 
-    const auto typed_memory_ptr = prefer_typed_memory ? typed_memory_ptr_ : nullptr;
     const auto result = SharedMemoryResource::Create(
-        path, user_space_to_reserve, std::move(cb), permissions, &CreateAccessControlList, typed_memory_ptr);
+        path, user_space_to_reserve, std::move(cb), permissions, &CreateAccessControlList, effective_provider);
     if (!result.has_value())
     {
         score::mw::log::LogWarn("shm") << "Could not create Shared Memory " << path << ":" << result.error();
@@ -265,31 +282,43 @@ auto score::memory::shared::SharedMemoryFactoryImpl::CreateOrOpen(
 {
     if (IsInterVmShmPath(path))
     {
-        score::mw::log::LogError("shm")
-            << "Creating or opening inter-VM shared memory (path prefix '" << kInterVmSharedShmPrefix
-            << "') is not supported. No portable implementation exists yet. Rejecting path: " << path;
-        return nullptr;
+        if (intervm_memory_ptr_ == nullptr)
+        {
+            score::mw::log::LogError("shm")
+                << "Creating or opening inter-VM shared memory (path prefix '" << kInterVmSharedShmPrefix
+                << "') requires an InterVM memory provider set via SetInterVMMemoryProvider(). Rejecting path: "
+                << path;
+            return nullptr;
+        }
     }
 
     std::lock_guard<std::mutex> lock{mutex_};
     auto resource = GetResourceIfAlreadyOpened(path, resources_);
     if (resource == nullptr)
     {
-        if ((prefer_typed_memory) && (typed_memory_ptr_ == nullptr))
+        std::shared_ptr<TypedMemory> effective_provider = nullptr;
+        if (IsInterVmShmPath(path))
         {
-            score::mw::log::LogError("shm")
-                << "Shared memory has to be created in typed memory but no typed memory instance "
-                   "has been provided using the public interface SetTypedMemoryProvider ";
-            return nullptr;
+            effective_provider = intervm_memory_ptr_;
+        }
+        else if (prefer_typed_memory)
+        {
+            if (typed_memory_ptr_ == nullptr)
+            {
+                score::mw::log::LogError("shm")
+                    << "Shared memory has to be created in typed memory but no typed memory instance "
+                       "has been provided using the public interface SetTypedMemoryProvider ";
+                return nullptr;
+            }
+            effective_provider = typed_memory_ptr_;
         }
 
-        const auto typed_memory_ptr = prefer_typed_memory ? typed_memory_ptr_ : nullptr;
         const auto result = SharedMemoryResource::CreateOrOpen(path,
                                                                user_space_to_reserve,
                                                                std::move(cb),
                                                                access_control.permissions_,
                                                                &CreateAccessControlList,
-                                                               typed_memory_ptr);
+                                                               effective_provider);
         if (!result.has_value())
         {
             score::mw::log::LogWarn("shm")
@@ -379,7 +408,12 @@ auto SharedMemoryFactoryImpl::RemoveStaleArtefacts(const std::string& path) noex
 
 auto SharedMemoryFactoryImpl::SetTypedMemoryProvider(std::shared_ptr<TypedMemory> typed_memory_ptr) noexcept -> void
 {
-    typed_memory_ptr_ = typed_memory_ptr;
+    typed_memory_ptr_ = std::move(typed_memory_ptr);
+}
+
+auto SharedMemoryFactoryImpl::SetInterVMMemoryProvider(std::shared_ptr<TypedMemory> intervm_memory_ptr) noexcept -> void
+{
+    intervm_memory_ptr_ = std::move(intervm_memory_ptr);
 }
 
 }  // namespace score::memory::shared

--- a/score/memory/shared/shared_memory_factory_impl.h
+++ b/score/memory/shared/shared_memory_factory_impl.h
@@ -59,6 +59,9 @@ class SharedMemoryFactoryImpl final : public ISharedMemoryFactory
 
     void SetTypedMemoryProvider(std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr) noexcept override;
 
+    void SetInterVMMemoryProvider(
+        std::shared_ptr<score::memory::shared::TypedMemory> intervm_memory_ptr) noexcept override;
+
     std::size_t GetControlBlockSize() noexcept override
     {
         return sizeof(score::memory::shared::SharedMemoryResource::ControlBlock);
@@ -73,6 +76,7 @@ class SharedMemoryFactoryImpl final : public ISharedMemoryFactory
     std::mutex mutex_{};
     std::unordered_map<std::string, std::weak_ptr<score::memory::shared::SharedMemoryResource>> resources_{};
     std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr_{memory::shared::TypedMemory::Default()};
+    std::shared_ptr<score::memory::shared::TypedMemory> intervm_memory_ptr_{nullptr};
 };
 
 }  // namespace score::memory::shared

--- a/score/memory/shared/shared_memory_factory_mock.h
+++ b/score/memory/shared/shared_memory_factory_mock.h
@@ -56,6 +56,11 @@ class SharedMemoryFactoryMock : public ISharedMemoryFactory
                 (std::shared_ptr<score::memory::shared::TypedMemory>),
                 (noexcept, override));
 
+    MOCK_METHOD(void,
+                SetInterVMMemoryProvider,
+                (std::shared_ptr<score::memory::shared::TypedMemory>),
+                (noexcept, override));
+
     MOCK_METHOD(std::size_t, GetControlBlockSize, (), (noexcept, override));
 
     MOCK_METHOD(void, Clear, (), (noexcept, override));

--- a/score/memory/shared/shared_memory_factory_test.cpp
+++ b/score/memory/shared/shared_memory_factory_test.cpp
@@ -45,6 +45,20 @@ static constexpr uid_t kNonMatchingProviders[] = {2, 3};
 
 namespace
 {
+class InterVMMemoryProviderScope final
+{
+  public:
+    explicit InterVMMemoryProviderScope(std::shared_ptr<TypedMemory> intervm_memory_ptr) noexcept
+    {
+        SharedMemoryFactory::SetInterVMMemoryProvider(std::move(intervm_memory_ptr));
+    }
+
+    ~InterVMMemoryProviderScope()
+    {
+        SharedMemoryFactory::SetInterVMMemoryProvider(nullptr);
+    }
+};
+
 void RunNThreadsToCompletion(const std::function<void()>& function, const std::size_t num_threads)
 {
     std::vector<std::thread> threads{};
@@ -1195,36 +1209,42 @@ TEST_F(SharedMemoryFactoryDeathTest, FailingToInsertResourceIntoRegistryTerminat
     EXPECT_DEATH(resource_attorney.mapMemoryIntoProcess(), ".*");
 }
 
-TEST_F(SharedMemoryFactoryTest, OpenWithInterVmPathReturnsNullptr)
+TEST_F(SharedMemoryFactoryTest, OpenWithInterVmPathReturnsNullptrWhenProviderNotSet)
 {
     // Given a shared memory path using the inter-VM prefix
     const std::string inter_vm_path{"/intervm-shared-shmem/lola-data-0000000000004660-00001"};
 
+    // And no InterVM memory provider has been set
+
     // When opening shared memory using this path
-    // Then nullptr is returned and no OS calls are made (no mock expectations set)
+    // Then nullptr is returned because InterVM provider is required but not set
     const auto result = SharedMemoryFactory::Open(inter_vm_path, false);
     EXPECT_EQ(result, nullptr);
 }
 
-TEST_F(SharedMemoryFactoryTest, CreateWithInterVmPathReturnsNullptr)
+TEST_F(SharedMemoryFactoryTest, CreateWithInterVmPathReturnsNullptrWhenProviderNotSet)
 {
     // Given a shared memory path using the inter-VM prefix
     const std::string inter_vm_path{"/intervm-shared-shmem/lola-ctl-0000000000004660-00001-b"};
 
+    // And no InterVM memory provider has been set
+
     // When creating shared memory using this path
-    // Then nullptr is returned and no OS calls are made (no mock expectations set)
+    // Then nullptr is returned because InterVM provider is required but not set
     const auto result = SharedMemoryFactory::Create(
         inter_vm_path, [](std::shared_ptr<ISharedMemoryResource>) {}, kSharedMemorySize, {}, false);
     EXPECT_EQ(result, nullptr);
 }
 
-TEST_F(SharedMemoryFactoryTest, CreateOrOpenWithInterVmPathReturnsNullptr)
+TEST_F(SharedMemoryFactoryTest, CreateOrOpenWithInterVmPathReturnsNullptrWhenProviderNotSet)
 {
     // Given a shared memory path using the inter-VM prefix
     const std::string inter_vm_path{"/intervm-shared-shmem/lola-methods-0000000000004660-00001-00002-00003"};
 
+    // And no InterVM memory provider has been set
+
     // When creating or opening shared memory using this path
-    // Then nullptr is returned and no OS calls are made (no mock expectations set)
+    // Then nullptr is returned because InterVM provider is required but not set
     const auto result = SharedMemoryFactory::CreateOrOpen(
         inter_vm_path,
         [](std::shared_ptr<ISharedMemoryResource>) {},
@@ -1232,6 +1252,137 @@ TEST_F(SharedMemoryFactoryTest, CreateOrOpenWithInterVmPathReturnsNullptr)
         SharedMemoryResource::AccessControl{{}, {}},
         false);
     EXPECT_EQ(result, nullptr);
+}
+
+TEST_F(SharedMemoryFactoryTest, OpenWithInterVmPathSucceedsWhenProviderIsSet)
+{
+    InSequence sequence{};
+
+    // Given a shared memory path using the inter-VM prefix
+    const std::string inter_vm_path{"/intervm-shared-shmem/lola-data-0000000000004660-00001"};
+    const auto lock_file_path = SharedMemoryResourceTestAttorney::GetLockFilePath(inter_vm_path);
+
+    // And an InterVM memory provider has been set
+    auto intervm_mock = std::make_shared<TypedMemoryMock>();
+    InterVMMemoryProviderScope intervm_memory_provider_scope{intervm_mock};
+    SharedMemoryFactory::SetTypedMemoryProvider(nullptr);
+
+    // And the shared memory can be opened successfully
+    constexpr bool is_read_write = false;
+    expectCreateLockFileReturns(lock_file_path, kLockFileDescriptor);
+    expectShmOpenReturns(inter_vm_path, kFileDescriptor, is_read_write);
+    expectFstatReturns(kFileDescriptor);
+    expectMmapReturns(reinterpret_cast<void*>(1), kFileDescriptor, is_read_write);
+    EXPECT_CALL(*unistd_mock_, close(kLockFileDescriptor));
+    EXPECT_CALL(*unistd_mock_, unlink(StrEq(lock_file_path)));
+    EXPECT_CALL(*mman_mock_, munmap(_, _));
+    EXPECT_CALL(*unistd_mock_, close(kFileDescriptor));
+
+    // When opening shared memory using this path
+    const auto result = SharedMemoryFactory::Open(inter_vm_path, is_read_write);
+
+    // Then the resource is successfully opened
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result->getPath(), inter_vm_path);
+    EXPECT_FALSE(result->IsShmInTypedMemory());
+}
+
+TEST_F(SharedMemoryFactoryTest, CreateWithInterVmPathSucceedsWhenProviderIsSet)
+{
+    InSequence sequence{};
+
+    // Given a shared memory path using the inter-VM prefix
+    const std::string inter_vm_path{"/intervm-shared-shmem/lola-ctl-0000000000004660-00001-b"};
+    const auto lock_file_path = SharedMemoryResourceTestAttorney::GetLockFilePath(inter_vm_path);
+
+    // And an InterVM memory provider has been set
+    auto intervm_mock = std::make_shared<TypedMemoryMock>();
+    InterVMMemoryProviderScope intervm_memory_provider_scope{intervm_mock};
+    SharedMemoryFactory::SetTypedMemoryProvider(nullptr);
+
+    // And shared memory can be created successfully using the InterVM provider
+    std::array<std::uint8_t, kSharedMemorySize> dataRegion{};
+    const bool prefer_typed_memory = false;
+    const auto oflags = score::os::Fcntl::Open::kReadWrite | score::os::Fcntl::Open::kExclusive;
+    expectCreateLockFileReturns(lock_file_path, kLockFileDescriptor);
+    EXPECT_CALL(*intervm_mock, AllocateNamedTypedMemory(_, inter_vm_path, _)).WillOnce(Return(score::cpp::blank{}));
+    EXPECT_CALL(*mman_mock_, shm_open(StrEq(inter_vm_path), oflags, _)).WillOnce(Return(kFileDescriptor));
+    expectFstatReturns(kFileDescriptor);
+    EXPECT_CALL(*stat_mock_, stat(StrEq(kTSHMDeviceName), _, _))
+        .Times(::testing::AtMost(1))
+        .WillRepeatedly(Return(score::cpp::blank{}));
+    expectMmapReturns(dataRegion.data(), kFileDescriptor);
+    EXPECT_CALL(*unistd_mock_, close(kLockFileDescriptor));
+    EXPECT_CALL(*unistd_mock_, unlink(StrEq(lock_file_path)));
+
+    EXPECT_CALL(*mman_mock_, munmap(_, _));
+    EXPECT_CALL(*unistd_mock_, close(kFileDescriptor));
+
+    // When creating shared memory using this path
+    const auto result = SharedMemoryFactory::Create(
+        inter_vm_path, [](std::shared_ptr<ISharedMemoryResource>) {}, kSharedMemorySize, {}, prefer_typed_memory);
+
+    // Then the resource is successfully created
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result->getPath(), inter_vm_path);
+    EXPECT_TRUE(result->IsShmInTypedMemory());
+}
+
+TEST_F(SharedMemoryFactoryTest, CreateOrOpenWithInterVmPathSucceedsWhenProviderIsSet)
+{
+    InSequence sequence{};
+
+    // Given a shared memory path using the inter-VM prefix
+    const std::string inter_vm_path{"/intervm-shared-shmem/lola-methods-0000000000004660-00001-00002-00003"};
+    const auto lock_file_path = SharedMemoryResourceTestAttorney::GetLockFilePath(inter_vm_path);
+
+    // And an InterVM memory provider has been set
+    auto intervm_mock = std::make_shared<TypedMemoryMock>();
+    InterVMMemoryProviderScope intervm_memory_provider_scope{intervm_mock};
+    SharedMemoryFactory::SetTypedMemoryProvider(nullptr);
+
+    // And shared memory can be created successfully (CreateOrOpen tries Create after Open fails)
+    std::array<std::uint8_t, kSharedMemorySize> dataRegion{};
+    const bool prefer_typed_memory = false;
+    const auto oflags = score::os::Fcntl::Open::kReadWrite | score::os::Fcntl::Open::kExclusive;
+
+    // CreateOrOpen will first try to Open (which fails), then Create
+    constexpr std::int32_t open_lock_file_descriptor = 10;
+    constexpr bool is_read_write = true;
+
+    // Expect the Open attempt to fail
+    expectCreateLockFileReturns(lock_file_path, open_lock_file_descriptor);
+    expectShmOpenReturns(inter_vm_path, score::cpp::make_unexpected(Error::createFromErrno(ENOENT)), is_read_write);
+    EXPECT_CALL(*unistd_mock_, close(open_lock_file_descriptor));
+    EXPECT_CALL(*unistd_mock_, unlink(StrEq(lock_file_path)));
+
+    // Then expect the Create to succeed
+    expectCreateLockFileReturns(lock_file_path, kLockFileDescriptor);
+    EXPECT_CALL(*intervm_mock, AllocateNamedTypedMemory(_, inter_vm_path, _)).WillOnce(Return(score::cpp::blank{}));
+    EXPECT_CALL(*mman_mock_, shm_open(StrEq(inter_vm_path), oflags, _)).WillOnce(Return(kFileDescriptor));
+    expectFstatReturns(kFileDescriptor);
+    EXPECT_CALL(*stat_mock_, stat(StrEq(kTSHMDeviceName), _, _))
+        .Times(::testing::AtMost(1))
+        .WillRepeatedly(Return(score::cpp::blank{}));
+    expectMmapReturns(dataRegion.data(), kFileDescriptor);
+    EXPECT_CALL(*unistd_mock_, close(kLockFileDescriptor));
+    EXPECT_CALL(*unistd_mock_, unlink(StrEq(lock_file_path)));
+
+    EXPECT_CALL(*mman_mock_, munmap(_, _));
+    EXPECT_CALL(*unistd_mock_, close(kFileDescriptor));
+
+    // When creating or opening shared memory using this path
+    const auto result = SharedMemoryFactory::CreateOrOpen(
+        inter_vm_path,
+        [](std::shared_ptr<ISharedMemoryResource>) {},
+        kSharedMemorySize,
+        SharedMemoryResource::AccessControl{{}, {}},
+        prefer_typed_memory);
+
+    // Then the resource is successfully created or opened
+    ASSERT_NE(result, nullptr);
+    EXPECT_EQ(*result->getPath(), inter_vm_path);
+    EXPECT_TRUE(result->IsShmInTypedMemory());
 }
 
 }  // namespace score::memory::shared::test

--- a/score/memory/shared/shared_memory_resource.h
+++ b/score/memory/shared/shared_memory_resource.h
@@ -22,7 +22,6 @@
 #include "score/os/fcntl.h"
 #include "score/os/mman.h"
 #include "score/os/stat.h"
-#include "score/os/utils/interprocess/interprocess_mutex.h"
 
 #include <score/expected.hpp>
 #include <score/memory_resource.hpp>


### PR DESCRIPTION
Add a separate InterVM memory provider that is used when the shm path has the inter-VM prefix (/intervm-shared-shmem/).

Issue: https://github.com/eclipse-score/communication/issues/387