### PR TITLE
fix(misra): resolve remaining 4 signed-integer-overflow findings

### DIFF
--- a/score/message_passing/client_connection.cpp
+++ b/score/message_passing/client_connection.cpp
@@ -387,12 +387,17 @@ void ClientConnection::TryConnect() noexcept
         const auto retry_increase_ms =
             (static_cast<std::int64_t>(connect_retry_ms_) + static_cast<std::int64_t>(kConnectRetryT) - 1) /
             static_cast<std::int64_t>(kConnectRetryT);
-        if ((retry_increase_ms <= kConnectRetryMsMax) &&
-            (connect_retry_ms_ <= (kConnectRetryMsMax - retry_increase_ms)))
+        if (retry_increase_ms <= kConnectRetryMsMax)
         {
-            // At this point checks guarantee no data loss
-            // coverity[autosar_cpp14_a4_7_1_violation]
-            connect_retry_ms_ += static_cast<std::int32_t>(retry_increase_ms);
+            // retry_increase_ms is now known to be <= kConnectRetryMsMax, so this subtraction (evaluated in
+            // std::int64_t) cannot underflow.
+            const auto max_allowed_current_retry_ms = kConnectRetryMsMax - retry_increase_ms;
+            if (connect_retry_ms_ <= max_allowed_current_retry_ms)
+            {
+                // At this point checks guarantee no data loss
+                // coverity[autosar_cpp14_a4_7_1_violation]
+                connect_retry_ms_ += static_cast<std::int32_t>(retry_increase_ms);
+            }
         }
 
         engine_->EnqueueCommand(

--- a/score/message_passing/client_connection.cpp
+++ b/score/message_passing/client_connection.cpp
@@ -379,6 +379,11 @@ void ClientConnection::TryConnect() noexcept
         }
         std::int32_t retry_delay = connect_retry_ms_;
 
+        // kConnectRetryT is a positive compile-time constant, so it can never be 0 or -1; this guarantees the
+        // division below can never hit the undefined-behavior case of dividend == INT64_MIN with divisor == -1,
+        // nor divide by zero.
+        static_assert(kConnectRetryT > 0,
+                      "kConnectRetryT must be a positive divisor to avoid overflow/underflow in division.");
         const auto retry_increase_ms =
             (static_cast<std::int64_t>(connect_retry_ms_) + static_cast<std::int64_t>(kConnectRetryT) - 1) /
             static_cast<std::int64_t>(kConnectRetryT);

--- a/score/message_passing/client_connection.cpp
+++ b/score/message_passing/client_connection.cpp
@@ -394,9 +394,13 @@ void ClientConnection::TryConnect() noexcept
             const auto max_allowed_current_retry_ms = kConnectRetryMsMax - retry_increase_ms;
             if (connect_retry_ms_ <= max_allowed_current_retry_ms)
             {
-                // At this point checks guarantee no data loss
+                // At this point checks guarantee connect_retry_ms_ + retry_increase_ms <= kConnectRetryMsMax,
+                // which fits well within std::int32_t; compute the sum in std::int64_t and assign once instead
+                // of using operator+= on connect_retry_ms_, so the addition and the narrowing cast back to
+                // std::int32_t are both provably free of overflow/data loss.
                 // coverity[autosar_cpp14_a4_7_1_violation]
-                connect_retry_ms_ += static_cast<std::int32_t>(retry_increase_ms);
+                connect_retry_ms_ =
+                    static_cast<std::int32_t>(static_cast<std::int64_t>(connect_retry_ms_) + retry_increase_ms);
             }
         }
 

--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance.cpp
@@ -46,6 +46,7 @@
 #include <cstring>
 #include <exception>
 #include <functional>
+#include <limits>
 #include <memory>
 #include <mutex>
 #include <set>
@@ -918,7 +919,17 @@ void MessagePassingServiceInstance::NotifyEventRemote(const ElementFqId event_id
             // previous condition will be true only if the distance between current node id and last node id in the map
             // is more than one. So, no way for overflow.
             // coverity[autosar_cpp14_a4_7_1_violation]
-            start_node_id = nodeIdentifiersTmp.back() + 1;
+            const pid_t last_node_id = nodeIdentifiersTmp.back();
+            if (last_node_id < std::numeric_limits<pid_t>::max())
+            {
+                start_node_id = last_node_id + 1;
+            }
+            else
+            {
+                // last_node_id already holds the maximum representable pid_t; no larger node id can exist, so
+                // there is nothing left to copy in a further iteration.
+                break;
+            }
         }
     } while (num_ids_copied.second == true);
 


### PR DESCRIPTION
Resolves the remaining 4 open CodeQL/MISRA findings for rule `cpp/misra/signed-integer-overflow` (RULE-4-1-3), following up on #844 (alert #904). Each finding/operation type is fixed in its own commit:

1. **Alert #905** — `client_connection.cpp:383`, `/` division may overflow. `kConnectRetryT` is a positive compile-time constant, so it can never be `0` or `-1`; the division can never invoke the classic INT_MIN/-1 division-overflow UB. Added a `static_assert` making that invariant explicit at the point of use.

2. **Alert #5456** — `client_connection.cpp:386`, `-` subtraction may overflow. The bound on `retry_increase_ms` was established via the left operand of a short-circuited `&&` in the same condition as the subtraction, which the analyzer couldn't correlate. Restructured into a nested `if` so the bound is established by a preceding statement immediately before the subtraction (same style as #844). No behavior change.

3. **Alert #907** — `client_connection.cpp:390`, `+=` may overflow. Replaced `connect_retry_ms_ += static_cast<std::int32_t>(retry_increase_ms)` with computing the sum in `std::int64_t` (bounded by the preceding guards to fit `std::int32_t`) and assigning the narrowed result once, instead of mutating the `int32_t` in place. No behavior change.

4. **Alert #908** — `message_passing_service_instance.cpp:921`, `+` may overflow. `nodeIdentifiersTmp.back() + 1` could theoretically overflow `pid_t` if the last copied node id were already at `pid_t`'s max. Added an explicit guard: if so, there's no larger id to continue pagination with, so stop the copy loop (equivalent to the existing 'no more ids' path) instead of computing an overflowing increment.

## Verification
- `bazel build //score/message_passing:message_passing_common`
- `bazel test //score/message_passing:client_connection_test` — passes
- `bazel build //score/mw/com/impl/bindings/lola/messaging:message_passing_service_instance`
- `bazel test //score/mw/com/impl/bindings/lola/messaging:message_passing_service_instance_test` — passes
- `bazel build --config=tsan` on both targets — passes

All changes are behavior-preserving; no test assertions were modified.