### PR TITLE
Fix noexcept MISRA findings

### DIFF
--- a/score/memory/shared/shared_memory_resource.cpp
+++ b/score/memory/shared/shared_memory_resource.cpp
@@ -356,7 +356,7 @@ score::cpp::expected<std::shared_ptr<SharedMemoryResource>, score::os::Error> Sh
     InitializeCallback initialize_callback,
     const UserPermissions& permissions,
     AccessControlListFactory acl_factory,
-    std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr) noexcept
+    std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr)
 {
     auto resource = CreateInstance(std::move(input_path), std::move(acl_factory), typed_memory_ptr);
     const auto result = resource->CreateImpl(user_space_to_reserve, std::move(initialize_callback), permissions);
@@ -377,7 +377,7 @@ score::cpp::expected<std::shared_ptr<SharedMemoryResource>, score::os::Error> Sh
     InitializeCallback initialize_callback,
     const UserPermissions& permissions,
     AccessControlListFactory acl_factory,
-    std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr) noexcept
+    std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr)
 {
     auto resource = CreateInstance(shared_memory_resource_id, std::move(acl_factory), typed_memory_ptr);
     const auto result = resource->CreateImpl(user_space_to_reserve, std::move(initialize_callback), permissions);
@@ -402,7 +402,7 @@ score::cpp::expected<std::shared_ptr<SharedMemoryResource>, score::os::Error> Sh
     InitializeCallback initialize_callback,
     const UserPermissions& permissions,
     AccessControlListFactory acl_factory,
-    std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr) noexcept
+    std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr)
 {
     auto resource = CreateInstance(std::move(input_path), std::move(acl_factory), typed_memory_ptr);
     const auto result = resource->CreateOrOpenImpl(user_space_to_reserve, std::move(initialize_callback), permissions);
@@ -437,7 +437,7 @@ score::cpp::expected<std::shared_ptr<SharedMemoryResource>, score::os::Error> Sh
 
 SharedMemoryResource::SharedMemoryResource(std::string input_path,
                                            AccessControlListFactory acl_factory,
-                                           std::shared_ptr<TypedMemory> typed_memory_ptr) noexcept
+                                           std::shared_ptr<TypedMemory> typed_memory_ptr)
     : SharedMemoryResource(std::variant<std::string, std::uint64_t>{std::move(input_path)},
                            std::move(acl_factory),
                            std::move(typed_memory_ptr))
@@ -446,7 +446,7 @@ SharedMemoryResource::SharedMemoryResource(std::string input_path,
 
 SharedMemoryResource::SharedMemoryResource(std::uint64_t shared_memory_resource_id,
                                            AccessControlListFactory acl_factory,
-                                           std::shared_ptr<TypedMemory> typed_memory_ptr) noexcept
+                                           std::shared_ptr<TypedMemory> typed_memory_ptr)
     : SharedMemoryResource(std::variant<std::string, std::uint64_t>{shared_memory_resource_id},
                            std::move(acl_factory),
                            std::move(typed_memory_ptr))
@@ -551,7 +551,7 @@ score::cpp::expected_blank<Error> SharedMemoryResource::CreateImpl(const std::si
 
 score::cpp::expected_blank<Error> SharedMemoryResource::CreateOrOpenImpl(const std::size_t user_space_to_reserve,
                                                                          InitializeCallback initialize_callback,
-                                                                         const UserPermissions& permissions) noexcept
+                                                                         const UserPermissions& permissions)
 {
     const auto* const path = std::get_if<std::string>(&shared_memory_resource_identifier_);
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(path != nullptr, "shm-object file path is not set.");
@@ -598,7 +598,7 @@ score::cpp::expected_blank<Error> SharedMemoryResource::CreateOrOpenImpl(const s
     return {};
 }
 
-score::cpp::expected_blank<Error> SharedMemoryResource::OpenImpl(const bool is_read_write) noexcept
+score::cpp::expected_blank<Error> SharedMemoryResource::OpenImpl(const bool is_read_write)
 {
     if (is_read_write)
     {

--- a/score/memory/shared/shared_memory_resource.h
+++ b/score/memory/shared/shared_memory_resource.h
@@ -141,7 +141,7 @@ class SharedMemoryResource : public ISharedMemoryResource, public std::enable_sh
     /// allocated in the system os.
     SharedMemoryResource(std::string input_path,
                          AccessControlListFactory acl_factory,
-                         std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr) noexcept;
+                         std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr);
 
     /// \brief Constructor of the class SharedMemoryResource.
     /// \details Constructor should only be used by SharedMemoryResource::CreateAnonymous
@@ -153,7 +153,7 @@ class SharedMemoryResource : public ISharedMemoryResource, public std::enable_sh
     /// allocated in the system os.
     SharedMemoryResource(std::uint64_t shared_memory_resource_id,
                          AccessControlListFactory acl_factory,
-                         std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr) noexcept;
+                         std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr);
 
     SharedMemoryResource(std::variant<std::string, std::uint64_t> identifier,
                          AccessControlListFactory acl_factory,
@@ -269,7 +269,7 @@ class SharedMemoryResource : public ISharedMemoryResource, public std::enable_sh
         InitializeCallback initialize_callback,
         const UserPermissions& permissions,
         AccessControlListFactory acl_factory,
-        std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr = nullptr) noexcept;
+        std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr = nullptr);
 
     /// \brief Creates anonymous shared-mem-object.
     /// \attention This implementation only works in QNX environment because typed memory is only implemented for QNX
@@ -294,7 +294,7 @@ class SharedMemoryResource : public ISharedMemoryResource, public std::enable_sh
         InitializeCallback initialize_callback,
         const UserPermissions& permissions,
         AccessControlListFactory acl_factory,
-        std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr) noexcept;
+        std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr);
 
     /// \brief Creates shared-mem-object under the path (path_) if it not yet exists or opens it otherwise.
     /// \param input_path path of the memory region: a string that describes a regular file path name that will be
@@ -318,7 +318,7 @@ class SharedMemoryResource : public ISharedMemoryResource, public std::enable_sh
         InitializeCallback initialize_callback,
         const UserPermissions& permissions,
         AccessControlListFactory acl_factory,
-        std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr) noexcept;
+        std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr);
 
     /// \brief Opens shared-mem-object under the path (path_) and maps it into memory with the length of the underlying
     ///        shm-object file.
@@ -350,7 +350,7 @@ class SharedMemoryResource : public ISharedMemoryResource, public std::enable_sh
     // coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
     score::cpp::expected_blank<score::os::Error> CreateOrOpenImpl(const std::size_t user_space_to_reserve,
                                                                   InitializeCallback initialize_callback,
-                                                                  const UserPermissions& permissions) noexcept;
+                                                                  const UserPermissions& permissions);
 
     /// \brief Called by SharedMemoryResource::Open() after calling the constructor.
     /// \details Despite being an "open" operation, this method creates a temporary lock file to prevent a race
@@ -362,7 +362,7 @@ class SharedMemoryResource : public ISharedMemoryResource, public std::enable_sh
     /// partially-initialized memory.
     /// \return in case of error an score::os::Error is returned.
     // coverity[autosar_cpp14_m7_3_1_violation] false-positive: class method (Ticket-234468)
-    score::cpp::expected_blank<score::os::Error> OpenImpl(const bool is_read_write) noexcept;
+    score::cpp::expected_blank<score::os::Error> OpenImpl(const bool is_read_write);
 
     /// \brief UnlinkFilesystemEntry() should be used by the skeleton to unlink the shared memory region so that
     /// no process can open it anymore. This will not deallocate the shared memory region, that is done in

--- a/score/memory/shared/shared_memory_test_resources.cpp
+++ b/score/memory/shared/shared_memory_test_resources.cpp
@@ -116,7 +116,7 @@ score::cpp::expected<std::shared_ptr<SharedMemoryResource>, score::os::Error> Sh
     SharedMemoryResource::InitializeCallback initialize_callback,
     const UserPermissions& permissions,
     score::os::IAccessControlList* acl_control_list,
-    std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr) noexcept
+    std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr)
 {
     if (acl_control_list == nullptr)
     {
@@ -145,13 +145,12 @@ score::cpp::expected<std::shared_ptr<SharedMemoryResource>, score::os::Error> Sh
 }
 
 score::cpp::expected<std::shared_ptr<SharedMemoryResource>, score::os::Error>
-SharedMemoryResourceTestAttorney::CreateAnonymous(
-    std::uint64_t shared_memory_resource_id,
-    const std::size_t user_space_to_reserve,
-    SharedMemoryResource::InitializeCallback initialize_callback,
-    const UserPermissions& permissions,
-    score::os::IAccessControlList* acl_control_list,
-    std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr) noexcept
+SharedMemoryResourceTestAttorney::CreateAnonymous(std::uint64_t shared_memory_resource_id,
+                                                  const std::size_t user_space_to_reserve,
+                                                  SharedMemoryResource::InitializeCallback initialize_callback,
+                                                  const UserPermissions& permissions,
+                                                  score::os::IAccessControlList* acl_control_list,
+                                                  std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr)
 {
     if (acl_control_list == nullptr)
     {
@@ -180,13 +179,12 @@ SharedMemoryResourceTestAttorney::CreateAnonymous(
 }
 
 score::cpp::expected<std::shared_ptr<SharedMemoryResource>, score::os::Error>
-SharedMemoryResourceTestAttorney::CreateOrOpen(
-    std::string input_path,
-    const std::size_t user_space_to_reserve,
-    SharedMemoryResource::InitializeCallback initialize_callback,
-    const UserPermissions& permissions,
-    score::os::IAccessControlList* acl_control_list,
-    std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr) noexcept
+SharedMemoryResourceTestAttorney::CreateOrOpen(std::string input_path,
+                                               const std::size_t user_space_to_reserve,
+                                               SharedMemoryResource::InitializeCallback initialize_callback,
+                                               const UserPermissions& permissions,
+                                               score::os::IAccessControlList* acl_control_list,
+                                               std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr)
 {
     if (acl_control_list == nullptr)
     {

--- a/score/memory/shared/shared_memory_test_resources.h
+++ b/score/memory/shared/shared_memory_test_resources.h
@@ -88,7 +88,7 @@ class SharedMemoryResourceTestAttorney
         SharedMemoryResource::InitializeCallback initialize_callback,
         const UserPermissions& permissions = {},
         score::os::IAccessControlList* acl_control_list = nullptr,
-        std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr = nullptr) noexcept;
+        std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr = nullptr);
 
     static score::cpp::expected<std::shared_ptr<SharedMemoryResource>, score::os::Error> CreateAnonymous(
         std::uint64_t shared_memory_resource_id,
@@ -96,7 +96,7 @@ class SharedMemoryResourceTestAttorney
         SharedMemoryResource::InitializeCallback initialize_callback,
         const UserPermissions& permissions = {},
         score::os::IAccessControlList* acl_control_list = nullptr,
-        std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr = nullptr) noexcept;
+        std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr = nullptr);
 
     static score::cpp::expected<std::shared_ptr<SharedMemoryResource>, score::os::Error> CreateOrOpen(
         std::string input_path,
@@ -104,7 +104,7 @@ class SharedMemoryResourceTestAttorney
         SharedMemoryResource::InitializeCallback initialize_callback,
         const UserPermissions& permissions = {},
         score::os::IAccessControlList* acl_control_list = nullptr,
-        std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr = nullptr) noexcept;
+        std::shared_ptr<score::memory::shared::TypedMemory> typed_memory_ptr = nullptr);
 
     static score::cpp::expected<std::shared_ptr<SharedMemoryResource>, score::os::Error> Open(
         std::string input_path,

--- a/score/mw/com/api_surface.lock.json
+++ b/score/mw/com/api_surface.lock.json
@@ -233,13 +233,13 @@
       "name": "FindService",
       "qualified_name": "score::mw::com::GenericProxy::FindService",
       "kind": "method",
-      "signature": "static FindService : Result<ServiceHandleContainer<HandleType>> (InstanceSpecifier) noexcept"
+      "signature": "static FindService : Result<ServiceHandleContainer<HandleType>> (InstanceSpecifier)"
     },
     {
       "name": "FindService",
       "qualified_name": "score::mw::com::GenericProxy::FindService",
       "kind": "method",
-      "signature": "static FindService : Result<ServiceHandleContainer<HandleType>> (InstanceIdentifier) noexcept"
+      "signature": "static FindService : Result<ServiceHandleContainer<HandleType>> (InstanceIdentifier)"
     },
     {
       "name": "GetEvents",
@@ -257,19 +257,19 @@
       "name": "StartFindService",
       "qualified_name": "score::mw::com::GenericProxy::StartFindService",
       "kind": "method",
-      "signature": "static StartFindService : Result<FindServiceHandle> (FindServiceHandler<HandleType>, InstanceIdentifier) noexcept"
+      "signature": "static StartFindService : Result<FindServiceHandle> (FindServiceHandler<HandleType>, InstanceIdentifier)"
     },
     {
       "name": "StartFindService",
       "qualified_name": "score::mw::com::GenericProxy::StartFindService",
       "kind": "method",
-      "signature": "static StartFindService : Result<FindServiceHandle> (FindServiceHandler<HandleType>, InstanceSpecifier) noexcept"
+      "signature": "static StartFindService : Result<FindServiceHandle> (FindServiceHandler<HandleType>, InstanceSpecifier)"
     },
     {
       "name": "StopFindService",
       "qualified_name": "score::mw::com::GenericProxy::StopFindService",
       "kind": "method",
-      "signature": "static StopFindService : score::Result<void> (const FindServiceHandle) noexcept"
+      "signature": "static StopFindService : score::Result<void> (const FindServiceHandle)"
     },
     {
       "name": "GetFreeSampleCount",
@@ -281,7 +281,7 @@
       "name": "GetNumNewSamplesAvailable",
       "qualified_name": "score::mw::com::GenericProxyEvent::GetNumNewSamplesAvailable",
       "kind": "method",
-      "signature": "GetNumNewSamplesAvailable : Result<std::size_t> () const noexcept"
+      "signature": "GetNumNewSamplesAvailable : Result<std::size_t> () const"
     },
     {
       "name": "GetSubscriptionState",
@@ -883,7 +883,7 @@
       "name": "OfferService",
       "qualified_name": "score::mw::com::GenericSkeleton::OfferService",
       "kind": "method",
-      "signature": "OfferService : Result<void> () noexcept [[nodiscard]]"
+      "signature": "OfferService : Result<void> () [[nodiscard]]"
     },
     {
       "name": "SkeletonBase",
@@ -895,7 +895,7 @@
       "name": "StopOfferService",
       "qualified_name": "score::mw::com::GenericSkeleton::StopOfferService",
       "kind": "method",
-      "signature": "StopOfferService : void () noexcept"
+      "signature": "StopOfferService : void ()"
     },
     {
       "name": "~SkeletonBase",

--- a/score/mw/com/impl/bindings/lola/generic_proxy_event.cpp
+++ b/score/mw/com/impl/bindings/lola/generic_proxy_event.cpp
@@ -49,7 +49,7 @@ SubscriptionState GenericProxyEvent::GetSubscriptionState() const noexcept
     return proxy_event_common_.GetSubscriptionState();
 }
 
-inline Result<std::size_t> GenericProxyEvent::GetNumNewSamplesAvailable() const noexcept
+inline Result<std::size_t> GenericProxyEvent::GetNumNewSamplesAvailable() const
 {
     /// In case of LoLa binding we can also dispatch to GetNumNewSamplesAvailableImpl() in case of kSubscriptionPending!
     /// Because a pre-condition to kSubscriptionPending is that we once had a successful subscription... and then we can

--- a/score/mw/com/impl/bindings/lola/generic_proxy_event.h
+++ b/score/mw/com/impl/bindings/lola/generic_proxy_event.h
@@ -61,7 +61,7 @@ class GenericProxyEvent final : public GenericProxyEventBinding
     void Unsubscribe() noexcept override;
 
     SubscriptionState GetSubscriptionState() const noexcept override;
-    Result<std::size_t> GetNumNewSamplesAvailable() const noexcept override;
+    Result<std::size_t> GetNumNewSamplesAvailable() const override;
     Result<std::size_t> GetNewSamples(Callback&& receiver, TrackerGuardFactory& tracker) override;
     std::size_t GetSampleSize() const noexcept override;
     bool HasSerializedFormat() const noexcept override;

--- a/score/mw/com/impl/bindings/lola/generic_skeleton_event.h
+++ b/score/mw/com/impl/bindings/lola/generic_skeleton_event.h
@@ -42,6 +42,8 @@ class GenericSkeletonEvent : public GenericSkeletonEventBinding
                          const memory::DataTypeSizeInfo& size_info,
                          impl::tracing::SkeletonEventTracingData tracing_data = {});
 
+    ~GenericSkeletonEvent() noexcept override = default;
+
     Result<void> Send(score::mw::com::impl::SampleAllocateePtr<void> sample) noexcept override;
 
     Result<score::mw::com::impl::SampleAllocateePtr<void>> Allocate(SampleAllocateeGuard guard) noexcept override;

--- a/score/mw/com/impl/bindings/lola/proxy_event.h
+++ b/score/mw/com/impl/bindings/lola/proxy_event.h
@@ -96,7 +96,7 @@ class ProxyEvent final : public ProxyEventBinding<SampleType>
     {
         return proxy_event_common_.GetSubscriptionState();
     }
-    Result<std::size_t> GetNumNewSamplesAvailable() const noexcept override;
+    Result<std::size_t> GetNumNewSamplesAvailable() const override;
     Result<std::size_t> GetNewSamples(Callback&& receiver, TrackerGuardFactory& tracker) noexcept override;
 
     Result<void> SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) noexcept override
@@ -165,7 +165,7 @@ inline const std::uint8_t* ProxyEvent<SampleType>::InitialiseEventSlotsRawArray(
 }
 
 template <typename SampleType>
-inline Result<std::size_t> ProxyEvent<SampleType>::GetNumNewSamplesAvailable() const noexcept
+inline Result<std::size_t> ProxyEvent<SampleType>::GetNumNewSamplesAvailable() const
 {
     /// In case of LoLa binding we can also dispatch to GetNumNewSamplesAvailableImpl() in case of kSubscriptionPending!
     /// Because a pre-condition to kSubscriptionPending is that we once had a successful subscription... and then we can

--- a/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client.cpp
+++ b/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client.cpp
@@ -222,9 +222,9 @@ auto ServiceDiscoveryClient::OfferService(const InstanceIdentifier instance_iden
     return {};
 }
 
-auto ServiceDiscoveryClient::StopOfferService(
-    const InstanceIdentifier instance_identifier,
-    const IServiceDiscovery::QualityTypeSelector quality_type_selector) noexcept -> Result<void>
+auto ServiceDiscoveryClient::StopOfferService(const InstanceIdentifier instance_identifier,
+                                              const IServiceDiscovery::QualityTypeSelector quality_type_selector)
+    -> Result<void>
 {
     const EnrichedInstanceIdentifier enriched_instance_identifier{instance_identifier};
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(
@@ -264,7 +264,7 @@ auto ServiceDiscoveryClient::StopOfferService(
     return {};
 }
 
-auto ServiceDiscoveryClient::StopFindService(const FindServiceHandle find_service_handle) noexcept -> Result<void>
+auto ServiceDiscoveryClient::StopFindService(const FindServiceHandle find_service_handle) -> Result<void>
 {
     {
         // Suppress Autosar C++14 A8-5-3 states that auto variables shall not be initialized using braced
@@ -286,7 +286,7 @@ auto ServiceDiscoveryClient::TransferSearchRequests() noexcept -> void
     TransferObsoleteSearchRequests();
 }
 
-auto ServiceDiscoveryClient::TransferNewSearchRequest(NewSearchRequest search_request) noexcept
+auto ServiceDiscoveryClient::TransferNewSearchRequest(NewSearchRequest search_request)
     -> SearchRequestsContainer::value_type&
 {
     auto& [find_service_handle,
@@ -319,7 +319,7 @@ auto ServiceDiscoveryClient::TransferNewSearchRequest(NewSearchRequest search_re
     return *(added_search_request.first);
 }
 
-auto ServiceDiscoveryClient::TransferObsoleteSearchRequests() noexcept -> void
+auto ServiceDiscoveryClient::TransferObsoleteSearchRequests() -> void
 {
     for (const auto& obsolete_search_request : obsolete_search_requests_)
     {

--- a/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client.h
+++ b/score/mw/com/impl/bindings/lola/service_discovery/client/service_discovery_client.h
@@ -58,13 +58,13 @@ class ServiceDiscoveryClient final : public IServiceDiscoveryClient
 
     [[nodiscard]] Result<void> StopOfferService(
         const InstanceIdentifier instance_identifier,
-        const IServiceDiscovery::QualityTypeSelector quality_type_selector) noexcept override;
+        const IServiceDiscovery::QualityTypeSelector quality_type_selector) override;
 
     [[nodiscard]] Result<void> StartFindService(const FindServiceHandle find_service_handle,
                                                 FindServiceHandler<HandleType> handler,
                                                 const EnrichedInstanceIdentifier enriched_instance_identifier) override;
 
-    [[nodiscard]] Result<void> StopFindService(const FindServiceHandle find_service_handle) noexcept override;
+    [[nodiscard]] Result<void> StopFindService(const FindServiceHandle find_service_handle) override;
     [[nodiscard]] Result<ServiceHandleContainer<HandleType>> FindService(
         const EnrichedInstanceIdentifier enriched_instance_identifier) override;
 
@@ -152,8 +152,8 @@ class ServiceDiscoveryClient final : public IServiceDiscoveryClient
     void OnInstanceFlagFileRemoved(const WatchesContainer::iterator& watch_iterator, std::string_view name);
 
     void TransferSearchRequests() noexcept;
-    SearchRequestsContainer::value_type& TransferNewSearchRequest(NewSearchRequest search_request) noexcept;
-    void TransferObsoleteSearchRequests() noexcept;
+    SearchRequestsContainer::value_type& TransferNewSearchRequest(NewSearchRequest search_request);
+    void TransferObsoleteSearchRequests();
 
     void TransferObsoleteSearchRequest(const FindServiceHandle& find_service_handle);
 

--- a/score/mw/com/impl/bindings/lola/service_discovery/flag_file.cpp
+++ b/score/mw/com/impl/bindings/lola/service_discovery/flag_file.cpp
@@ -75,7 +75,7 @@ auto GetMatchingFlagFilePaths(const EnrichedInstanceIdentifier& enriched_instanc
                       // anonymous namespace, or static function with internal linkage, or private member function shall
                       // be used.". Rationale: False-positive, this lambda function is used by std::for_each.
                       // coverity[autosar_cpp14_a0_1_3_violation : FALSE]
-                      [&flag_file_paths, quality_type](const filesystem::DirectoryEntry& entry) noexcept {
+                      [&flag_file_paths, quality_type](const filesystem::DirectoryEntry& entry) {
                           const auto file_status = entry.Status();
                           const auto substring_iterator = entry.GetPath().Native().find(quality_type);
                           const bool is_regular_file =
@@ -94,7 +94,7 @@ auto GetMatchingFlagFilePaths(const EnrichedInstanceIdentifier& enriched_instanc
 
 auto RemoveMatchingFlagFiles(const EnrichedInstanceIdentifier& enriched_instance_identifier,
                              const FlagFile::Disambiguator offer_disambiguator,
-                             filesystem::Filesystem& filesystem) noexcept -> score::Result<void>
+                             filesystem::Filesystem& filesystem) -> score::Result<void>
 {
     const auto matching_file_paths = GetMatchingFlagFilePaths(enriched_instance_identifier);
 
@@ -163,7 +163,7 @@ auto GetSearchPathForIdentifier(const EnrichedInstanceIdentifier& enriched_insta
     return search_path;
 }
 
-FlagFile::~FlagFile()
+FlagFile::~FlagFile() noexcept(false)
 {
     if (is_offered_)
     {
@@ -230,7 +230,7 @@ FlagFile::FlagFile(FlagFile&& other) noexcept
     other.is_offered_ = false;
 }
 
-auto FlagFile::Exists(const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept -> bool
+auto FlagFile::Exists(const EnrichedInstanceIdentifier& enriched_instance_identifier) -> bool
 {
     return !GetMatchingFlagFilePaths(enriched_instance_identifier).empty();
 }

--- a/score/mw/com/impl/bindings/lola/service_discovery/flag_file.h
+++ b/score/mw/com/impl/bindings/lola/service_discovery/flag_file.h
@@ -38,7 +38,7 @@ class FlagFile
   public:
     using Disambiguator = std::uint64_t;
 
-    ~FlagFile();
+    ~FlagFile() noexcept(false);
 
     /// \brief Creates a flag file for the provided InstanceIdentifier which is read/writable by the creating user and
     /// only readable by everyone else.
@@ -59,7 +59,7 @@ class FlagFile
     /// The service discovery path is: `<sd>/mw_com_lola/<service_id>/<instance_id>. Since flag files are always created
     /// in the instance directory, this function will always return false if the InstanceIdentifier does not contain an
     /// Instance ID.
-    static auto Exists(const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept -> bool;
+    static auto Exists(const EnrichedInstanceIdentifier& enriched_instance_identifier) -> bool;
 
     /// \brief Creates each directory in the search path (found using GetSearchPathForIdentifier()) for an
     /// InstanceIdentifier in the filesystem.

--- a/score/mw/com/impl/bindings/lola/skeleton_event.h
+++ b/score/mw/com/impl/bindings/lola/skeleton_event.h
@@ -77,7 +77,7 @@ class SkeletonEvent final : public SkeletonEventBinding<SampleType>
     SkeletonEvent& operator=(const SkeletonEvent&) & = delete;
     SkeletonEvent& operator=(SkeletonEvent&&) & noexcept = delete;
 
-    ~SkeletonEvent() override = default;
+    ~SkeletonEvent() noexcept override = default;
 
     /// \brief Sends a value by _copy_ towards a consumer. It will allocate the necessary space and then copy the value
     /// into Shared Memory.

--- a/score/mw/com/impl/bindings/lola/subscription_not_subscribed_states.cpp
+++ b/score/mw/com/impl/bindings/lola/subscription_not_subscribed_states.cpp
@@ -128,7 +128,7 @@ void NotSubscribedState::SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandl
     state_machine_.event_receiver_handler_ = std::move(handler);
 }
 
-void NotSubscribedState::UnsetReceiveHandler() noexcept
+void NotSubscribedState::UnsetReceiveHandler()
 {
     state_machine_.event_receiver_handler_ = std::nullopt;
 }

--- a/score/mw/com/impl/bindings/lola/subscription_not_subscribed_states.h
+++ b/score/mw/com/impl/bindings/lola/subscription_not_subscribed_states.h
@@ -41,7 +41,7 @@ class NotSubscribedState final : public SubscriptionStateBase
     void ReOfferEvent(const pid_t new_event_source_pid) noexcept override;
 
     void SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) noexcept override;
-    void UnsetReceiveHandler() noexcept override;
+    void UnsetReceiveHandler() override;
     std::optional<std::uint16_t> GetMaxSampleCount() const noexcept override;
     std::optional<SlotCollector>& GetSlotCollector() & noexcept override;
     const std::optional<SlotCollector>& GetSlotCollector() const& noexcept override;

--- a/score/mw/com/impl/bindings/lola/subscription_state_base.h
+++ b/score/mw/com/impl/bindings/lola/subscription_state_base.h
@@ -46,7 +46,7 @@ class SubscriptionStateBase
     virtual void ReOfferEvent(const pid_t new_event_source_pid) = 0;
 
     virtual void SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) = 0;
-    virtual void UnsetReceiveHandler() noexcept = 0;
+    virtual void UnsetReceiveHandler() = 0;
     virtual std::optional<std::uint16_t> GetMaxSampleCount() const = 0;
     virtual std::optional<SlotCollector>& GetSlotCollector() & noexcept = 0;
     virtual const std::optional<SlotCollector>& GetSlotCollector() const& noexcept = 0;

--- a/score/mw/com/impl/bindings/lola/subscription_state_machine.cpp
+++ b/score/mw/com/impl/bindings/lola/subscription_state_machine.cpp
@@ -104,7 +104,7 @@ void SubscriptionStateMachine::SetReceiveHandler(std::weak_ptr<ScopedEventReceiv
     GetCurrentEventState().SetReceiveHandler(std::move(handler));
 }
 
-void SubscriptionStateMachine::UnsetReceiveHandler() noexcept
+void SubscriptionStateMachine::UnsetReceiveHandler()
 {
     std::lock_guard<std::mutex> lock{state_mutex_};
     GetCurrentEventState().UnsetReceiveHandler();

--- a/score/mw/com/impl/bindings/lola/subscription_state_machine.h
+++ b/score/mw/com/impl/bindings/lola/subscription_state_machine.h
@@ -104,7 +104,7 @@ class SubscriptionStateMachine : public std::enable_shared_from_this<Subscriptio
     // State Machine Methods. These are not modeled by the state machine UML and do not cause transitions between
     // states.
     void SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) noexcept;
-    void UnsetReceiveHandler() noexcept;
+    void UnsetReceiveHandler();
     void SetSubscriptionStateChangeHandler(SubscriptionStateChangeHandler handler) noexcept;
     void UnsetSubscriptionStateChangeHandler() noexcept;
 

--- a/score/mw/com/impl/bindings/lola/subscription_subscribed_states.cpp
+++ b/score/mw/com/impl/bindings/lola/subscription_subscribed_states.cpp
@@ -78,7 +78,7 @@ void SubscribedState::SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler>
     state_machine_.event_receive_handler_manager_.Register(std::move(handler));
 }
 
-void SubscribedState::UnsetReceiveHandler() noexcept
+void SubscribedState::UnsetReceiveHandler()
 {
     state_machine_.event_receive_handler_manager_.Unregister();
 }

--- a/score/mw/com/impl/bindings/lola/subscription_subscribed_states.h
+++ b/score/mw/com/impl/bindings/lola/subscription_subscribed_states.h
@@ -43,7 +43,7 @@ class SubscribedState final : public SubscriptionStateBase
     void ReOfferEvent(const pid_t) override;
 
     void SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) override;
-    void UnsetReceiveHandler() noexcept override;
+    void UnsetReceiveHandler() override;
     std::optional<std::uint16_t> GetMaxSampleCount() const override;
     std::optional<SlotCollector>& GetSlotCollector() & noexcept override;
     const std::optional<SlotCollector>& GetSlotCollector() const& noexcept override;

--- a/score/mw/com/impl/bindings/lola/subscription_subscription_pending_states.cpp
+++ b/score/mw/com/impl/bindings/lola/subscription_subscription_pending_states.cpp
@@ -85,7 +85,7 @@ void SubscriptionPendingState::SetReceiveHandler(std::weak_ptr<ScopedEventReceiv
     state_machine_.event_receiver_handler_ = std::move(handler);
 }
 
-void SubscriptionPendingState::UnsetReceiveHandler() noexcept
+void SubscriptionPendingState::UnsetReceiveHandler()
 {
     state_machine_.event_receiver_handler_ = std::nullopt;
 }

--- a/score/mw/com/impl/bindings/lola/subscription_subscription_pending_states.h
+++ b/score/mw/com/impl/bindings/lola/subscription_subscription_pending_states.h
@@ -43,7 +43,7 @@ class SubscriptionPendingState final : public SubscriptionStateBase
     void ReOfferEvent(const pid_t new_event_source_pid) override;
 
     void SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) noexcept override;
-    void UnsetReceiveHandler() noexcept override;
+    void UnsetReceiveHandler() override;
     std::optional<std::uint16_t> GetMaxSampleCount() const override;
     std::optional<SlotCollector>& GetSlotCollector() & noexcept override;
     const std::optional<SlotCollector>& GetSlotCollector() const& noexcept override;

--- a/score/mw/com/impl/bindings/lola/type_erased_sample_ptrs_guard.cpp
+++ b/score/mw/com/impl/bindings/lola/type_erased_sample_ptrs_guard.cpp
@@ -20,12 +20,12 @@ namespace score::mw::com::impl::lola::tracing
 {
 
 TypeErasedSamplePtrsGuard::TypeErasedSamplePtrsGuard(
-    const impl::tracing::ServiceElementTracingData service_element_tracing_data) noexcept
+    const impl::tracing::ServiceElementTracingData service_element_tracing_data)
     : service_element_tracing_data_{service_element_tracing_data}
 {
 }
 
-TypeErasedSamplePtrsGuard::~TypeErasedSamplePtrsGuard() noexcept
+TypeErasedSamplePtrsGuard::~TypeErasedSamplePtrsGuard() noexcept(false)
 {
     const auto* const tracing_runtime = impl::Runtime::getInstance().GetTracingRuntime();
     if (tracing_runtime != nullptr)

--- a/score/mw/com/impl/bindings/lola/type_erased_sample_ptrs_guard.h
+++ b/score/mw/com/impl/bindings/lola/type_erased_sample_ptrs_guard.h
@@ -24,9 +24,8 @@ namespace score::mw::com::impl::lola::tracing
 class TypeErasedSamplePtrsGuard
 {
   public:
-    explicit TypeErasedSamplePtrsGuard(
-        const impl::tracing::ServiceElementTracingData service_element_tracing_data) noexcept;
-    ~TypeErasedSamplePtrsGuard() noexcept;
+    explicit TypeErasedSamplePtrsGuard(const impl::tracing::ServiceElementTracingData service_element_tracing_data);
+    ~TypeErasedSamplePtrsGuard() noexcept(false);
 
     TypeErasedSamplePtrsGuard(const TypeErasedSamplePtrsGuard&) = delete;
     TypeErasedSamplePtrsGuard& operator=(const TypeErasedSamplePtrsGuard&) = delete;

--- a/score/mw/com/impl/bindings/mock_binding/proxy_event.h
+++ b/score/mw/com/impl/bindings/mock_binding/proxy_event.h
@@ -153,7 +153,7 @@ class ProxyEventFacade : public ProxyEventBinding<SampleType>
     {
         return proxy_event_.Subscribe(n);
     }
-    Result<std::size_t> GetNumNewSamplesAvailable() const noexcept override
+    Result<std::size_t> GetNumNewSamplesAvailable() const override
     {
         return proxy_event_.GetNumNewSamplesAvailable();
     }

--- a/score/mw/com/impl/generic_skeleton.cpp
+++ b/score/mw/com/impl/generic_skeleton.cpp
@@ -142,12 +142,12 @@ ServiceElementMapView<GenericSkeletonEvent> GenericSkeleton::GetEvents() const n
     return ServiceElementMapViewFactory<GenericSkeletonEvent>::Create(*events_);
 }
 
-Result<void> GenericSkeleton::OfferService() noexcept
+Result<void> GenericSkeleton::OfferService()
 {
     return SkeletonBase::OfferService();
 }
 
-void GenericSkeleton::StopOfferService() noexcept
+void GenericSkeleton::StopOfferService()
 {
     SkeletonBase::StopOfferService();
 }

--- a/score/mw/com/impl/generic_skeleton.h
+++ b/score/mw/com/impl/generic_skeleton.h
@@ -74,10 +74,10 @@ class GenericSkeleton : public SkeletonBase
 
     /// \brief Offers the service instance.
     /// \return A blank result, or an error if offering fails.
-    [[nodiscard]] Result<void> OfferService() noexcept;
+    [[nodiscard]] Result<void> OfferService();
 
     /// \brief Stops offering the service instance.
-    void StopOfferService() noexcept;
+    void StopOfferService();
 
   private:
     // Private constructor, only callable by static Create methods.

--- a/score/mw/com/impl/handle_type.cpp
+++ b/score/mw/com/impl/handle_type.cpp
@@ -81,7 +81,7 @@ auto operator<(const HandleType& lhs, const HandleType& rhs) -> bool
     return std::tie(lhs.identifier_, lhs.instance_id_) < std::tie(rhs.identifier_, rhs.instance_id_);
 }
 
-auto make_HandleType(InstanceIdentifier identifier, std::optional<ServiceInstanceId> instance_id) noexcept -> HandleType
+auto make_HandleType(InstanceIdentifier identifier, std::optional<ServiceInstanceId> instance_id) -> HandleType
 {
     return HandleType(std::move(identifier), instance_id);
 }

--- a/score/mw/com/impl/handle_type.h
+++ b/score/mw/com/impl/handle_type.h
@@ -38,7 +38,7 @@ class HandleType;
  * this value will be used instead of the value in the configuration, referenced from identifier.
  * \return A constructed InstanceIdentifier
  */
-HandleType make_HandleType(InstanceIdentifier identifier, std::optional<ServiceInstanceId> instance_id = {}) noexcept;
+HandleType make_HandleType(InstanceIdentifier identifier, std::optional<ServiceInstanceId> instance_id = {});
 
 /**
  * \brief It types the handle for a specific service
@@ -113,7 +113,7 @@ class HandleType
     // Design decision: Friend class required to access private constructor.
     // This way more implementation details can be hidden from the user.
     // coverity[autosar_cpp14_a11_3_1_violation]
-    friend HandleType make_HandleType(InstanceIdentifier, std::optional<ServiceInstanceId> instance_id) noexcept;
+    friend HandleType make_HandleType(InstanceIdentifier, std::optional<ServiceInstanceId> instance_id);
 };
 
 }  // namespace score::mw::com::impl

--- a/score/mw/com/impl/i_service_discovery.h
+++ b/score/mw/com/impl/i_service_discovery.h
@@ -37,18 +37,16 @@ class IServiceDiscovery
     virtual ~IServiceDiscovery() = default;
     IServiceDiscovery() = default;
 
-    [[nodiscard]] virtual Result<void> OfferService(InstanceIdentifier) noexcept = 0;
-    [[nodiscard]] virtual Result<void> StopOfferService(InstanceIdentifier) noexcept = 0;
-    [[nodiscard]] virtual Result<void> StopOfferService(InstanceIdentifier,
-                                                        QualityTypeSelector quality_type) noexcept = 0;
+    [[nodiscard]] virtual Result<void> OfferService(InstanceIdentifier) = 0;
+    [[nodiscard]] virtual Result<void> StopOfferService(InstanceIdentifier) = 0;
+    [[nodiscard]] virtual Result<void> StopOfferService(InstanceIdentifier, QualityTypeSelector quality_type) = 0;
+    virtual Result<FindServiceHandle> StartFindService(FindServiceHandler<HandleType>, const InstanceSpecifier) = 0;
+    virtual Result<FindServiceHandle> StartFindService(FindServiceHandler<HandleType>, InstanceIdentifier) = 0;
     virtual Result<FindServiceHandle> StartFindService(FindServiceHandler<HandleType>,
-                                                       const InstanceSpecifier) noexcept = 0;
-    virtual Result<FindServiceHandle> StartFindService(FindServiceHandler<HandleType>, InstanceIdentifier) noexcept = 0;
-    virtual Result<FindServiceHandle> StartFindService(FindServiceHandler<HandleType>,
-                                                       const EnrichedInstanceIdentifier) noexcept = 0;
-    [[nodiscard]] virtual Result<void> StopFindService(const FindServiceHandle) noexcept = 0;
+                                                       const EnrichedInstanceIdentifier) = 0;
+    [[nodiscard]] virtual Result<void> StopFindService(const FindServiceHandle) = 0;
     [[nodiscard]] virtual Result<ServiceHandleContainer<HandleType>> FindService(
-        InstanceIdentifier instance_identifier) noexcept = 0;
+        InstanceIdentifier instance_identifier) = 0;
     [[nodiscard]] virtual Result<ServiceHandleContainer<HandleType>> FindService(
         InstanceSpecifier instance_specifier) = 0;
 

--- a/score/mw/com/impl/i_service_discovery_client.h
+++ b/score/mw/com/impl/i_service_discovery_client.h
@@ -34,12 +34,12 @@ class IServiceDiscoveryClient
     [[nodiscard]] virtual Result<void> OfferService(const InstanceIdentifier instance_identifier) = 0;
     [[nodiscard]] virtual Result<void> StopOfferService(
         const InstanceIdentifier instance_identifier,
-        const IServiceDiscovery::QualityTypeSelector quality_type_selector) noexcept = 0;
+        const IServiceDiscovery::QualityTypeSelector quality_type_selector) = 0;
     [[nodiscard]] virtual Result<void> StartFindService(
         const FindServiceHandle find_service_handle,
         FindServiceHandler<HandleType> handler,
         const EnrichedInstanceIdentifier enriched_instance_identifier) = 0;
-    [[nodiscard]] virtual Result<void> StopFindService(const FindServiceHandle find_service_handle) noexcept = 0;
+    [[nodiscard]] virtual Result<void> StopFindService(const FindServiceHandle find_service_handle) = 0;
     [[nodiscard]] virtual Result<ServiceHandleContainer<HandleType>> FindService(
         const EnrichedInstanceIdentifier enriched_instance_identifier) = 0;
 

--- a/score/mw/com/impl/instance_identifier.h
+++ b/score/mw/com/impl/instance_identifier.h
@@ -187,7 +187,7 @@ class InstanceIdentifier final
     // This way more implementation details can be hidden from the user.
     // coverity[autosar_cpp14_a11_3_1_violation]
     friend InstanceIdentifier make_InstanceIdentifier(const ServiceInstanceDeployment& instance_deployment,
-                                                      const ServiceTypeDeployment& type_deployment) noexcept;
+                                                      const ServiceTypeDeployment& type_deployment);
 
     // Suppress "AUTOSAR C++14 A11-3-1", The rule states: "Friend declarations shall not be used".
     // Design decision. This class provides a view to the private members of this class.
@@ -218,7 +218,7 @@ class InstanceIdentifier final
  * \return A constructed InstanceIdentifier
  */
 inline InstanceIdentifier make_InstanceIdentifier(const ServiceInstanceDeployment& instance_deployment,
-                                                  const ServiceTypeDeployment& type_deployment) noexcept
+                                                  const ServiceTypeDeployment& type_deployment)
 {
     return InstanceIdentifier{instance_deployment, type_deployment};
 }
@@ -236,7 +236,7 @@ class InstanceIdentifierView final
   public:
     explicit InstanceIdentifierView(const InstanceIdentifier&);
 
-    json::Object Serialize() const noexcept
+    json::Object Serialize() const
     {
         return identifier_.Serialize();
     };

--- a/score/mw/com/impl/proxy_base.cpp
+++ b/score/mw/com/impl/proxy_base.cpp
@@ -42,7 +42,7 @@ const HandleType& ProxyBase::GetHandle() const& noexcept
     return handle_;
 }
 
-auto ProxyBase::FindService(InstanceSpecifier specifier) noexcept -> Result<ServiceHandleContainer<HandleType>>
+auto ProxyBase::FindService(InstanceSpecifier specifier) -> Result<ServiceHandleContainer<HandleType>>
 {
     const auto find_service_result = Runtime::getInstance().GetServiceDiscovery().FindService(std::move(specifier));
     if (!find_service_result.has_value())
@@ -52,8 +52,7 @@ auto ProxyBase::FindService(InstanceSpecifier specifier) noexcept -> Result<Serv
     return find_service_result;
 }
 
-auto ProxyBase::FindService(InstanceIdentifier instance_identifier) noexcept
-    -> Result<ServiceHandleContainer<HandleType>>
+auto ProxyBase::FindService(InstanceIdentifier instance_identifier) -> Result<ServiceHandleContainer<HandleType>>
 {
     const auto find_service_result =
         Runtime::getInstance().GetServiceDiscovery().FindService(std::move(instance_identifier));
@@ -65,8 +64,8 @@ auto ProxyBase::FindService(InstanceIdentifier instance_identifier) noexcept
     return find_service_result;
 }
 
-auto ProxyBase::StartFindService(FindServiceHandler<HandleType> handler,
-                                 InstanceIdentifier instance_identifier) noexcept -> Result<FindServiceHandle>
+auto ProxyBase::StartFindService(FindServiceHandler<HandleType> handler, InstanceIdentifier instance_identifier)
+    -> Result<FindServiceHandle>
 {
     const auto start_find_service_result = Runtime::getInstance().GetServiceDiscovery().StartFindService(
         std::move(handler), std::move(instance_identifier));
@@ -77,7 +76,7 @@ auto ProxyBase::StartFindService(FindServiceHandler<HandleType> handler,
     return start_find_service_result;
 }
 
-auto ProxyBase::StartFindService(FindServiceHandler<HandleType> handler, InstanceSpecifier instance_specifier) noexcept
+auto ProxyBase::StartFindService(FindServiceHandler<HandleType> handler, InstanceSpecifier instance_specifier)
     -> Result<FindServiceHandle>
 {
     const auto start_find_service_result = Runtime::getInstance().GetServiceDiscovery().StartFindService(
@@ -89,7 +88,7 @@ auto ProxyBase::StartFindService(FindServiceHandler<HandleType> handler, Instanc
     return start_find_service_result;
 }
 
-score::Result<void> ProxyBase::StopFindService(const FindServiceHandle handle) noexcept
+score::Result<void> ProxyBase::StopFindService(const FindServiceHandle handle)
 {
     const auto stop_find_service_result = Runtime::getInstance().GetServiceDiscovery().StopFindService(handle);
     if (!(stop_find_service_result.has_value()))

--- a/score/mw/com/impl/proxy_base.h
+++ b/score/mw/com/impl/proxy_base.h
@@ -62,7 +62,7 @@ class ProxyBase
      *         failure, returns an error code.
      * \requirement SWS_CM_00622
      */
-    static Result<ServiceHandleContainer<HandleType>> FindService(InstanceSpecifier specifier) noexcept;
+    static Result<ServiceHandleContainer<HandleType>> FindService(InstanceSpecifier specifier);
 
     /**
      * \api
@@ -72,7 +72,7 @@ class ProxyBase
      * \return A result which on success contains a list of found handles that can be used to create a proxy. On
      *         failure, returns an error code.
      */
-    static Result<ServiceHandleContainer<HandleType>> FindService(InstanceIdentifier instance_identifier) noexcept;
+    static Result<ServiceHandleContainer<HandleType>> FindService(InstanceIdentifier instance_identifier);
 
     /**
      * \api
@@ -85,7 +85,7 @@ class ProxyBase
      *         error code.
      */
     static Result<FindServiceHandle> StartFindService(FindServiceHandler<HandleType> handler,
-                                                      InstanceIdentifier instance_identifier) noexcept;
+                                                      InstanceIdentifier instance_identifier);
 
     /**
      * \api
@@ -98,7 +98,7 @@ class ProxyBase
      *         error code.
      */
     static Result<FindServiceHandle> StartFindService(FindServiceHandler<HandleType> handler,
-                                                      InstanceSpecifier instance_specifier) noexcept;
+                                                      InstanceSpecifier instance_specifier);
 
     /**
      * \api
@@ -108,7 +108,7 @@ class ProxyBase
      * \param handle The handle returned by StartFindService identifying the find operation to stop.
      * \return A result indicating success or failure of stopping the find operation.
      */
-    static score::Result<void> StopFindService(const FindServiceHandle handle) noexcept;
+    static score::Result<void> StopFindService(const FindServiceHandle handle);
 
     /**
      * \api

--- a/score/mw/com/impl/proxy_event_base.cpp
+++ b/score/mw/com/impl/proxy_event_base.cpp
@@ -181,7 +181,7 @@ SubscriptionState ProxyEventBase::GetSubscriptionState() const noexcept
     return binding_base_->GetSubscriptionState();
 }
 
-Result<std::size_t> ProxyEventBase::GetNumNewSamplesAvailable() const noexcept
+Result<std::size_t> ProxyEventBase::GetNumNewSamplesAvailable() const
 {
     if (proxy_event_base_mock_ != nullptr)
     {

--- a/score/mw/com/impl/proxy_event_base.h
+++ b/score/mw/com/impl/proxy_event_base.h
@@ -139,7 +139,7 @@ class ProxyEventBase : public EnableReferenceToMoveableFromThis<ProxyEventBase>
      *         actual new samples. I.e. an implementation is allowed to report a lower number than actual new samples,
      *         which would be provided by a call to GetNewSamples().
      */
-    Result<std::size_t> GetNumNewSamplesAvailable() const noexcept;
+    Result<std::size_t> GetNumNewSamplesAvailable() const;
 
     /**
      * \api

--- a/score/mw/com/impl/proxy_event_binding_base.h
+++ b/score/mw/com/impl/proxy_event_binding_base.h
@@ -90,7 +90,7 @@ class ProxyEventBindingBase
     /// \return Either 0 if no new samples are available (and GetNewSamples() wouldn't return any) or N, where 1 <= N <=
     /// actual new samples. I.e. an implementation is allowed to report a lower number than actual new samples, which
     /// would be provided by a call to GetNewSamples().
-    virtual Result<std::size_t> GetNumNewSamplesAvailable() const noexcept = 0;
+    virtual Result<std::size_t> GetNumNewSamplesAvailable() const = 0;
 
     /// \brief Returns the current max sample count that was provided in the Subscribe call that was most recently
     /// processed or is currently processing.

--- a/score/mw/com/impl/proxy_event_binding_base_test.cpp
+++ b/score/mw/com/impl/proxy_event_binding_base_test.cpp
@@ -48,7 +48,7 @@ class DummyProxyEventBinding final : public ProxyEventBindingBase
     {
         return {};
     }
-    Result<std::size_t> GetNumNewSamplesAvailable() const noexcept override
+    Result<std::size_t> GetNumNewSamplesAvailable() const override
     {
         return {};
     }

--- a/score/mw/com/impl/service_discovery.cpp
+++ b/score/mw/com/impl/service_discovery.cpp
@@ -60,22 +60,20 @@ ServiceDiscovery::~ServiceDiscovery() noexcept
     }
 }
 
-auto ServiceDiscovery::OfferService(score::mw::com::impl::InstanceIdentifier instance_identifier) noexcept
-    -> Result<void>
+auto ServiceDiscovery::OfferService(score::mw::com::impl::InstanceIdentifier instance_identifier) -> Result<void>
 {
     auto& service_discovery_client = GetServiceDiscoveryClient(instance_identifier);
 
     return service_discovery_client.OfferService(std::move(instance_identifier));
 }
 
-auto ServiceDiscovery::StopOfferService(score::mw::com::impl::InstanceIdentifier instance_identifier) noexcept
-    -> Result<void>
+auto ServiceDiscovery::StopOfferService(score::mw::com::impl::InstanceIdentifier instance_identifier) -> Result<void>
 {
     return StopOfferService(instance_identifier, QualityTypeSelector::kBoth);
 }
 
 auto ServiceDiscovery::StopOfferService(score::mw::com::impl::InstanceIdentifier instance_identifier,
-                                        QualityTypeSelector quality_type) noexcept -> Result<void>
+                                        QualityTypeSelector quality_type) -> Result<void>
 {
     auto& service_discovery_client = GetServiceDiscoveryClient(instance_identifier);
 
@@ -83,8 +81,7 @@ auto ServiceDiscovery::StopOfferService(score::mw::com::impl::InstanceIdentifier
 }
 
 auto ServiceDiscovery::StartFindService(FindServiceHandler<HandleType> handler,
-                                        const InstanceSpecifier instance_specifier) noexcept
-    -> Result<FindServiceHandle>
+                                        const InstanceSpecifier instance_specifier) -> Result<FindServiceHandle>
 {
     const auto instance_identifiers = runtime_.resolve(instance_specifier);
     const std::vector<EnrichedInstanceIdentifier> enriched_instance_identifiers(instance_identifiers.begin(),
@@ -135,15 +132,15 @@ auto ServiceDiscovery::StartFindService(FindServiceHandler<HandleType> handler,
     return find_service_handle;
 }
 
-auto ServiceDiscovery::StartFindService(FindServiceHandler<HandleType> handler,
-                                        InstanceIdentifier instance_identifier) noexcept -> Result<FindServiceHandle>
+auto ServiceDiscovery::StartFindService(FindServiceHandler<HandleType> handler, InstanceIdentifier instance_identifier)
+    -> Result<FindServiceHandle>
 {
     EnrichedInstanceIdentifier enriched_instance_identifier{std::move(instance_identifier)};
     return StartFindService(std::move(handler), std::move(enriched_instance_identifier));
 }
 
 auto ServiceDiscovery::StartFindService(FindServiceHandler<HandleType> handler,
-                                        const EnrichedInstanceIdentifier enriched_instance_identifier) noexcept
+                                        const EnrichedInstanceIdentifier enriched_instance_identifier)
     -> Result<FindServiceHandle>
 {
     auto find_service_handle = GetNextFreeFindServiceHandle();
@@ -173,8 +170,7 @@ auto ServiceDiscovery::StartFindService(FindServiceHandler<HandleType> handler,
     return result;
 }
 
-[[nodiscard]] auto ServiceDiscovery::StopFindService(const FindServiceHandle find_service_handle) noexcept
-    -> Result<void>
+[[nodiscard]] auto ServiceDiscovery::StopFindService(const FindServiceHandle find_service_handle) -> Result<void>
 {
     // Make a copy of the EnrichedInstanceIdentifiers for which we need to call StopFindService. We make a copy under
     // lock to ensure that the map isn't modified while we're accessing it. However, StopFindService is called on the
@@ -209,7 +205,7 @@ auto ServiceDiscovery::StartFindService(FindServiceHandler<HandleType> handler,
 
 auto ServiceDiscovery::StartFindServiceImpl(FindServiceHandle find_service_handle,
                                             std::weak_ptr<FindServiceHandler<HandleType>> handler_weak_ptr,
-                                            const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept
+                                            const EnrichedInstanceIdentifier& enriched_instance_identifier)
     -> Result<FindServiceHandle>
 {
     auto result = BindingSpecificStartFindService(find_service_handle, handler_weak_ptr, enriched_instance_identifier);
@@ -224,7 +220,7 @@ auto ServiceDiscovery::StartFindServiceImpl(FindServiceHandle find_service_handl
 void ServiceDiscovery::RemoveUnusedInstanceIdentifiers(
     FindServiceHandle find_service_handle,
     std::vector<EnrichedInstanceIdentifier>::const_iterator last_used_iterator,
-    std::vector<EnrichedInstanceIdentifier>::const_iterator container_end) noexcept
+    std::vector<EnrichedInstanceIdentifier>::const_iterator container_end)
 {
     const bool all_identifiers_processed{last_used_iterator == container_end};
     // GCOV_EXCL_START : This is a never true. Defensive programming: This function is only called by StartFindService.
@@ -307,16 +303,16 @@ auto ServiceDiscovery::GetServiceDiscoveryClient(const InstanceIdentifier& insta
     return binding_runtime->GetServiceDiscoveryClient();
 }
 
-auto ServiceDiscovery::BindingSpecificStartFindService(
-    FindServiceHandle search_handle,
-    std::weak_ptr<FindServiceHandler<HandleType>> handler_weak_ptr,
-    const EnrichedInstanceIdentifier& enriched_instance_identifier) noexcept -> Result<void>
+auto ServiceDiscovery::BindingSpecificStartFindService(FindServiceHandle search_handle,
+                                                       std::weak_ptr<FindServiceHandler<HandleType>> handler_weak_ptr,
+                                                       const EnrichedInstanceIdentifier& enriched_instance_identifier)
+    -> Result<void>
 {
     auto& service_discovery_client = GetServiceDiscoveryClient(enriched_instance_identifier.GetInstanceIdentifier());
 
     return service_discovery_client.StartFindService(
         search_handle,
-        [handler_weak_ptr](auto container, auto handle) noexcept {
+        [handler_weak_ptr](auto container, auto handle) {
             if (auto handler_shared_ptr = handler_weak_ptr.lock())
             {
                 (*handler_shared_ptr)(container, handle);
@@ -325,8 +321,7 @@ auto ServiceDiscovery::BindingSpecificStartFindService(
         enriched_instance_identifier);
 }
 
-Result<ServiceHandleContainer<HandleType>> ServiceDiscovery::FindService(
-    InstanceIdentifier instance_identifier) noexcept
+Result<ServiceHandleContainer<HandleType>> ServiceDiscovery::FindService(InstanceIdentifier instance_identifier)
 {
     EnrichedInstanceIdentifier enriched_instance_identifier{std::move(instance_identifier)};
     auto& service_discovery_client = GetServiceDiscoveryClient(enriched_instance_identifier.GetInstanceIdentifier());

--- a/score/mw/com/impl/service_discovery.h
+++ b/score/mw/com/impl/service_discovery.h
@@ -44,17 +44,16 @@ class ServiceDiscovery final : public IServiceDiscovery
     ServiceDiscovery& operator=(ServiceDiscovery&&) noexcept = delete;
     ~ServiceDiscovery() noexcept override;
 
-    [[nodiscard]] Result<void> OfferService(InstanceIdentifier) noexcept override;
-    [[nodiscard]] Result<void> StopOfferService(InstanceIdentifier) noexcept override;
-    [[nodiscard]] Result<void> StopOfferService(InstanceIdentifier, QualityTypeSelector quality_type) noexcept override;
+    [[nodiscard]] Result<void> OfferService(InstanceIdentifier) override;
+    [[nodiscard]] Result<void> StopOfferService(InstanceIdentifier) override;
+    [[nodiscard]] Result<void> StopOfferService(InstanceIdentifier, QualityTypeSelector quality_type) override;
+    Result<FindServiceHandle> StartFindService(FindServiceHandler<HandleType>, const InstanceSpecifier) override;
+    Result<FindServiceHandle> StartFindService(FindServiceHandler<HandleType>, InstanceIdentifier) override;
     Result<FindServiceHandle> StartFindService(FindServiceHandler<HandleType>,
-                                               const InstanceSpecifier) noexcept override;
-    Result<FindServiceHandle> StartFindService(FindServiceHandler<HandleType>, InstanceIdentifier) noexcept override;
-    Result<FindServiceHandle> StartFindService(FindServiceHandler<HandleType>,
-                                               const EnrichedInstanceIdentifier) noexcept override;
-    [[nodiscard]] Result<void> StopFindService(const FindServiceHandle) noexcept override;
+                                               const EnrichedInstanceIdentifier) override;
+    [[nodiscard]] Result<void> StopFindService(const FindServiceHandle) override;
     [[nodiscard]] Result<ServiceHandleContainer<HandleType>> FindService(
-        InstanceIdentifier instance_identifier) noexcept override;
+        InstanceIdentifier instance_identifier) override;
     [[nodiscard]] Result<ServiceHandleContainer<HandleType>> FindService(InstanceSpecifier instance_specifier) override;
 
   private:
@@ -65,7 +64,7 @@ class ServiceDiscovery final : public IServiceDiscovery
     /// safe.
     Result<FindServiceHandle> StartFindServiceImpl(FindServiceHandle,
                                                    std::weak_ptr<FindServiceHandler<HandleType>> handler_weak_ptr,
-                                                   const EnrichedInstanceIdentifier&) noexcept;
+                                                   const EnrichedInstanceIdentifier&);
 
     /// \brief Generates the next available FindServiceHandle
     ///
@@ -93,16 +92,15 @@ class ServiceDiscovery final : public IServiceDiscovery
     /// safe.
     Result<void> BindingSpecificStartFindService(FindServiceHandle,
                                                  std::weak_ptr<FindServiceHandler<HandleType>> handler_weak_ptr,
-                                                 const EnrichedInstanceIdentifier&) noexcept;
+                                                 const EnrichedInstanceIdentifier&);
 
     /// \brief Removes any InstanceIdentifiers which were added to handle_to_instances_ but were never processed since
     /// StartFindService on another binding failed and we returned early.
     ///
     /// This function is thread safe as it locks container_mutex_ internally as it updates handle_to_instances_.
-    void RemoveUnusedInstanceIdentifiers(
-        FindServiceHandle find_service_handle,
-        std::vector<EnrichedInstanceIdentifier>::const_iterator last_used_iterator,
-        std::vector<EnrichedInstanceIdentifier>::const_iterator container_end) noexcept;
+    void RemoveUnusedInstanceIdentifiers(FindServiceHandle find_service_handle,
+                                         std::vector<EnrichedInstanceIdentifier>::const_iterator last_used_iterator,
+                                         std::vector<EnrichedInstanceIdentifier>::const_iterator container_end);
 
     IRuntime& runtime_;
     std::atomic<std::size_t> next_free_uid_;

--- a/score/mw/com/impl/tracing/common_event_tracing.cpp
+++ b/score/mw/com/impl/tracing/common_event_tracing.cpp
@@ -46,7 +46,7 @@ Result<void> TraceData(const ServiceElementInstanceIdentifierView service_elemen
                        const TracingRuntime::TracePointType trace_point,
                        const BindingType binding_type,
                        const std::pair<const void*, std::size_t>& local_data_chunk,
-                       const std::optional<TracingRuntime::TracePointDataId> trace_point_data_id) noexcept
+                       const std::optional<TracingRuntime::TracePointDataId> trace_point_data_id)
 {
     auto* const tracing_runtime = impl::Runtime::getInstance().GetTracingRuntime();
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(tracing_runtime != nullptr);
@@ -64,7 +64,7 @@ Result<void> TraceShmData(const BindingType binding_type,
                           const TracingRuntime::TracePointType trace_point,
                           TracingRuntime::TracePointDataId trace_point_data_id,
                           TypeErasedSamplePtr sample_ptr,
-                          const std::pair<const void*, std::size_t>& data_chunk) noexcept
+                          const std::pair<const void*, std::size_t>& data_chunk)
 {
     auto* const tracing_runtime = impl::Runtime::getInstance().GetTracingRuntime();
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(tracing_runtime != nullptr);
@@ -82,7 +82,7 @@ Result<void> TraceShmData(const BindingType binding_type,
 ServiceElementInstanceIdentifierView GetServiceElementInstanceIdentifierView(
     const InstanceIdentifier& instance_identifier,
     const std::string_view service_element_name,
-    const ServiceElementType service_element_type) noexcept
+    const ServiceElementType service_element_type)
 {
     const auto instance_specifier_view = GetInstanceSpecifier(instance_identifier);
     const auto service_type = GetServiceType(instance_identifier);

--- a/score/mw/com/impl/tracing/common_event_tracing.h
+++ b/score/mw/com/impl/tracing/common_event_tracing.h
@@ -38,7 +38,7 @@ Result<void> TraceData(const ServiceElementInstanceIdentifierView service_elemen
                        const TracingRuntime::TracePointType trace_point,
                        const BindingType binding_type,
                        const std::pair<const void*, std::size_t>& local_data_chunk = {nullptr, 0U},
-                       const std::optional<TracingRuntime::TracePointDataId> trace_point_data_id = {}) noexcept;
+                       const std::optional<TracingRuntime::TracePointDataId> trace_point_data_id = {});
 
 Result<void> TraceShmData(const BindingType binding_type,
                           const ServiceElementTracingData service_element_tracing_data,
@@ -46,12 +46,12 @@ Result<void> TraceShmData(const BindingType binding_type,
                           const TracingRuntime::TracePointType trace_point,
                           TracingRuntime::TracePointDataId trace_point_data_id,
                           TypeErasedSamplePtr sample_ptr,
-                          const std::pair<const void*, std::size_t>& data_chunk) noexcept;
+                          const std::pair<const void*, std::size_t>& data_chunk);
 
 ServiceElementInstanceIdentifierView GetServiceElementInstanceIdentifierView(
     const InstanceIdentifier& instance_identifier,
     const std::string_view service_element_name,
-    const ServiceElementType service_element_type) noexcept;
+    const ServiceElementType service_element_type);
 
 }  // namespace score::mw::com::impl::tracing
 

--- a/score/mw/com/impl/tracing/proxy_event_tracing.cpp
+++ b/score/mw/com/impl/tracing/proxy_event_tracing.cpp
@@ -34,7 +34,7 @@ namespace
 
 void UpdateTracingDataFromTraceResult(Result<void> trace_result,
                                       ProxyEventTracingData& proxy_event_tracing_data,
-                                      bool& proxy_event_trace_point) noexcept
+                                      bool& proxy_event_trace_point)
 {
     if (!trace_result.has_value())
     {
@@ -61,7 +61,7 @@ void UpdateTracingDataFromTraceResult(Result<void> trace_result,
 // This is false positive. Function is declared only once.
 // coverity[autosar_cpp14_a3_1_1_violation]
 ProxyEventTracingData GenerateProxyTracingStructFromEventConfig(const InstanceIdentifier& instance_identifier,
-                                                                const std::string_view event_name) noexcept
+                                                                const std::string_view event_name)
 {
     const auto* const tracing_config = Runtime::getInstance().GetTracingFilterConfig();
     ProxyEventTracingData proxy_event_tracing_data{};
@@ -115,7 +115,7 @@ ProxyEventTracingData GenerateProxyTracingStructFromEventConfig(const InstanceId
 // This is false positive. Function is declared only once.
 // coverity[autosar_cpp14_a3_1_1_violation]
 ProxyEventTracingData GenerateProxyTracingStructFromFieldConfig(const InstanceIdentifier& instance_identifier,
-                                                                const std::string_view field_name) noexcept
+                                                                const std::string_view field_name)
 {
     const auto* const tracing_config = Runtime::getInstance().GetTracingFilterConfig();
     ProxyEventTracingData proxy_event_tracing_data{};
@@ -166,7 +166,7 @@ ProxyEventTracingData GenerateProxyTracingStructFromFieldConfig(const InstanceId
 
 void TraceSubscribe(ProxyEventTracingData& proxy_event_tracing_data,
                     const ProxyEventBindingBase& proxy_event_binding_base,
-                    const std::size_t max_sample_count) noexcept
+                    const std::size_t max_sample_count)
 {
     if (proxy_event_tracing_data.enable_subscribe)
     {
@@ -201,7 +201,7 @@ void TraceSubscribe(ProxyEventTracingData& proxy_event_tracing_data,
 }
 
 void TraceUnsubscribe(ProxyEventTracingData& proxy_event_tracing_data,
-                      const ProxyEventBindingBase& proxy_event_binding_base) noexcept
+                      const ProxyEventBindingBase& proxy_event_binding_base)
 {
     if (proxy_event_tracing_data.enable_unsubscribe)
     {
@@ -236,7 +236,7 @@ void TraceUnsubscribe(ProxyEventTracingData& proxy_event_tracing_data,
 }
 
 void TraceSetReceiveHandler(ProxyEventTracingData& proxy_event_tracing_data,
-                            const ProxyEventBindingBase& proxy_event_binding_base) noexcept
+                            const ProxyEventBindingBase& proxy_event_binding_base)
 {
     if (proxy_event_tracing_data.enable_set_receive_handler)
     {
@@ -271,7 +271,7 @@ void TraceSetReceiveHandler(ProxyEventTracingData& proxy_event_tracing_data,
 }
 
 void TraceUnsetReceiveHandler(ProxyEventTracingData& proxy_event_tracing_data,
-                              const ProxyEventBindingBase& proxy_event_binding_base) noexcept
+                              const ProxyEventBindingBase& proxy_event_binding_base)
 {
     if (proxy_event_tracing_data.enable_unset_receive_handler)
     {
@@ -306,7 +306,7 @@ void TraceUnsetReceiveHandler(ProxyEventTracingData& proxy_event_tracing_data,
 }
 
 void TraceGetNewSamples(ProxyEventTracingData& proxy_event_tracing_data,
-                        const ProxyEventBindingBase& proxy_event_binding_base) noexcept
+                        const ProxyEventBindingBase& proxy_event_binding_base)
 {
     if (proxy_event_tracing_data.enable_get_new_samples)
     {
@@ -342,7 +342,7 @@ void TraceGetNewSamples(ProxyEventTracingData& proxy_event_tracing_data,
 
 void TraceCallGetNewSamplesCallback(ProxyEventTracingData& proxy_event_tracing_data,
                                     const ProxyEventBindingBase& proxy_event_binding_base,
-                                    ITracingRuntime::TracePointDataId trace_point_data_id) noexcept
+                                    ITracingRuntime::TracePointDataId trace_point_data_id)
 {
     if (proxy_event_tracing_data.enable_new_samples_callback)
     {
@@ -380,7 +380,7 @@ void TraceCallGetNewSamplesCallback(ProxyEventTracingData& proxy_event_tracing_d
 }
 
 void TraceCallReceiveHandler(ProxyEventTracingData& proxy_event_tracing_data,
-                             const ProxyEventBindingBase& proxy_event_binding_base) noexcept
+                             const ProxyEventBindingBase& proxy_event_binding_base)
 {
     if (proxy_event_tracing_data.enable_call_receive_handler)
     {
@@ -417,12 +417,12 @@ void TraceCallReceiveHandler(ProxyEventTracingData& proxy_event_tracing_data,
 score::cpp::callback<void(void), 128U> CreateTracingReceiveHandler(
     ProxyEventTracingData& proxy_event_tracing_data,
     const ProxyEventBindingBase& proxy_event_binding_base,
-    EventReceiveHandler handler) noexcept
+    EventReceiveHandler handler)
 {
     if (proxy_event_tracing_data.enable_call_receive_handler)
     {
         score::cpp::callback<void(void), 128U> tracing_receive_handler =
-            [&proxy_event_tracing_data, &proxy_event_binding_base, handler = std::move(handler)]() noexcept {
+            [&proxy_event_tracing_data, &proxy_event_binding_base, handler = std::move(handler)]() {
                 TraceCallReceiveHandler(proxy_event_tracing_data, proxy_event_binding_base);
                 handler();
             };

--- a/score/mw/com/impl/tracing/proxy_event_tracing.h
+++ b/score/mw/com/impl/tracing/proxy_event_tracing.h
@@ -34,37 +34,36 @@ namespace score::mw::com::impl::tracing
 {
 
 ProxyEventTracingData GenerateProxyTracingStructFromEventConfig(const InstanceIdentifier& instance_identifier,
-                                                                const std::string_view event_name) noexcept;
+                                                                const std::string_view event_name);
 ProxyEventTracingData GenerateProxyTracingStructFromFieldConfig(const InstanceIdentifier& instance_identifier,
-                                                                const std::string_view field_name) noexcept;
+                                                                const std::string_view field_name);
 
 void TraceSubscribe(ProxyEventTracingData& proxy_event_tracing_data,
                     const ProxyEventBindingBase& proxy_event_binding_base,
-                    const std::size_t max_sample_count) noexcept;
+                    const std::size_t max_sample_count);
 void TraceUnsubscribe(ProxyEventTracingData& proxy_event_tracing_data,
-                      const ProxyEventBindingBase& proxy_event_binding_base) noexcept;
+                      const ProxyEventBindingBase& proxy_event_binding_base);
 void TraceSetReceiveHandler(ProxyEventTracingData& proxy_event_tracing_data,
-                            const ProxyEventBindingBase& proxy_event_binding_base) noexcept;
+                            const ProxyEventBindingBase& proxy_event_binding_base);
 void TraceUnsetReceiveHandler(ProxyEventTracingData& proxy_event_tracing_data,
-                              const ProxyEventBindingBase& proxy_event_binding_base) noexcept;
+                              const ProxyEventBindingBase& proxy_event_binding_base);
 void TraceGetNewSamples(ProxyEventTracingData& proxy_event_tracing_data,
-                        const ProxyEventBindingBase& proxy_event_binding_base) noexcept;
+                        const ProxyEventBindingBase& proxy_event_binding_base);
 void TraceCallGetNewSamplesCallback(ProxyEventTracingData& proxy_event_tracing_data,
                                     const ProxyEventBindingBase& proxy_event_binding_base,
-                                    ITracingRuntime::TracePointDataId trace_point_data_id) noexcept;
+                                    ITracingRuntime::TracePointDataId trace_point_data_id);
 void TraceCallReceiveHandler(ProxyEventTracingData& proxy_event_tracing_data,
-                             const ProxyEventBindingBase& proxy_event_binding_base) noexcept;
+                             const ProxyEventBindingBase& proxy_event_binding_base);
 
 score::cpp::callback<void(void), 128U> CreateTracingReceiveHandler(
     ProxyEventTracingData& proxy_event_tracing_data,
     const ProxyEventBindingBase& proxy_event_binding_base,
-    EventReceiveHandler handler) noexcept;
+    EventReceiveHandler handler);
 
 template <typename SampleType, typename ReceiverType>
 auto CreateTracingGetNewSamplesCallback(ProxyEventTracingData& proxy_event_tracing_data,
                                         const ProxyEventBindingBase& proxy_event_binding_base,
-                                        ReceiverType&& receiver) noexcept ->
-    typename ProxyEventBinding<SampleType>::Callback
+                                        ReceiverType&& receiver) -> typename ProxyEventBinding<SampleType>::Callback
 {
     // LCOV_EXCL_BR_START (Tool incorrectly marks the branch when the condition is true as not covered. However, the
     // lines in that branch are marked as covered indicating that the branch is indeed taken. Suppression can be removed
@@ -78,7 +77,7 @@ auto CreateTracingGetNewSamplesCallback(ProxyEventTracingData& proxy_event_traci
             // reference. std::forward is already used here.
             // coverity[autosar_cpp14_a18_9_2_violation : FALSE]
             [&proxy_event_tracing_data, &proxy_event_binding_base, receiver = std::forward<ReceiverType>(receiver)](
-                SamplePtr<SampleType> sample_ptr, ITracingRuntime::TracePointDataId trace_point_data_id) noexcept {
+                SamplePtr<SampleType> sample_ptr, ITracingRuntime::TracePointDataId trace_point_data_id) {
                 TraceCallGetNewSamplesCallback(proxy_event_tracing_data, proxy_event_binding_base, trace_point_data_id);
                 // Suppress "AUTOSAR C++14 A18-9-2", The rule states: "Forwarding values to other functions shall be
                 // done via: (1) std::move if the value is an rvalue reference, (2) std::forward if the value is
@@ -96,7 +95,7 @@ auto CreateTracingGetNewSamplesCallback(ProxyEventTracingData& proxy_event_traci
             // reference. std::forward is already used here.
             // coverity[autosar_cpp14_a18_9_2_violation : FALSE]
             [receiver = std::forward<ReceiverType>(receiver)](SamplePtr<SampleType> sample_ptr,
-                                                              ITracingRuntime::TracePointDataId) noexcept {
+                                                              ITracingRuntime::TracePointDataId) {
                 // Suppress "AUTOSAR C++14 A18-9-2", The rule states: "Forwarding values to other functions shall be
                 // done via: (1) std::move if the value is an rvalue reference, (2) std::forward if the value is
                 // forwarding reference. std::move is already used here.
@@ -110,7 +109,7 @@ auto CreateTracingGetNewSamplesCallback(ProxyEventTracingData& proxy_event_traci
 template <typename ReceiverType>
 typename GenericProxyEventBinding::Callback CreateTracingGenericGetNewSamplesCallback(
     ProxyEventTracingData& /* proxy_event_tracing_data */,
-    ReceiverType&& receiver) noexcept
+    ReceiverType&& receiver)
 {
     // Suppress "AUTOSAR C++14 A18-9-2", The rule states: "Forwarding values to other functions shall be done
     // via: (1) std::move if the value is an rvalue reference, (2) std::forward if the value is forwarding
@@ -118,7 +117,7 @@ typename GenericProxyEventBinding::Callback CreateTracingGenericGetNewSamplesCal
     // coverity[autosar_cpp14_a18_9_2_violation : FALSE]
     typename GenericProxyEventBinding::Callback tracing_receiver = [receiver = std::forward<ReceiverType>(receiver)](
                                                                        SamplePtr<void> sample_ptr,
-                                                                       ITracingRuntime::TracePointDataId) noexcept {
+                                                                       ITracingRuntime::TracePointDataId) {
         // Suppress "AUTOSAR C++14 A18-9-2", The rule states: "Forwarding values to other functions shall be done
         // via: (1) std::move if the value is an rvalue reference, (2) std::forward if the value is forwarding
         // reference. std::move is already used here.

--- a/score/mw/com/impl/tracing/skeleton_event_tracing.cpp
+++ b/score/mw/com/impl/tracing/skeleton_event_tracing.cpp
@@ -37,7 +37,7 @@ namespace detail_skeleton_event_tracing
 
 void UpdateTracingDataFromTraceResult(const Result<void> trace_result,
                                       SkeletonEventTracingData& skeleton_event_tracing_data,
-                                      bool& skeleton_event_trace_point) noexcept
+                                      bool& skeleton_event_trace_point)
 {
     if (!trace_result.has_value())
     {
@@ -63,7 +63,7 @@ namespace
 {
 template <ServiceElementType service_element_type>
 std::uint8_t GetNumberOfTracingSlots(const InstanceIdentifier& instance_identifier,
-                                     std::string_view service_element_name) noexcept
+                                     std::string_view service_element_name)
 {
     static_assert(service_element_type != ServiceElementType::INVALID);
 
@@ -118,7 +118,7 @@ std::uint8_t GetNumberOfTracingSlots(const InstanceIdentifier& instance_identifi
     const auto& service_element_instance_deployment = service_element_instance_deployment_it->second;
     // coverity[autosar_cpp14_a7_1_8_violation : FALSE]
     // coverity[autosar_cpp14_m6_4_1_violation : FALSE]
-    const auto slots_per_tracing_point = [&service_element_instance_deployment]() noexcept {
+    const auto slots_per_tracing_point = [&service_element_instance_deployment]() {
         if constexpr (service_element_type == ServiceElementType::EVENT)
         {
             return service_element_instance_deployment.GetNumberOfTracingSlots();
@@ -140,7 +140,7 @@ std::uint8_t GetNumberOfTracingSlots(const InstanceIdentifier& instance_identifi
 // coverity[autosar_cpp14_a3_1_1_violation]
 SkeletonEventTracingData GenerateSkeletonTracingStructFromEventConfig(const InstanceIdentifier& instance_identifier,
                                                                       const BindingType binding_type,
-                                                                      const std::string_view event_name) noexcept
+                                                                      const std::string_view event_name)
 {
     auto& runtime = Runtime::getInstance();
     auto* const tracing_runtime = runtime.GetTracingRuntime();
@@ -193,7 +193,7 @@ SkeletonEventTracingData GenerateSkeletonTracingStructFromEventConfig(const Inst
 // coverity[autosar_cpp14_a3_1_1_violation]
 SkeletonEventTracingData GenerateSkeletonTracingStructFromFieldConfig(const InstanceIdentifier& instance_identifier,
                                                                       const BindingType binding_type,
-                                                                      const std::string_view field_name) noexcept
+                                                                      const std::string_view field_name)
 {
     auto& runtime = Runtime::getInstance();
     const auto* const tracing_config = runtime.GetTracingFilterConfig();

--- a/score/mw/com/impl/tracing/skeleton_event_tracing.h
+++ b/score/mw/com/impl/tracing/skeleton_event_tracing.h
@@ -59,7 +59,7 @@ template <typename SampleType>
 // an exception.
 // This suppression should be removed after fixing [Ticket-173043](broken_link_j/Ticket-173043)
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-TracingData ExtractBindingTracingData(const impl::SampleAllocateePtr<SampleType>& sample_data_ptr) noexcept
+TracingData ExtractBindingTracingData(const impl::SampleAllocateePtr<SampleType>& sample_data_ptr)
 {
     const auto& binding_ptr_variant = SampleAllocateePtrView{sample_data_ptr}.GetUnderlyingVariant();
     auto visitor = score::cpp::overload(
@@ -87,7 +87,7 @@ TracingData ExtractBindingTracingData(const impl::SampleAllocateePtr<SampleType>
         [](const mock_binding::SampleAllocateePtr<SampleType>& ptr) -> TracingData {
             return {0U, {ptr.get(), sizeof(SampleType)}};
         },
-        [](const score::cpp::blank&) noexcept -> TracingData {
+        [](const score::cpp::blank&) -> TracingData {
             std::terminate();
         });
     return std::visit(visitor, binding_ptr_variant);
@@ -102,7 +102,7 @@ template <typename SampleType>
 // an exception.
 // This suppression should be removed after fixing [Ticket-173043](broken_link_j/Ticket-173043)
 // coverity[autosar_cpp14_a15_5_3_violation : FALSE]
-TypeErasedSamplePtr CreateTypeErasedSamplePtr(impl::SampleAllocateePtr<SampleType>& sample_data_ptr) noexcept
+TypeErasedSamplePtr CreateTypeErasedSamplePtr(impl::SampleAllocateePtr<SampleType>& sample_data_ptr)
 {
     auto& binding_ptr_variant = SampleAllocateePtrMutableView{sample_data_ptr}.GetUnderlyingVariant();
     auto visitor = score::cpp::overload(
@@ -124,7 +124,7 @@ TypeErasedSamplePtr CreateTypeErasedSamplePtr(impl::SampleAllocateePtr<SampleTyp
         // LCOV_EXCL_START (Defensive programming: CreateTypeErasedSamplePtr is always called after
         // ExtractBindingTracingData. If the SampleAllocateePtr contains a blank binding, then ExtractBindingTracingData
         // will terminate. Therefore, we will never reach this branch.
-        [](score::cpp::blank&) noexcept -> TypeErasedSamplePtr {
+        [](score::cpp::blank&) -> TypeErasedSamplePtr {
             std::terminate();
         });
     // LCOV_EXCL_STOP
@@ -134,23 +134,23 @@ TypeErasedSamplePtr CreateTypeErasedSamplePtr(impl::SampleAllocateePtr<SampleTyp
 
 void UpdateTracingDataFromTraceResult(const Result<void> trace_result,
                                       SkeletonEventTracingData& skeleton_event_tracing_data,
-                                      bool& skeleton_event_trace_point) noexcept;
+                                      bool& skeleton_event_trace_point);
 
 }  // namespace detail_skeleton_event_tracing
 
 tracing::SkeletonEventTracingData GenerateSkeletonTracingStructFromEventConfig(
     const InstanceIdentifier& instance_identifier,
     const BindingType binding_type,
-    const std::string_view event_name) noexcept;
+    const std::string_view event_name);
 tracing::SkeletonEventTracingData GenerateSkeletonTracingStructFromFieldConfig(
     const InstanceIdentifier& instance_identifier,
     const BindingType binding_type,
-    const std::string_view field_name) noexcept;
+    const std::string_view field_name);
 
 template <typename SampleType>
 void TraceSend(SkeletonEventTracingData& skeleton_event_tracing_data,
                const SkeletonEventBindingBase& skeleton_event_binding_base,
-               impl::SampleAllocateePtr<SampleType>& sample_data_ptr) noexcept
+               impl::SampleAllocateePtr<SampleType>& sample_data_ptr)
 {
     if (skeleton_event_tracing_data.enable_send)
     {
@@ -195,7 +195,7 @@ void TraceSend(SkeletonEventTracingData& skeleton_event_tracing_data,
 template <typename SampleType>
 void TraceSendWithAllocate(SkeletonEventTracingData& skeleton_event_tracing_data,
                            const SkeletonEventBindingBase& skeleton_event_binding_base,
-                           impl::SampleAllocateePtr<SampleType>& sample_data_ptr) noexcept
+                           impl::SampleAllocateePtr<SampleType>& sample_data_ptr)
 {
     if (skeleton_event_tracing_data.enable_send_with_allocate)
     {
@@ -239,14 +239,14 @@ void TraceSendWithAllocate(SkeletonEventTracingData& skeleton_event_tracing_data
 
 template <typename SampleType>
 auto CreateTracingSendCallback(SkeletonEventTracingData& skeleton_event_tracing_data,
-                               const SkeletonEventBindingBase& skeleton_event_binding_base) noexcept
+                               const SkeletonEventBindingBase& skeleton_event_binding_base)
     -> std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>
 {
     std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> tracing_handler{};
     if (skeleton_event_tracing_data.enable_send)
     {
         tracing_handler = [&skeleton_event_tracing_data, &skeleton_event_binding_base](
-                              impl::SampleAllocateePtr<SampleType>& sample_data_ptr) mutable noexcept {
+                              impl::SampleAllocateePtr<SampleType>& sample_data_ptr) mutable {
             TraceSend<SampleType>(skeleton_event_tracing_data, skeleton_event_binding_base, sample_data_ptr);
         };
     }
@@ -255,14 +255,14 @@ auto CreateTracingSendCallback(SkeletonEventTracingData& skeleton_event_tracing_
 
 template <typename SampleType>
 auto CreateTracingSendWithAllocateCallback(SkeletonEventTracingData& skeleton_event_tracing_data,
-                                           const SkeletonEventBindingBase& skeleton_event_binding_base) noexcept
+                                           const SkeletonEventBindingBase& skeleton_event_binding_base)
     -> std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback>
 {
     std::optional<typename SkeletonEventBinding<SampleType>::SendTraceCallback> tracing_handler{};
     if (skeleton_event_tracing_data.enable_send_with_allocate)
     {
         tracing_handler = [&skeleton_event_tracing_data, &skeleton_event_binding_base](
-                              impl::SampleAllocateePtr<SampleType>& sample_data_ptr) mutable noexcept {
+                              impl::SampleAllocateePtr<SampleType>& sample_data_ptr) mutable {
             TraceSendWithAllocate<SampleType>(
                 skeleton_event_tracing_data, skeleton_event_binding_base, sample_data_ptr);
         };


### PR DESCRIPTION
Remove noexcept from APIs and helpers that can propagate exceptions, including tracing, service discovery, proxy, LoLa binding, and shared-memory paths.