### PR TITLE
docs: fix four broken links

### DIFF
--- a/score/memory/shared/design/OffsetPtrDesign.md
+++ b/score/memory/shared/design/OffsetPtrDesign.md
@@ -174,8 +174,8 @@ We rely on having sufficient tests to ensure that the implementation behaves as 
 ### Bounds checking iterators / element access
 
 LoLa uses [DynamicArrays](../../../containers/dynamic_array.h) for
-its [ServiceDataStorage](../../../../mw/com/impl/bindings/lola/service_data_storage.h)
-and [ServiceDataControl](../../../../mw/com/impl/bindings/lola/service_data_control.h).
+its [ServiceDataStorage](../../../mw/com/impl/bindings/lola/service_data_storage.h)
+and [ServiceDataControl](../../../mw/com/impl/bindings/lola/service_data_control.h).
 A `DynamicArray` is a fixed-size array data structure whose size can be, dynamically set at construction.
 Since these both reside in shared memory, the underlying pointer type used by `DynamicArray` must be an `OffsetPtr`.
 The `DynamicArray` is therefore susceptible to similar issues of memory corruption as an `OffsetPtr`.

--- a/score/memory/shared/design/README.md
+++ b/score/memory/shared/design/README.md
@@ -5,7 +5,7 @@ an abstraction layer is introduced.
 ## Use Cases / Customer Functions
 There are no direct Customer Functions associated with this part of `ara::core`.
 This is caused by the fact that the shared memory abstraction represents an implementation detail,
-which is necessary to fulfill the [Basic Architectural thoughts](../../../../mw/com/design/README.md) of `ara::com`.
+which is necessary to fulfill the [Basic Architectural thoughts](../../../mw/com/design/README.md) of `ara::com`.
 
 In fact, the usage of shared memory or its allocators shall be fully transparent for a user of the `ara`-API.
 

--- a/score/mw/com/dependability/software_architectural_design/method/README.md
+++ b/score/mw/com/dependability/software_architectural_design/method/README.md
@@ -156,7 +156,7 @@ Then the user provided service-method will be called with the `IN-args`/`OUT-arg
 
 When the user provided service-method-handler returns, it has already updated/set the `OUT-args` in the `METHOD`-shm-object. Then a reply-message is sent back via `message_passing` to the caller and the skeleton side is done with the processing of the method call and the thread will again wait for reception of a new call message.
 
-![Process Call Method](hhttp://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/eclipse-score/communication/master/score/mw/com/dependability/software_architectural_design/method/assets/process_method_call.puml)
+![Process Call Method](http://www.plantuml.com/plantuml/proxy?cache=no&src=https://raw.githubusercontent.com/eclipse-score/communication/master/score/mw/com/dependability/software_architectural_design/method/assets/process_method_call.puml)
 
 #### Concluding call of method
 


### PR DESCRIPTION
Four links in the design docs do not resolve. The targets all exist — the links are wrong.

## One level too many

`score/memory/shared/design/` is three levels below `score/`, but three links there use `../../../../`, which lands above the repository root:

| File | Link | Resolves to | Should be |
|---|---|---|---|
| `OffsetPtrDesign.md:177` | `ServiceDataStorage` | `mw/com/...` ✗ | `score/mw/com/...` |
| `OffsetPtrDesign.md:178` | `ServiceDataControl` | `mw/com/...` ✗ | `score/mw/com/...` |
| `README.md:8` | Basic Architectural thoughts | `mw/com/design/README.md` ✗ | `score/mw/com/design/README.md` |

Dropping one `../` makes each of them land on a file that is present in the tree.

## A typo in an image URL

```diff
-![Process Call Method](hhttp://www.plantuml.com/plantuml/proxy?...)
+![Process Call Method](http://www.plantuml.com/plantuml/proxy?...)
```

The extra `h` means the PlantUML diagram in `dependability/software_architectural_design/method/README.md` does not render at all. The other diagram in the same file (line 143, "Init Call Method") already uses `http://www.plantuml.com`, and the `.puml` source the URL points at is present at `method/assets/process_method_call.puml`.

## What I did not touch

I resolved every relative link in the repository's markdown against the tree. The other unresolved ones are left alone because I could not fix them without guessing, and several look deliberate:

- The `broken_link_a/`, `broken_link_c/`, `broken_link_g/` prefixes appear to be placeholders left where internal links were scrubbed for open-sourcing. That is the project's own marker, not something to repoint.
- Links into `../../../../docs/features/ipc/lola/…` and `../../../../intc/typedmemd/…` point at trees that are not part of this repository.
- `OffsetPtrDesign.md:176` references `containers/dynamic_array.h`, which is not in this repository — I believe it lives in `baselibs`, but I did not want to assume the right form of a cross-repository link.
- `OffsetPtrDesign.md:80` links to `../../shared/test/performance`; there is no `performance` directory under `score/memory/shared` (only `test_offset_ptr`), so I do not know what it was meant to point at.
- `README.md:130` and `:131` list `score/mw/com/message_passing/design/README.md` and `score/mw/com/doc/assumptions/README.md`. `message_passing` is at `score/message_passing` and has no `design/` directory, and there is no `assumptions` directory anywhere, so both targets are missing rather than misspelled.

Happy to follow up on any of those if someone can confirm the intended targets.

## Checks

- Each corrected path was re-resolved against a clone of `main`; all four now exist.
- Documentation only — 3 files, `+4/-4`, no code or build changes.
- ECA signed; commit carries `Signed-off-by`.

## AI disclosure

AI-assisted (Claude Code): the link sweep and this description were produced with the tool, and I verified the findings myself before opening — I checked each target against the tree, confirmed that dropping one `../` resolves the three design links, confirmed the `.puml` asset exists and that the sibling diagram in the same file already uses `http://`, and went through the remaining unresolved links one by one to separate the deliberate placeholders from genuine gaps. I have reviewed and understood the change and take responsibility for it.
