### PR TITLE
fix(misra): remove noexcept from functions that can propagate exceptions (RULE-18-5-1)

### DIFF
--- a/score/memory/shared/memory_resource_proxy.cpp
+++ b/score/memory/shared/memory_resource_proxy.cpp
@@ -76,7 +76,7 @@ auto MemoryResourceProxy::deallocate(void* const memory, const std::size_t byte)
 // before calling value(), an exception will never be called and therefore there will never be an implicit
 // std::terminate call.
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-void MemoryResourceProxy::PerformBoundsCheck(const std::uint64_t memory_identifier) const noexcept
+void MemoryResourceProxy::PerformBoundsCheck(const std::uint64_t memory_identifier) const
 {
     auto memory_bounds =
         score::memory::shared::MemoryResourceRegistry::getInstance().GetBoundsFromIdentifier(memory_identifier);

--- a/score/memory/shared/memory_resource_proxy.h
+++ b/score/memory/shared/memory_resource_proxy.h
@@ -77,7 +77,7 @@ class MemoryResourceProxy
     static bool EnableBoundsChecking(const bool enable) noexcept;
 
   private:
-    void PerformBoundsCheck(const std::uint64_t memory_identifier) const noexcept;
+    void PerformBoundsCheck(const std::uint64_t memory_identifier) const;
 
     const std::uint64_t memory_identifier_;
     /// \brief shall bounds-checking be enabled or not within the process.

--- a/score/memory/shared/offset_ptr_bounds_check.cpp
+++ b/score/memory/shared/offset_ptr_bounds_check.cpp
@@ -94,7 +94,7 @@ bool DoesOffsetPtrNotInSharedMemoryPassBoundsChecks(const void* const offset_ptr
                                                     const std::ptrdiff_t offset,
                                                     const MemoryRegionBounds& offset_ptr_memory_bounds,
                                                     const std::size_t pointed_type_size,
-                                                    const std::size_t offset_ptr_size) noexcept
+                                                    const std::size_t offset_ptr_size)
 {
     // Check that the entire OffsetPtr lies outside a memory region
     const auto offset_ptr_address_as_integer = CastPointerToInteger(offset_ptr_address);

--- a/score/memory/shared/offset_ptr_bounds_check.h
+++ b/score/memory/shared/offset_ptr_bounds_check.h
@@ -32,7 +32,7 @@ bool DoesOffsetPtrNotInSharedMemoryPassBoundsChecks(const void* const offset_ptr
                                                     const std::ptrdiff_t offset,
                                                     const MemoryRegionBounds& offset_ptr_memory_bounds,
                                                     const std::size_t pointed_type_size,
-                                                    const std::size_t offset_ptr_size) noexcept;
+                                                    const std::size_t offset_ptr_size);
 
 }  // namespace score::memory::shared
 

--- a/score/memory/shared/polymorphic_offset_ptr_allocator.h
+++ b/score/memory/shared/polymorphic_offset_ptr_allocator.h
@@ -52,8 +52,7 @@ class PolymorphicOffsetPtrAllocator
     // Non-explicit constructor is good enough for maintaining required implicit conversion.
     // In addition semantically is a copy constructor.
     // NOLINTNEXTLINE(google-explicit-constructor): Tolerated, discard explicit.
-    PolymorphicOffsetPtrAllocator(const PolymorphicOffsetPtrAllocator<U>& rhs) noexcept
-        : proxy_(rhs.getMemoryResourceProxy())
+    PolymorphicOffsetPtrAllocator(const PolymorphicOffsetPtrAllocator<U>& rhs) : proxy_(rhs.getMemoryResourceProxy())
     {
     }
 
@@ -65,7 +64,7 @@ class PolymorphicOffsetPtrAllocator
     auto allocate(size_type size) -> pointer;
     void deallocate(pointer p, size_type size);
 
-    OffsetPtr<const MemoryResourceProxy> getMemoryResourceProxy() const noexcept;
+    OffsetPtr<const MemoryResourceProxy> getMemoryResourceProxy() const;
 
     template <typename U>
     friend bool operator==(const PolymorphicOffsetPtrAllocator<U>& lhs,
@@ -141,7 +140,7 @@ template <typename T>
 // SCORE_LANGUAGE_FUTURECPP_EXPECT_CONTRACT_VIOLATED macro) and will NEVER throw an exception in production code.
 // Therefore, an implicit termination due to an exception being thrown will never occur here in production.
 // coverity[autosar_cpp14_a15_5_3_violation]
-OffsetPtr<const MemoryResourceProxy> PolymorphicOffsetPtrAllocator<T>::getMemoryResourceProxy() const noexcept
+OffsetPtr<const MemoryResourceProxy> PolymorphicOffsetPtrAllocator<T>::getMemoryResourceProxy() const
 {
     return proxy_;
 }

--- a/score/memory/shared/shared_memory_resource.cpp
+++ b/score/memory/shared/shared_memory_resource.cpp
@@ -457,7 +457,7 @@ SharedMemoryResource::SharedMemoryResource(std::uint64_t shared_memory_resource_
 // coverity[autosar_cpp14_a15_5_3_violation]
 SharedMemoryResource::SharedMemoryResource(std::variant<std::string, std::uint64_t> identifier,
                                            AccessControlListFactory acl_factory,
-                                           std::shared_ptr<TypedMemory> typed_memory_ptr) noexcept
+                                           std::shared_ptr<TypedMemory> typed_memory_ptr)
     : ISharedMemoryResource{},
       std::enable_shared_from_this<SharedMemoryResource>{},
       file_descriptor_{-1},
@@ -497,7 +497,7 @@ SharedMemoryResource::SharedMemoryResource(std::variant<std::string, std::uint64
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
 score::cpp::expected_blank<Error> SharedMemoryResource::CreateImpl(const std::size_t user_space_to_reserve,
                                                                    const InitializeCallback initialize_callback,
-                                                                   const UserPermissions& permissions) noexcept
+                                                                   const UserPermissions& permissions)
 {
     this->opening_mode_ = Fcntl::Open::kReadWrite;
     this->map_mode_ = ::score::os::Mman::Protection::kRead | ::score::os::Mman::Protection::kWrite;
@@ -613,7 +613,7 @@ score::cpp::expected_blank<Error> SharedMemoryResource::OpenImpl(const bool is_r
 
 // Warning is due to score::cpp::expected value() but the rationale is the same as for score::Result::value() above
 // coverity[autosar_cpp14_a15_5_3_violation]
-auto SharedMemoryResource::acquireLockAndOpenSharedMemory() noexcept -> score::cpp::expected_blank<Error>
+auto SharedMemoryResource::acquireLockAndOpenSharedMemory() -> score::cpp::expected_blank<Error>
 {
     const auto* const path = std::get_if<std::string>(&shared_memory_resource_identifier_);
     const auto is_named_shm = (path != nullptr);
@@ -987,7 +987,7 @@ auto SharedMemoryResource::initializeControlBlock() noexcept -> void
 
 // Warning is due to std::optional::value but the rationale is the same as for std::optional:value() above
 // coverity[autosar_cpp14_a15_5_3_violation]
-auto SharedMemoryResource::acquireLockFile() const noexcept -> std::optional<LockFile>
+auto SharedMemoryResource::acquireLockFile() const -> std::optional<LockFile>
 {
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(lock_file_path_.has_value(), "Lock file path is not set.");
 
@@ -1011,7 +1011,7 @@ auto SharedMemoryResource::acquireLockFile() const noexcept -> std::optional<Loc
 // Warning is due to std::optional::value but the rationale is the same as for std::optional:value() above
 // coverity[autosar_cpp14_a15_5_3_violation]
 score::cpp::expected_blank<score::os::Error> SharedMemoryResource::CreateLockFileForNamedSharedMemory(
-    std::optional<LockFile>& lock_file) noexcept
+    std::optional<LockFile>& lock_file)
 {
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(lock_file_path_.has_value(), "Lock file path is not set.");
     lock_file = LockFile::Create(this->lock_file_path_.value());

--- a/score/memory/shared/shared_memory_resource.h
+++ b/score/memory/shared/shared_memory_resource.h
@@ -158,7 +158,7 @@ class SharedMemoryResource : public ISharedMemoryResource, public std::enable_sh
 
     SharedMemoryResource(std::variant<std::string, std::uint64_t> identifier,
                          AccessControlListFactory acl_factory,
-                         std::shared_ptr<TypedMemory> typed_memory_ptr) noexcept;
+                         std::shared_ptr<TypedMemory> typed_memory_ptr);
 
   private:
     // Suppress "AUTOSAR C++14 A11-3-1" rule finding: "Friend declarations shall not be used.".
@@ -219,14 +219,14 @@ class SharedMemoryResource : public ISharedMemoryResource, public std::enable_sh
     /// acquired within the timeout, the process terminates. The caller must keep the returned LockFile alive for the
     /// duration of the critical section (e.g. shm_open + fstat + mmap) to ensure mutual exclusion with CreateImpl.
     /// \return The acquired LockFile. The function never returns std::nullopt; it either succeeds or terminates.
-    std::optional<LockFile> acquireLockFile() const noexcept;
+    std::optional<LockFile> acquireLockFile() const;
 
     /// \brief Acquires a lock file and then opens an existing shared-memory object.
     /// \details The lock file is held across the entire shm_open + fstat + mmap sequence to prevent a concurrent
     /// CreateImpl from initializing the same SHM region while this function is reading it.
     /// \return Empty result on success, score::os::Error on failure (e.g. shared-memory object does not exist).
     // coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
-    score::cpp::expected_blank<score::os::Error> acquireLockAndOpenSharedMemory() noexcept;
+    score::cpp::expected_blank<score::os::Error> acquireLockAndOpenSharedMemory();
 
     void loadInternalsFromSharedMemory() noexcept;
     void initializeInternalsInSharedMemory() noexcept;
@@ -240,7 +240,7 @@ class SharedMemoryResource : public ISharedMemoryResource, public std::enable_sh
     // coverity[autosar_cpp14_a15_5_3_violation]
     // coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
     // coverity[autosar_cpp14_a0_1_3_violation] false-positive: used in CreateImpl
-    std::shared_ptr<SharedMemoryResource> getSharedPtr() noexcept
+    std::shared_ptr<SharedMemoryResource> getSharedPtr()
     {
         return shared_from_this();
     }
@@ -344,7 +344,7 @@ class SharedMemoryResource : public ISharedMemoryResource, public std::enable_sh
     // coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
     score::cpp::expected_blank<score::os::Error> CreateImpl(const std::size_t user_space_to_reserve,
                                                             const InitializeCallback initialize_callback,
-                                                            const UserPermissions& permissions) noexcept;
+                                                            const UserPermissions& permissions);
 
     /// \brief Called by SharedMemoryResource::CreateOrOpen() after calling the constructor.
     /// \return in case of error an score::os::Error is returned.
@@ -419,8 +419,7 @@ class SharedMemoryResource : public ISharedMemoryResource, public std::enable_sh
     bool do_is_equal(const memory_resource& other) const noexcept override;
 
     // coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
-    score::cpp::expected_blank<score::os::Error> CreateLockFileForNamedSharedMemory(
-        std::optional<LockFile>& lock_file) noexcept;
+    score::cpp::expected_blank<score::os::Error> CreateLockFileForNamedSharedMemory(std::optional<LockFile>& lock_file);
     // coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
     void AllocateInTypedMemory(const UserPermissions& permissions, os::Fcntl::Open& flags) noexcept;
 

--- a/score/message_passing/unix_domain/unix_domain_server.cpp
+++ b/score/message_passing/unix_domain/unix_domain_server.cpp
@@ -49,7 +49,7 @@ void UnixDomainServer::ServerConnection::AcceptConnection(UserData&& data,
     endpoint_.owner = &server_;
     endpoint_.fd = fd_;
     endpoint_.max_receive_size = server_.max_request_size_;
-    endpoint_.input = [this]() noexcept {
+    endpoint_.input = [this]() {
         if (!ProcessInput())
         {
             server_.engine_->UnregisterPosixEndpoint(endpoint_);

--- a/score/mw/com/api_surface.lock.json
+++ b/score/mw/com/api_surface.lock.json
@@ -341,7 +341,7 @@
       "name": "OfferService",
       "qualified_name": "score::mw::com::GenericSkeleton::OfferService",
       "kind": "method",
-      "signature": "OfferService : Result<void> () noexcept [[nodiscard]]"
+      "signature": "OfferService : Result<void> () [[nodiscard]]"
     },
     {
       "name": "StopOfferService",
@@ -421,7 +421,13 @@
       "name": "InitializeRuntime",
       "qualified_name": "score::mw::com::runtime::IRuntime::InitializeRuntime",
       "kind": "method",
-      "signature": "InitializeRuntime : void (const std::int32_t, score::cpp::span<const score::StringLiteral>)"
+      "signature": "InitializeRuntime : void (const std::int32_t, score::cpp::span<const char *>) [[deprecated]]"
+    },
+    {
+      "name": "InitializeRuntime",
+      "qualified_name": "score::mw::com::runtime::IRuntime::InitializeRuntime",
+      "kind": "method",
+      "signature": "InitializeRuntime : void (const cpp::span<safecpp::zstring_view>)"
     },
     {
       "name": "InitializeRuntime",
@@ -454,10 +460,22 @@
       "signature": "operator= : IRuntime &(const IRuntime &) &"
     },
     {
+      "name": "InitializeRuntime",
+      "qualified_name": "score::mw::com::runtime::InitializeRuntime",
+      "kind": "function",
+      "signature": "InitializeRuntime : void (const std::int32_t, const char **) [[deprecated]]"
+    },
+    {
       "name": "RuntimeConfiguration",
       "qualified_name": "score::mw::com::runtime::RuntimeConfiguration::RuntimeConfiguration",
       "kind": "constructor",
       "signature": "RuntimeConfiguration : void ()"
+    },
+    {
+      "name": "RuntimeConfiguration",
+      "qualified_name": "score::mw::com::runtime::RuntimeConfiguration::RuntimeConfiguration",
+      "kind": "constructor",
+      "signature": "RuntimeConfiguration : void (const std::int32_t, const char **) [[deprecated]]"
     },
     {
       "name": "~InstanceIdentifier",

--- a/score/mw/com/impl/bindings/lola/generic_proxy_event.cpp
+++ b/score/mw/com/impl/bindings/lola/generic_proxy_event.cpp
@@ -63,7 +63,7 @@ inline Result<std::size_t> GenericProxyEvent::GetNumNewSamplesAvailable() const 
     return GetNumNewSamplesAvailableImpl();
 }
 
-inline Result<std::size_t> GenericProxyEvent::GetNewSamples(Callback&& receiver, TrackerGuardFactory& tracker) noexcept
+inline Result<std::size_t> GenericProxyEvent::GetNewSamples(Callback&& receiver, TrackerGuardFactory& tracker)
 {
     /// In case of LoLa binding we can also dispatch to GetNewSamplesImpl() in case of kSubscriptionPending!
     /// Because a pre-condition to kSubscriptionPending is that we once had a successful subscription... and then we can
@@ -123,7 +123,7 @@ std::optional<std::uint16_t> GenericProxyEvent::GetMaxSampleCount() const noexce
     return proxy_event_common_.GetMaxSampleCount();
 }
 
-Result<std::size_t> GenericProxyEvent::GetNumNewSamplesAvailableImpl() const noexcept
+Result<std::size_t> GenericProxyEvent::GetNumNewSamplesAvailableImpl() const
 {
     return proxy_event_common_.GetNumNewSamplesAvailable();
 }

--- a/score/mw/com/impl/bindings/lola/generic_proxy_event.h
+++ b/score/mw/com/impl/bindings/lola/generic_proxy_event.h
@@ -62,7 +62,7 @@ class GenericProxyEvent final : public GenericProxyEventBinding
 
     SubscriptionState GetSubscriptionState() const noexcept override;
     Result<std::size_t> GetNumNewSamplesAvailable() const noexcept override;
-    Result<std::size_t> GetNewSamples(Callback&& receiver, TrackerGuardFactory& tracker) noexcept override;
+    Result<std::size_t> GetNewSamples(Callback&& receiver, TrackerGuardFactory& tracker) override;
     std::size_t GetSampleSize() const noexcept override;
     bool HasSerializedFormat() const noexcept override;
 
@@ -82,7 +82,7 @@ class GenericProxyEvent final : public GenericProxyEventBinding
 
   private:
     Result<std::size_t> GetNewSamplesImpl(Callback&& receiver, TrackerGuardFactory& tracker);
-    Result<std::size_t> GetNumNewSamplesAvailableImpl() const noexcept;
+    Result<std::size_t> GetNumNewSamplesAvailableImpl() const;
 
     ProxyEventCommon proxy_event_common_;
     const EventMetaInfo& meta_info_;

--- a/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client.cpp
+++ b/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client.cpp
@@ -44,7 +44,7 @@ auto ReadMaskSet(const os::InotifyEvent& event, const os::InotifyEvent::ReadMask
 }
 
 std::vector<HandleType> GetKnownHandles(EnrichedInstanceIdentifier enriched_instance_identifier,
-                                        QualityAwareContainer<KnownInstancesContainer> known_instances) noexcept
+                                        QualityAwareContainer<KnownInstancesContainer> known_instances)
 {
     std::vector<HandleType> known_handles{};
     // Suppress "AUTOSAR C++14 M6-4-3" rule finding. This rule declares: "A switch statement shall be
@@ -328,8 +328,7 @@ auto ServiceDiscoveryClient::TransferObsoleteSearchRequests() noexcept -> void
     obsolete_search_requests_.clear();
 }
 
-auto ServiceDiscoveryClient::TransferObsoleteSearchRequest(const FindServiceHandle& find_service_handle) noexcept
-    -> void
+auto ServiceDiscoveryClient::TransferObsoleteSearchRequest(const FindServiceHandle& find_service_handle) -> void
 {
     const auto search_iterator = search_requests_.find(find_service_handle);
     if (search_iterator == search_requests_.end())
@@ -373,7 +372,7 @@ auto ServiceDiscoveryClient::TransferObsoleteSearchRequest(const FindServiceHand
 
 auto ServiceDiscoveryClient::HandleEvents(
     const score::cpp::expected<score::cpp::static_vector<os::InotifyEvent, os::InotifyInstance::max_events>, os::Error>&
-        expected_events) noexcept -> void
+        expected_events) -> void
 {
     // Suppress Autosar C++14 A8-5-3 states that auto variables shall not be initialized using braced initialization.
     // This is a false positive, we don't use auto here.
@@ -447,7 +446,7 @@ auto ServiceDiscoveryClient::HandleEvents(
     HandleCreationEvents(creation_events);
 }
 
-auto ServiceDiscoveryClient::HandleDeletionEvents(const std::vector<os::InotifyEvent>& events) noexcept -> void
+auto ServiceDiscoveryClient::HandleDeletionEvents(const std::vector<os::InotifyEvent>& events) -> void
 {
     std::unordered_set<FindServiceHandle> impacted_searches{};
     for (const auto& event : events)
@@ -486,7 +485,7 @@ auto ServiceDiscoveryClient::HandleDeletionEvents(const std::vector<os::InotifyE
     CallHandlers(impacted_searches);
 }
 
-auto ServiceDiscoveryClient::HandleCreationEvents(const std::vector<os::InotifyEvent>& events) noexcept -> void
+auto ServiceDiscoveryClient::HandleCreationEvents(const std::vector<os::InotifyEvent>& events) -> void
 {
     std::unordered_set<FindServiceHandle> impacted_searches{};
     for (const auto& event : events)
@@ -515,7 +514,7 @@ auto ServiceDiscoveryClient::HandleCreationEvents(const std::vector<os::InotifyE
     CallHandlers(impacted_searches);
 }
 
-auto ServiceDiscoveryClient::CallHandlers(const std::unordered_set<FindServiceHandle>& search_keys) noexcept -> void
+auto ServiceDiscoveryClient::CallHandlers(const std::unordered_set<FindServiceHandle>& search_keys) -> void
 {
     for (const auto& search_key : search_keys)
     {
@@ -598,7 +597,7 @@ auto ServiceDiscoveryClient::CallHandlers(const std::unordered_set<FindServiceHa
 }
 
 auto ServiceDiscoveryClient::StoreWatch(const os::InotifyWatchDescriptor& watch_descriptor,
-                                        const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept
+                                        const EnrichedInstanceIdentifier& enriched_instance_identifier)
     -> WatchesContainer::iterator
 {
     const auto watch_result = watches_.emplace(
@@ -623,7 +622,7 @@ auto ServiceDiscoveryClient::StoreWatch(const os::InotifyWatchDescriptor& watch_
     return watch_result.first;
 }
 
-auto ServiceDiscoveryClient::EraseWatch(const WatchesContainer::iterator& watch_iterator) noexcept -> void
+auto ServiceDiscoveryClient::EraseWatch(const WatchesContainer::iterator& watch_iterator) -> void
 {
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(watch_iterator->second.find_service_handles.empty(),
                                                       "Watch must not be associated to any searches");
@@ -818,7 +817,7 @@ auto ServiceDiscoveryClient::OnInstanceDirectoryCreated(const WatchesContainer::
 }
 
 void ServiceDiscoveryClient::OnInstanceFlagFileCreated(const WatchesContainer::iterator& watch_iterator,
-                                                       const std::string_view name) noexcept
+                                                       const std::string_view name)
 {
     const auto& enriched_instance_identifier = watch_iterator->second.enriched_instance_identifier;
 
@@ -863,7 +862,7 @@ void ServiceDiscoveryClient::OnInstanceFlagFileCreated(const WatchesContainer::i
 }
 
 void ServiceDiscoveryClient::OnInstanceFlagFileRemoved(const WatchesContainer::iterator& watch_iterator,
-                                                       std::string_view name) noexcept
+                                                       std::string_view name)
 {
     const auto& enriched_instance_identifier = watch_iterator->second.enriched_instance_identifier;
 

--- a/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client.h
+++ b/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client.h
@@ -133,12 +133,12 @@ class ServiceDiscoveryClient final : public IServiceDiscoveryClient
     using WatchesContainer = std::unordered_map<os::InotifyWatchDescriptor, Watch>;
     using Disambiguator = std::uint64_t;
 
-    void CallHandlers(const std::unordered_set<FindServiceHandle>& search_keys) noexcept;
+    void CallHandlers(const std::unordered_set<FindServiceHandle>& search_keys);
 
     WatchesContainer::iterator StoreWatch(const os::InotifyWatchDescriptor& watch_descriptor,
-                                          const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept;
+                                          const EnrichedInstanceIdentifier& enriched_instance_identifier);
 
-    void EraseWatch(const WatchesContainer::iterator& watch_iterator) noexcept;
+    void EraseWatch(const WatchesContainer::iterator& watch_iterator);
 
     void LinkWatchWithSearchRequest(const WatchesContainer::iterator& watch_iterator,
                                     const SearchRequestsContainer::iterator& search_iterator) noexcept;
@@ -148,22 +148,21 @@ class ServiceDiscoveryClient final : public IServiceDiscoveryClient
 
     void OnInstanceDirectoryCreated(const WatchesContainer::iterator& watch_iterator, std::string_view name);
 
-    void OnInstanceFlagFileCreated(const WatchesContainer::iterator& watch_iterator,
-                                   const std::string_view name) noexcept;
-    void OnInstanceFlagFileRemoved(const WatchesContainer::iterator& watch_iterator, std::string_view name) noexcept;
+    void OnInstanceFlagFileCreated(const WatchesContainer::iterator& watch_iterator, const std::string_view name);
+    void OnInstanceFlagFileRemoved(const WatchesContainer::iterator& watch_iterator, std::string_view name);
 
     void TransferSearchRequests() noexcept;
     SearchRequestsContainer::value_type& TransferNewSearchRequest(NewSearchRequest search_request) noexcept;
     void TransferObsoleteSearchRequests() noexcept;
 
-    void TransferObsoleteSearchRequest(const FindServiceHandle& find_service_handle) noexcept;
+    void TransferObsoleteSearchRequest(const FindServiceHandle& find_service_handle);
 
     void HandleEvents(
         const score::cpp::expected<score::cpp::static_vector<os::InotifyEvent, os::InotifyInstance::max_events>,
-                                   os::Error>& expected_events) noexcept;
+                                   os::Error>& expected_events);
 
-    void HandleDeletionEvents(const std::vector<os::InotifyEvent>& events) noexcept;
-    void HandleCreationEvents(const std::vector<os::InotifyEvent>& events) noexcept;
+    void HandleDeletionEvents(const std::vector<os::InotifyEvent>& events);
+    void HandleCreationEvents(const std::vector<os::InotifyEvent>& events);
 
     std::atomic<Disambiguator> offer_disambiguator_;
 

--- a/score/mw/com/impl/bindings/lola/service_discovery/flag_file.cpp
+++ b/score/mw/com/impl/bindings/lola/service_discovery/flag_file.cpp
@@ -49,7 +49,7 @@ constexpr os::Stat::Mode ALL_PERMISSIONS{os::Stat::Mode::kReadWriteExecUser | os
 
 auto GetFlagFilePath(const EnrichedInstanceIdentifier& enriched_instance_identifier,
                      const FlagFile::Disambiguator disambiguator,
-                     const os::Unistd& unistd = os::internal::UnistdImpl{}) noexcept -> filesystem::Path
+                     const os::Unistd& unistd = os::internal::UnistdImpl{}) -> filesystem::Path
 {
     const auto pid = unistd.getpid();
 
@@ -60,7 +60,7 @@ auto GetFlagFilePath(const EnrichedInstanceIdentifier& enriched_instance_identif
     return GetSearchPathForIdentifier(enriched_instance_identifier) / file_name;
 }
 
-auto GetMatchingFlagFilePaths(const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept
+auto GetMatchingFlagFilePaths(const EnrichedInstanceIdentifier& enriched_instance_identifier)
     -> std::vector<filesystem::Path>
 {
     const auto search_path = GetSearchPathForIdentifier(enriched_instance_identifier);
@@ -181,7 +181,7 @@ FlagFile::~FlagFile()
 
 auto FlagFile::Make(EnrichedInstanceIdentifier enriched_instance_identifier,
                     Disambiguator offer_disambiguator,
-                    filesystem::Filesystem filesystem) noexcept -> score::Result<FlagFile>
+                    filesystem::Filesystem filesystem) -> score::Result<FlagFile>
 {
     const auto clearing_result = RemoveMatchingFlagFiles(enriched_instance_identifier, offer_disambiguator, filesystem);
     if (!clearing_result.has_value())

--- a/score/mw/com/impl/bindings/lola/service_discovery/flag_file.h
+++ b/score/mw/com/impl/bindings/lola/service_discovery/flag_file.h
@@ -47,7 +47,7 @@ class FlagFile
     /// exist.
     static auto Make(EnrichedInstanceIdentifier enriched_instance_identifier,
                      Disambiguator offer_disambiguator,
-                     filesystem::Filesystem filesystem) noexcept -> score::Result<FlagFile>;
+                     filesystem::Filesystem filesystem) -> score::Result<FlagFile>;
 
     FlagFile(const FlagFile&) = delete;
     FlagFile(FlagFile&&) noexcept;

--- a/score/mw/com/impl/bindings/lola/service_discovery/flag_file_crawler.cpp
+++ b/score/mw/com/impl/bindings/lola/service_discovery/flag_file_crawler.cpp
@@ -40,7 +40,7 @@ namespace
 {
 
 QualityAwareContainer<KnownInstancesContainer> GetAlreadyExistingInstances(
-    std::vector<EnrichedInstanceIdentifier>& quality_unaware_identifiers_to_check) noexcept
+    std::vector<EnrichedInstanceIdentifier>& quality_unaware_identifiers_to_check)
 {
     QualityAwareContainer<KnownInstancesContainer> known_instances{};
     for (const auto& quality_unaware_identifier_to_check : quality_unaware_identifiers_to_check)
@@ -127,7 +127,7 @@ auto FlagFileCrawler::Crawl(const EnrichedInstanceIdentifier& enriched_instance_
     return std::get<1>(result.value());
 }
 
-auto FlagFileCrawler::CrawlAndWatch(const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept
+auto FlagFileCrawler::CrawlAndWatch(const EnrichedInstanceIdentifier& enriched_instance_identifier)
     -> score::Result<std::tuple<std::unordered_map<os::InotifyWatchDescriptor, EnrichedInstanceIdentifier>,
                                 QualityAwareContainer<KnownInstancesContainer>>>
 {

--- a/score/mw/com/impl/bindings/lola/service_discovery/flag_file_crawler.h
+++ b/score/mw/com/impl/bindings/lola/service_discovery/flag_file_crawler.h
@@ -39,7 +39,7 @@ class FlagFileCrawler
     auto Crawl(const EnrichedInstanceIdentifier& enriched_instance_identifier)
         -> score::Result<QualityAwareContainer<KnownInstancesContainer>>;
 
-    auto CrawlAndWatch(const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept
+    auto CrawlAndWatch(const EnrichedInstanceIdentifier& enriched_instance_identifier)
         -> score::Result<std::tuple<std::unordered_map<os::InotifyWatchDescriptor, EnrichedInstanceIdentifier>,
                                     QualityAwareContainer<KnownInstancesContainer>>>;
 

--- a/score/mw/com/impl/bindings/lola/subscription_state_base.h
+++ b/score/mw/com/impl/bindings/lola/subscription_state_base.h
@@ -41,11 +41,11 @@ class SubscriptionStateBase
     SubscriptionStateBase& operator=(SubscriptionStateBase&&) & noexcept = delete;
 
     virtual Result<void> SubscribeEvent(const std::size_t max_sample_count) = 0;
-    virtual void UnsubscribeEvent() noexcept = 0;
-    virtual void StopOfferEvent() noexcept = 0;
+    virtual void UnsubscribeEvent() = 0;
+    virtual void StopOfferEvent() = 0;
     virtual void ReOfferEvent(const pid_t new_event_source_pid) = 0;
 
-    virtual void SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) noexcept = 0;
+    virtual void SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) = 0;
     virtual void UnsetReceiveHandler() noexcept = 0;
     virtual std::optional<std::uint16_t> GetMaxSampleCount() const = 0;
     virtual std::optional<SlotCollector>& GetSlotCollector() & noexcept = 0;

--- a/score/mw/com/impl/bindings/lola/subscription_subscribed_states.cpp
+++ b/score/mw/com/impl/bindings/lola/subscription_subscribed_states.cpp
@@ -52,7 +52,7 @@ Result<void> SubscribedState::SubscribeEvent(const std::size_t max_sample_count)
     }
 }
 
-void SubscribedState::UnsubscribeEvent() noexcept
+void SubscribedState::UnsubscribeEvent()
 {
     // Unsubscribe functionality will be done in NotSubscribedState::OnEntry() which will be called synchronously by
     // TransitionToState. We do this to avoid code duplication between SubscriptionPendingState::UnsubscribeEvent() and
@@ -60,20 +60,20 @@ void SubscribedState::UnsubscribeEvent() noexcept
     state_machine_.TransitionToState(SubscriptionStateMachineState::NOT_SUBSCRIBED_STATE);
 }
 
-void SubscribedState::StopOfferEvent() noexcept
+void SubscribedState::StopOfferEvent()
 {
     state_machine_.provider_service_instance_is_available_ = false;
     state_machine_.TransitionToState(SubscriptionStateMachineState::SUBSCRIPTION_PENDING_STATE);
 }
 
-void SubscribedState::ReOfferEvent(const pid_t) noexcept
+void SubscribedState::ReOfferEvent(const pid_t)
 {
     ::score::mw::log::LogWarn("lola") << CreateLoggingString("Service cannot be re-offered while already subscribed.",
                                                              state_machine_.GetElementFqId(),
                                                              state_machine_.GetCurrentStateNoLock());
 }
 
-void SubscribedState::SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) noexcept
+void SubscribedState::SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler)
 {
     state_machine_.event_receive_handler_manager_.Register(std::move(handler));
 }

--- a/score/mw/com/impl/bindings/lola/subscription_subscribed_states.h
+++ b/score/mw/com/impl/bindings/lola/subscription_subscribed_states.h
@@ -38,11 +38,11 @@ class SubscribedState final : public SubscriptionStateBase
     ~SubscribedState() noexcept override = default;
 
     Result<void> SubscribeEvent(const std::size_t) override;
-    void UnsubscribeEvent() noexcept override;
-    void StopOfferEvent() noexcept override;
-    void ReOfferEvent(const pid_t) noexcept override;
+    void UnsubscribeEvent() override;
+    void StopOfferEvent() override;
+    void ReOfferEvent(const pid_t) override;
 
-    void SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) noexcept override;
+    void SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) override;
     void UnsetReceiveHandler() noexcept override;
     std::optional<std::uint16_t> GetMaxSampleCount() const override;
     std::optional<SlotCollector>& GetSlotCollector() & noexcept override;

--- a/score/mw/com/impl/bindings/lola/subscription_subscription_pending_states.cpp
+++ b/score/mw/com/impl/bindings/lola/subscription_subscription_pending_states.cpp
@@ -54,7 +54,7 @@ Result<void> SubscriptionPendingState::SubscribeEvent(const std::size_t max_samp
     }
 }
 
-void SubscriptionPendingState::UnsubscribeEvent() noexcept
+void SubscriptionPendingState::UnsubscribeEvent()
 {
     // Unsubscribe functionality will be done in NotSubscribedState::OnEntry() which will be called synchronously by
     // TransitionToState. We do this to avoid code duplication between SubscriptionPendingState::UnsubscribeEvent() and

--- a/score/mw/com/impl/bindings/lola/subscription_subscription_pending_states.h
+++ b/score/mw/com/impl/bindings/lola/subscription_subscription_pending_states.h
@@ -38,7 +38,7 @@ class SubscriptionPendingState final : public SubscriptionStateBase
     ~SubscriptionPendingState() noexcept override = default;
 
     Result<void> SubscribeEvent(const std::size_t max_sample_count) override;
-    void UnsubscribeEvent() noexcept override;
+    void UnsubscribeEvent() override;
     void StopOfferEvent() noexcept override;
     void ReOfferEvent(const pid_t new_event_source_pid) override;
 

--- a/score/mw/com/impl/bindings/lola/transaction_log_local_view.cpp
+++ b/score/mw/com/impl/bindings/lola/transaction_log_local_view.cpp
@@ -173,7 +173,7 @@ void TransactionLogLocalView::DereferenceTransactionCommit(SlotIndexType slot_in
 }
 
 Result<void> TransactionLogLocalView::RollbackProxyElementLog(const DereferenceSlotCallback& dereference_slot_callback,
-                                                              const UnsubscribeCallback& unsubscribe_callback) noexcept
+                                                              const UnsubscribeCallback& unsubscribe_callback)
 {
     const bool was_no_subscribe_recorded{!subscribe_transactions_.get().GetTransactionBegin() &&
                                          !subscribe_transactions_.get().GetTransactionEnd()};

--- a/score/mw/com/impl/bindings/lola/transaction_log_local_view.h
+++ b/score/mw/com/impl/bindings/lola/transaction_log_local_view.h
@@ -82,7 +82,7 @@ class TransactionLogLocalView
     /// will decrement all reference counts that the old Proxy had incremented in the EventDataControl which were
     /// recorded in this TransactionLog.
     Result<void> RollbackProxyElementLog(const DereferenceSlotCallback& dereference_slot_callback,
-                                         const UnsubscribeCallback& unsubscribe_callback) noexcept;
+                                         const UnsubscribeCallback& unsubscribe_callback);
 
     /// \brief Rollback all previous increments that were recorded in the transaction log.
     /// \param dereference_slot_callback Callback which will decrement the slot in EventDataControl with the provided

--- a/score/mw/com/impl/configuration/configuration_common_resources.h
+++ b/score/mw/com/impl/configuration/configuration_common_resources.h
@@ -134,8 +134,7 @@ class DoConstructVariant<score::cpp::blank>
 
 /// ConstructVariant dispatches to DoConstructVariant in a template class to avoid function template specialization
 template <typename VariantHeldType>
-auto ConstructVariant(const score::json::Object& json_object, std::string_view json_variant_key) noexcept
-    -> VariantHeldType
+auto ConstructVariant(const score::json::Object& json_object, std::string_view json_variant_key) -> VariantHeldType
 {
     return DoConstructVariant<VariantHeldType>::Do(json_object, json_variant_key);
 }

--- a/score/mw/com/impl/configuration/lola_event_instance_deployment.cpp
+++ b/score/mw/com/impl/configuration/lola_event_instance_deployment.cpp
@@ -47,7 +47,7 @@ LolaEventInstanceDeployment::LolaEventInstanceDeployment(std::optional<SampleSlo
 {
 }
 
-LolaEventInstanceDeployment::LolaEventInstanceDeployment(const score::json::Object& json_object) noexcept
+LolaEventInstanceDeployment::LolaEventInstanceDeployment(const score::json::Object& json_object)
     : LolaEventInstanceDeployment(LolaEventInstanceDeployment::CreateFromJson(json_object))
 {
 }

--- a/score/mw/com/impl/configuration/lola_event_instance_deployment.h
+++ b/score/mw/com/impl/configuration/lola_event_instance_deployment.h
@@ -35,7 +35,7 @@ class LolaEventInstanceDeployment
                                          const bool enforce_max_samples,
                                          const TracingSlotSizeType number_of_tracing_slots) noexcept;
 
-    explicit LolaEventInstanceDeployment(const score::json::Object& json_object) noexcept;
+    explicit LolaEventInstanceDeployment(const score::json::Object& json_object);
 
     static LolaEventInstanceDeployment CreateFromJson(const score::json::Object& json_object);
 

--- a/score/mw/com/impl/configuration/lola_field_instance_deployment.cpp
+++ b/score/mw/com/impl/configuration/lola_field_instance_deployment.cpp
@@ -38,7 +38,7 @@ LolaFieldInstanceDeployment::LolaFieldInstanceDeployment(LolaEventInstanceDeploy
 {
 }
 
-LolaFieldInstanceDeployment::LolaFieldInstanceDeployment(const score::json::Object& json_object) noexcept
+LolaFieldInstanceDeployment::LolaFieldInstanceDeployment(const score::json::Object& json_object)
     : LolaFieldInstanceDeployment(LolaFieldInstanceDeployment::CreateFromJson(json_object))
 {
 }
@@ -54,7 +54,7 @@ LolaFieldInstanceDeployment LolaFieldInstanceDeployment::CreateFromJson(const sc
     return LolaFieldInstanceDeployment(std::move(event_deployment), use_get_if_available, use_set_if_available);
 }
 
-score::json::Object LolaFieldInstanceDeployment::Serialize() const noexcept
+score::json::Object LolaFieldInstanceDeployment::Serialize() const
 {
     auto json_object = lola_event_instance_deployment_.Serialize();
 

--- a/score/mw/com/impl/configuration/lola_field_instance_deployment.h
+++ b/score/mw/com/impl/configuration/lola_field_instance_deployment.h
@@ -31,11 +31,11 @@ class LolaFieldInstanceDeployment
                                          const bool use_get_if_available,
                                          const bool use_set_if_available) noexcept;
 
-    explicit LolaFieldInstanceDeployment(const score::json::Object& json_object) noexcept;
+    explicit LolaFieldInstanceDeployment(const score::json::Object& json_object);
 
     static LolaFieldInstanceDeployment CreateFromJson(const score::json::Object& json_object);
 
-    score::json::Object Serialize() const noexcept;
+    score::json::Object Serialize() const;
 
     // Note the struct is not compliant to POD type containing non-POD member.
     // The struct is used as a config storage obtained by performing the parsing json object.

--- a/score/mw/com/impl/configuration/service_instance_id.cpp
+++ b/score/mw/com/impl/configuration/service_instance_id.cpp
@@ -101,7 +101,7 @@ std::string ToHashStringImpl(const ServiceInstanceId::BindingInformation& bindin
 // This rule states: Common class initialization for non-constant members shall be done by a delegating constructor.
 // Justification: This constructor is used by other constructors for delegation.
 // coverity[autosar_cpp14_a12_1_5_violation]
-ServiceInstanceId::ServiceInstanceId(BindingInformation binding_info) noexcept
+ServiceInstanceId::ServiceInstanceId(BindingInformation binding_info)
     : binding_info_{std::move(binding_info)}, hash_string_{ToHashStringImpl(binding_info_)}
 {
 }

--- a/score/mw/com/impl/configuration/service_instance_id.h
+++ b/score/mw/com/impl/configuration/service_instance_id.h
@@ -33,7 +33,7 @@ class ServiceInstanceId
     using BindingInformation = std::variant<LolaServiceInstanceId, score::cpp::blank>;
 
     explicit ServiceInstanceId(const score::json::Object& json_object);
-    explicit ServiceInstanceId(BindingInformation binding_info) noexcept;
+    explicit ServiceInstanceId(BindingInformation binding_info);
 
     score::json::Object Serialize() const;
     std::string_view ToHashString() const noexcept;

--- a/score/mw/com/impl/configuration/service_type_deployment.cpp
+++ b/score/mw/com/impl/configuration/service_type_deployment.cpp
@@ -89,7 +89,7 @@ std::string ToHashStringImpl(const ServiceTypeDeployment::BindingInformation& bi
 // This rule states: Common class initialization for non-constant members shall be done by a delegating constructor.
 // Justification: This constructor is used by other constructors for delegation.
 // coverity[autosar_cpp14_a12_1_5_violation]
-ServiceTypeDeployment::ServiceTypeDeployment(const BindingInformation binding) noexcept
+ServiceTypeDeployment::ServiceTypeDeployment(const BindingInformation binding)
     : binding_info_{binding}, hash_string_{ToHashStringImpl(binding_info_)}
 {
 }

--- a/score/mw/com/impl/configuration/service_type_deployment.h
+++ b/score/mw/com/impl/configuration/service_type_deployment.h
@@ -34,7 +34,7 @@ class ServiceTypeDeployment
 
     explicit ServiceTypeDeployment(const score::json::Object& json_object);
 
-    explicit ServiceTypeDeployment(const BindingInformation binding) noexcept;
+    explicit ServiceTypeDeployment(const BindingInformation binding);
 
     score::json::Object Serialize() const;
     std::string_view ToHashString() const noexcept;

--- a/score/mw/com/impl/enriched_instance_identifier.cpp
+++ b/score/mw/com/impl/enriched_instance_identifier.cpp
@@ -15,7 +15,7 @@
 namespace score::mw::com::impl
 {
 
-bool operator==(const EnrichedInstanceIdentifier& lhs, const EnrichedInstanceIdentifier& rhs) noexcept
+bool operator==(const EnrichedInstanceIdentifier& lhs, const EnrichedInstanceIdentifier& rhs)
 {
     return (((lhs.GetInstanceIdentifier() == rhs.GetInstanceIdentifier()) &&
              ((lhs.GetInstanceId() == rhs.GetInstanceId()))) &&

--- a/score/mw/com/impl/enriched_instance_identifier.h
+++ b/score/mw/com/impl/enriched_instance_identifier.h
@@ -38,7 +38,7 @@ namespace score::mw::com::impl
 class EnrichedInstanceIdentifier final
 {
   public:
-    explicit EnrichedInstanceIdentifier(InstanceIdentifier instance_identifier) noexcept
+    explicit EnrichedInstanceIdentifier(InstanceIdentifier instance_identifier)
         : EnrichedInstanceIdentifier(
               InstanceIdentifierView{instance_identifier}.GetServiceInstanceId(),
               InstanceIdentifierView{instance_identifier}.GetServiceInstanceDeployment().asilLevel_,
@@ -50,7 +50,7 @@ class EnrichedInstanceIdentifier final
     // initialized by the constructor shall be initialized using member initializers".
     // This is false positive, all data members are initialized using member initializers in the delegated constructor.
     // coverity[autosar_cpp14_a12_6_1_violation]
-    EnrichedInstanceIdentifier(InstanceIdentifier instance_identifier, const ServiceInstanceId instance_id) noexcept
+    EnrichedInstanceIdentifier(InstanceIdentifier instance_identifier, const ServiceInstanceId instance_id)
         : EnrichedInstanceIdentifier(
               std::optional<ServiceInstanceId>{instance_id},
               InstanceIdentifierView{instance_identifier}.GetServiceInstanceDeployment().asilLevel_,
@@ -145,7 +145,7 @@ class EnrichedInstanceIdentifier final
     QualityType quality_type_;
 };
 
-bool operator==(const EnrichedInstanceIdentifier& lhs, const EnrichedInstanceIdentifier& rhs) noexcept;
+bool operator==(const EnrichedInstanceIdentifier& lhs, const EnrichedInstanceIdentifier& rhs);
 
 }  // namespace score::mw::com::impl
 

--- a/score/mw/com/impl/generic_proxy_event_binding.h
+++ b/score/mw/com/impl/generic_proxy_event_binding.h
@@ -48,7 +48,7 @@ class GenericProxyEventBinding : public ProxyEventBindingBase
     /// \param receiver Callback that will be used to hand over data to the upper layer.
     /// \param reference_tracker Tracker that is used to produce reference counted SamplePtrs.
     /// \return Number of samples that were handed over to the callable.
-    virtual Result<std::size_t> GetNewSamples(Callback&& receiver, TrackerGuardFactory& tracker) noexcept = 0;
+    virtual Result<std::size_t> GetNewSamples(Callback&& receiver, TrackerGuardFactory& tracker) = 0;
 
     /// \brief return the (aligned) size in bytes of the underlying event sample data type.
     /// \return size in bytes.

--- a/score/mw/com/impl/handle_type.cpp
+++ b/score/mw/com/impl/handle_type.cpp
@@ -49,7 +49,7 @@ ServiceInstanceId ExtractInstanceId(std::optional<ServiceInstanceId> instance_id
 
 }  // namespace
 
-HandleType::HandleType(InstanceIdentifier identifier, std::optional<ServiceInstanceId> instance_id) noexcept
+HandleType::HandleType(InstanceIdentifier identifier, std::optional<ServiceInstanceId> instance_id)
     : identifier_{std::move(identifier)}, instance_id_{ExtractInstanceId(instance_id, identifier_)}
 {
 }
@@ -71,12 +71,12 @@ auto HandleType::GetServiceTypeDeployment() const noexcept -> const ServiceTypeD
     return instance_id.GetServiceTypeDeployment();
 }
 
-auto operator==(const HandleType& lhs, const HandleType& rhs) noexcept -> bool
+auto operator==(const HandleType& lhs, const HandleType& rhs) -> bool
 {
     return ((lhs.identifier_ == rhs.identifier_) && (lhs.instance_id_ == rhs.instance_id_));
 }
 
-auto operator<(const HandleType& lhs, const HandleType& rhs) noexcept -> bool
+auto operator<(const HandleType& lhs, const HandleType& rhs) -> bool
 {
     return std::tie(lhs.identifier_, lhs.instance_id_) < std::tie(rhs.identifier_, rhs.instance_id_);
 }

--- a/score/mw/com/impl/handle_type.h
+++ b/score/mw/com/impl/handle_type.h
@@ -63,7 +63,7 @@ class HandleType
      * \param rhs The second instance to check for equality
      * \return true if lhs and rhs equal, false otherwise
      */
-    friend bool operator==(const HandleType& lhs, const HandleType& rhs) noexcept;
+    friend bool operator==(const HandleType& lhs, const HandleType& rhs);
 
     /**
      * \brief LessThanComparable operator
@@ -72,7 +72,7 @@ class HandleType
      * \param rhs The second HandleType instance to compare
      * \return true if lhs is less than rhs, false otherwise
      */
-    friend bool operator<(const HandleType& lhs, const HandleType& rhs) noexcept;
+    friend bool operator<(const HandleType& lhs, const HandleType& rhs);
 
     /**
      * \brief Query the associated instance
@@ -107,7 +107,7 @@ class HandleType
     InstanceIdentifier identifier_;
     ServiceInstanceId instance_id_;
 
-    explicit HandleType(InstanceIdentifier, std::optional<ServiceInstanceId> instance_id) noexcept;
+    explicit HandleType(InstanceIdentifier, std::optional<ServiceInstanceId> instance_id);
 
     // Suppress "AUTOSAR C++14 A11-3-1", The rule states: "Friend declarations shall not be used".
     // Design decision: Friend class required to access private constructor.

--- a/score/mw/com/impl/instance_identifier.cpp
+++ b/score/mw/com/impl/instance_identifier.cpp
@@ -116,14 +116,14 @@ InstanceIdentifier::InstanceIdentifier(const json::Object& json_object, std::str
 // This adds more risk than doing the initialization of the members in each constructor.
 // coverity[autosar_cpp14_a12_1_5_violation : FALSE]
 InstanceIdentifier::InstanceIdentifier(const ServiceInstanceDeployment& deployment,
-                                       const ServiceTypeDeployment& type_deployment) noexcept
+                                       const ServiceTypeDeployment& type_deployment)
     : instance_deployment_{&deployment},
       type_deployment_{&type_deployment},
       serialized_string_{ToStringImpl(Serialize())}
 {
 }
 
-auto InstanceIdentifier::Serialize() const noexcept -> json::Object
+auto InstanceIdentifier::Serialize() const -> json::Object
 {
     json::Object json_object{};
     json_object[kSerializationVersionKey] = score::json::Any{serializationVersion};
@@ -139,13 +139,13 @@ auto InstanceIdentifier::ToString() const noexcept -> std::string_view
     return serialized_string_;
 }
 
-auto operator==(const InstanceIdentifier& lhs, const InstanceIdentifier& rhs) noexcept -> bool
+auto operator==(const InstanceIdentifier& lhs, const InstanceIdentifier& rhs) -> bool
 {
     return (((lhs.instance_deployment_->service_ == rhs.instance_deployment_->service_) &&
              (*lhs.instance_deployment_ == *rhs.instance_deployment_)));
 }
 
-auto operator<(const InstanceIdentifier& lhs, const InstanceIdentifier& rhs) noexcept -> bool
+auto operator<(const InstanceIdentifier& lhs, const InstanceIdentifier& rhs) -> bool
 {
     return std::tie(lhs.instance_deployment_->service_, *lhs.instance_deployment_) <
            std::tie(rhs.instance_deployment_->service_, *rhs.instance_deployment_);

--- a/score/mw/com/impl/instance_identifier.h
+++ b/score/mw/com/impl/instance_identifier.h
@@ -119,7 +119,7 @@ class InstanceIdentifier final
      * \param rhs The second instance to check for equality
      * \return true if other and *this equal, false otherwise
      */
-    friend bool operator==(const InstanceIdentifier& lhs, const InstanceIdentifier& rhs) noexcept;
+    friend bool operator==(const InstanceIdentifier& lhs, const InstanceIdentifier& rhs);
 
     /**
      * \api
@@ -129,7 +129,7 @@ class InstanceIdentifier final
      * \param rhs The second InstanceIdentifier instance to compare
      * \return true if *this is less then other, false otherwise
      */
-    friend bool operator<(const InstanceIdentifier& lhs, const InstanceIdentifier& rhs) noexcept;
+    friend bool operator<(const InstanceIdentifier& lhs, const InstanceIdentifier& rhs);
 
   private:
     const ServiceInstanceDeployment* instance_deployment_;
@@ -150,14 +150,14 @@ class InstanceIdentifier final
      * @param version version info
      * @param deployment deployment info
      */
-    explicit InstanceIdentifier(const ServiceInstanceDeployment&, const ServiceTypeDeployment&) noexcept;
+    explicit InstanceIdentifier(const ServiceInstanceDeployment&, const ServiceTypeDeployment&);
 
     static void SetConfiguration(Configuration* const configuration) noexcept
     {
         InstanceIdentifier::configuration_ = configuration;
     }
 
-    json::Object Serialize() const noexcept;
+    json::Object Serialize() const;
 
     /**
      * @brief serialized format of this InstanceIdentifier instance

--- a/score/mw/com/impl/methods/proxy_method_without_in_args_or_return.h
+++ b/score/mw/com/impl/methods/proxy_method_without_in_args_or_return.h
@@ -44,7 +44,7 @@ class ProxyMethod<void()> final : public ProxyMethodBase
     friend class ProxyMethodView;
 
   public:
-    ProxyMethod(ProxyBase& proxy_base, std::string_view method_name) noexcept
+    ProxyMethod(ProxyBase& proxy_base, std::string_view method_name)
         : ProxyMethodBase(method_name,
                           ProxyMethodBindingFactory<void()>::Create(proxy_base.GetHandle(),
                                                                     ProxyBaseView{proxy_base}.GetBinding(),
@@ -56,7 +56,7 @@ class ProxyMethod<void()> final : public ProxyMethodBase
         proxy_base_view.RegisterMethod(method_name_, GetReferenceToMoveable());
     }
 
-    ProxyMethod(std::string_view method_name, std::unique_ptr<ProxyMethodBinding> proxy_method_binding) noexcept
+    ProxyMethod(std::string_view method_name, std::unique_ptr<ProxyMethodBinding> proxy_method_binding)
         : ProxyMethodBase(method_name, std::move(proxy_method_binding), MethodType::kMethod)
     {
     }

--- a/score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_impl.h
+++ b/score/mw/com/impl/plumbing/skeleton_service_element_binding_factory_impl.h
@@ -194,7 +194,7 @@ template <typename SkeletonServiceElementBinding, typename SkeletonServiceElemen
 auto CreateGenericSkeletonEventOrField(const InstanceIdentifier& identifier,
                                        SkeletonBase& parent,
                                        const std::string_view service_element_name,
-                                       const memory::DataTypeSizeInfo& size_info) noexcept
+                                       const memory::DataTypeSizeInfo& size_info)
     -> std::unique_ptr<SkeletonServiceElementBinding>
 {
     static_assert((element_type == ServiceElementType::EVENT) || (element_type == ServiceElementType::FIELD));

--- a/score/mw/com/impl/proxy_field_base.h
+++ b/score/mw/com/impl/proxy_field_base.h
@@ -75,7 +75,7 @@ class ProxyFieldBase : public EnableReferenceToMoveableFromThis<ProxyFieldBase>
      */
     /// \{
   protected:
-    Result<void> Subscribe(const std::size_t max_sample_count) noexcept
+    Result<void> Subscribe(const std::size_t max_sample_count)
     {
         SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(proxy_event_base_dispatch_ != nullptr);
         return proxy_event_base_dispatch_->Subscribe(max_sample_count);

--- a/score/mw/com/impl/runtime.cpp
+++ b/score/mw/com/impl/runtime.cpp
@@ -126,7 +126,7 @@ void Runtime::Initialize(const runtime::RuntimeConfiguration& runtime_configurat
     score::cpp::ignore = initialization_config_.emplace(std::move(config));
 }
 
-auto Runtime::getInstance() noexcept -> IRuntime&
+auto Runtime::getInstance() -> IRuntime&
 {
     if (mock_ != nullptr)
     {

--- a/score/mw/com/impl/runtime.h
+++ b/score/mw/com/impl/runtime.h
@@ -79,7 +79,7 @@ class Runtime final : public IRuntime
     /// \brief get singleton.
     /// \details Might return either reference to a real Runtime instance or to a mock.
     /// \return singleton ref.
-    static IRuntime& getInstance() noexcept;
+    static IRuntime& getInstance();
 
     /// \brief Inject a mock instance as the runtime singleton. Injecting a nullptr will withdraw the mock again.
     /// \details If a mock instance is injected, a call to getInstance() will just return the mock and no implicit call

--- a/score/mw/com/impl/service_discovery.cpp
+++ b/score/mw/com/impl/service_discovery.cpp
@@ -290,7 +290,7 @@ auto ServiceDiscovery::StoreInstanceIdentifier(const FindServiceHandle& find_ser
                                                       std::forward_as_tuple(enriched_instance_identifier));
 }
 
-auto ServiceDiscovery::GetServiceDiscoveryClient(const InstanceIdentifier& instance_identifier) noexcept
+auto ServiceDiscovery::GetServiceDiscoveryClient(const InstanceIdentifier& instance_identifier)
     -> IServiceDiscoveryClient&
 {
     InstanceIdentifierView instance_identifier_view{instance_identifier};

--- a/score/mw/com/impl/service_discovery.h
+++ b/score/mw/com/impl/service_discovery.h
@@ -84,7 +84,7 @@ class ServiceDiscovery final : public IServiceDiscovery
     /// This function is NOT threadsafe and should be called with container_mutex_ locked.
     void StoreInstanceIdentifier(const FindServiceHandle&, const EnrichedInstanceIdentifier&) noexcept;
 
-    IServiceDiscoveryClient& GetServiceDiscoveryClient(const InstanceIdentifier&) noexcept;
+    IServiceDiscoveryClient& GetServiceDiscoveryClient(const InstanceIdentifier&);
 
     /// \brief Call the binding specific StartFindService
     ///

--- a/score/mw/com/impl/skeleton_base.cpp
+++ b/score/mw/com/impl/skeleton_base.cpp
@@ -148,7 +148,7 @@ score::Result<std::vector<utils::ScopeExit<>>> SkeletonBase::OfferServiceFields(
     return {std::move(offer_guards)};
 }
 
-auto SkeletonBase::OfferService() noexcept -> Result<void>
+auto SkeletonBase::OfferService() -> Result<void>
 {
     if (skeleton_mock_ != nullptr)
     {

--- a/score/mw/com/impl/skeleton_base.h
+++ b/score/mw/com/impl/skeleton_base.h
@@ -73,7 +73,7 @@ class SkeletonBase
      * \return On failure, returns an error code according to the SW Component Requirements SCR-17434118 and
      * SCR-566325.
      */
-    [[nodiscard]] Result<void> OfferService() noexcept;
+    [[nodiscard]] Result<void> OfferService();
 
     /**
      * \api

--- a/score/mw/com/impl/tracing/configuration/i_tracing_filter_config.h
+++ b/score/mw/com/impl/tracing/configuration/i_tracing_filter_config.h
@@ -73,7 +73,7 @@ class ITracingFilterConfig
                                InstanceSpecifierView instance_specifier,
                                ProxyFieldTracePointType proxy_field_trace_point_type) noexcept = 0;
 
-    virtual std::uint16_t GetNumberOfTracingSlots(score::mw::com::impl::Configuration& config) const noexcept = 0;
+    virtual std::uint16_t GetNumberOfTracingSlots(score::mw::com::impl::Configuration& config) const = 0;
 };
 
 }  // namespace score::mw::com::impl::tracing

--- a/score/mw/com/impl/tracing/configuration/tracing_filter_config.cpp
+++ b/score/mw/com/impl/tracing/configuration/tracing_filter_config.cpp
@@ -399,7 +399,7 @@ void TracingFilterConfig::AddTracePoint(std::string_view service_type,
 }
 
 /// @brief: Find the number of configured tracing slots for all trace points.
-std::uint16_t TracingFilterConfig::GetNumberOfTracingSlots(score::mw::com::impl::Configuration& config) const noexcept
+std::uint16_t TracingFilterConfig::GetNumberOfTracingSlots(score::mw::com::impl::Configuration& config) const
 {
     std::unordered_set<ServiceElementIdentifierView> service_element_identifier_view_set{};
     const std::array<std::size_t, 4U> number_trace_points_list{

--- a/score/mw/com/impl/tracing/configuration/tracing_filter_config.h
+++ b/score/mw/com/impl/tracing/configuration/tracing_filter_config.h
@@ -62,7 +62,7 @@ class TracingFilterConfig : public ITracingFilterConfig
                        InstanceSpecifierView instance_specifier,
                        ProxyFieldTracePointType proxy_field_trace_point_type) noexcept override;
 
-    std::uint16_t GetNumberOfTracingSlots(score::mw::com::impl::Configuration& config) const noexcept override;
+    std::uint16_t GetNumberOfTracingSlots(score::mw::com::impl::Configuration& config) const override;
 
   private:
     std::set<std::string, std::less<>> config_names_;

--- a/score/mw/com/impl/tracing/tracing_runtime.cpp
+++ b/score/mw/com/impl/tracing/tracing_runtime.cpp
@@ -174,7 +174,7 @@ analysis::tracing::AraComMetaInfo CreateMetaInfo(
     const ServiceElementInstanceIdentifierView& service_element_instance_identifier,
     const TracingRuntime::TracePointType& trace_point_type,
     const std::optional<TracingRuntime::TracePointDataId> trace_point_data_id,
-    const IBindingTracingRuntime& binding_runtime) noexcept
+    const IBindingTracingRuntime& binding_runtime)
 {
     const analysis::tracing::TracePointType ext_trace_point_type = InternalToExternalTracePointType(trace_point_type);
     // Convert std::optional to score::cpp::optional for baselibs API compatibility


### PR DESCRIPTION
## Summary

Follow-up to PR #807. Resolves all 60 remaining open CodeQL/MISRA findings for rule `cpp/misra/noexcept-function-should-not-propagate-to-the-caller` on `main`.

## Problem

60 functions were declared `noexcept(true)` but the static analyzer can prove they may propagate exceptions (via `std::visit`, `std::optional` access, JSON parsing, shared memory operations, inotify). This violates MISRA C++ Rule 18-5-1 / AUTOSAR A15-4-2.

## Fix

Remove the `noexcept` specifier from each flagged function. Declarations and definitions are kept in sync. For virtual functions, `noexcept` was also removed from the base class interface (`ITracingFilterConfig`, `SubscriptionStateBase`, `IGenericProxyEventBinding`).

## Files Changed

- `score/memory/shared/`: `polymorphic_offset_ptr_allocator`, `shared_memory_resource`, `offset_ptr_bounds_check`, `memory_resource_proxy`
- `score/mw/com/impl/`: `enriched_instance_identifier`, `handle_type`, `instance_identifier`, `proxy_field_base`, `runtime`, `service_discovery`, `skeleton_base`
- `score/mw/com/impl/bindings/lola/`: `generic_proxy_event`, subscription states, `transaction_log_local_view`, service discovery (flag files, client)
- `score/mw/com/impl/configuration/`: `configuration_common_resources`, deployment/instance/type deployment constructors
- `score/mw/com/impl/methods/`: proxy method constructors
- `score/mw/com/impl/plumbing/`: skeleton binding factory
- `score/mw/com/impl/tracing/`: `tracing_runtime`, `tracing_filter_config`
- `score/message_passing/unix_domain/`: lambda in `unix_domain_server`

Closes https://github.com/eclipse-score/communication/security/code-scanning?query=is%3Aopen+branch%3Amain+tool%3ACodeQL+rule%3Acpp%2Fmisra%2Fnoexcept-function-should-not-propagate-to-the-caller