### PR TITLE
Preserve remote caches when upload fails

### DIFF
--- a/.github/actions/00_infrastructure/setup_bazel_cache/dist/post/index.js
+++ b/.github/actions/00_infrastructure/setup_bazel_cache/dist/post/index.js
@@ -72185,9 +72185,13 @@ async function run() {
       const diskKey = `disk-cache-${diskCacheName}-${runId}`;
       info(`Saving disk cache with key: ${diskKey}`);
       try {
-        await saveCache2([diskCacheDir], diskKey);
-        info("Disk cache saved.");
-        await deleteOldCaches(`disk-cache-${diskCacheName}-`, diskKey);
+        const cacheId = await saveCache2([diskCacheDir], diskKey);
+        if (typeof cacheId !== "number" || cacheId < 0) {
+          warning("Disk cache upload did not complete; keeping existing remote caches.");
+        } else {
+          info("Disk cache saved.");
+          await deleteOldCaches(`disk-cache-${diskCacheName}-`, diskKey);
+        }
       } catch (error2) {
         if (error2.name === "ReserveCacheError" || error2.message?.includes("Unable to reserve cache")) {
           info("Disk cache already exists, skipping save.");
@@ -72201,9 +72205,13 @@ async function run() {
       const repoKey = `repo-cache-${hash}`;
       info(`Saving repository cache with key: ${repoKey}`);
       try {
-        await saveCache2([repoCacheDir], repoKey);
-        info("Repository cache saved.");
-        await deleteOldCaches("repo-cache-", repoKey);
+        const cacheId = await saveCache2([repoCacheDir], repoKey);
+        if (typeof cacheId !== "number" || cacheId < 0) {
+          warning("Repository cache upload did not complete; keeping existing remote caches.");
+        } else {
+          info("Repository cache saved.");
+          await deleteOldCaches("repo-cache-", repoKey);
+        }
       } catch (error2) {
         if (error2.name === "ReserveCacheError" || error2.message?.includes("Unable to reserve cache")) {
           info("Repository cache already exists (same content hash), skipping save.");

--- a/.github/actions/00_infrastructure/setup_bazel_cache/src/post.js
+++ b/.github/actions/00_infrastructure/setup_bazel_cache/src/post.js
@@ -90,9 +90,13 @@ async function run() {
       const diskKey = `disk-cache-${diskCacheName}-${runId}`;
       core.info(`Saving disk cache with key: ${diskKey}`);
       try {
-        await cache.saveCache([diskCacheDir], diskKey);
-        core.info("Disk cache saved.");
-        await deleteOldCaches(`disk-cache-${diskCacheName}-`, diskKey);
+        const cacheId = await cache.saveCache([diskCacheDir], diskKey);
+        if (typeof cacheId !== "number" || cacheId < 0) {
+          core.warning("Disk cache upload did not complete; keeping existing remote caches.");
+        } else {
+          core.info("Disk cache saved.");
+          await deleteOldCaches(`disk-cache-${diskCacheName}-`, diskKey);
+        }
       } catch (error) {
         if (error.name === "ReserveCacheError" || error.message?.includes("Unable to reserve cache")) {
           core.info("Disk cache already exists, skipping save.");
@@ -108,9 +112,13 @@ async function run() {
       const repoKey = `repo-cache-${hash}`;
       core.info(`Saving repository cache with key: ${repoKey}`);
       try {
-        await cache.saveCache([repoCacheDir], repoKey);
-        core.info("Repository cache saved.");
-        await deleteOldCaches("repo-cache-", repoKey);
+        const cacheId = await cache.saveCache([repoCacheDir], repoKey);
+        if (typeof cacheId !== "number" || cacheId < 0) {
+          core.warning("Repository cache upload did not complete; keeping existing remote caches.");
+        } else {
+          core.info("Repository cache saved.");
+          await deleteOldCaches("repo-cache-", repoKey);
+        }
       } catch (error) {
         if (error.name === "ReserveCacheError" || error.message?.includes("Unable to reserve cache")) {
           core.info("Repository cache already exists (same content hash), skipping save.");


### PR DESCRIPTION
## Summary
- Check the result of saveCache before deleting older remote Bazel caches.
- Preserve existing caches when uploads are skipped or unsuccessful.
- Rebuild the bundled cache action.

## Validation
- npm run build in .github/actions/00_infrastructure/setup_bazel_cache
- git diff --check