### PR TITLE
Modernize gtest macro and suppress self-assign warning in memory/shared tests

### DIFF
--- a/score/memory/shared/shared_memory_factory_test.cpp
+++ b/score/memory/shared/shared_memory_factory_test.cpp
@@ -90,7 +90,7 @@ std::string GetShmFilePath(const std::string& input_path) noexcept
 
 using SharedMemoryFactoryTest = SharedMemoryResourceTest;
 
-INSTANTIATE_TEST_CASE_P(SharedMemoryFactoryTests, SharedMemoryFactoryTest, ::testing::Values(true, false));
+INSTANTIATE_TEST_SUITE_P(SharedMemoryFactoryTests, SharedMemoryFactoryTest, ::testing::Values(true, false));
 
 TEST_P(SharedMemoryFactoryTest, ReturnExistingResourceOnReopening)
 {
@@ -1132,7 +1132,7 @@ TEST_F(SharedMemoryFactoryTest, CreatingAnonymousSharedMemoryInSystemMemory)
 
 using SharedMemoryFactoryDeathTest = SharedMemoryFactoryTest;
 
-INSTANTIATE_TEST_CASE_P(SharedMemoryFactoryDeathTests, SharedMemoryFactoryDeathTest, ::testing::Values(true, false));
+INSTANTIATE_TEST_SUITE_P(SharedMemoryFactoryDeathTests, SharedMemoryFactoryDeathTest, ::testing::Values(true, false));
 
 TEST_P(SharedMemoryFactoryDeathTest, CreatingSharedMemoryTerminate)
 {

--- a/score/memory/shared/test_offset_ptr/assignment_test.cpp
+++ b/score/memory/shared/test_offset_ptr/assignment_test.cpp
@@ -12,6 +12,7 @@
  ********************************************************************************/
 #include "score/memory/shared/offset_ptr.h"
 #include "score/memory/shared/test_offset_ptr/offset_ptr_test_resources.h"
+#include "score/quality/compiler_warnings/warnings.h"
 
 #include <gtest/gtest.h>
 #include <utility>
@@ -52,6 +53,8 @@ template <typename T>
 using OffsetPtrAssignmentVoidOnlyFixture = OffsetPtrNoBoundsCheckingMemoryResourceFixture<T>;
 TYPED_TEST_SUITE(OffsetPtrAssignmentVoidOnlyFixture, AllMemoryResourceAndVoidTypeCombinations, );
 
+DISABLE_WARNING_PUSH
+DISABLE_WARNING_SELF_ASSIGN_OVERLOADED  // testing correctness of implementation
 TYPED_TEST(OffsetPtrAssignmentFixture, OffsetPtrAssigmentOperatorHandlesSelfAssignment)
 {
     using PointedType = typename TypeParam::second_type::Type;
@@ -64,6 +67,7 @@ TYPED_TEST(OffsetPtrAssignmentFixture, OffsetPtrAssigmentOperatorHandlesSelfAssi
 
     EXPECT_EQ(OffsetPtrCreator<PointedType>::GetRawPointer(offset_ptr_0), raw_ptr);
 }
+DISABLE_WARNING_POP  // "-Wself-assign-overloaded"
 
 TYPED_TEST(OffsetPtrAssignmentFixture, OffsetPtrAssigmentOperatorHandlesOffsetPtr)
 {


### PR DESCRIPTION
## Summary
Fixes #873:
1. `score/memory/shared/shared_memory_factory_test.cpp` used the deprecated `INSTANTIATE_TEST_CASE_P` macro (two occurrences) — renamed to `INSTANTIATE_TEST_SUITE_P`.
2. `score/memory/shared/test_offset_ptr/assignment_test.cpp`'s `OffsetPtrAssigmentOperatorHandlesSelfAssignment` test deliberately does `offset_ptr_0 = offset_ptr_0;` but didn't suppress the resulting `-Wself-assign-overloaded` warning. Wrapped it with `DISABLE_WARNING_PUSH` / `DISABLE_WARNING_SELF_ASSIGN_OVERLOADED` / `DISABLE_WARNING_POP` from `score/quality/compiler_warnings/warnings.h`, matching the existing convention for self-move testing in `score_baselibs`' `intrusive_list_test.cpp`.

Both are mechanical, non-functional test-only changes with no behavior change to the code under test.

## Test plan
- [x] `bazel build //score/memory/shared/test_offset_ptr:offset_ptr_test //score/memory/shared:shared_memory_factory_test` — clean, target warnings no longer present
- [x] `bazel test //score/memory/shared/test_offset_ptr:offset_ptr_test //score/memory/shared:shared_memory_factory_test` — both pass