### PR TITLE
mw/com: Mark skeleton_recreation_test as flaky

### DIFF
--- a/score/mw/com/test/methods/edge_cases_test/integration_test/BUILD
+++ b/score/mw/com/test/methods/edge_cases_test/integration_test/BUILD
@@ -52,8 +52,8 @@ integration_test(
     filesystem = ":filesystem",
     # Test fails regularly when running on qnx-8 due to a bug in
     # inotify in which we receive spurious inotify events.
-    # To be enabled on qnx once the bug is fixed or
+    # To be reevaluated once the bug is fixed or
     # service discovery is reimplemented to not rely on
     # inotify events (SWP-214271).
-    target_compatible_with = ["@platforms//os:linux"],
+    flaky = True,
 )


### PR DESCRIPTION
Test fails regularly when running on qnx-8 due to a bug in inotify in which we receive spurious inotify events. To be reevaluated once the bug is fixed or service discovery is reimplemented to not rely on inotify events.