### PR TITLE
fix(ci): correctly cancel in-progress QNX runs on PR updates

### DIFF
--- a/.github/workflows/build_and_test_qnx.yml
+++ b/.github/workflows/build_and_test_qnx.yml
@@ -46,7 +46,7 @@ on:
 
 concurrency:
   group: build_and_test_qnx-${{ github.event.pull_request.number || github.run_id }}
-  cancel-in-progress: ${{ startsWith(github.ref, 'refs/pull/') }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request_target' }}
 
 jobs:
     precheck:


### PR DESCRIPTION
pull_request_target sets github.ref to the default branch ref (e.g. refs/heads/main), never refs/pull/*/merge, so the previous startsWith(github.ref, 'refs/pull/') check always evaluated to false and cancel-in-progress never took effect for PR-triggered runs. Base the condition on github.event_name instead so superseded runs on the same PR are actually cancelled.