### PR TITLE
Fix linter report collection

### DIFF
--- a/.github/actions/00_infrastructure/merge_sarif_reports/action.yml
+++ b/.github/actions/00_infrastructure/merge_sarif_reports/action.yml
@@ -1,0 +1,126 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+name: "Merge rules_lint SARIF reports"
+description: >-
+  Collects the per-file SARIF ".report" files emitted by rules_lint_machine
+  (discovered via a Bazel Build Event Protocol JSON stream) and merges them
+  into a single, valid SARIF document with one run per distinct tool, via the
+  official Microsoft SARIF SDK's `Sarif.Multitool merge` command, suitable
+  for uploading to GitHub Code Scanning via github/codeql-action/upload-sarif.
+
+inputs:
+  bep-json:
+    description: "Path to the Bazel Build Event Protocol JSON file (--build_event_json_file) to scan for emitted '.report' files."
+    required: true
+  output-file:
+    description: "Path to write the merged SARIF document to."
+    required: true
+  sarif-multitool-version:
+    description: "Version of the @microsoft/sarif-multitool npm package to use."
+    required: false
+    default: "5.6.0"
+
+outputs:
+  sarif-file:
+    description: "Path to the merged SARIF document (same as the output-file input). Only meaningful if 'found' is 'true'."
+    value: ${{ inputs.output-file }}
+
+runs:
+  using: "composite"
+  steps:
+    - name: Merge SARIF reports
+      id: merge
+      shell: bash
+      run: |
+        set -euo pipefail
+
+        WORK_DIR="$(mktemp -d)"
+        STAGE_DIR="${WORK_DIR}/reports"
+        mkdir -p "${STAGE_DIR}"
+
+        # Ask Bazel directly (via its Build Event Protocol JSON stream) which
+        # files were produced by the rules_lint_machine output group.
+        ALL_REPORTS=$(jq -r '
+          select(.id.namedSet != null)
+          | .namedSetOfFiles.files[]?
+          | select(.name | endswith(".report"))
+          | .uri
+        ' "${{ inputs.bep-json }}" 2>/dev/null | sed 's|^file://||' | sort -u)
+
+        # A ".report" file is completely empty (0 bytes) when
+        # rules_lint_machine declared the output but the linter never
+        # actually ran against the target (e.g. header-only cc_library
+        # targets with no srcs to compile/analyze). This is different from
+        # a clean, actually-linted file, which still produces a small but
+        # valid SARIF document (an empty `results` array). An empty file is
+        # not valid SARIF/JSON at all, so treat it as a hard failure rather
+        # than silently dropping it, since it usually indicates the linter
+        # was skipped/misconfigured for that target.
+        REPORTS=""
+        EMPTY_SOURCES=""
+        for f in ${ALL_REPORTS}; do
+          if [[ -s "${f}" ]]; then
+            REPORTS+="${f}"$'\n'
+          else
+            # Recover the original linted source/header path from the
+            # report filename, e.g.
+            # ".../foo.cpp.AspectRulesLintClangTidy.report" -> ".../foo.cpp".
+            SOURCE_FILE=$(echo "${f}" | sed -E 's/\.AspectRulesLint[A-Za-z]*\.report$//')
+            EMPTY_SOURCES+="${SOURCE_FILE}"$'\n'
+          fi
+        done
+        REPORTS=$(echo "${REPORTS}" | sed '/^$/d')
+        EMPTY_SOURCES=$(echo "${EMPTY_SOURCES}" | sed '/^$/d')
+
+        if [[ -n "${EMPTY_SOURCES}" ]]; then
+          echo "::error::Found empty (0-byte) rules_lint SARIF report(s), which indicates the linter did not actually run for these file(s):"
+          while IFS= read -r src; do
+            echo "::error file=${src}::Empty rules_lint SARIF report for file ${src}; the linter did not run against it (e.g. no compile action, misconfigured target)."
+          done <<< "${EMPTY_SOURCES}"
+          exit 1
+        fi
+
+        if [[ -z "${REPORTS}" ]]; then
+          echo "::error::No non-empty SARIF reports found; nothing to merge/upload."
+          exit 1
+        fi
+
+        # Stage every per-file SARIF report as a symlink, numbered to avoid
+        # basename collisions, in a single flat directory. Handing
+        # `Sarif.Multitool merge` one glob specifier over that directory
+        # (rather than hundreds of individual file paths) keeps the
+        # invocation to a single argv entry no matter how many report files
+        # there are, avoiding shell/xargs argument-length limits that can
+        # otherwise silently corrupt the output (as previously happened with
+        # `xargs jq -s ...`, which split into multiple invocations once the
+        # report list exceeded xargs' default ~128KiB argument limit, each
+        # appending a separate SARIF document to the same output file).
+        i=0
+        while IFS= read -r f; do
+          i=$((i + 1))
+          ln -s "$(readlink -f "${f}")" "${STAGE_DIR}/report_$(printf '%06d' "${i}")"
+        done <<< "${REPORTS}"
+
+        # Merge all per-file SARIF reports into a single SARIF document via
+        # the official Microsoft SARIF SDK CLI. `sarif merge` coalesces runs
+        # by tool name/version into one run per distinct tool by default
+        # (deduplicating identical results), which is required since GitHub
+        # Code Scanning (as of 2025-07-22) rejects SARIF uploads containing
+        # multiple runs that share the same tool/category.
+        npx --yes "@microsoft/sarif-multitool@${{ inputs.sarif-multitool-version }}" \
+          merge "${STAGE_DIR}/*" \
+          --output-directory "$(dirname "${{ inputs.output-file }}")" \
+          --output-file "$(basename "${{ inputs.output-file }}")"
+
+        echo "Merged ${i} report(s) into ${{ inputs.output-file }}"

--- a/.github/workflows/_linter.yml
+++ b/.github/workflows/_linter.yml
@@ -122,49 +122,16 @@ jobs:
       - name: Collect SARIF reports
         if: always() && inputs.fetch-only != 'true'
         id: sarif
-        run: |
-          mkdir -p /tmp/sarif-reports
-
-          # Ask Bazel directly (via its Build Event Protocol JSON stream) which
-          # files were produced by the rules_lint_machine output group.
-          ALL_REPORTS=$(jq -r '
-            select(.id.namedSet != null)
-            | .namedSetOfFiles.files[]?
-            | select(.name | endswith(".report"))
-            | .uri
-          ' /tmp/bep.json 2>/dev/null | sed 's|^file://||' | sort -u)
-
-          # Reports for targets with no violations are declared but empty;
-          # skip those before merging.
-          REPORTS=""
-          for f in ${ALL_REPORTS}; do
-            [[ -s "${f}" ]] && REPORTS+="${f}"$'\n'
-          done
-          REPORTS=$(echo "${REPORTS}" | sed '/^$/d')
-
-          if [[ -z "${REPORTS}" ]]; then
-            echo "No non-empty SARIF reports found; nothing to merge/upload."
-            echo "found=false" >> "$GITHUB_OUTPUT"
-            exit 0
-          fi
-
-          # Merge all per-file SARIF reports (one per linted source file) into a
-          # single SARIF document with one combined "runs[0].results" array,
-          # since they all share the same tool driver for a given linter.
-          echo "${REPORTS}" | xargs jq -s '{
-            "$schema": .[0]["$schema"],
-            version: .[0].version,
-            runs: [ (.[0].runs[0] * { results: (map(.runs[0].results) | add) }) ]
-          }' > "/tmp/sarif-reports/${{ matrix.id }}.sarif"
-
-          echo "found=true" >> "$GITHUB_OUTPUT"
-          echo "Merged $(echo "${REPORTS}" | wc -l) report(s) into /tmp/sarif-reports/${{ matrix.id }}.sarif"
+        uses: ./.github/actions/00_infrastructure/merge_sarif_reports
+        with:
+          bep-json: /tmp/bep.json
+          output-file: ${{ matrix.id }}.sarif
 
       - name: Upload SARIF reports to GitHub Code Scanning
-        if: always() && inputs.fetch-only != 'true' && steps.sarif.outputs.found == 'true'
+        if: always() && inputs.fetch-only != 'true'
         uses: github/codeql-action/upload-sarif@v4
         with:
-          sarif_file: /tmp/sarif-reports/${{ matrix.id }}.sarif
+          sarif_file: ${{ matrix.id }}.sarif
           category: ${{ matrix.id }}
           # Block this step until GitHub has finished processing the
           # uploaded SARIF (default, made explicit here) so that any
@@ -179,6 +146,6 @@ jobs:
           name: ${{ matrix.id }}-findings
           path: |
             ${{ matrix.id }}_raw.log
-            /tmp/sarif-reports/${{ matrix.id }}.sarif
+            ${{ matrix.id }}.sarif
           if-no-files-found: ignore
           retention-days: 7

--- a/quality/api_surface/tests/BUILD
+++ b/quality/api_surface/tests/BUILD
@@ -18,51 +18,61 @@ load("//quality/api_surface:api_surface.bzl", "api_surface_test")
 
 cc_library(
     name = "basic_class_lib",
+    srcs = ["basic_class.cpp"],
     hdrs = ["basic_class.h"],
 )
 
 cc_library(
     name = "type_alias_lib",
+    srcs = ["type_alias.cpp"],
     hdrs = ["type_alias.h"],
 )
 
 cc_library(
     name = "inheritance_lib",
+    srcs = ["inheritance.cpp"],
     hdrs = ["inheritance.h"],
 )
 
 cc_library(
     name = "template_alias_lib",
+    srcs = ["template_alias.cpp"],
     hdrs = ["template_alias.h"],
 )
 
 cc_library(
     name = "private_changes_lib",
+    srcs = ["private_changes.cpp"],
     hdrs = ["private_changes.h"],
 )
 
 cc_library(
     name = "types_in_signatures_lib",
+    srcs = ["types_in_signatures.cpp"],
     hdrs = ["types_in_signatures.h"],
 )
 
 cc_library(
     name = "enum_and_free_functions_lib",
+    srcs = ["enum_and_free_functions.cpp"],
     hdrs = ["enum_and_free_functions.h"],
 )
 
 cc_library(
     name = "internal_namespace_lib",
+    srcs = ["internal_namespace.cpp"],
     hdrs = ["internal_namespace.h"],
 )
 
 cc_library(
     name = "result_type_support_lib",
+    srcs = ["result_type_support.cpp"],
     hdrs = ["result_type_support.h"],
 )
 
 cc_library(
     name = "result_type_regression_lib",
+    srcs = ["result_type_regression.cpp"],
     hdrs = ["result_type_regression.h"],
     deps = [":result_type_support_lib"],
 )
@@ -141,56 +151,67 @@ api_surface_test(
 
 cc_library(
     name = "multi_inheritance_lib",
+    srcs = ["multi_inheritance.cpp"],
     hdrs = ["multi_inheritance.h"],
 )
 
 cc_library(
     name = "ref_qualifiers_lib",
+    srcs = ["ref_qualifiers.cpp"],
     hdrs = ["ref_qualifiers.h"],
 )
 
 cc_library(
     name = "member_function_templates_lib",
+    srcs = ["member_function_templates.cpp"],
     hdrs = ["member_function_templates.h"],
 )
 
 cc_library(
     name = "globals_lib",
+    srcs = ["globals.cpp"],
     hdrs = ["globals.h"],
 )
 
 cc_library(
     name = "protected_methods_lib",
+    srcs = ["protected_methods.cpp"],
     hdrs = ["protected_methods.h"],
 )
 
 cc_library(
     name = "constexpr_members_lib",
+    srcs = ["constexpr_members.cpp"],
     hdrs = ["constexpr_members.h"],
 )
 
 cc_library(
     name = "forward_declared_lib",
+    srcs = ["forward_declared.cpp"],
     hdrs = ["forward_declared.h"],
 )
 
 cc_library(
     name = "extern_c_lib",
+    srcs = ["extern_c.cpp"],
     hdrs = ["extern_c.h"],
 )
 
 cc_library(
     name = "extern_explicit_lib",
+    srcs = ["extern_explicit.cpp"],
     hdrs = ["extern_explicit.h"],
 )
 
 cc_library(
     name = "cpp_attributes_lib",
+    srcs = ["cpp_attributes.cpp"],
     hdrs = ["cpp_attributes.h"],
 )
 
 cc_library(
     name = "sfinae_lib",
+    srcs = ["sfinae.cpp"],
     hdrs = ["sfinae.h"],
 )
 
@@ -199,11 +220,13 @@ cc_library(
 
 cc_library(
     name = "private_changes_v2_lib",
+    srcs = ["private_changes_v2.cpp"],
     hdrs = ["private_changes_v2.h"],
 )
 
 cc_library(
     name = "all_private_lib",
+    srcs = ["all_private.cpp"],
     hdrs = ["all_private.h"],
 )
 

--- a/quality/api_surface/tests/all_private.cpp
+++ b/quality/api_surface/tests/all_private.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/all_private.h"

--- a/quality/api_surface/tests/basic_class.cpp
+++ b/quality/api_surface/tests/basic_class.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/basic_class.h"

--- a/quality/api_surface/tests/constexpr_members.cpp
+++ b/quality/api_surface/tests/constexpr_members.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/constexpr_members.h"

--- a/quality/api_surface/tests/cpp_attributes.cpp
+++ b/quality/api_surface/tests/cpp_attributes.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/cpp_attributes.h"

--- a/quality/api_surface/tests/enum_and_free_functions.cpp
+++ b/quality/api_surface/tests/enum_and_free_functions.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/enum_and_free_functions.h"

--- a/quality/api_surface/tests/extern_c.cpp
+++ b/quality/api_surface/tests/extern_c.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/extern_c.h"

--- a/quality/api_surface/tests/extern_explicit.cpp
+++ b/quality/api_surface/tests/extern_explicit.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/extern_explicit.h"

--- a/quality/api_surface/tests/forward_declared.cpp
+++ b/quality/api_surface/tests/forward_declared.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/forward_declared.h"

--- a/quality/api_surface/tests/globals.cpp
+++ b/quality/api_surface/tests/globals.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/globals.h"

--- a/quality/api_surface/tests/inheritance.cpp
+++ b/quality/api_surface/tests/inheritance.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/inheritance.h"

--- a/quality/api_surface/tests/internal_namespace.cpp
+++ b/quality/api_surface/tests/internal_namespace.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/internal_namespace.h"

--- a/quality/api_surface/tests/member_function_templates.cpp
+++ b/quality/api_surface/tests/member_function_templates.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/member_function_templates.h"

--- a/quality/api_surface/tests/multi_inheritance.cpp
+++ b/quality/api_surface/tests/multi_inheritance.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/multi_inheritance.h"

--- a/quality/api_surface/tests/private_changes.cpp
+++ b/quality/api_surface/tests/private_changes.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/private_changes.h"

--- a/quality/api_surface/tests/private_changes_v2.cpp
+++ b/quality/api_surface/tests/private_changes_v2.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/private_changes_v2.h"

--- a/quality/api_surface/tests/protected_methods.cpp
+++ b/quality/api_surface/tests/protected_methods.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/protected_methods.h"

--- a/quality/api_surface/tests/ref_qualifiers.cpp
+++ b/quality/api_surface/tests/ref_qualifiers.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/ref_qualifiers.h"

--- a/quality/api_surface/tests/result_type_regression.cpp
+++ b/quality/api_surface/tests/result_type_regression.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/result_type_regression.h"

--- a/quality/api_surface/tests/result_type_support.cpp
+++ b/quality/api_surface/tests/result_type_support.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/result_type_support.h"

--- a/quality/api_surface/tests/sfinae.cpp
+++ b/quality/api_surface/tests/sfinae.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/sfinae.h"

--- a/quality/api_surface/tests/template_alias.cpp
+++ b/quality/api_surface/tests/template_alias.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/template_alias.h"

--- a/quality/api_surface/tests/type_alias.cpp
+++ b/quality/api_surface/tests/type_alias.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/type_alias.h"

--- a/quality/api_surface/tests/types_in_signatures.cpp
+++ b/quality/api_surface/tests/types_in_signatures.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "quality/api_surface/tests/types_in_signatures.h"

--- a/score/memory/shared/BUILD
+++ b/score/memory/shared/BUILD
@@ -471,6 +471,7 @@ cc_library(
 
 cc_library(
     name = "user_permission",
+    srcs = ["user_permission.cpp"],
     hdrs = ["user_permission.h"],
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],

--- a/score/memory/shared/user_permission.cpp
+++ b/score/memory/shared/user_permission.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "score/memory/shared/user_permission.h"

--- a/score/message_passing/BUILD
+++ b/score/message_passing/BUILD
@@ -51,6 +51,7 @@ test_suite(
 
 cc_library(
     name = "message_passing",
+    srcs = ["message_passing.cpp"],
     hdrs = [
         "client_factory.h",
         "engine.h",

--- a/score/message_passing/message_passing.cpp
+++ b/score/message_passing/message_passing.cpp
@@ -1,0 +1,16 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "score/message_passing/client_factory.h"
+#include "score/message_passing/engine.h"
+#include "score/message_passing/server_factory.h"

--- a/score/mw/com/doc/tutorial/chapter_13/BUILD
+++ b/score/mw/com/doc/tutorial/chapter_13/BUILD
@@ -23,12 +23,14 @@ load("//score/mw/com/test:pkg_application.bzl", "pkg_application")
 
 cc_library(
     name = "heap_check_lib",
+    srcs = ["heap_check/heap_check.cpp"],
     hdrs = ["heap_check/heap_check.h"],
     includes = ["."],
 )
 
 cc_library(
     name = "service_interface",
+    srcs = ["common/tire_pressure_service.cpp"],
     hdrs = ["common/tire_pressure_service.h"],
     includes = ["."],
     deps = [

--- a/score/mw/com/doc/tutorial/chapter_13/common/tire_pressure_service.cpp
+++ b/score/mw/com/doc/tutorial/chapter_13/common/tire_pressure_service.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "common/tire_pressure_service.h"

--- a/score/mw/com/doc/tutorial/chapter_13/heap_check/heap_check.cpp
+++ b/score/mw/com/doc/tutorial/chapter_13/heap_check/heap_check.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "heap_check/heap_check.h"

--- a/score/mw/com/gateway/gateway_application/BUILD
+++ b/score/mw/com/gateway/gateway_application/BUILD
@@ -48,6 +48,7 @@ cc_library(
 
 cc_library(
     name = "gateway_core",
+    srcs = ["gateway_core.cpp"],
     hdrs = ["gateway_core.h"],
     features = COMPILER_WARNING_FEATURES,
     visibility = [
@@ -119,6 +120,7 @@ cc_unit_test(
 
 cc_library(
     name = "gateway_core_mock",
+    srcs = ["gateway_core_mock.cpp"],
     hdrs = ["gateway_core_mock.h"],
     features = COMPILER_WARNING_FEATURES,
     visibility = [

--- a/score/mw/com/gateway/gateway_application/gateway_core.cpp
+++ b/score/mw/com/gateway/gateway_application/gateway_core.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "score/mw/com/gateway/gateway_application/gateway_core.h"

--- a/score/mw/com/gateway/gateway_application/gateway_core_mock.cpp
+++ b/score/mw/com/gateway/gateway_application/gateway_core_mock.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "score/mw/com/gateway/gateway_application/gateway_core_mock.h"

--- a/score/mw/com/gateway/transport_layer/BUILD
+++ b/score/mw/com/gateway/transport_layer/BUILD
@@ -66,6 +66,7 @@ cc_library(
 
 cc_library(
     name = "transport_mock",
+    srcs = ["transport_mock.cpp"],
     hdrs = ["transport_mock.h"],
     features = COMPILER_WARNING_FEATURES,
     visibility = ["//score/mw/com/gateway:__subpackages__"],

--- a/score/mw/com/gateway/transport_layer/sample/BUILD
+++ b/score/mw/com/gateway/transport_layer/sample/BUILD
@@ -16,6 +16,7 @@ load("//score/mw:common_features.bzl", "COMPILER_WARNING_FEATURES")
 
 cc_library(
     name = "i_bidirectional_transport",
+    srcs = ["i_bidirectional_transport.cpp"],
     hdrs = ["i_bidirectional_transport.h"],
     features = COMPILER_WARNING_FEATURES,
     visibility = [
@@ -223,6 +224,7 @@ cc_unit_test(
 
 cc_library(
     name = "bidirectional_transport_mock",
+    srcs = ["bidirectional_transport_mock.cpp"],
     hdrs = ["bidirectional_transport_mock.h"],
     features = COMPILER_WARNING_FEATURES,
     visibility = [

--- a/score/mw/com/gateway/transport_layer/sample/bidirectional_transport_mock.cpp
+++ b/score/mw/com/gateway/transport_layer/sample/bidirectional_transport_mock.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "score/mw/com/gateway/transport_layer/sample/bidirectional_transport_mock.h"

--- a/score/mw/com/gateway/transport_layer/sample/configuration/BUILD
+++ b/score/mw/com/gateway/transport_layer/sample/configuration/BUILD
@@ -34,6 +34,7 @@ filegroup(
 
 cc_library(
     name = "hypervisor_socket_configuration",
+    srcs = ["hypervisor_socket_configuration.cpp"],
     hdrs = ["hypervisor_socket_configuration.h"],
     features = COMPILER_WARNING_FEATURES,
     deps = ["@score_baselibs//score/network:ipv4_address"],

--- a/score/mw/com/gateway/transport_layer/sample/configuration/hypervisor_socket_configuration.cpp
+++ b/score/mw/com/gateway/transport_layer/sample/configuration/hypervisor_socket_configuration.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "score/mw/com/gateway/transport_layer/sample/configuration/hypervisor_socket_configuration.h"

--- a/score/mw/com/gateway/transport_layer/sample/i_bidirectional_transport.cpp
+++ b/score/mw/com/gateway/transport_layer/sample/i_bidirectional_transport.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "score/mw/com/gateway/transport_layer/sample/i_bidirectional_transport.h"

--- a/score/mw/com/gateway/transport_layer/sample/messages/BUILD
+++ b/score/mw/com/gateway/transport_layer/sample/messages/BUILD
@@ -28,6 +28,7 @@ cc_library(
 
 cc_library(
     name = "serialization",
+    srcs = ["serialization.cpp"],
     hdrs = ["serialization.h"],
     features = COMPILER_WARNING_FEATURES,
     visibility = [

--- a/score/mw/com/gateway/transport_layer/sample/messages/serialization.cpp
+++ b/score/mw/com/gateway/transport_layer/sample/messages/serialization.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "score/mw/com/gateway/transport_layer/sample/messages/serialization.h"

--- a/score/mw/com/gateway/transport_layer/transport_mock.cpp
+++ b/score/mw/com/gateway/transport_layer/transport_mock.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "score/mw/com/gateway/transport_layer/transport_mock.h"

--- a/score/mw/com/impl/BUILD
+++ b/score/mw/com/impl/BUILD
@@ -211,6 +211,7 @@ cc_library(
 
 cc_library(
     name = "generic_skeleton_event_binding",
+    srcs = ["generic_skeleton_event_binding.cpp"],
     hdrs = [
         "generic_skeleton_event_binding.h",
     ],
@@ -900,6 +901,7 @@ cc_library(
 cc_library(
     name = "runtime_mock",
     testonly = True,
+    srcs = ["runtime_mock.cpp"],
     hdrs = ["runtime_mock.h"],
     features = COMPILER_WARNING_FEATURES,
     visibility = [

--- a/score/mw/com/impl/bindings/lola/BUILD
+++ b/score/mw/com/impl/bindings/lola/BUILD
@@ -195,6 +195,7 @@ cc_library(
 cc_library(
     name = "runtime_mock",
     testonly = True,
+    srcs = ["runtime_mock.cpp"],
     hdrs = ["runtime_mock.h"],
     features = COMPILER_WARNING_FEATURES,
     visibility = ["//score/mw/com/impl:__subpackages__"],

--- a/score/mw/com/impl/bindings/lola/messaging/BUILD
+++ b/score/mw/com/impl/bindings/lola/messaging/BUILD
@@ -229,6 +229,7 @@ cc_library(
 
 cc_library(
     name = "messaging",
+    srcs = ["messaging.cpp"],
     hdrs = [
         "thread_abstraction.h",
     ],

--- a/score/mw/com/impl/bindings/lola/messaging/messaging.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/messaging.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "score/mw/com/impl/bindings/lola/messaging/thread_abstraction.h"

--- a/score/mw/com/impl/bindings/lola/runtime_mock.cpp
+++ b/score/mw/com/impl/bindings/lola/runtime_mock.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "score/mw/com/impl/bindings/lola/runtime_mock.h"

--- a/score/mw/com/impl/bindings/mock_binding/BUILD
+++ b/score/mw/com/impl/bindings/mock_binding/BUILD
@@ -94,6 +94,7 @@ cc_library(
 
 cc_library(
     name = "sample_allocatee_ptr",
+    srcs = ["sample_allocatee_ptr.cpp"],
     hdrs = ["sample_allocatee_ptr.h"],
     features = COMPILER_WARNING_FEATURES,
     tags = ["FFI"],

--- a/score/mw/com/impl/generic_skeleton_event_binding.cpp
+++ b/score/mw/com/impl/generic_skeleton_event_binding.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "score/mw/com/impl/generic_skeleton_event_binding.h"

--- a/score/mw/com/impl/methods/BUILD
+++ b/score/mw/com/impl/methods/BUILD
@@ -46,6 +46,7 @@ cc_library(
 
 cc_library(
     name = "callable_traits",
+    srcs = ["callable_traits.cpp"],
     hdrs = [
         "callable_traits.h",
         "callable_traits_impl.h",

--- a/score/mw/com/impl/methods/callable_traits.cpp
+++ b/score/mw/com/impl/methods/callable_traits.cpp
@@ -11,3 +11,4 @@
  * SPDX-License-Identifier: Apache-2.0
  ********************************************************************************/
 #include "score/mw/com/impl/methods/callable_traits.h"
+#include "score/mw/com/impl/methods/callable_traits_impl.h"

--- a/score/mw/com/impl/runtime_mock.cpp
+++ b/score/mw/com/impl/runtime_mock.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2025 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "score/mw/com/impl/runtime_mock.h"

--- a/score/mw/com/rust/score_com_cpp_bridge/BUILD
+++ b/score/mw/com/rust/score_com_cpp_bridge/BUILD
@@ -18,6 +18,7 @@ load("//score/mw:common_features.bzl", "COMPILER_WARNING_FEATURES")
 # This provides registration macros for generated C++ code that bridges Rust and C++ types.
 cc_library(
     name = "register_interface",
+    srcs = ["register_interface.cpp"],
     hdrs = ["register_interface.h"],
     features = COMPILER_WARNING_FEATURES,
     visibility = [

--- a/score/mw/com/rust/score_com_cpp_bridge/register_interface.cpp
+++ b/score/mw/com/rust/score_com_cpp_bridge/register_interface.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "score/mw/com/rust/score_com_cpp_bridge/register_interface.h"

--- a/score/mw/com/test/api/BUILD
+++ b/score/mw/com/test/api/BUILD
@@ -17,6 +17,7 @@ load("//quality/unit_testing:unit_testing.bzl", "cc_unit_test")
 
 cc_library(
     name = "api",
+    srcs = ["api_under_test_smoke.cpp"],
     hdrs = glob(["api_under_test/**/*.h"]),
     features = COMPILER_WARNING_FEATURES,
     strip_include_prefix = "api_under_test",

--- a/score/mw/com/test/api/api_under_test_smoke.cpp
+++ b/score/mw/com/test/api/api_under_test_smoke.cpp
@@ -1,0 +1,25 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "our/name_space/impl_type_collectionoftypes.h"
+#include "our/name_space/impl_type_multidimarray.h"
+#include "our/name_space/impl_type_multidimvector.h"
+#include "our/name_space/impl_type_myenum.h"
+#include "our/name_space/impl_type_mytype.h"
+#include "our/name_space/impl_type_somearray.h"
+#include "our/name_space/impl_type_somestruct.h"
+#include "our/name_space/impl_type_somevector.h"
+#include "our/name_space/impl_type_valueevttype.h"
+#include "our/name_space/someinterface/someinterface_common.h"
+#include "our/name_space/someinterface/someinterface_proxy.h"
+#include "our/name_space/someinterface/someinterface_skeleton.h"

--- a/score/mw/service/BUILD
+++ b/score/mw/service/BUILD
@@ -15,6 +15,7 @@ load("//score/mw:common_features.bzl", "COMPILER_WARNING_FEATURES")
 
 cc_library(
     name = "provided_service",
+    srcs = ["provided_service.cpp"],
     hdrs = ["provided_service.h"],
     features = COMPILER_WARNING_FEATURES,
     visibility = ["//visibility:public"],
@@ -22,6 +23,7 @@ cc_library(
 
 cc_library(
     name = "provided_service_container",
+    srcs = ["provided_service_container.cpp"],
     hdrs = ["provided_service_container.h"],
     features = COMPILER_WARNING_FEATURES,
     visibility = ["//visibility:public"],
@@ -32,13 +34,18 @@ cc_library(
 
 cc_library(
     name = "proxy_future",
+    srcs = ["proxy_future.cpp"],
     hdrs = ["proxy_future.h"],
     features = COMPILER_WARNING_FEATURES,
     visibility = ["//visibility:public"],
+    deps = [
+        "@score_baselibs//score/concurrency/future",
+    ],
 )
 
 cc_library(
     name = "service",
+    srcs = ["proxy_needs.cpp"],
     hdrs = ["proxy_needs.h"],
     features = COMPILER_WARNING_FEATURES,
     visibility = ["//visibility:public"],
@@ -49,6 +56,7 @@ cc_library(
 
 cc_library(
     name = "factory",
+    srcs = ["proxy_needs_factory.cpp"],
     hdrs = ["proxy_needs_factory.h"],
     features = COMPILER_WARNING_FEATURES,
     visibility = ["//visibility:public"],
@@ -59,6 +67,7 @@ cc_library(
 
 cc_library(
     name = "proxy_data",
+    srcs = ["proxy_data.cpp"],
     hdrs = ["proxy_data.h"],
     features = COMPILER_WARNING_FEATURES,
     visibility = ["//visibility:public"],

--- a/score/mw/service/backend/mw_com/BUILD
+++ b/score/mw/service/backend/mw_com/BUILD
@@ -15,6 +15,7 @@ load("//score/mw:common_features.bzl", "COMPILER_WARNING_FEATURES")
 
 cc_library(
     name = "provided_service_builder",
+    srcs = ["provided_service_builder.cpp"],
     hdrs = ["provided_service_builder.h"],
     features = COMPILER_WARNING_FEATURES,
     visibility = ["//visibility:public"],
@@ -26,6 +27,7 @@ cc_library(
 
 cc_library(
     name = "provided_service_decorator",
+    srcs = ["provided_service_decorator.cpp"],
     hdrs = ["provided_service_decorator.h"],
     features = COMPILER_WARNING_FEATURES,
     visibility = ["//visibility:public"],
@@ -36,6 +38,7 @@ cc_library(
 
 cc_library(
     name = "single_instantiation_strategy",
+    srcs = ["single_instantiation_strategy.cpp"],
     hdrs = ["single_instantiation_strategy.h"],
     features = COMPILER_WARNING_FEATURES,
     visibility = ["//visibility:public"],

--- a/score/mw/service/backend/mw_com/provided_service_builder.cpp
+++ b/score/mw/service/backend/mw_com/provided_service_builder.cpp
@@ -1,0 +1,14 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "score/mw/service/backend/mw_com/provided_service_builder.h"

--- a/score/mw/service/backend/mw_com/provided_service_decorator.cpp
+++ b/score/mw/service/backend/mw_com/provided_service_decorator.cpp
@@ -1,0 +1,13 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/service/backend/mw_com/provided_service_decorator.h"

--- a/score/mw/service/backend/mw_com/single_instantiation_strategy.cpp
+++ b/score/mw/service/backend/mw_com/single_instantiation_strategy.cpp
@@ -1,0 +1,13 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/service/backend/mw_com/single_instantiation_strategy.h"

--- a/score/mw/service/provided_service.cpp
+++ b/score/mw/service/provided_service.cpp
@@ -1,0 +1,13 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/service/provided_service.h"

--- a/score/mw/service/provided_service_container.cpp
+++ b/score/mw/service/provided_service_container.cpp
@@ -1,0 +1,13 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/service/provided_service_container.h"

--- a/score/mw/service/provided_service_container.h
+++ b/score/mw/service/provided_service_container.h
@@ -67,47 +67,45 @@ class ProvidedServices final : public ProvidedServicesBase
     constexpr ProvidedServices(const ProvidedServices&) = delete;
 
     template <typename ServiceType, typename... Args>
-    ProvidedServices& Add(Args&&... args) &
+    ProvidedServices& Add(Args&&...) &
     {
         ++count_;
         return *this;
     }
 
     template <typename ServiceType, typename... Args>
-    ProvidedServices&& Add(Args&&... args) &&
+    ProvidedServices&& Add(Args&&...) &&
     {
         ++count_;
         return std::move(*this);
     }
 
     template <typename ServiceType, typename... Args>
-    ProvidedServices& AddViaInstanceSpecifier(InstanceSpecifierView instance_specifier, Args&&... args) &
+    ProvidedServices& AddViaInstanceSpecifier(InstanceSpecifierView, Args&&...) &
     {
         return *this;
     }
 
     template <typename ServiceType, typename... Args>
-    ProvidedServices&& AddViaInstanceSpecifier(InstanceSpecifierView instance_specifier, Args&&... args) &&
+    ProvidedServices&& AddViaInstanceSpecifier(InstanceSpecifierView, Args&&...) &&
     {
         return std::move(*this);
     }
 
     template <typename ServiceBaseType, typename ServiceImplType, typename... Args>
-    ProvidedServices& EmplaceServiceInstance(std::in_place_type_t<ServiceImplType>, Args&&... args) &
+    ProvidedServices& EmplaceServiceInstance(std::in_place_type_t<ServiceImplType>, Args&&...) &
     {
         return *this;
     }
 
     template <typename ServiceBaseType, typename ServiceImplType, typename... Args>
-    ProvidedServices&& EmplaceServiceInstance(std::in_place_type_t<ServiceImplType>, Args&&... args) &&
+    ProvidedServices&& EmplaceServiceInstance(std::in_place_type_t<ServiceImplType>, Args&&...) &&
     {
         return std::move(*this);
     }
 
     template <typename ServiceBaseType, typename ServiceImplType, typename... Args>
-    ProvidedServices& EmplaceServiceInstance(InstanceSpecifierView instance_specifier,
-                                             std::in_place_type_t<ServiceImplType>,
-                                             Args&&... args)
+    ProvidedServices& EmplaceServiceInstance(InstanceSpecifierView, std::in_place_type_t<ServiceImplType>, Args&&...)
     {
         return *this;
     }
@@ -123,7 +121,7 @@ class ProvidedServices final : public ProvidedServicesBase
     /// @param instance_specifier unique identifier for the service instance
     /// @return a valid smartpointer in case the dynamic_cast to `ServiceType` succeeds, nullptr otherwise
     template <typename ServiceType>
-    auto Extract(InstanceSpecifierView instance_specifier) noexcept
+    auto Extract(InstanceSpecifierView) noexcept
     {
         return nullptr;
     }
@@ -140,13 +138,13 @@ class ProvidedServices final : public ProvidedServicesBase
     }
 
     template <typename ServiceType>
-    const ServiceType* Get(InstanceSpecifierView instance_specifier) const noexcept
+    const ServiceType* Get(InstanceSpecifierView) const noexcept
     {
         return nullptr;
     }
 
     template <typename ServiceType>
-    ServiceType* Get(InstanceSpecifierView instance_specifier) noexcept
+    ServiceType* Get(InstanceSpecifierView) noexcept
     {
         return nullptr;
     }
@@ -157,13 +155,13 @@ class ProvidedServices final : public ProvidedServicesBase
         return false;
     }
 
-    bool Has(InstanceSpecifierView instance_specifier) const noexcept
+    bool Has(InstanceSpecifierView) const noexcept
     {
         return false;
     }
 
     template <typename ServiceType>
-    bool Has(InstanceSpecifierView instance_specifier) const noexcept
+    bool Has(InstanceSpecifierView) const noexcept
     {
         return false;
     }

--- a/score/mw/service/proxy_data.cpp
+++ b/score/mw/service/proxy_data.cpp
@@ -1,0 +1,13 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/service/proxy_data.h"

--- a/score/mw/service/proxy_future.cpp
+++ b/score/mw/service/proxy_future.cpp
@@ -1,0 +1,13 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/service/proxy_future.h"

--- a/score/mw/service/proxy_needs.cpp
+++ b/score/mw/service/proxy_needs.cpp
@@ -1,0 +1,13 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/service/proxy_needs.h"

--- a/score/mw/service/proxy_needs_factory.cpp
+++ b/score/mw/service/proxy_needs_factory.cpp
@@ -1,0 +1,13 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/service/proxy_needs_factory.h"

--- a/tools/lint/BUILD
+++ b/tools/lint/BUILD
@@ -11,6 +11,10 @@
 # SPDX-License-Identifier: Apache-2.0
 # *******************************************************************************
 
-# Makes tools/lint/ a Bazel package so linters.bzl can be referenced as a
-# label target (//tools/lint:linters.bzl%clang_tidy_aspect) in bazelrc.
-exports_files(["linters.bzl"])
+# Makes tools/lint/ a Bazel package so linters.bzl and clang_tidy_lint_gate.bzl
+# can be referenced as label targets (e.g.
+# //tools/lint:linters.bzl%clang_tidy_aspect) in bazelrc.
+exports_files([
+    "linters.bzl",
+    "clang_tidy_lint_gate.bzl",
+])

--- a/tools/lint/clang_tidy_lint_gate.bzl
+++ b/tools/lint/clang_tidy_lint_gate.bzl
@@ -1,0 +1,207 @@
+"""Clang-tidy lint aspect that skips pure alias/aggregator `cc_library` targets.
+
+`aspect_rules_lint`'s `lint_clang_tidy_aspect()` (used via `//tools/lint:linters.bzl%clang_tidy_aspect`)
+always declares a ".report" output for every visited `cc_library`/`cc_binary`
+target, even for pure alias/aggregator libraries that declare neither `srcs`
+nor `hdrs` of their own (they exist solely to forward their public API via
+`deps`). For those targets there is nothing to compile or analyze, so
+`aspect_rules_lint` takes its "noop" path and simply touches an empty (0-byte)
+report file.
+
+This module reimplements the same thin aspect-dispatch
+logic as `aspect_rules_lint`'s `_clang_tidy_aspect_impl` (the actual
+clang-tidy invocation is reused as-is via the public `clang_tidy_action()`
+helper, so none of that logic is duplicated), adding two behavioral changes:
+
+  1. Targets that have neither `srcs` nor `hdrs` (pure alias/aggregator
+     libraries) are skipped entirely before any output is declared.
+  2. Any other target that ends up with zero actually-compilable files (e.g.
+     `hdrs` but no `srcs`, or `srcs` that resolve to no recognized C/C++
+     source extension) now fails the analysis phase with an actionable
+     error message, instead of silently falling back to aspect_rules_lint's
+     "noop" path.
+"""
+
+load("@aspect_rules_lint//lint:clang_tidy.bzl", "clang_tidy_action")
+load("@aspect_rules_lint//lint/private:lint_aspect.bzl", "LintOptionsInfo", "OPTIONAL_SARIF_PARSER_TOOLCHAIN", "OUTFILE_FORMAT", "output_files", "parse_to_sarif_action", "patch_and_output_files", "should_visit")
+load("@aspect_rules_lint//lint/private:patcher_action.bzl", "patcher_attrs")
+load("@bazel_skylib//rules/directory:providers.bzl", "DirectoryInfo")
+
+visibility(["//..."])
+
+_MNEMONIC = "AspectRulesLintClangTidy"
+
+def _is_source(file):
+    permitted_source_types = ["c", "cc", "cpp", "cxx", "c++", "C"]
+    return file.is_source and file.extension in permitted_source_types
+
+def _filter_srcs(rule):
+    # some rules can return a CcInfo without having a srcs attribute
+    if not hasattr(rule.attr, "srcs"):
+        return []
+    if "lint-genfiles" in rule.attr.tags:
+        return rule.files.srcs
+    return [s for s in rule.files.srcs if _is_source(s)]
+
+def _has_nothing_to_lint(rule):
+    """True for alias/aggregator cc_library targets with no srcs and no hdrs.
+
+    Such targets forward their entire public API via `deps` and own no code
+    of their own, so there is nothing for clang-tidy to compile or analyze.
+    """
+    srcs = getattr(rule.attr, "srcs", [])
+    hdrs = getattr(rule.attr, "hdrs", [])
+    return len(srcs) == 0 and len(hdrs) == 0
+
+def _fail_if_nothing_compilable(target, files_to_lint):
+    """
+    Any `cc_library`/`cc_binary` that declares `hdrs` and/or `srcs` (i.e. is
+    not caught by `_has_nothing_to_lint` above) but still ends up with zero
+    files for clang-tidy to actually compile has no compile action of its
+    own. aspect_rules_lint's own clang-tidy aspect silently falls back to
+    its "noop" path in that case.
+    Fail loudly here at analysis time with actionable guidance, instead of
+    silently ignoring this.
+    """
+    if len(files_to_lint) == 0:
+        fail((
+            "{label}: cc_library/cc_binary has no compilable source files for " +
+            "clang-tidy to analyze (its `srcs`/`hdrs` don't resolve to any " +
+            "recognized C/C++ source file), so it would silently produce an " +
+            "empty SARIF report.\n" +
+            "Fix this by either:\n" +
+            "  - adding a `srcs` .cpp file that #includes the header(s), or\n" +
+            "  - if this is intentionally a pure alias/aggregator target with no " +
+            "code of its own, removing `hdrs` too (forward the API via `deps` only)."
+        ).format(label = target.label))
+
+def _clang_tidy_gate_aspect_impl(target, ctx):
+    if not should_visit(ctx.rule, ctx.attr._rule_kinds):
+        return []
+
+    if CcInfo not in target:
+        return []
+
+    # The one behavioral addition over aspect_rules_lint's own
+    # _clang_tidy_aspect_impl: skip declaring any output at all for targets
+    # with nothing of their own to lint, instead of producing an empty
+    # placeholder report via the noop path below.
+    if _has_nothing_to_lint(ctx.rule):
+        return []
+
+    files_to_lint = _filter_srcs(ctx.rule)
+
+    # Safeguard: catch any "nothing actually compilable" misconfiguration at
+    # analysis time instead of letting it resurface as an empty SARIF report
+    # in CI. This subsumes (and replaces) aspect_rules_lint's own noop path
+    # for len(files_to_lint) == 0, which is what silently produced the empty
+    # reports in the first place.
+    _fail_if_nothing_compilable(target, files_to_lint)
+
+    compilation_context = target[CcInfo].compilation_context
+    if hasattr(ctx.rule.attr, "implementation_deps"):
+        compilation_context = cc_common.merge_compilation_contexts(
+            compilation_contexts = [compilation_context] +
+                                   [implementation_dep[CcInfo].compilation_context for implementation_dep in ctx.rule.attr.implementation_deps],
+        )
+
+    if ctx.attr._options[LintOptionsInfo].fix:
+        outputs, info = patch_and_output_files(_MNEMONIC, target, ctx, files_to_lint = files_to_lint)
+    else:
+        outputs, info = output_files(_MNEMONIC, target, ctx, files_to_lint = files_to_lint)
+
+    for output, file in zip(outputs, files_to_lint):
+        clang_tidy_action(
+            ctx,
+            compilation_context,
+            ctx.executable,
+            [file],
+            output.human.out,
+            output.human.exit_code,
+            patch = getattr(output, "patch", None),
+        )
+
+        raw_machine_report = ctx.actions.declare_file(OUTFILE_FORMAT.format(label = target.label.name + "_rules_lint/" + file.short_path, mnemonic = _MNEMONIC, suffix = "raw_machine_report"))
+        clang_tidy_action(ctx, compilation_context, ctx.executable, [file], raw_machine_report, output.machine.exit_code)
+        parse_to_sarif_action(ctx, _MNEMONIC, raw_machine_report, output.machine.out)
+    return [info]
+
+DEFAULT_RULE_KINDS = ["cc_binary", "cc_library"]
+
+def lint_clang_tidy_gate_aspect(
+        binary,
+        configs = [],
+        global_config = [],
+        gcc_install_dir = [],
+        deps = [],
+        header_filter = "",
+        lint_target_headers = False,
+        angle_includes_are_system = True,
+        verbose = False,
+        rule_kinds = DEFAULT_RULE_KINDS):
+    """Same factory signature as aspect_rules_lint's `lint_clang_tidy_aspect`.
+
+    See that function's docstring in `@aspect_rules_lint//lint:clang_tidy.bzl`
+    for a description of each argument; behavior is identical except that
+    targets with neither `srcs` nor `hdrs` are skipped entirely (see module
+    docstring above).
+    """
+
+    if type(global_config) == "string":
+        global_config = [global_config]
+
+    return aspect(
+        implementation = _clang_tidy_gate_aspect_impl,
+        attrs = patcher_attrs | {
+            "_options": attr.label(
+                default = "@aspect_rules_lint//lint:options",
+                providers = [LintOptionsInfo],
+            ),
+            "_configs": attr.label_list(
+                default = configs,
+                allow_files = True,
+            ),
+            "_global_config": attr.label_list(
+                default = global_config,
+                allow_files = True,
+            ),
+            "_deps": attr.label_list(
+                default = deps,
+            ),
+            "_gcc_install_dir": attr.label_list(
+                default = gcc_install_dir,
+                providers = [DirectoryInfo],
+            ),
+            "_lint_target_headers": attr.bool(
+                default = lint_target_headers,
+            ),
+            "_header_filter": attr.string(
+                default = header_filter,
+            ),
+            "_angle_includes_are_system": attr.bool(
+                default = angle_includes_are_system,
+            ),
+            "_verbose": attr.bool(
+                default = verbose,
+            ),
+            "_clang_tidy": attr.label(
+                default = binary,
+                executable = True,
+                cfg = "exec",
+            ),
+            "_clang_tidy_wrapper": attr.label(
+                default = Label("@aspect_rules_lint//lint:clang_tidy_wrapper"),
+                executable = True,
+                cfg = "exec",
+            ),
+            "_cc_toolchain": attr.label(default = Label("@bazel_tools//tools/cpp:current_cc_toolchain")),
+            "_rule_kinds": attr.string_list(
+                default = rule_kinds,
+            ),
+        },
+        toolchains = [
+            OPTIONAL_SARIF_PARSER_TOOLCHAIN,
+            "@bazel_tools//tools/cpp:toolchain_type",
+        ],
+        fragments = ["cpp"],
+    )

--- a/tools/lint/linters.bzl
+++ b/tools/lint/linters.bzl
@@ -16,6 +16,7 @@
 load("@aspect_rules_lint//lint:clang_tidy.bzl", "lint_clang_tidy_aspect")
 load("@aspect_rules_lint//lint:lint_test.bzl", "lint_test")
 load("@bazel_skylib//rules:write_file.bzl", "write_file")
+load(":clang_tidy_lint_gate.bzl", "lint_clang_tidy_gate_aspect")
 
 visibility(["//..."])
 
@@ -33,8 +34,20 @@ clang_tidy = lint_clang_tidy_aspect(
 # Create a test rule for clang-tidy (for individual targets)
 clang_tidy_test = lint_test(aspect = clang_tidy)
 
-# Export the aspect for use in multirun
-clang_tidy_aspect = clang_tidy
+# Same as `clang_tidy` above, but skips cc_library targets that have neither
+# `srcs` nor `hdrs` (pure alias/aggregator libraries with nothing to lint).
+# Used for CI SARIF collection so those targets don't produce empty reports
+# that `merge_sarif_reports` would otherwise treat as a hard failure. See
+# clang_tidy_lint_gate.bzl for details.
+clang_tidy_aspect = lint_clang_tidy_gate_aspect(
+    binary = Label("@llvm_toolchain//:clang-tidy"),
+    configs = [
+        Label("//:.clang-tidy"),
+    ],
+    lint_target_headers = True,
+    angle_includes_are_system = True,
+    verbose = False,
+)
 
 APPLY_PATCHES = [
     'echo ""',


### PR DESCRIPTION
Report collection failed if too many reports were generated. The resulting xargs call lead to two jq calls because of too many arguments. This in turn lead to two JSON root objects being put in a single file.

Fixed additional issue that clang-tidy not running on targets was silently ignored.