### PR TITLE
memory/shared: fix static destruction order fiasco via nifty-counter idiom

### DIFF
--- a/score/memory/shared/BUILD
+++ b/score/memory/shared/BUILD
@@ -43,6 +43,7 @@ cc_library(
         "//visibility:public",  # platform_only
     ],
     deps = [
+        ":memory_resource_registry",
         ":types",
         ":user_permission",
         "@score_baselibs//score/language/futurecpp",
@@ -165,6 +166,7 @@ cc_library(
         "@score_baselibs//score/os:mman",
         "@score_baselibs//score/os:unistd",
         "@score_baselibs//score/os/utils/acl",
+        "@score_baselibs//score/utils:static_destruction_guard",
     ],
 )
 
@@ -178,7 +180,7 @@ cc_library(
         "@score_baselibs//score/mw/log:frontend",
         "@score_baselibs//score/os:errno_logging",
         "@score_baselibs//score/os:unistd",
-        "@score_baselibs//score/utils/meyer_singleton",
+        "@score_baselibs//score/utils:static_destruction_guard",
     ],
     tags = ["FFI"],
     deps = [
@@ -284,7 +286,7 @@ cc_library(
         ":memory_region_map",
         "@score_baselibs//score/language/futurecpp",
         "@score_baselibs//score/result",
-        "@score_baselibs//score/utils/meyer_singleton",
+        "@score_baselibs//score/utils:static_destruction_guard",
     ],
 )
 

--- a/score/memory/shared/i_shared_memory_resource.h
+++ b/score/memory/shared/i_shared_memory_resource.h
@@ -14,6 +14,11 @@
 #define SCORE_LIB_MEMORY_SHARED_I_SHARED_MEMORY_RESOURCE_H
 
 #include "score/memory/shared/managed_memory_resource.h"
+// Pulls in the MemoryResourceRegistry nifty-counter (see detail::nifty_counter_memory_resource_registry),
+// guaranteeing that MemoryResourceRegistry outlives any std::shared_ptr<ISharedMemoryResource>
+// a client stores in a static/long-lived context, since ~SharedMemoryResource() accesses
+// MemoryResourceRegistry::getInstance().
+#include "score/memory/shared/memory_resource_registry.h"
 #include "score/memory/shared/user_permission.h"
 
 #include "score/os/acl.h"

--- a/score/memory/shared/memory_resource_registry.cpp
+++ b/score/memory/shared/memory_resource_registry.cpp
@@ -16,7 +16,8 @@
 #include "score/memory/shared/shared_memory_error.h"
 
 #include "score/mw/log/logging.h"
-#include "score/utils/meyer_singleton/meyer_singleton.h"
+
+#include "score/utils/static_destruction_guard.h"
 
 #include <score/utility.hpp>
 
@@ -25,15 +26,12 @@
 
 auto score::memory::shared::MemoryResourceRegistry::getInstance() -> MemoryResourceRegistry&
 {
-    // Suppress "AUTOSAR C++14 A3-3-2" rule finding. This rule states: "Static and thread-local objects shall be
-    // constant-initialized.".
-    // Documentation and example for Rule A3-3-2 in
-    // https://www.autosar.org/fileadmin/standards/R20-11/AP/AUTOSAR_RS_CPP14Guidelines.pdf show that
-    // MemoryResourceRegistry would need a constexpr constructor to be compliant. This is not possible here
-    // because MemoryResourceRegistry contains a std::shared_time_mutex and std::unordered_map which don't have
-    // constexpr constructors.
-    // coverity[autosar_cpp14_a3_3_2_violation]
-    return score::singleton::MeyerSingleton<MemoryResourceRegistry>::GetInstance();
+    // MemoryResourceRegistry is kept alive via the nifty-counter idiom (see
+    // detail::nifty_counter_memory_resource_registry) rather than a plain
+    // function-local static (Meyer's singleton), to avoid the static destruction order fiasco: a
+    // std::shared_ptr<ISharedMemoryResource> stored in some other static/long-lived
+    // context could otherwise be destroyed after this registry, and ~SharedMemoryResource() accesses this registry.
+    return ::score::utils::StaticDestructionGuard<MemoryResourceRegistry>::GetStorage();
 }
 
 auto score::memory::shared::MemoryResourceRegistry::at(const MemoryResourceIdentifier identifier) const noexcept

--- a/score/memory/shared/memory_resource_registry.h
+++ b/score/memory/shared/memory_resource_registry.h
@@ -16,7 +16,8 @@
 #include "score/memory/shared/managed_memory_resource.h"
 #include "score/memory/shared/memory_region_bounds.h"
 #include "score/memory/shared/memory_region_map.h"
-#include "score/utils/meyer_singleton/meyer_singleton.h"
+
+#include "score/utils/static_destruction_guard.h"
 
 #include "score/result/result.h"
 
@@ -56,11 +57,13 @@ class MemoryResourceRegistry final
 {
     // Suppress "AUTOSAR C++14 A11-3-1"
     // The MemoryResourceRegistry class is intended to only be constructed as a singleton object. Therefore, the
-    // constructor should be private and the user should initialize the MemoryResourceRegistry via getInstance(). The
-    // MeyerSingleton class is used to create the MemoryResourceRegistry singleton. Therefore, MeyerSingleton needs
-    // access to the private MemoryResourceRegistry constructor.
+    // constructor should be private and the user should initialize the MemoryResourceRegistry via getInstance(). A
+    // nifty-counter (see score::utils::StaticDestructionGuard) is used to create the MemoryResourceRegistry singleton,
+    // so that it is guaranteed to outlive any std::shared_ptr<ISharedMemoryResource> that a client might keep alive in
+    // a static/long-lived context (see detail::nifty_counter_memory_resource_registry below). StaticDestructionGuard
+    // therefore needs access to the private MemoryResourceRegistry constructor.
     // coverity[autosar_cpp14_a11_3_1_violation]
-    friend class singleton::MeyerSingleton<MemoryResourceRegistry>;
+    friend class ::score::utils::StaticDestructionGuard<MemoryResourceRegistry>;
 
   public:
     using MemoryResourceIdentifier = std::uint64_t;
@@ -125,6 +128,21 @@ class MemoryResourceRegistry final
 
     MemoryRegionMap region_map_{};
 };
+
+namespace detail
+{
+
+/// \brief Nifty-counter keeping the MemoryResourceRegistry singleton alive.
+/// \details Every translation unit that (transitively) includes this header gets its own instance of this guard.
+///          The guarded MemoryResourceRegistry is constructed on the very first such instance's construction and is
+///          only destroyed once the very last one is destroyed. This avoids the classic "static destruction order
+///          fiasco": ~SharedMemoryResource() accesses MemoryResourceRegistry::getInstance(), and a
+///          std::shared_ptr<ISharedMemoryResource> can end up stored in a static/long-lived context whose own
+///          destruction order relative to a plain function-local static singleton is otherwise unspecified.
+// coverity[autosar_cpp14_a3_3_2_violation] non-trivial constructor is required to implement the nifty-counter idiom
+static ::score::utils::StaticDestructionGuard<MemoryResourceRegistry> nifty_counter_memory_resource_registry;
+
+}  // namespace detail
 
 }  // namespace score::memory::shared
 

--- a/score/memory/shared/shared_memory_factory.cpp
+++ b/score/memory/shared/shared_memory_factory.cpp
@@ -14,7 +14,7 @@
 #include "score/memory/shared/i_shared_memory_factory.h"
 #include "score/memory/shared/shared_memory_factory_impl.h"
 
-#include "score/utils/meyer_singleton/meyer_singleton.h"
+#include "score/utils/static_destruction_guard.h"
 
 #include <score/span.hpp>
 
@@ -98,11 +98,11 @@ auto SharedMemoryFactory::instance() noexcept -> ISharedMemoryFactory&
         return *mock_;
     }
 
-    // Suppress "AUTOSAR C++14 A3-3-2" rule finding. This rule states: "Static and thread-local objects shall be
-    // constant-initialized.".
-    // Rationale: SharedMemoryFactoryImpl does not have a constexpr constructor.
-    // coverity[autosar_cpp14_a3_3_2_violation]
-    return singleton::MeyerSingleton<SharedMemoryFactoryImpl>::GetInstance();
+    // SharedMemoryFactoryImpl is kept alive via the nifty-counter idiom (see
+    // detail::nifty_counter_shared_memory_factory_impl) rather than a plain
+    // function-local static (Meyer's singleton), for the same static destruction order reasons as
+    // MemoryResourceRegistry.
+    return ::score::utils::StaticDestructionGuard<SharedMemoryFactoryImpl>::GetStorage();
 }
 
 auto SharedMemoryFactory::InjectMock(ISharedMemoryFactory* mock) noexcept -> void

--- a/score/memory/shared/shared_memory_factory_impl.h
+++ b/score/memory/shared/shared_memory_factory_impl.h
@@ -17,6 +17,8 @@
 #include "score/memory/shared/shared_memory_resource.h"
 #include "score/memory/shared/typedshm/typedshm_wrapper/typed_memory.h"
 
+#include "score/utils/static_destruction_guard.h"
+
 #include <score/span.hpp>
 
 #include <memory>
@@ -78,6 +80,20 @@ class SharedMemoryFactoryImpl final : public ISharedMemoryFactory
     std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr_{memory::shared::TypedMemory::Default()};
     std::shared_ptr<score::memory::shared::TypedMemory> intervm_memory_ptr_{nullptr};
 };
+
+namespace detail
+{
+
+/// \brief Nifty-counter (see score::utils::StaticDestructionGuard) keeping the SharedMemoryFactoryImpl singleton alive.
+/// \details Only translation units that include this (internal) header get a guard instance, i.e. this protects
+///          SharedMemoryFactoryImpl's own construction/destruction ordering against other statics within this
+///          library, analogous to the MemoryResourceRegistry nifty-counter. It is intentionally not exposed via the
+///          public shared_memory_factory.h to avoid pulling the concrete SharedMemoryResource/TypedMemory dependencies
+///          into that lightweight public header.
+// coverity[autosar_cpp14_a3_3_2_violation] non-trivial constructor is required to implement the nifty-counter idiom
+static ::score::utils::StaticDestructionGuard<SharedMemoryFactoryImpl> nifty_counter_shared_memory_factory_impl;
+
+}  // namespace detail
 
 }  // namespace score::memory::shared
 


### PR DESCRIPTION
MemoryResourceRegistry and SharedMemoryFactoryImpl were plain Meyer singletons (MeyerSingleton<T>::GetInstance()). ~SharedMemoryResource() accesses MemoryResourceRegistry::getInstance(), so if a client stores a std::shared_ptr<ISharedMemoryResource> in a static/long-lived context created before the registry's first use, that static could be destroyed after the registry, causing UB/crashes at shutdown.

Both singletons now use score::os::StaticDestructionGuard (the nifty-counter idiom), matching the pattern already used by score::os::Mman. The guard for MemoryResourceRegistry is pulled into the public i_shared_memory_resource.h so any client holding a static shared_ptr<ISharedMemoryResource> is protected; the guard for SharedMemoryFactoryImpl stays internal to shared_memory_factory_impl.h to keep the public shared_memory_factory.h lightweight.

<!-- review-checklist-merge-queue-notice:start -->
## Review Checklist Evidence Notice - Merge Queue

This pull request was modified after the review checklist evidence was recorded.
The review checklist evidence visible here does no longer reflect the evidence that will be recorded at merge.
Please rely on the evidence in the git history once the pull request was merged.

The git history shows the evidence state at the time of merge queue entry.
A pull request may only enter the merge queue when all necessary review checklist acknowledgements are in place.
Changes made after this pull request enters the merge queue may update the evidence here,
but they do not affect the evidence recorded in the git history.
<!-- review-checklist-merge-queue-notice:end -->