### PR TITLE
fix(misra): mark exception-unfriendly functions noexcept

### DIFF
--- a/score/memory/shared/offset_ptr.h
+++ b/score/memory/shared/offset_ptr.h
@@ -377,7 +377,7 @@ class OffsetPtr
 
     template <typename T>
     // coverity[autosar_cpp14_a11_3_1_violation] See rationale for autosar_cpp14_a11_3_1_violation above
-    friend void swap(OffsetPtr<T>& left, OffsetPtr<T>& right);
+    friend void swap(OffsetPtr<T>& left, OffsetPtr<T>& right) noexcept;
 };
 
 // maybe-unitialized is triggered here by some compilers, because they thing that `this` in the initalizer-list
@@ -522,7 +522,7 @@ auto OffsetPtr<PointedType>::CopyFrom(const OffsetPtr<OtherPointedType>& source_
             !source_offset_ptr_bounds.has_value() && !target_offset_ptr_bounds.has_value();
         if (copying_from_shm_to_stack)
         {
-            memory_bounds = source_offset_ptr_bounds.value();
+            memory_bounds = *source_offset_ptr_bounds;
         }
         else if (copying_from_stack_to_stack)
         {
@@ -1083,7 +1083,7 @@ inline auto operator-(T1* const ptr1, const OffsetPtr<T2>& offset_ptr2) -> typen
 
 template <typename T>
 // coverity[autosar_cpp14_m3_2_3_violation : FALSE] See rationale for autosar_cpp14_m3_2_3_violation above
-void swap(OffsetPtr<T>& left, OffsetPtr<T>& right)
+void swap(OffsetPtr<T>& left, OffsetPtr<T>& right) noexcept
 {
     auto* const right_ptr = OffsetPtr<T>::GetPointerWithoutBoundsCheck(&right, right.offset_);
     right = left;

--- a/score/message_passing/unix_domain/unix_domain_server.cpp
+++ b/score/message_passing/unix_domain/unix_domain_server.cpp
@@ -134,15 +134,16 @@ bool UnixDomainServer::ServerConnection::ProcessInput()
     return true;
 }
 
-UnixDomainServer::ServerConnection::~ServerConnection() noexcept(false)
+UnixDomainServer::ServerConnection::~ServerConnection() noexcept
 {
     if (user_data_.has_value())
     {
         auto& user_data = *user_data_;
         using HandlerPointerT = score::cpp::pmr::unique_ptr<IConnectionHandler>;
-        if (std::holds_alternative<HandlerPointerT>(user_data))
+        auto* const handler = std::get_if<HandlerPointerT>(&user_data);
+        if (handler != nullptr)
         {
-            std::get<HandlerPointerT>(user_data)->OnDisconnect(*this);
+            (*handler)->OnDisconnect(*this);
         }
         else
         {

--- a/score/message_passing/unix_domain/unix_domain_server.h
+++ b/score/message_passing/unix_domain/unix_domain_server.h
@@ -52,7 +52,7 @@ class UnixDomainServer final : public IServer
         void AcceptConnection(UserData&& data, score::cpp::pmr::unique_ptr<ServerConnection>&& self) noexcept;
         bool ProcessInput();
 
-        ~ServerConnection() noexcept(false);
+        ~ServerConnection() noexcept;
 
       private:
         UnixDomainServer& server_;

--- a/score/mw/com/impl/bindings/lola/methods/type_erased_call_queue.cpp
+++ b/score/mw/com/impl/bindings/lola/methods/type_erased_call_queue.cpp
@@ -90,7 +90,7 @@ TypeErasedCallQueue::TypeErasedCallQueue(memory::shared::ManagedMemoryResource& 
     std::tie(in_args_queue_start_address_, return_queue_start_address_) = AllocateQueue();
 }
 
-TypeErasedCallQueue::~TypeErasedCallQueue() noexcept(false)
+TypeErasedCallQueue::~TypeErasedCallQueue() noexcept
 {
     if (in_args_queue_start_address_.data != nullptr)
     {

--- a/score/mw/com/impl/bindings/lola/methods/type_erased_call_queue.h
+++ b/score/mw/com/impl/bindings/lola/methods/type_erased_call_queue.h
@@ -42,7 +42,7 @@ class TypeErasedCallQueue final
     TypeErasedCallQueue(memory::shared::ManagedMemoryResource& resource,
                         const TypeErasedElementInfo& type_erased_element_info);
 
-    ~TypeErasedCallQueue() noexcept(false);
+    ~TypeErasedCallQueue() noexcept;
 
     TypeErasedCallQueue(const TypeErasedCallQueue&) = delete;
     TypeErasedCallQueue& operator=(const TypeErasedCallQueue&) = delete;


### PR DESCRIPTION
Resolves all 4 open CodeQL/MISRA findings for rule cpp/misra/exception-unfriendly-function-must-be-noexcept on main.

- offset_ptr.h: swap() friend declaration and definition now noexcept. CopyFrom() used .value() on an optional that is only accessed after a has_value()-implying guard; replaced with dereference so no throw is possible along the reachable path.
- type_erased_call_queue.cpp: ~TypeErasedCallQueue() was marked noexcept(false) (commit 9c059d7e) to satisfy the propagate rule. All do_deallocate() overrides in this codebase (SharedMemoryResource, MyMemoryResource, MyBoundedMemoryResource) never throw, so the destructor is genuinely non-throwing; removed noexcept(false).
- unix_domain_server.cpp: ~ServerConnection() used std::get<HandlerPointerT>(user_data) guarded by holds_alternative, which the analyzer cannot correlate; replaced with std::get_if (never throws). IConnectionHandler::OnDisconnect is already declared noexcept. Removed noexcept(false).