### PR TITLE
Fix cpp/misra/out-of-range-enum-cast-critical-unspecified-behavior (alert #909)

### DIFF
--- a/score/mw/com/impl/bindings/lola/application_id_pid_mapping_entry.cpp
+++ b/score/mw/com/impl/bindings/lola/application_id_pid_mapping_entry.cpp
@@ -21,8 +21,16 @@ std::pair<ApplicationIdPidMappingEntry::MappingEntryStatus, std::uint32_t>
 ApplicationIdPidMappingEntry::GetStatusAndApplicationIdAtomic() noexcept
 {
     constexpr std::uint64_t kMaskApplicationId = 0x00000000FFFFFFFFU;
+    // MappingEntryStatus has an underlying type of std::uint16_t (see CreateKey() below, which only ever stores a
+    // std::uint16_t-sized status in bits 32..47 of the key). Masking to 16 bits here (in addition to the shift)
+    // makes the value range of status_part provably fit the enum's underlying type, avoiding an out-of-range enum
+    // cast (CodeQL cpp/misra/out-of-range-enum-cast-critical-unspecified-behavior).
+    constexpr std::uint64_t kMaskStatus = 0x000000000000FFFFU;
     auto status_applictionid = key_application_id_status_.load();
-    const auto status_part = static_cast<std::uint32_t>(status_applictionid >> 32U);
+    static_assert(std::is_same<std::uint16_t,
+                               std::underlying_type<ApplicationIdPidMappingEntry::MappingEntryStatus>::type>::value,
+                  "MappingEntryStatus is not of expected underlying type");
+    const auto status_part = static_cast<std::uint16_t>((status_applictionid >> 32U) & kMaskStatus);
     const auto application_id_part = static_cast<std::uint32_t>(status_applictionid & kMaskApplicationId);
     // Suppress "AUTOSAR C++14 A7-2-1" rule: "An expression with enum underlying type shall only have values
     // corresponding to the enumerators of the enumeration.".


### PR DESCRIPTION
## Summary

Fixes CodeQL alert [#909](https://github.com/eclipse-score/communication/security/code-scanning/909) (`cpp/misra/out-of-range-enum-cast-critical-unspecified-behavior`, MISRA RULE-4-1-3) in `score/mw/com/impl/bindings/lola/application_id_pid_mapping_entry.cpp`.

## Root cause

`GetStatusAndApplicationIdAtomic()` packs/unpacks a 64-bit atomic key where the top 32 bits hold a `MappingEntryStatus` (underlying type `std::uint16_t`) and the bottom 32 bits hold an application id. The status bits were extracted as:

```cpp
const auto status_part = static_cast<std::uint32_t>(status_applictionid >> 32U);
...
return {static_cast<ApplicationIdPidMappingEntry::MappingEntryStatus>(status_part), application_id_part};
```

`CreateKey()` (the only place the key is constructed) only ever stores a `std::uint16_t`-sized status in bits 32..47, leaving bits 48..63 always zero — so at runtime `status_part` is always in range. However, CodeQL's local range analysis only sees `status_applictionid >> 32U` cast to `std::uint32_t`, which spans the full `0..4294967295` range — wider than `MappingEntryStatus`'s representable range of `0..65535` — and flags the enum cast as potential critical unspecified behavior, since it can't see the invariant established in a different function (`CreateKey`).

## Fix

Mask the extracted value to 16 bits before casting, so its statically-provable range exactly matches the enum's underlying type:

```cpp
constexpr std::uint64_t kMaskStatus = 0x000000000000FFFFU;
const auto status_part = static_cast<std::uint16_t>((status_applictionid >> 32U) & kMaskStatus);
```

This makes the safety locally provable at the cast site instead of relying on an invariant established elsewhere, consistent with prior fixes for similar CodeQL/MISRA findings in this repo. No behavior change: since bits 48..63 are always zero by construction, the masked value is identical to the previous value in all cases.

## Verification

- `bazel build //score/mw/com/impl/bindings/lola:application_id_pid_mapping_entry` — pass
- `bazel build --config=tsan //score/mw/com/impl/bindings/lola:application_id_pid_mapping_entry` — pass
- `bazel test //score/mw/com/impl/bindings/lola:application_id_pid_mapping_test` — pass