### PR TITLE
fix: concatenate nested namespace declarations

### DIFF
--- a/score/message_passing/client_connection.cpp
+++ b/score/message_passing/client_connection.cpp
@@ -23,11 +23,7 @@
 #include <cstdint>
 #include <thread>
 
-namespace score
-{
-namespace message_passing
-{
-namespace detail
+namespace score::message_passing::detail
 {
 
 namespace
@@ -666,6 +662,4 @@ void ClientConnection::ProcessStateChange(const State state) noexcept
     }
 }
 
-}  // namespace detail
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing::detail

--- a/score/message_passing/client_connection.h
+++ b/score/message_passing/client_connection.h
@@ -25,11 +25,7 @@
 #include <mutex>
 #include <optional>
 
-namespace score
-{
-namespace message_passing
-{
-namespace detail
+namespace score::message_passing::detail
 {
 
 class ClientConnection final : public IClientConnection
@@ -143,8 +139,6 @@ class ClientConnection final : public IClientConnection
     ISharedResourceEngine::PosixEndpointEntry posix_endpoint_;
 };
 
-}  // namespace detail
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing::detail
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_CLIENT_CONNECTION_H

--- a/score/message_passing/client_connection_test.cpp
+++ b/score/message_passing/client_connection_test.cpp
@@ -20,9 +20,7 @@
 #include <future>
 #include <thread>
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 namespace
 {
@@ -1234,5 +1232,4 @@ TEST_F(ClientConnectionTest, ConnectedReceivesPingInCallback)
 }
 
 }  // namespace
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing

--- a/score/message_passing/client_server_communication.h
+++ b/score/message_passing/client_server_communication.h
@@ -15,11 +15,7 @@
 
 #include <cstdint>
 
-namespace score
-{
-namespace message_passing
-{
-namespace detail
+namespace score::message_passing::detail
 {
 
 enum class ClientToServer : std::uint8_t
@@ -34,8 +30,6 @@ enum class ServerToClient : std::uint8_t
     NOTIFY
 };
 
-}  // namespace detail
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing::detail
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_CLIENT_SERVER_COMMUNICATION_H

--- a/score/message_passing/i_client_connection.h
+++ b/score/message_passing/i_client_connection.h
@@ -19,9 +19,7 @@
 #include <score/expected.hpp>
 #include <score/span.hpp>
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 /// \brief Interface of a Message Passing Client connection
@@ -163,7 +161,6 @@ class IClientConnection
     IClientConnection& operator=(IClientConnection&&) = delete;
 };
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_I_CLIENT_CONNECTION_H

--- a/score/message_passing/i_client_factory.h
+++ b/score/message_passing/i_client_factory.h
@@ -20,9 +20,7 @@
 
 #include <cstdint>
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 /// \brief A generic factory interface to create instances of IClientConnection.
@@ -80,7 +78,6 @@ class IClientFactory
     IClientFactory& operator=(IClientFactory&&) = delete;
 };
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_I_CLIENT_FACTORY_H

--- a/score/message_passing/i_connection_handler.h
+++ b/score/message_passing/i_connection_handler.h
@@ -18,9 +18,7 @@
 #include <score/expected.hpp>
 #include <score/span.hpp>
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 // forward declaration
@@ -47,7 +45,6 @@ class IConnectionHandler
     virtual void OnDisconnect(IServerConnection& connection) noexcept = 0;
 };
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_I_CONNECTION_HANDLER_H

--- a/score/message_passing/i_server.h
+++ b/score/message_passing/i_server.h
@@ -17,9 +17,7 @@
 
 #include "score/os/errno.h"
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 /// \brief Interface of a Message Passing Server.
@@ -60,7 +58,6 @@ class IServer
     IServer& operator=(IServer&&) = delete;
 };
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_I_SERVER_H

--- a/score/message_passing/i_server_connection.h
+++ b/score/message_passing/i_server_connection.h
@@ -20,9 +20,7 @@
 #include <score/expected.hpp>
 #include <score/span.hpp>
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 /// \brief Interface of a Message Passing Server connection
@@ -49,7 +47,6 @@ class IServerConnection
     IServerConnection& operator=(IServerConnection&&) = delete;
 };
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_I_SERVER_CONNECTION_H

--- a/score/message_passing/i_server_factory.h
+++ b/score/message_passing/i_server_factory.h
@@ -20,9 +20,7 @@
 
 #include <cstdint>
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 class IServerFactory
@@ -52,7 +50,6 @@ class IServerFactory
     IServerFactory& operator=(IServerFactory&&) = delete;
 };
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_I_SERVER_FACTORY_H

--- a/score/message_passing/i_shared_resource_engine.h
+++ b/score/message_passing/i_shared_resource_engine.h
@@ -23,9 +23,7 @@
 #include "score/message_passing/log/logging_callback.h"
 #include "score/message_passing/timed_command_queue_entry.h"
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 class ISharedResourceEngine
@@ -95,7 +93,6 @@ class ISharedResourceEngine
     ISharedResourceEngine& operator=(ISharedResourceEngine&&) = delete;
 };
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_I_SHARED_RESOURCE_ENGINE_H

--- a/score/message_passing/mock/client_connection_mock.h
+++ b/score/message_passing/mock/client_connection_mock.h
@@ -17,9 +17,7 @@
 
 #include "gmock/gmock.h"
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 class ClientConnectionMock : public IClientConnection
@@ -114,7 +112,6 @@ class ClientConnectionMockFacade : public IClientConnection
     ClientConnectionMock& client_connection_mock_;
 };
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_MOCK_CLIENT_CONNECTION_MOCK_H

--- a/score/message_passing/mock/client_factory_mock.h
+++ b/score/message_passing/mock/client_factory_mock.h
@@ -17,9 +17,7 @@
 
 #include "gmock/gmock.h"
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 class ClientFactoryMock : public IClientFactory
@@ -33,7 +31,6 @@ class ClientFactoryMock : public IClientFactory
     virtual ~ClientFactoryMock() = default;  // virtual to make compiler happy
 };
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_MOCK_CLIENT_FACTORY_MOCK_H

--- a/score/message_passing/mock/server_connection_mock.h
+++ b/score/message_passing/mock/server_connection_mock.h
@@ -17,9 +17,7 @@
 
 #include "gmock/gmock.h"
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 class ServerConnectionMock : public IServerConnection
@@ -40,7 +38,6 @@ class ServerConnectionMock : public IServerConnection
     virtual ~ServerConnectionMock() = default;  // virtual to make compiler happy
 };
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_MOCK_SERVER_CONNECTION_MOCK_H

--- a/score/message_passing/mock/server_factory_mock.h
+++ b/score/message_passing/mock/server_factory_mock.h
@@ -17,9 +17,7 @@
 
 #include "gmock/gmock.h"
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 class ServerFactoryMock : public IServerFactory
@@ -33,7 +31,6 @@ class ServerFactoryMock : public IServerFactory
     virtual ~ServerFactoryMock() = default;  // virtual to make compiler happy
 };
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_MOCK_SERVER_FACTORY_MOCK_H

--- a/score/message_passing/mock/server_mock.h
+++ b/score/message_passing/mock/server_mock.h
@@ -17,9 +17,7 @@
 
 #include "gmock/gmock.h"
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 class ServerMock : public IServer
@@ -39,6 +37,6 @@ class ServerMock : public IServer
     }
 };
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing
+
 #endif  // SCORE_MW_COM_MESSAGE_PASSING_NEW_SERVER_MOCK_H

--- a/score/message_passing/mock/shared_resource_engine_mock.h
+++ b/score/message_passing/mock/shared_resource_engine_mock.h
@@ -17,9 +17,7 @@
 
 #include "gmock/gmock.h"
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 class SharedResourceEngineMock : public ISharedResourceEngine
@@ -51,6 +49,6 @@ class SharedResourceEngineMock : public ISharedResourceEngine
     MOCK_METHOD(void, CleanUpOwner, (const void* const owner), (noexcept, override));
 };
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing
+
 #endif  // SCORE_LIB_MESSAGE_PASSING_MOCK_SHARED_RESOURCE_ENGINE_MOCK_H

--- a/score/message_passing/qnx_dispatch/qnx_dispatch_client_factory.cpp
+++ b/score/message_passing/qnx_dispatch/qnx_dispatch_client_factory.cpp
@@ -15,9 +15,7 @@
 #include "score/message_passing/client_connection.h"
 #include "score/message_passing/qnx_dispatch/qnx_dispatch_engine.h"
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 // coverity[autosar_cpp14_a3_3_1_violation] False positive: Constructor implementation for class declared in header
 QnxDispatchClientFactory::QnxDispatchClientFactory(score::cpp::pmr::memory_resource* const resource) noexcept
@@ -41,5 +39,4 @@ score::cpp::pmr::unique_ptr<IClientConnection> QnxDispatchClientFactory::Create(
         engine_->GetMemoryResource(), engine_, protocol_config, client_config);
 }
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing

--- a/score/message_passing/qnx_dispatch/qnx_dispatch_client_factory.h
+++ b/score/message_passing/qnx_dispatch/qnx_dispatch_client_factory.h
@@ -15,9 +15,7 @@
 
 #include "score/message_passing/i_client_factory.h"
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 // Suppress "AUTOSAR C++14 M3-2-3" rule finding. This rule states: "A type, object or function that is used in multiple
@@ -51,7 +49,6 @@ class QnxDispatchClientFactory final : public IClientFactory
     const std::shared_ptr<QnxDispatchEngine> engine_;
 };
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_QNX_DISPATCH_QNX_DISPATCH_CLIENT_FACTORY_H

--- a/score/message_passing/qnx_dispatch/qnx_dispatch_server_factory.cpp
+++ b/score/message_passing/qnx_dispatch/qnx_dispatch_server_factory.cpp
@@ -15,9 +15,7 @@
 #include "score/message_passing/qnx_dispatch/qnx_dispatch_engine.h"
 #include "score/message_passing/qnx_dispatch/qnx_dispatch_server.h"
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 // coverity[autosar_cpp14_a2_10_6_violation] false-positive: there is nothing with the same name
@@ -42,5 +40,4 @@ score::cpp::pmr::unique_ptr<IServer> QnxDispatchServerFactory::Create(const Serv
         engine_->GetMemoryResource(), engine_, protocol_config, server_config);
 }
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing

--- a/score/message_passing/qnx_dispatch/qnx_dispatch_server_factory.h
+++ b/score/message_passing/qnx_dispatch/qnx_dispatch_server_factory.h
@@ -15,9 +15,7 @@
 
 #include "score/message_passing/i_server_factory.h"
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 class QnxDispatchEngine;
@@ -49,7 +47,6 @@ class QnxDispatchServerFactory final : public IServerFactory
     const std::shared_ptr<QnxDispatchEngine> engine_;
 };
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_QNX_DISPATCH_QNX_DISPATCH_SERVER_FACTORY_H

--- a/score/message_passing/qnx_dispatch/qnx_resource_path.cpp
+++ b/score/message_passing/qnx_dispatch/qnx_resource_path.cpp
@@ -17,11 +17,7 @@
 
 #include <iterator>
 
-namespace score
-{
-namespace message_passing
-{
-namespace detail
+namespace score::message_passing::detail
 {
 
 QnxResourcePath::QnxResourcePath(const std::string_view identifier) noexcept
@@ -38,6 +34,4 @@ QnxResourcePath::QnxResourcePath(const std::string_view identifier) noexcept
     buffer_.push_back('\0');  // AUTOSAR C++14 M5-0-11: Use character literal instead of plain integer
 }
 
-}  // namespace detail
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing::detail

--- a/score/message_passing/qnx_dispatch/qnx_resource_path.h
+++ b/score/message_passing/qnx_dispatch/qnx_resource_path.h
@@ -17,11 +17,7 @@
 
 #include <string_view>
 
-namespace score
-{
-namespace message_passing
-{
-namespace detail
+namespace score::message_passing::detail
 {
 
 inline constexpr std::string_view GetQnxPrefix() noexcept
@@ -47,8 +43,6 @@ class QnxResourcePath
     score::cpp::static_vector<char, GetQnxPrefix().size() + kMaxIdentifierLen + 1U> buffer_;
 };
 
-}  // namespace detail
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing::detail
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_QNX_DISPATCH_QNX_RESOURCE_PATH_H

--- a/score/message_passing/qnx_dispatch_engine_test.cpp
+++ b/score/message_passing/qnx_dispatch_engine_test.cpp
@@ -14,9 +14,7 @@
 
 #include "score/message_passing/resource_manager_fixture_base.h"
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 namespace
 {
@@ -606,5 +604,4 @@ TEST_F(QnxDispatchEngineTestFixture, CleanupNonOwner)
 }
 
 }  // namespace
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing

--- a/score/message_passing/qnx_dispatch_mocked_server_test.cpp
+++ b/score/message_passing/qnx_dispatch_mocked_server_test.cpp
@@ -16,9 +16,7 @@
 
 #include "score/message_passing/resource_manager_fixture_base.h"
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 namespace
 {
@@ -92,5 +90,4 @@ TEST_F(QnxDispatchMockedServerFixture, ServerOpenConnectOcbAttachFailure)
 }
 
 }  // namespace
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing

--- a/score/message_passing/qnx_dispatch_server_test.cpp
+++ b/score/message_passing/qnx_dispatch_server_test.cpp
@@ -19,9 +19,7 @@
 
 #include <fcntl.h>
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 namespace
 {
@@ -123,5 +121,4 @@ TEST(QnxDispatchServerTest, RunningServerWithConnection)
 }
 
 }  // namespace
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing

--- a/score/message_passing/qnx_dispatch_server_to_client_test.cpp
+++ b/score/message_passing/qnx_dispatch_server_to_client_test.cpp
@@ -19,9 +19,7 @@
 
 #include <future>
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 namespace
 {
@@ -615,5 +613,4 @@ TEST_P(ServerToClientQnxFixture, EchoServerClientRestart)
 INSTANTIATE_TEST_SUITE_P(QnxDispatch, ServerToClientQnxFixture, testing::Values(false, true));
 
 }  // namespace
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing

--- a/score/message_passing/resource_manager_fixture_base.h
+++ b/score/message_passing/resource_manager_fixture_base.h
@@ -31,9 +31,7 @@
 
 #include <gmock/gmock.h>
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 /// \brief Provides QNX Resource Manager emulation layer for use with OSAL mocks
@@ -722,7 +720,6 @@ class ResourceManagerFixtureBase : public ::testing::Test
     const score::cpp::unexpected<score::os::Error> kFakeOsError{score::os::Error::createFromErrno(EINVAL)};
 };
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_RESOURCE_MANAGER_FIXTURE_BASE_H

--- a/score/message_passing/server_types.h
+++ b/score/message_passing/server_types.h
@@ -20,9 +20,7 @@
 
 #include <variant>
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 using UserData = std::variant<void*, std::uintptr_t, score::cpp::pmr::unique_ptr<IConnectionHandler>>;
@@ -50,7 +48,6 @@ struct ClientIdentity
     gid_t gid;
 };
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_SERVER_TYPES_H

--- a/score/message_passing/service_protocol_config.h
+++ b/score/message_passing/service_protocol_config.h
@@ -17,9 +17,7 @@
 #include <memory>
 #include <string_view>
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 /// \brief The common part of the library configuration of a server and a client
@@ -32,7 +30,6 @@ struct ServiceProtocolConfig
     std::uint32_t max_notify_size;  ///< Maximum size in bytes for the notification message from server to client
 };
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_SERVICE_PROTOCOL_CONFIG_H

--- a/score/message_passing/timed_command_queue.cpp
+++ b/score/message_passing/timed_command_queue.cpp
@@ -14,11 +14,7 @@
 
 #include <score/utility.hpp>
 
-namespace score
-{
-namespace message_passing
-{
-namespace detail
+namespace score::message_passing::detail
 {
 
 void TimedCommandQueue::RegisterImmediateEntry(Entry& entry, QueuedCallback callback, const void* const owner) noexcept
@@ -80,6 +76,4 @@ void TimedCommandQueue::CleanUpOwner(const void* const owner) noexcept
         });
 }
 
-}  // namespace detail
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing::detail

--- a/score/message_passing/timed_command_queue.h
+++ b/score/message_passing/timed_command_queue.h
@@ -17,11 +17,7 @@
 
 #include <mutex>
 
-namespace score
-{
-namespace message_passing
-{
-namespace detail
+namespace score::message_passing::detail
 {
 
 /// \brief Intrusive list based priority queue ordered by a time point
@@ -83,8 +79,6 @@ class TimedCommandQueue
     score::containers::intrusive_list<Entry, TimedCommandQueue> queue_;
 };
 
-}  // namespace detail
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing::detail
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_TIMED_COMMAND_QUEUE_H

--- a/score/message_passing/timed_command_queue_entry.h
+++ b/score/message_passing/timed_command_queue_entry.h
@@ -19,11 +19,7 @@
 
 #include <chrono>
 
-namespace score
-{
-namespace message_passing
-{
-namespace detail
+namespace score::message_passing::detail
 {
 
 class TimedCommandQueue;
@@ -46,8 +42,6 @@ class TimedCommandQueueEntry : public score::containers::intrusive_list_element<
     QueuedCallback callback_{};
 };
 
-}  // namespace detail
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing::detail
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_TIMED_COMMAND_QUEUE_ENTRY_H

--- a/score/message_passing/unix_domain/unix_domain_client_factory.cpp
+++ b/score/message_passing/unix_domain/unix_domain_client_factory.cpp
@@ -15,9 +15,7 @@
 #include "score/message_passing/client_connection.h"
 #include "score/message_passing/unix_domain/unix_domain_engine.h"
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 UnixDomainClientFactory::UnixDomainClientFactory(score::cpp::pmr::memory_resource* const resource) noexcept
@@ -40,5 +38,4 @@ score::cpp::pmr::unique_ptr<IClientConnection> UnixDomainClientFactory::Create(
         engine_->GetMemoryResource(), engine_, protocol_config, client_config);
 }
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing

--- a/score/message_passing/unix_domain/unix_domain_client_factory.h
+++ b/score/message_passing/unix_domain/unix_domain_client_factory.h
@@ -15,9 +15,7 @@
 
 #include "score/message_passing/i_client_factory.h"
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 class UnixDomainEngine;
@@ -42,7 +40,6 @@ class UnixDomainClientFactory final : public IClientFactory
     const std::shared_ptr<UnixDomainEngine> engine_;
 };
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_UNIX_DOMAIN_UNIX_DOMAIN_CLIENT_FACTORY_H

--- a/score/message_passing/unix_domain/unix_domain_engine.cpp
+++ b/score/message_passing/unix_domain/unix_domain_engine.cpp
@@ -17,9 +17,7 @@
 #include <future>
 #include <tuple>
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 UnixDomainEngine::UnixDomainEngine(score::cpp::pmr::memory_resource* memory_resource, LoggingCallback logger) noexcept
@@ -354,5 +352,4 @@ std::int32_t UnixDomainEngine::ProcessTimerQueue() noexcept
     return static_cast<std::int32_t>(distance_ms + 1);
 }
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing

--- a/score/message_passing/unix_domain/unix_domain_engine.h
+++ b/score/message_passing/unix_domain/unix_domain_engine.h
@@ -31,9 +31,7 @@
 
 #include <poll.h>
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 /// \brief Class encapsulating resources needed for Unix Domain Client/Server implementation
@@ -152,7 +150,6 @@ class UnixDomainEngine final : public ISharedResourceEngine
     score::cpp::pmr::vector<std::uint8_t> posix_receive_buffer_;
 };
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_UNIX_DOMAIN_UNIX_DOMAIN_ENGINE_H

--- a/score/message_passing/unix_domain/unix_domain_server.cpp
+++ b/score/message_passing/unix_domain/unix_domain_server.cpp
@@ -19,11 +19,7 @@
 #include <score/utility.hpp>
 #include <tuple>
 
-namespace score
-{
-namespace message_passing
-{
-namespace detail
+namespace score::message_passing::detail
 {
 
 namespace
@@ -274,6 +270,4 @@ void UnixDomainServer::ProcessConnect() noexcept
     connection->AcceptConnection(std::move(data_expected.value()), std::move(connection));
 }
 
-}  // namespace detail
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing::detail

--- a/score/message_passing/unix_domain/unix_domain_server.h
+++ b/score/message_passing/unix_domain/unix_domain_server.h
@@ -23,11 +23,7 @@
 
 #include <optional>
 
-namespace score
-{
-namespace message_passing
-{
-namespace detail
+namespace score::message_passing::detail
 {
 
 class UnixDomainServer final : public IServer
@@ -97,8 +93,6 @@ class UnixDomainServer final : public IServer
     ISharedResourceEngine::PosixEndpointEntry listener_endpoint_;
 };
 
-}  // namespace detail
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing::detail
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_UNIX_DOMAIN_UNIX_DOMAIN_SERVER_H

--- a/score/message_passing/unix_domain/unix_domain_server_factory.cpp
+++ b/score/message_passing/unix_domain/unix_domain_server_factory.cpp
@@ -15,9 +15,7 @@
 #include "score/message_passing/unix_domain/unix_domain_engine.h"
 #include "score/message_passing/unix_domain/unix_domain_server.h"
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 UnixDomainServerFactory::UnixDomainServerFactory(score::cpp::pmr::memory_resource* const resource) noexcept
@@ -39,5 +37,4 @@ score::cpp::pmr::unique_ptr<IServer> UnixDomainServerFactory::Create(const Servi
         engine_->GetMemoryResource(), engine_, protocol_config, server_config);
 }
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing

--- a/score/message_passing/unix_domain/unix_domain_server_factory.h
+++ b/score/message_passing/unix_domain/unix_domain_server_factory.h
@@ -15,9 +15,7 @@
 
 #include "score/message_passing/i_server_factory.h"
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 
 class UnixDomainEngine;
@@ -42,7 +40,6 @@ class UnixDomainServerFactory final : public IServerFactory
     const std::shared_ptr<UnixDomainEngine> engine_;
 };
 
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing
 
 #endif  // SCORE_LIB_MESSAGE_PASSING_UNIX_DOMAIN_UNIX_DOMAIN_SERVER_FACTORY_H

--- a/score/message_passing/unix_domain_server_test.cpp
+++ b/score/message_passing/unix_domain_server_test.cpp
@@ -21,9 +21,7 @@
 
 #include <type_traits>
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 namespace
 {
@@ -115,5 +113,4 @@ TEST(UnixDomainServerTest, RunningServersWithSameId)
 #endif
 
 }  // namespace
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing

--- a/score/message_passing/unix_domain_server_to_client_test.cpp
+++ b/score/message_passing/unix_domain_server_to_client_test.cpp
@@ -19,9 +19,7 @@
 
 #include <future>
 
-namespace score
-{
-namespace message_passing
+namespace score::message_passing
 {
 namespace
 {
@@ -435,5 +433,4 @@ TEST_P(ServerToClientTestFixtureUnix, EchoServerClientRestart)
 INSTANTIATE_TEST_SUITE_P(UnixDomain, ServerToClientTestFixtureUnix, testing::Values(false, true));
 
 }  // namespace
-}  // namespace message_passing
-}  // namespace score
+}  // namespace score::message_passing

--- a/score/mw/com/impl/bindings/lola/transaction_log_id_test.cpp
+++ b/score/mw/com/impl/bindings/lola/transaction_log_id_test.cpp
@@ -16,15 +16,7 @@
 
 #include <gtest/gtest.h>
 
-namespace score
-{
-namespace mw
-{
-namespace com
-{
-namespace impl
-{
-namespace lola
+namespace score::mw::com::impl::lola
 {
 namespace
 {
@@ -108,8 +100,4 @@ INSTANTIATE_TEST_CASE_P(TransactionLogIdEqualityFixture,
                                                                           kDifferentInstanceSpecifier.ToString()})));
 
 }  // namespace
-}  // namespace lola
-}  // namespace impl
-}  // namespace com
-}  // namespace mw
-}  // namespace score
+}  // namespace score::mw::com::impl::lola

--- a/score/mw/com/impl/plumbing/proxy_method_binding_factory_impl.cpp
+++ b/score/mw/com/impl/plumbing/proxy_method_binding_factory_impl.cpp
@@ -16,9 +16,7 @@
 
 #include <score/assert.hpp>
 
-namespace score::mw::com::impl
-{
-namespace detail
+namespace score::mw::com::impl::detail
 {
 
 bool IsMethodOrFieldEnabled(const LolaServiceInstanceDeployment& lola_service_instance_deployment,
@@ -73,6 +71,4 @@ LolaMethodInstanceDeployment::QueueSize GetQueueSize(HandleType parent_handle,
     return lola_method_instance_deployment.queue_size_.value();
 }
 
-}  // namespace detail
-
-}  // namespace score::mw::com::impl
+}  // namespace score::mw::com::impl::detail

--- a/score/mw/com/impl/tracing/test/skeleton_event_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/test/skeleton_event_tracing_test.cpp
@@ -29,13 +29,7 @@
 #include <utility>
 #include <vector>
 
-namespace score
-{
-namespace mw
-{
-namespace com
-{
-namespace impl
+namespace score::mw::com::impl
 {
 namespace
 {
@@ -1168,7 +1162,4 @@ TEST_F(SkeletonEventTracingSendWithAllocateFixture, SendCallsAreNotTracedWhenTra
 }
 
 }  // namespace
-}  // namespace impl
-}  // namespace com
-}  // namespace mw
-}  // namespace score
+}  // namespace score::mw::com::impl

--- a/score/mw/com/impl/tracing/test/skeleton_field_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/test/skeleton_field_tracing_test.cpp
@@ -30,13 +30,7 @@
 #include <utility>
 #include <vector>
 
-namespace score
-{
-namespace mw
-{
-namespace com
-{
-namespace impl
+namespace score::mw::com::impl
 {
 namespace
 {
@@ -1254,7 +1248,4 @@ TEST_F(SkeletonFieldTracingSendWithAllocateFixture, SendCallsAreNotTracedWhenTra
 }
 
 }  // namespace
-}  // namespace impl
-}  // namespace com
-}  // namespace mw
-}  // namespace score
+}  // namespace score::mw::com::impl

--- a/score/mw/com/impl/tracing/test/skeleton_tracing_test.cpp
+++ b/score/mw/com/impl/tracing/test/skeleton_tracing_test.cpp
@@ -28,13 +28,7 @@
 #include <utility>
 #include <vector>
 
-namespace score
-{
-namespace mw
-{
-namespace com
-{
-namespace impl
+namespace score::mw::com::impl
 {
 namespace
 {
@@ -529,7 +523,4 @@ TEST_F(SkeletonBaseUnregisterShmTracingFixture,
 }
 
 }  // namespace
-}  // namespace impl
-}  // namespace com
-}  // namespace mw
-}  // namespace score
+}  // namespace score::mw::com::impl

--- a/score/mw/service/backend/mw_com/provided_service_builder.h
+++ b/score/mw/service/backend/mw_com/provided_service_builder.h
@@ -19,11 +19,7 @@
 
 #include <utility>
 
-namespace score
-{
-namespace mw
-{
-namespace service
+namespace score::mw::service
 {
 
 // Forward declare to allow alias
@@ -33,9 +29,7 @@ template <typename ServiceType>
 class ProvidedServiceDecorator;
 }
 
-namespace backend
-{
-namespace mw_com
+namespace backend::mw_com
 {
 
 /// @brief Minimal stub for config_daemon testing
@@ -76,15 +70,12 @@ class ProvidedServiceBuilder
 // Backward compatibility: Tests expect mw::service::backend::mw_com::ProvidedServices
 using ProvidedServices = score::mw::service::ProvidedServices<ProvidedServiceDecorator>;
 
-}  // namespace mw_com
-}  // namespace backend
+}  // namespace backend::mw_com
 
 // Make ProvidedServiceBuilder available in mw::service namespace
 // for backward compatibility with existing code
 using backend::mw_com::ProvidedServiceBuilder;
 
-}  // namespace service
-}  // namespace mw
-}  // namespace score
+}  // namespace score::mw::service
 
 #endif  // SCORE_MW_SERVICE_BACKEND_MW_COM_PROVIDED_SERVICE_BUILDER_H

--- a/score/mw/service/backend/mw_com/provided_service_decorator.h
+++ b/score/mw/service/backend/mw_com/provided_service_decorator.h
@@ -19,15 +19,7 @@
 #include <memory>
 #include <utility>
 
-namespace score
-{
-namespace mw
-{
-namespace service
-{
-namespace backend
-{
-namespace mw_com
+namespace score::mw::service::backend::mw_com
 {
 
 /// @brief Simplified stub decorator for provided services
@@ -110,10 +102,6 @@ class ProvidedServiceDecorator : public ProvidedService
     ServiceHolder service_;
 };
 
-}  // namespace mw_com
-}  // namespace backend
-}  // namespace service
-}  // namespace mw
-}  // namespace score
+}  // namespace score::mw::service::backend::mw_com
 
 #endif  // SCORE_MW_SERVICE_BACKEND_MW_COM_PROVIDED_SERVICE_DECORATOR_H

--- a/score/mw/service/backend/mw_com/provided_services.h
+++ b/score/mw/service/backend/mw_com/provided_services.h
@@ -22,11 +22,7 @@
 #include <utility>
 #include <vector>
 
-namespace score
-{
-namespace mw
-{
-namespace service
+namespace score::mw::service
 {
 class ProvidedService;
 
@@ -124,8 +120,6 @@ class ProvidedServices : public ProvidedServicesBase
     std::vector<std::pair<std::string, ProvidedServiceHolder>> services_;
 };
 
-}  // namespace service
-}  // namespace mw
-}  // namespace score
+}  // namespace score::mw::service
 
 #endif  // SCORE_MW_SERVICE_BACKEND_MW_COM_PROVIDED_SERVICES_H

--- a/score/mw/service/backend/mw_com/single_instantiation_strategy.h
+++ b/score/mw/service/backend/mw_com/single_instantiation_strategy.h
@@ -18,15 +18,7 @@
 #include <string>
 #include <utility>
 
-namespace score
-{
-namespace mw
-{
-namespace service
-{
-namespace backend
-{
-namespace mw_com
+namespace score::mw::service::backend::mw_com
 {
 
 /// @brief Stub for SingleInstantiationStrategy
@@ -68,10 +60,6 @@ class SingleInstantiationStrategy
     SingleInstantiationStrategy& operator=(SingleInstantiationStrategy&&) noexcept = default;
 };
 
-}  // namespace mw_com
-}  // namespace backend
-}  // namespace service
-}  // namespace mw
-}  // namespace score
+}  // namespace score::mw::service::backend::mw_com
 
 #endif  // SCORE_MW_SERVICE_BACKEND_MW_COM_SINGLE_INSTANTIATION_STRATEGY_H

--- a/score/mw/service/provided_service.h
+++ b/score/mw/service/provided_service.h
@@ -14,11 +14,7 @@
 #ifndef SCORE_MW_SERVICE_PROVIDED_SERVICE_H
 #define SCORE_MW_SERVICE_PROVIDED_SERVICE_H
 
-namespace score
-{
-namespace mw
-{
-namespace service
+namespace score::mw::service
 {
 
 /// @brief Minimal stub base class for provided services
@@ -50,8 +46,6 @@ class ProvidedService
     ProvidedService& operator=(const ProvidedService&) & noexcept = default;
 };
 
-}  // namespace service
-}  // namespace mw
-}  // namespace score
+}  // namespace score::mw::service
 
 #endif  // SCORE_MW_SERVICE_PROVIDED_SERVICE_H

--- a/score/mw/service/provided_service_container.h
+++ b/score/mw/service/provided_service_container.h
@@ -21,11 +21,7 @@
 #include <string>
 #include <string_view>
 
-namespace score
-{
-namespace mw
-{
-namespace service
+namespace score::mw::service
 {
 
 class ProvidedServicesBase
@@ -243,8 +239,6 @@ class ProvidedServiceContainer
     std::unique_ptr<ProvidedServicesBase> services_;
 };
 
-}  // namespace service
-}  // namespace mw
-}  // namespace score
+}  // namespace score::mw::service
 
 #endif  // SCORE_MW_SERVICE_PROVIDED_SERVICE_CONTAINER_H

--- a/score/mw/service/proxy_data.h
+++ b/score/mw/service/proxy_data.h
@@ -16,11 +16,7 @@
 
 #include "score/mw/service/proxy_needs.h"
 
-namespace score
-{
-namespace mw
-{
-namespace service
+namespace score::mw::service
 {
 
 /// @brief Stub alias for OptionalProxyData — wraps an optional proxy instance.
@@ -28,8 +24,6 @@ namespace service
 template <typename T>
 using OptionalProxyData = Optional<T>;
 
-}  // namespace service
-}  // namespace mw
-}  // namespace score
+}  // namespace score::mw::service
 
 #endif  // SCORE_MW_SERVICE_PROXY_DATA_H

--- a/score/mw/service/proxy_future.h
+++ b/score/mw/service/proxy_future.h
@@ -16,11 +16,7 @@
 
 #include "score/concurrency/future/interruptible_future.h"
 
-namespace score
-{
-namespace mw
-{
-namespace service
+namespace score::mw::service
 {
 
 /**
@@ -30,8 +26,6 @@ namespace service
 template <typename T>
 using ProxyFuture = score::concurrency::InterruptibleFuture<T>;
 
-}  // namespace service
-}  // namespace mw
-}  // namespace score
+}  // namespace score::mw::service
 
 #endif  // SCORE_MW_SERVICE_PROXY_FUTURE_H

--- a/score/mw/service/proxy_needs.h
+++ b/score/mw/service/proxy_needs.h
@@ -26,9 +26,7 @@ namespace cpp
 class stop_token;
 }  // namespace cpp
 
-namespace mw
-{
-namespace service
+namespace mw::service
 {
 
 /// @brief Wrapper for optional proxy instances
@@ -148,8 +146,8 @@ class ProxyNeeds
     }
 };
 
-}  // namespace service
-}  // namespace mw
+}  // namespace mw::service
+
 }  // namespace score
 
 #endif  // SCORE_MW_SERVICE_PROXY_NEEDS_H

--- a/score/mw/service/proxy_needs_factory.h
+++ b/score/mw/service/proxy_needs_factory.h
@@ -19,11 +19,7 @@
 #include <memory>
 #include <utility>
 
-namespace score
-{
-namespace mw
-{
-namespace service
+namespace score::mw::service
 {
 
 /// @brief Stub factory for creating ProxyNeeds instances
@@ -67,8 +63,6 @@ class ProxyNeedsFactory
     }
 };
 
-}  // namespace service
-}  // namespace mw
-}  // namespace score
+}  // namespace score::mw::service
 
 #endif  // SCORE_MW_SERVICE_PROXY_NEEDS_FACTORY_H


### PR DESCRIPTION
Apply clang-tidy modernize-concat-nested-namespaces fixes across the repository.