### PR TITLE
Fix several broken links

### DIFF
--- a/score/memory/shared/design/README.md
+++ b/score/memory/shared/design/README.md
@@ -339,7 +339,7 @@ Obviously, since the SharedMemoryResource is contained within a shared_ptr, in t
 
 ## Ownership of the SharedMemoryResource
 
-Getting the `uid` of the creator of the underlying memory managed by a `SharedMemoryResource` is essential to ensure that only memory with the expected allowed providers can be opened by a user of the library as this feature is used by some ASIL B components (for example see this [requirement](broken_link_c/issue/33047276) or this [one](broken_link_c/issue/8742625)).
+Getting the `uid` of the creator of the underlying memory managed by a `SharedMemoryResource` is essential to ensure that only memory with the expected allowed providers can be opened by a user of the library as this feature is used by some ASIL B components (for example see this [requirement](broken_link_c/issue/33047276) or ScoreReq.CompReq CheckTheUidOfTheProducer).
 This library only supports opening a shared memory area based on the path therefore this concept is only valid for the named memory use case, annonymous memory is not considered.
 
 There are 2 possible use-cases :

--- a/score/mw/com/design/README.md
+++ b/score/mw/com/design/README.md
@@ -184,7 +184,7 @@ that we need, we find that in spirit it does not contradict the guideline, and w
 
 ## Assumptions of Use (AoUs)
 
-A full list of AoUs can be seen [here](broken_link_c/issue/6221478). The following presents only a
+A full list of AoUs can be seen [in the safety analysis folder](../dependability/safety_analysis/aou.trlc). The following presents only a
 small selection.
 
 ## Use of `std::terminate` in `LoLa`

--- a/score/mw/com/impl/configuration/README.md
+++ b/score/mw/com/impl/configuration/README.md
@@ -131,7 +131,6 @@ identification via `serviceTypeName`. This is typically a lengthy string represe
 layer a `binding`-specific more efficient representation is needed. In case of `SHM` `binding` this is an
 unsigned integer (16 bit), which (like the `serviceTypeName`) needs to be unique in the communication setup. I.e. **all**
 applications communicating via `SHM` `binding` need to agree on a unique assignment of `serviceId`s to `service-types`.
-To keep track within BMW, we currently manage the `serviceId` namespace [here](broken_link_cf/pages/viewpage.action?spaceKey=psp&title=LoLa+service+IDs+used+within+BMW)
 
 Then, for each service element (event, field, method), which the `service-type` (the `service-interface` in our C++
 representation) contains, we need to configure a pair of name and id. So in our example the `service-type`

--- a/score/mw/com/test/smokeyeyes/smokeyeyes.cpp
+++ b/score/mw/com/test/smokeyeyes/smokeyeyes.cpp
@@ -38,7 +38,6 @@
 
 using namespace std::chrono_literals;
 
-// uid 1300 - 1311 is reserved for use. See broken_link_cf/display/ipnext/User+Management
 const uid_t kUidStart{1300};
 
 namespace score::mw::com::test


### PR DESCRIPTION
It fixes the broken link in to ways depending on the scenario:
- It makes it point to the right element
- It removes the text containing the broken link because it is not relevant for S-CORE.

Note: In some of the files touched, I left some broken links. The reason is that some of them do not have yet a trivial replacement.