### PR TITLE
mw/com/test: Fix deprecated Initialize

### DIFF
--- a/score/mw/com/BUILD
+++ b/score/mw/com/BUILD
@@ -67,6 +67,7 @@ cc_library(
         ":types",
         "//score/mw/com/impl:runtime",
         "//score/mw/com/mocking:i_runtime",
+        "@score_baselibs//score/language/safecpp/string_view:zstring_view",
     ],
 )
 

--- a/score/mw/com/test/common_test_resources/BUILD
+++ b/score/mw/com/test/common_test_resources/BUILD
@@ -234,6 +234,7 @@ cc_library(
     ],
     deps = [
         ":command_line_parser",
+        ":general_resources",
         ":stop_token_sig_term_handler",
         "//score/mw/com",
     ],
@@ -405,11 +406,14 @@ cc_library(
     srcs = ["general_resources.cpp"],
     hdrs = ["general_resources.h"],
     features = COMPILER_WARNING_FEATURES,
+    visibility = ["//score/mw/com/test:__subpackages__"],
     deps = [
         ":check_point_control",
         ":child_process_guard",
         ":shared_memory_object_guard",
+        "//score/mw/com",
         "@score_baselibs//score/language/futurecpp",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
 )
 

--- a/score/mw/com/test/common_test_resources/sctf_test_runner.cpp
+++ b/score/mw/com/test/common_test_resources/sctf_test_runner.cpp
@@ -16,6 +16,7 @@
 #include "score/mw/com/runtime.h"
 #include "score/mw/com/test/common_test_resources/command_line_parser.h"
 #include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include <boost/program_options.hpp>
 #include <chrono>
@@ -226,7 +227,7 @@ SctfTestRunner::SctfTestRunner(int argc, const char** argv, const std::vector<Pa
             std::cerr << "setuid failed: " << strerror(errno) << std::endl;
         }
     }
-    score::mw::com::runtime::InitializeRuntime(argc, argv);
+    score::mw::com::runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
 }
 
 void SctfTestRunner::SetupSigTermHandler()

--- a/score/mw/com/test/concurrent_skeleton_creation/BUILD
+++ b/score/mw/com/test/concurrent_skeleton_creation/BUILD
@@ -29,6 +29,7 @@ cc_binary(
         "//score/mw/com",
         "//score/mw/com/test/common_test_resources:bigdata_type",
         "@score_baselibs//score/language/futurecpp",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
 )
 

--- a/score/mw/com/test/concurrent_skeleton_creation/concurrent_skeleton_creation_application.cpp
+++ b/score/mw/com/test/concurrent_skeleton_creation/concurrent_skeleton_creation_application.cpp
@@ -13,9 +13,11 @@
 
 #include "score/mw/com/test/concurrent_skeleton_creation/concurrent_skeleton_creation_application.h"
 
+#include "score/language/safecpp/string_view/zstring_view.h"
 #include "score/mw/com/runtime.h"
 #include "score/mw/com/test/common_test_resources/big_datatype.h"
 #include "score/mw/com/types.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include <score/jthread.hpp>
 #include <score/stop_token.hpp>
@@ -54,7 +56,7 @@ void CreateAndOfferSkeleton(const score::mw::com::InstanceSpecifier& instance_sp
  */
 int main(int argc, const char** argv)
 {
-    score::mw::com::runtime::InitializeRuntime(argc, argv);
+    score::mw::com::runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
 
     const auto instance_specifier_result_1 =
         score::mw::com::InstanceSpecifier::Create(std::string{"score/cp60/MapApiLanesStamped1"});

--- a/score/mw/com/test/fields/field_initial_value/BUILD
+++ b/score/mw/com/test/fields/field_initial_value/BUILD
@@ -48,6 +48,7 @@ cc_binary(
         "//score/mw/com/test/common_test_resources:process_synchronizer",
         "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
         "@score_baselibs//score/mw/log",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
 )
 

--- a/score/mw/com/test/fields/field_initial_value/service.cpp
+++ b/score/mw/com/test/fields/field_initial_value/service.cpp
@@ -16,6 +16,7 @@
 #include "score/mw/com/test/common_test_resources/process_synchronizer.h"
 #include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
 #include "score/mw/com/test/fields/field_initial_value/test_datatype.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include <score/stop_token.hpp>
 
@@ -80,7 +81,7 @@ void run_service(const score::cpp::stop_token& stop_token)
 
 int main(int argc, const char** argv)
 {
-    score::mw::com::runtime::InitializeRuntime(argc, argv);
+    score::mw::com::runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
 
     score::cpp::stop_source stop_source{};
     const bool sig_term_handler_setup_success = score::mw::com::SetupStopTokenSigTermHandler(stop_source);

--- a/score/mw/com/test/methods/semi_dynamic_methods/BUILD
+++ b/score/mw/com/test/methods/semi_dynamic_methods/BUILD
@@ -102,6 +102,7 @@ cc_binary(
         "//score/mw/com",
         "//score/mw/com/test/common_test_resources:assert_handler",
         "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
 )
 
@@ -116,6 +117,7 @@ cc_binary(
         ":consumer",
         "//score/mw/com",
         "//score/mw/com/test/common_test_resources:assert_handler",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
 )
 
@@ -132,6 +134,7 @@ cc_binary(
         "//score/mw/com",
         "//score/mw/com/test/common_test_resources:assert_handler",
         "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
 )
 

--- a/score/mw/com/test/methods/semi_dynamic_methods/main_consumer.cpp
+++ b/score/mw/com/test/methods/semi_dynamic_methods/main_consumer.cpp
@@ -13,11 +13,12 @@
 #include "score/mw/com/runtime.h"
 #include "score/mw/com/test/common_test_resources/assert_handler.h"
 #include "score/mw/com/test/methods/semi_dynamic_methods/consumer.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 int main(int argc, const char** argv)
 {
     score::mw::com::test::SetupAssertHandler();
-    score::mw::com::runtime::InitializeRuntime(argc, argv);
+    score::mw::com::runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
     score::mw::com::test::run_consumer();
     return EXIT_SUCCESS;
 }

--- a/score/mw/com/test/methods/semi_dynamic_methods/main_consumer_and_provider.cpp
+++ b/score/mw/com/test/methods/semi_dynamic_methods/main_consumer_and_provider.cpp
@@ -16,6 +16,7 @@
 #include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
 #include "score/mw/com/test/methods/semi_dynamic_methods/consumer.h"
 #include "score/mw/com/test/methods/semi_dynamic_methods/provider.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include <cstdlib>
 #include <future>
@@ -24,7 +25,7 @@
 int main(int argc, const char** argv)
 {
     score::mw::com::test::SetupAssertHandler();
-    score::mw::com::runtime::InitializeRuntime(argc, argv);
+    score::mw::com::runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
 
     score::cpp::stop_source stop_source{};
     const bool sig_term_handler_setup_success = score::mw::com::SetupStopTokenSigTermHandler(stop_source);

--- a/score/mw/com/test/methods/semi_dynamic_methods/main_provider.cpp
+++ b/score/mw/com/test/methods/semi_dynamic_methods/main_provider.cpp
@@ -14,13 +14,14 @@
 #include "score/mw/com/test/common_test_resources/assert_handler.h"
 #include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
 #include "score/mw/com/test/methods/semi_dynamic_methods/provider.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include <score/stop_token.hpp>
 
 int main(int argc, const char** argv)
 {
     score::mw::com::test::SetupAssertHandler();
-    score::mw::com::runtime::InitializeRuntime(argc, argv);
+    score::mw::com::runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
 
     score::cpp::stop_source stop_source{};
     const bool sig_term_handler_setup_success = score::mw::com::SetupStopTokenSigTermHandler(stop_source);

--- a/score/mw/com/test/move_semantics/skeleton_event/BUILD
+++ b/score/mw/com/test/move_semantics/skeleton_event/BUILD
@@ -91,6 +91,7 @@ cc_binary(
         "//score/mw/com/test/common_test_resources:assert_handler",
         "//score/mw/com/test/common_test_resources:fail_test",
         "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
 )
 
@@ -108,6 +109,7 @@ cc_binary(
         "//score/mw/com/test/common_test_resources:assert_handler",
         "//score/mw/com/test/common_test_resources:fail_test",
         "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
 )
 
@@ -126,6 +128,7 @@ cc_binary(
         "//score/mw/com/test/common_test_resources:assert_handler",
         "//score/mw/com/test/common_test_resources:fail_test",
         "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
 )
 

--- a/score/mw/com/test/move_semantics/skeleton_event/main_consumer.cpp
+++ b/score/mw/com/test/move_semantics/skeleton_event/main_consumer.cpp
@@ -16,13 +16,14 @@
 #include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
 #include "score/mw/com/test/move_semantics/skeleton_event/consumer.h"
 #include "score/mw/com/test/move_semantics/skeleton_event/test_parameters.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 int main(int argc, const char** argv)
 {
     auto test_configuration{score::mw::com::test::ReadCommandLineArguments(argc, argv)};
 
     score::mw::com::test::SetupAssertHandler();
-    score::mw::com::runtime::InitializeRuntime(argc, argv);
+    score::mw::com::runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
 
     score::cpp::stop_source stop_source{};
     const bool sig_term_handler_setup_success = score::mw::com::SetupStopTokenSigTermHandler(stop_source);

--- a/score/mw/com/test/move_semantics/skeleton_event/main_consumer_and_provider.cpp
+++ b/score/mw/com/test/move_semantics/skeleton_event/main_consumer_and_provider.cpp
@@ -17,13 +17,14 @@
 #include "score/mw/com/test/move_semantics/skeleton_event/consumer.h"
 #include "score/mw/com/test/move_semantics/skeleton_event/provider.h"
 #include "score/mw/com/test/move_semantics/skeleton_event/test_parameters.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 int main(int argc, const char** argv)
 {
     auto test_configuration{score::mw::com::test::ReadCommandLineArguments(argc, argv)};
 
     score::mw::com::test::SetupAssertHandler();
-    score::mw::com::runtime::InitializeRuntime(argc, argv);
+    score::mw::com::runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
 
     score::cpp::stop_source stop_source{};
     const bool sig_term_handler_setup_success = score::mw::com::SetupStopTokenSigTermHandler(stop_source);

--- a/score/mw/com/test/move_semantics/skeleton_event/main_provider.cpp
+++ b/score/mw/com/test/move_semantics/skeleton_event/main_provider.cpp
@@ -16,13 +16,14 @@
 #include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
 #include "score/mw/com/test/move_semantics/skeleton_event/provider.h"
 #include "score/mw/com/test/move_semantics/skeleton_event/test_parameters.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 int main(int argc, const char** argv)
 {
     auto test_configuration{score::mw::com::test::ReadCommandLineArguments(argc, argv)};
 
     score::mw::com::test::SetupAssertHandler();
-    score::mw::com::runtime::InitializeRuntime(argc, argv);
+    score::mw::com::runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
 
     score::cpp::stop_source stop_source{};
     const bool sig_term_handler_setup_success = score::mw::com::SetupStopTokenSigTermHandler(stop_source);

--- a/score/mw/com/test/partial_restart/consumer_restart/BUILD
+++ b/score/mw/com/test/partial_restart/consumer_restart/BUILD
@@ -39,6 +39,7 @@ cc_binary(
         "@boost.program_options",
         "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/mw/log",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
 )
 
@@ -48,9 +49,11 @@ cc_library(
     hdrs = ["consumer.h"],
     features = COMPILER_WARNING_FEATURES,
     deps = [
+        "//score/mw/com/test/common_test_resources:general_resources",
         "//score/mw/com/test/common_test_resources:test_resources",
         "//score/mw/com/test/partial_restart:consumer_handle_notification_data",
         "//score/mw/com/test/partial_restart:test_datatype",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
 )
 
@@ -61,7 +64,9 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     implementation_deps = [
         "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:general_resources",
         "//score/mw/com/test/partial_restart:test_datatype",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
     deps = [
         "//score/mw/com/test/common_test_resources:test_resources",

--- a/score/mw/com/test/partial_restart/consumer_restart/consumer.cpp
+++ b/score/mw/com/test/partial_restart/consumer_restart/consumer.cpp
@@ -20,6 +20,7 @@
 #include "score/concurrency/notification.h"
 #include "score/mw/com/test/common_test_resources/general_resources.h"
 #include "score/scope_exit/scope_exit.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include <iostream>
 
@@ -60,7 +61,7 @@ void DoConsumerActions(score::mw::com::test::CheckPointControl& check_point_cont
         std::cerr
             << "Consumer: Initializing LoLa/mw::com runtime from cmd-line args handed over by parent/controller ..."
             << std::endl;
-        mw::com::runtime::InitializeRuntime(argc, argv);
+        score::mw::com::runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
         std::cerr << "Consumer: Initializing LoLa/mw::com runtime done." << std::endl;
     }
 

--- a/score/mw/com/test/partial_restart/consumer_restart/consumer_restart_application.cpp
+++ b/score/mw/com/test/partial_restart/consumer_restart/consumer_restart_application.cpp
@@ -18,6 +18,7 @@
 #include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
 #include "score/mw/com/test/partial_restart/consumer_restart/consumer.h"
 #include "score/mw/com/test/partial_restart/consumer_restart/provider.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include <score/stop_token.hpp>
 #include <optional>

--- a/score/mw/com/test/partial_restart/consumer_restart/provider.cpp
+++ b/score/mw/com/test/partial_restart/consumer_restart/provider.cpp
@@ -20,6 +20,7 @@
 
 #include "score/mw/com/runtime.h"
 #include "score/scope_exit/scope_exit.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include <chrono>
 #include <iostream>
@@ -51,7 +52,7 @@ void DoProviderActions(CheckPointControl& check_point_control,
         std::cerr
             << "Provider: Initializing LoLa/mw::com runtime from cmd-line args handed over by parent/controller ..."
             << std::endl;
-        mw::com::runtime::InitializeRuntime(argc, argv);
+        score::mw::com::runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
         std::cerr << "Provider: Initializing LoLa/mw::com runtime done." << std::endl;
     }
 

--- a/score/mw/com/test/partial_restart/provider_restart/BUILD
+++ b/score/mw/com/test/partial_restart/provider_restart/BUILD
@@ -33,11 +33,13 @@ cc_binary(
     features = COMPILER_WARNING_FEATURES,
     deps = [
         ":controller",
+        "//score/mw/com/test/common_test_resources:general_resources",
         "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
         "//score/mw/com/test/common_test_resources:test_resources",
         "@boost.program_options",
         "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/mw/log",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
 )
 
@@ -48,10 +50,12 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     implementation_deps = [
         "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:general_resources",
         "//score/mw/com/test/common_test_resources:generic_trace_api_test_resources",
         "//score/mw/com/test/common_test_resources:test_resources",
         "//score/mw/com/test/partial_restart:consumer_handle_notification_data",
         "//score/mw/com/test/partial_restart:test_datatype",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
     visibility = ["//score/mw/com/test/partial_restart:__subpackages__"],
     deps = [
@@ -66,8 +70,10 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     implementation_deps = [
         "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:general_resources",
         "//score/mw/com/test/common_test_resources:generic_trace_api_test_resources",
         "//score/mw/com/test/partial_restart:test_datatype",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
     visibility = ["//score/mw/com/test/partial_restart:__subpackages__"],
     deps = [
@@ -82,6 +88,7 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     implementation_deps = [
         "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:general_resources",
         "//score/mw/com/test/common_test_resources:generic_trace_api_test_resources",
         "//score/mw/com/test/common_test_resources:test_resources",
     ],

--- a/score/mw/com/test/partial_restart/provider_restart/consumer.cpp
+++ b/score/mw/com/test/partial_restart/provider_restart/consumer.cpp
@@ -23,6 +23,7 @@
 #include "score/mw/com/runtime.h"
 #include "score/mw/com/types.h"
 #include "score/scope_exit/scope_exit.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include <iostream>
 #include <mutex>
@@ -369,7 +370,7 @@ void DoConsumerActions(CheckPointControl& check_point_control,
         std::cerr
             << "Consumer: Initializing LoLa/mw::com runtime from cmd-line args handed over by parent/controller ..."
             << std::endl;
-        mw::com::runtime::InitializeRuntime(argc, argv);
+        score::mw::com::runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
         std::cerr << "Consumer: Initializing LoLa/mw::com runtime done." << std::endl;
     }
 

--- a/score/mw/com/test/partial_restart/provider_restart/provider.cpp
+++ b/score/mw/com/test/partial_restart/provider_restart/provider.cpp
@@ -22,6 +22,7 @@
 #include "score/mw/com/runtime.h"
 #include "score/mw/com/types.h"
 #include "score/scope_exit/scope_exit.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include <chrono>
 #include <iostream>
@@ -137,7 +138,7 @@ void DoProviderActions(CheckPointControl& check_point_control,
         std::cerr
             << "Provider: Initializing LoLa/mw::com runtime from cmd-line args handed over by parent/controller ..."
             << std::endl;
-        mw::com::runtime::InitializeRuntime(argc, argv);
+        score::mw::com::runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
         std::cerr << "Provider: Initializing LoLa/mw::com runtime done." << std::endl;
     }
 

--- a/score/mw/com/test/partial_restart/provider_restart_max_subscribers/BUILD
+++ b/score/mw/com/test/partial_restart/provider_restart_max_subscribers/BUILD
@@ -34,11 +34,13 @@ cc_binary(
     deps = [
         ":consumer",
         ":provider",
+        "//score/mw/com/test/common_test_resources:general_resources",
         "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
         "//score/mw/com/test/common_test_resources:test_resources",
         "@boost.program_options",
         "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/mw/log",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
 )
 
@@ -48,9 +50,11 @@ cc_library(
     hdrs = ["consumer.h"],
     features = COMPILER_WARNING_FEATURES,
     deps = [
+        "//score/mw/com/test/common_test_resources:general_resources",
         "//score/mw/com/test/common_test_resources:test_resources",
         "//score/mw/com/test/partial_restart:consumer_handle_notification_data",
         "//score/mw/com/test/partial_restart:test_datatype",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
 )
 
@@ -61,8 +65,10 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     implementation_deps = [
         "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:general_resources",
         "//score/mw/com/test/partial_restart:consumer_handle_notification_data",
         "//score/mw/com/test/partial_restart:test_datatype",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
     deps = [
         "//score/mw/com/test/common_test_resources:test_resources",

--- a/score/mw/com/test/partial_restart/provider_restart_max_subscribers/consumer.cpp
+++ b/score/mw/com/test/partial_restart/provider_restart_max_subscribers/consumer.cpp
@@ -19,6 +19,7 @@
 #include "score/mw/com/test/common_test_resources/general_resources.h"
 #include "score/mw/com/test/partial_restart/test_datatype.h"
 #include "score/mw/com/types.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include <chrono>
 #include <cstddef>
@@ -55,7 +56,7 @@ ConsumerActions::ConsumerActions(CheckPointControl& check_point_control,
         std::cerr
             << "Consumer: Initializing LoLa/mw::com runtime from cmd-line args handed over by parent/controller ..."
             << std::endl;
-        mw::com::runtime::InitializeRuntime(argc, argv);
+        score::mw::com::runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
         std::cerr << "Consumer: Initializing LoLa/mw::com runtime done." << std::endl;
     }
 }

--- a/score/mw/com/test/partial_restart/provider_restart_max_subscribers/provider.cpp
+++ b/score/mw/com/test/partial_restart/provider_restart_max_subscribers/provider.cpp
@@ -19,6 +19,7 @@
 
 #include "score/mw/com/runtime.h"
 #include "score/scope_exit/scope_exit.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include <iostream>
 
@@ -46,7 +47,7 @@ void DoProviderActions(CheckPointControl& check_point_control,
         std::cerr
             << "Provider: Initializing LoLa/mw::com runtime from cmd-line args handed over by parent/controller ..."
             << std::endl;
-        mw::com::runtime::InitializeRuntime(argc, argv);
+        runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
         std::cerr << "Provider: Initializing LoLa/mw::com runtime done." << std::endl;
     }
 

--- a/score/mw/com/test/partial_restart/provider_restart_max_subscribers/provider_restart_max_subscribers_application.cpp
+++ b/score/mw/com/test/partial_restart/provider_restart_max_subscribers/provider_restart_max_subscribers_application.cpp
@@ -21,6 +21,7 @@
 #include "score/mw/com/test/common_test_resources/general_resources.h"
 #include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
 #include "score/mw/com/test/partial_restart/test_datatype.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include "score/mw/com/test/common_test_resources/timeout_supervisor.h"
 #include <optional>

--- a/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/consumer.cpp
+++ b/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/consumer.cpp
@@ -118,8 +118,10 @@ void PerformFirstConsumerActions(CheckPointControl& check_point_control,
     //***************************************************
     std::cout << "First Consumer Step(1) - mw_com_config_path: " << mw_com_config_path << std::endl;
     // Initialize mw::com runtime with our explicit configuration
-    const char* argv[2U] = {"--service_instance_manifest", mw_com_config_path.data()};
-    runtime::InitializeRuntime(2U, argv);
+    using safecpp::literals::operator""_zsv;
+    const auto path = safecpp::zstring_view{mw_com_config_path.data(), mw_com_config_path.size()};
+    std::vector arguments = {"--service_instance_manifest"_zsv, path};
+    runtime::InitializeRuntime(arguments);
     //***************************************************************************
     // Step (2)- start find service and wait till it is found.
     //***************************************************************************
@@ -209,8 +211,10 @@ void PerformSecondConsumerActions(CheckPointControl& check_point_control,
     //***************************************************
     std::cout << "Second Consumer Step(1) - mw_com_config_path: " << mw_com_config_path << std::endl;
     // Initialize mw::com runtime with our explicit configuration
-    const char* argv[2U] = {"--service_instance_manifest", mw_com_config_path.data()};
-    runtime::InitializeRuntime(2U, argv);
+    using safecpp::literals::operator""_zsv;
+    const auto path = safecpp::zstring_view{mw_com_config_path.data(), mw_com_config_path.size()};
+    std::vector arguments = {"--service_instance_manifest"_zsv, path};
+    runtime::InitializeRuntime(arguments);
     //*********************************************************
     // Step (2)- start find service and wait till it is found.
     //*********************************************************

--- a/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/provider.cpp
+++ b/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/provider.cpp
@@ -40,8 +40,10 @@ void PerformProviderActions(CheckPointControl& check_point_control,
 
     std::cout << "Provider: Starting actions! mw_com_config_path: " << mw_com_config_path << std::endl;
     // Initialize mw::com runtime with our explicit configuration
-    const char* argv[2U] = {"--service_instance_manifest", mw_com_config_path.data()};
-    runtime::InitializeRuntime(2, argv);
+    using safecpp::literals::operator""_zsv;
+    const auto path = safecpp::zstring_view{mw_com_config_path.data(), mw_com_config_path.size()};
+    std::vector arguments = {"--service_instance_manifest"_zsv, path};
+    runtime::InitializeRuntime(arguments);
 
     //***************************************************
     // Step (1)- create and offer service

--- a/score/mw/com/test/receive_handler_usage/BUILD
+++ b/score/mw/com/test/receive_handler_usage/BUILD
@@ -32,6 +32,7 @@ cc_binary(
         "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
         "@score_baselibs//score/concurrency:notification",
         "@score_baselibs//score/language/futurecpp",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
 )
 

--- a/score/mw/com/test/receive_handler_usage/receive_handler_usage_application.cpp
+++ b/score/mw/com/test/receive_handler_usage/receive_handler_usage_application.cpp
@@ -19,6 +19,7 @@
 #include "score/mw/com/test/common_test_resources/big_datatype.h"
 #include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
 #include "score/mw/com/types.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include <score/jthread.hpp>
 #include <score/stop_token.hpp>
@@ -199,7 +200,7 @@ int main(int argc, const char** argv)
     }
 
     // This allows us more flexibility as we can hand over "-service_instance_manifest /path/to/mw_com_config.json
-    score::mw::com::runtime::InitializeRuntime(argc, argv);
+    score::mw::com::runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
 
     const auto instance_specifier_result =
         score::mw::com::InstanceSpecifier::Create(std::string{"score/cp60/MapApiLanesStamped"});

--- a/score/mw/com/test/service_discovery_during_consumer_crash/BUILD
+++ b/score/mw/com/test/service_discovery_during_consumer_crash/BUILD
@@ -45,11 +45,13 @@ cc_binary(
     deps = [
         ":consumer",
         ":provider",
+        "//score/mw/com/test/common_test_resources:general_resources",
         "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
         "//score/mw/com/test/common_test_resources:test_resources",
         "@boost.program_options",
         "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/mw/log",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
 )
 
@@ -60,7 +62,9 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     deps = [
         ":test_datatype",
+        "//score/mw/com/test/common_test_resources:general_resources",
         "//score/mw/com/test/common_test_resources:test_resources",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
 )
 
@@ -72,6 +76,8 @@ cc_library(
     implementation_deps = [
         ":test_datatype",
         "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:general_resources",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
     deps = [
         "//score/mw/com/test/common_test_resources:test_resources",

--- a/score/mw/com/test/service_discovery_during_consumer_crash/consumer.cpp
+++ b/score/mw/com/test/service_discovery_during_consumer_crash/consumer.cpp
@@ -15,6 +15,7 @@
 #include "score/mw/com/runtime.h"
 #include "score/mw/com/test/common_test_resources/check_point_control.h"
 #include "score/mw/com/test/common_test_resources/consumer_resources.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include "score/mw/com/test/common_test_resources/general_resources.h"
 #include "score/mw/com/test/service_discovery_during_consumer_crash/test_datatype.h"
@@ -51,7 +52,7 @@ void DoConsumerActionsFirstTime(score::mw::com::test::CheckPointControl& check_p
         std::cerr
             << "Consumer: Initializing LoLa/mw::com runtime from cmd-line args handed over by parent/controller ..."
             << std::endl;
-        mw::com::runtime::InitializeRuntime(argc, argv);
+        runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
         std::cerr << "Consumer: Initializing LoLa/mw::com runtime done." << std::endl;
     }
 
@@ -125,7 +126,7 @@ void DoConsumerActionsAfterRestart(score::mw::com::test::CheckPointControl& chec
         std::cerr << "Reconnected Consumer: Initializing LoLa/mw::com runtime from cmd-line args handed over by "
                      "parent/controller ..."
                   << std::endl;
-        mw::com::runtime::InitializeRuntime(argc, argv);
+        runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
         std::cerr << "Reconnected Consumer: Initializing LoLa/mw::com runtime done." << std::endl;
     }
 

--- a/score/mw/com/test/service_discovery_during_consumer_crash/provider.cpp
+++ b/score/mw/com/test/service_discovery_during_consumer_crash/provider.cpp
@@ -19,6 +19,7 @@
 #include "score/mw/com/test/service_discovery_during_consumer_crash/test_datatype.h"
 
 #include "score/mw/com/runtime.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include <chrono>
 #include <iostream>
@@ -41,7 +42,7 @@ void DoProviderActions(CheckPointControl& check_point_control,
         std::cerr
             << "Provider: Initializing LoLa/mw::com runtime from cmd-line args handed over by parent/controller ..."
             << std::endl;
-        mw::com::runtime::InitializeRuntime(argc, argv);
+        runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
         std::cerr << "Provider: Initializing LoLa/mw::com runtime done." << std::endl;
     }
 

--- a/score/mw/com/test/service_discovery_during_consumer_crash/service_discovery_during_consumer_crash_application.cpp
+++ b/score/mw/com/test/service_discovery_during_consumer_crash/service_discovery_during_consumer_crash_application.cpp
@@ -18,6 +18,7 @@
 #include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
 #include "score/mw/com/test/service_discovery_during_consumer_crash/consumer.h"
 #include "score/mw/com/test/service_discovery_during_consumer_crash/provider.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include <score/stop_token.hpp>
 

--- a/score/mw/com/test/service_discovery_during_provider_crash/BUILD
+++ b/score/mw/com/test/service_discovery_during_provider_crash/BUILD
@@ -45,11 +45,13 @@ cc_binary(
     deps = [
         ":consumer",
         ":provider",
+        "//score/mw/com/test/common_test_resources:general_resources",
         "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
         "//score/mw/com/test/common_test_resources:test_resources",
         "@boost.program_options",
         "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/mw/log",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
 )
 
@@ -60,7 +62,9 @@ cc_library(
     features = COMPILER_WARNING_FEATURES,
     deps = [
         ":test_datatype",
+        "//score/mw/com/test/common_test_resources:general_resources",
         "//score/mw/com/test/common_test_resources:test_resources",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
 )
 
@@ -72,6 +76,8 @@ cc_library(
     implementation_deps = [
         ":test_datatype",
         "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:general_resources",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
     deps = [
         "//score/mw/com/test/common_test_resources:test_resources",

--- a/score/mw/com/test/service_discovery_during_provider_crash/consumer.cpp
+++ b/score/mw/com/test/service_discovery_during_provider_crash/consumer.cpp
@@ -15,6 +15,7 @@
 #include "score/mw/com/runtime.h"
 #include "score/mw/com/test/common_test_resources/check_point_control.h"
 #include "score/mw/com/test/common_test_resources/consumer_resources.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include "score/mw/com/test/common_test_resources/general_resources.h"
 #include "score/mw/com/test/service_discovery_during_provider_crash/test_datatype.h"
@@ -41,7 +42,7 @@ void DoConsumerActions(score::mw::com::test::CheckPointControl& check_point_cont
         std::cerr
             << "Consumer: Initializing LoLa/mw::com runtime from cmd-line args handed over by parent/controller ..."
             << std::endl;
-        mw::com::runtime::InitializeRuntime(argc, argv);
+        runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
         std::cerr << "Consumer: Initializing LoLa/mw::com runtime done." << std::endl;
     }
 

--- a/score/mw/com/test/service_discovery_during_provider_crash/provider.cpp
+++ b/score/mw/com/test/service_discovery_during_provider_crash/provider.cpp
@@ -19,6 +19,7 @@
 #include "score/mw/com/test/service_discovery_during_provider_crash/test_datatype.h"
 
 #include "score/mw/com/runtime.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include <chrono>
 #include <iostream>
@@ -41,7 +42,7 @@ void DoProviderActions(CheckPointControl& check_point_control,
         std::cerr
             << "Provider: Initializing LoLa/mw::com runtime from cmd-line args handed over by parent/controller ..."
             << std::endl;
-        mw::com::runtime::InitializeRuntime(argc, argv);
+        runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
         std::cerr << "Provider: Initializing LoLa/mw::com runtime done." << std::endl;
     }
 

--- a/score/mw/com/test/service_discovery_during_provider_crash/service_discovery_during_provider_crash_application.cpp
+++ b/score/mw/com/test/service_discovery_during_provider_crash/service_discovery_during_provider_crash_application.cpp
@@ -18,6 +18,7 @@
 #include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
 #include "score/mw/com/test/service_discovery_during_provider_crash/consumer.h"
 #include "score/mw/com/test/service_discovery_during_provider_crash/provider.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include <score/stop_token.hpp>
 

--- a/score/mw/com/test/smokeyeyes/BUILD
+++ b/score/mw/com/test/smokeyeyes/BUILD
@@ -29,6 +29,7 @@ cc_binary(
         "@boost.interprocess",
         "@boost.program_options",
         "@score_baselibs//score/mw/log",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
 )
 

--- a/score/mw/com/test/smokeyeyes/smokeyeyes.cpp
+++ b/score/mw/com/test/smokeyeyes/smokeyeyes.cpp
@@ -14,6 +14,7 @@
 #include "score/mw/com/test/smokeyeyes/smokeyeyes.h"
 
 #include "score/mw/com/runtime.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include <boost/functional/hash.hpp>
 #include <boost/interprocess/anonymous_shared_memory.hpp>
@@ -456,7 +457,7 @@ int main(int argc, const char** argv)
     // Has to be done after forking as messaging permanently stores the pid as the node identifier
     if (args.count("service_instance_manifest") > 0U)
     {
-        mw::com::runtime::InitializeRuntime(argc, argv);
+        score::mw::com::runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
     }
 
     int result{};

--- a/score/mw/com/test/unsubscribe_deadlock/BUILD
+++ b/score/mw/com/test/unsubscribe_deadlock/BUILD
@@ -29,9 +29,11 @@ cc_binary(
         "//score/mw/com",
         "//score/mw/com/test/common_test_resources:assert_handler",
         "//score/mw/com/test/common_test_resources:bigdata_type",
+        "//score/mw/com/test/common_test_resources:general_resources",
         "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
         "@score_baselibs//score/concurrency:notification",
         "@score_baselibs//score/language/futurecpp",
+        "@score_baselibs//score/string_manipulation/arguments",
     ],
 )
 

--- a/score/mw/com/test/unsubscribe_deadlock/unsubscribe_deadlock_application.cpp
+++ b/score/mw/com/test/unsubscribe_deadlock/unsubscribe_deadlock_application.cpp
@@ -19,6 +19,7 @@
 #include "score/mw/com/test/common_test_resources/big_datatype.h"
 #include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
 #include "score/mw/com/types.h"
+#include "score/string_manipulation/arguments/arguments.h"
 
 #include <score/jthread.hpp>
 #include <score/stop_token.hpp>
@@ -113,7 +114,7 @@ int main(int argc, const char** argv)
         return EXIT_FAILURE;
     }
 
-    score::mw::com::runtime::InitializeRuntime(argc, argv);
+    score::mw::com::runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
 
     const auto instance_specifier_result =
         score::mw::com::InstanceSpecifier::Create(std::string{"score/cp60/MapApiLanesStamped"});


### PR DESCRIPTION
Refactored all usages in tests of deprecated
Runtime::Initialize(argc, argv) to use the
safecpp::zstring_view based overload instead.