### PR TITLE
fix(codeql): resolve compiled pack root via realpath to avoid symlink farm

### DIFF
--- a/quality/static_analysis/codeql_lint.py
+++ b/quality/static_analysis/codeql_lint.py
@@ -83,7 +83,14 @@ def _find_compiled_pack_root():
             "in this target's `data`. Refusing to fall back to any other query "
             "source.")
     # anchor = <pack_root>/qlpack.yml
-    pack_root = os.path.dirname(anchor)
+    # Resolve symlinks: Bazel runfiles are a symlink farm where individual files
+    # are symlinked into the runfiles tree.  CodeQL's data-extension glob
+    # (qlpack.yml `dataExtensions:`) does NOT follow symlinks when matching
+    # .model.yml files, so using the runfiles path causes all extensible
+    # predicates (allocationFunctionModel, throwingFunctionModel, etc.) to come
+    # up as undefined.  realpath() jumps from the runfiles symlink to the actual
+    # Bazel external-repository directory, where the model files are real files.
+    pack_root = os.path.dirname(os.path.realpath(anchor))
 
     suite_path = os.path.join(pack_root, MISRA_DEFAULT_SUITE_NAME)
     if not os.path.exists(suite_path):


### PR DESCRIPTION
Bazel runfiles are a symlink farm: individual files are symlinked into a mirrored tree.  CodeQL's data-extension glob (qlpack.yml `dataExtensions:`) does NOT follow symlinks when matching *.model.yml files, so when --search-path pointed into the runfiles tree the extensible predicates allocationFunctionModel, deallocationFunctionModel, throwingFunctionModel and unicodeHasBooleanProperty had no data loaded, causing 33 of 218 queries to fail with 'extensional predicate ... has not been defined'.

The fix: call os.path.realpath() on the anchor path returned by Rlocation() before deriving the pack root.  realpath() jumps from the runfiles symlink directly to the Bazel external-repository directory where the model files are real (non-symlink) files, so CodeQL's glob finds them correctly.

The pack itself (v2.62.0) and the bundle version (2.21.4) are correct and compatible; only the symlink-farm indirection was masking the extensions.