### PR TITLE
fix(misra): avoid signed overflow in ProcessTimerQueue distance calc

### DIFF
--- a/score/message_passing/unix_domain/unix_domain_engine.cpp
+++ b/score/message_passing/unix_domain/unix_domain_engine.cpp
@@ -345,12 +345,13 @@ std::int32_t UnixDomainEngine::ProcessTimerQueue() noexcept
     {
         return -1;
     }
-    const auto distance = std::chrono::duration_cast<std::chrono::milliseconds>(then - Clock::now()).count() + 1;
-    if (distance > INT32_MAX)
+    const auto distance_ms = std::chrono::duration_cast<std::chrono::milliseconds>(then - Clock::now()).count();
+    if (distance_ms >= INT32_MAX)
     {
         return INT32_MAX;
     }
-    return static_cast<std::int32_t>(distance);
+    // At this point distance_ms < INT32_MAX, so adding 1 cannot overflow.
+    return static_cast<std::int32_t>(distance_ms + 1);
 }
 
 }  // namespace message_passing


### PR DESCRIPTION
Resolves CodeQL/MISRA finding [#904](https://github.com/eclipse-score/communication/security/code-scanning/904) for rule `cpp/misra/signed-integer-overflow` (RULE-4-1-3).

## Problem
`UnixDomainEngine::ProcessTimerQueue()` computed:
```cpp
const auto distance = std::chrono::duration_cast<std::chrono::milliseconds>(then - Clock::now()).count() + 1;
if (distance > INT32_MAX) { return INT32_MAX; }
```
The `INT32_MAX` bound-check happens **after** the `+ 1`, so CodeQL cannot prove the addition itself doesn't overflow the millisecond count's underlying `long` type.

## Fix
Reorder so the bound-check happens **before** the `+1`:
```cpp
const auto distance_ms = std::chrono::duration_cast<std::chrono::milliseconds>(then - Clock::now()).count();
if (distance_ms >= INT32_MAX) { return INT32_MAX; }
return static_cast<std::int32_t>(distance_ms + 1);
```
Once `distance_ms < INT32_MAX`, adding `1` is provably safe. Behavior for all realistic timer distances (this only ever computes a millisecond poll timeout) is unchanged.

## Verification
- `bazel build //score/message_passing:message_passing_unix_domain` — passes
- `bazel build --config=tsan //score/message_passing:message_passing_unix_domain` — passes
- `bazel test //score/message_passing:unix_domain_test` — passes (1/1)

## Note
The same rule (`cpp/misra/signed-integer-overflow`) has 4 other open findings in `client_connection.cpp` and `message_passing_service_instance.cpp` that involve different arithmetic patterns (retry-delay calculation, node-id increment); those are left for a separate follow-up PR to keep this change focused and easy to review.