### PR TITLE
Remove misc-include-cleaner

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -92,7 +92,6 @@ Checks: >
   bugprone-copy-constructor-init,
   bugprone-dangling-handle,
   bugprone-suspicious-stringview-data-usage,
-  misc-include-cleaner,
   misc-use-anonymous-namespace,
   misc-use-internal-linkage,
   modernize-avoid-bind,


### PR DESCRIPTION
This check has various problems and would decrease code quality instead of increasing it.

This check only looks at the single file. This means, that the associated header and the source must include the same headers twice to silence the check.

When a header overrides an interface from a different header, headers would have to be duplicated.

And so on.