### PR TITLE
docs: fix broken sphinx include/toctree paths from prefix mismatch

### DIFF
--- a/.github/workflows/deploy_docs.yml
+++ b/.github/workflows/deploy_docs.yml
@@ -18,12 +18,17 @@ on:
   push:
     branches: [main]
     tags: ['v*']
+  # Intentionally no `paths:` filter here. The Sphinx build's dependency
+  # surface is a Bazel graph, not a fixed set of directories: e.g. the
+  # generated API docs depend on the *entire* //score/mw/com C++ target
+  # (via Doxygen/Breathe), and sphinx_docs_library sources can be added
+  # anywhere in the repo. Any path allowlist would either be incomplete
+  # (silently missing future doc-affecting changes, as happened before
+  # this fix) or so broad it approximates "no filter" anyway. Bazel's
+  # disk cache (configured below) keeps unaffected reruns cheap, so we
+  # let the build graph -- not a hand-maintained list -- decide relevance.
   pull_request:
     branches: [main]
-    paths:
-      - 'docs/**'
-      - '.github/workflows/deploy_docs.yml'
-      - '.github/actions/10_docs/build_sphinx_package/action.yml'
   workflow_dispatch:
   workflow_run:
     workflows: ["Nightly Quality Jobs"]

--- a/BUILD
+++ b/BUILD
@@ -26,7 +26,6 @@ sync_skills()
 sphinx_docs_library(
     name = "contributing_md",
     srcs = ["CONTRIBUTING.md"],
-    prefix = "docs/sphinx/",  # Place under sphinx out folder
     visibility = ["//docs/sphinx:__pkg__"],
 )
 

--- a/docs/sphinx/BUILD
+++ b/docs/sphinx/BUILD
@@ -88,6 +88,7 @@ sphinx_module(
     exec_compatible_with = ["@platforms//os:linux"],
     extra_opts = [
         "-Dbreathe_default_project=doxygen_build",
+        "-W",
     ],
     extra_opts_targets = [
         # Pass location of Doxygen XML output to Breathe via -D option

--- a/docs/sphinx/lola.rst
+++ b/docs/sphinx/lola.rst
@@ -15,14 +15,14 @@
 LoLa / mw::com
 ==============
 
-.. include:: README.md
+.. include:: score/mw/com/README.md
    :parser: myst_parser.sphinx_
 
 .. toctree::
    :hidden:
 
    self
-   tutorial/README
+   score/mw/com/doc/tutorial/README
    generated/api_index
-   mw_com_index/index
+   docs/sphinx/mw_com_index/index
 

--- a/docs/sphinx/lola.rst
+++ b/docs/sphinx/lola.rst
@@ -22,6 +22,7 @@ LoLa / mw::com
    :hidden:
 
    self
+   score/mw/com/README
    score/mw/com/doc/tutorial/README
    generated/api_index
    docs/sphinx/mw_com_index/index

--- a/docs/sphinx/message_passing.rst
+++ b/docs/sphinx/message_passing.rst
@@ -109,5 +109,5 @@ Features:
 
    self
    mp_safety
-   dependable_element_message_passing_index/index
+   docs/sphinx/dependable_element_message_passing_index/index
 

--- a/docs/sphinx/utils/extract_api_items.py
+++ b/docs/sphinx/utils/extract_api_items.py
@@ -28,6 +28,15 @@ from typing import Dict, List, Optional
 class APITagExtractor: # pylint: disable=too-few-public-methods
     """Extracts API-tagged items from Doxygen XML output."""
 
+    # Matches the compound (namespace/class/struct) portion of a Doxygen
+    # refid, e.g. "namespacescore_1_1mw_1_1com_1ad1234" -> group(1) is
+    # "namespacescore_1_1mw_1_1com". Shared by `_get_member_kind_from_xml`
+    # (to locate the compound's XML file) and `_get_enclosing_scope`
+    # (to detect/dedupe direct namespace/class-scope members).
+    _COMPOUND_REFID_RE = (
+        r'((?:namespace|class|struct)[^_]+(?:_1_1[^_]+)*?)_1[a-f0-9]'
+    )
+
     def __init__(self, xml_file_path: str):
         """Initialize the API extractor.
 
@@ -78,7 +87,70 @@ class APITagExtractor: # pylint: disable=too-few-public-methods
             sys.exit(1)
 
         self._extract_from_api_references(api_items)
+        self._drop_members_covered_by_enclosing_scope(api_items)
         return api_items
+
+    def _drop_members_covered_by_enclosing_scope(
+            self, api_items: Dict[str, List[Dict[str, str]]]
+    ) -> None:
+        """Remove members already documented via their enclosing
+        namespace or class/struct directive.
+
+        Two directives Breathe emits for other categories already pull in
+        *all* of a scope's direct members:
+        - ``.. doxygennamespace:: <name>\n   :content-only:`` (namespaces)
+        - ``.. doxygenclass:: <name>\n   :members:\n   :undoc-members:``
+          (classes/structs)
+
+        If a member belonging to such a scope is *also* individually
+        tagged with ``@api`` (which commonly happens, since Doxygen tags
+        a declaration both individually and as part of its enclosing
+        scope), it would otherwise be emitted a second time via
+        ``api_members.rst``, causing Sphinx/Breathe "Duplicate C++
+        declaration" warnings.
+
+        Args:
+            api_items: Dictionary of categorized API items, filtered in place
+        """
+        documented_scopes = {
+            item['name'] for item in api_items['namespaces']
+        } | {
+            item['name'] for item in api_items['classes']
+        }
+        if not documented_scopes:
+            return
+
+        api_items['members'] = [
+            member for member in api_items['members']
+            if self._get_enclosing_scope(member['id'])
+            not in documented_scopes
+        ]
+
+    def _get_enclosing_scope(self, refid: str) -> Optional[str]:
+        """Return the qualified name of the namespace/class/struct a
+        member directly belongs to, or None if it can't be determined.
+
+        Args:
+            refid: The reference ID from api.xml
+                   (e.g., "namespacescore_1_1mw_1_1com_1ad..." or
+                   "classscore_1_1mw_1_1com_1_1impl_1_1InstanceIdentifier"
+                   "_1a...")
+
+        Returns:
+            The qualified scope name (e.g. "score::mw::com" or
+            "score::mw::com::impl::InstanceIdentifier"), or None if
+            `refid` doesn't match a known compound naming pattern.
+        """
+        match = re.match(self._COMPOUND_REFID_RE, refid)
+        if not match:
+            return None
+        compound_name = match.group(1)
+        for kind_prefix in ('namespace', 'class', 'struct'):
+            if compound_name.startswith(kind_prefix):
+                return (
+                    compound_name[len(kind_prefix):].replace('_1_1', '::')
+                )
+        return None
 
     def _extract_member_signature(self, term_elem: ET.Element) -> str:
         """Extract member signature from term element.
@@ -124,10 +196,7 @@ class APITagExtractor: # pylint: disable=too-few-public-methods
         #   -> "classbmw_1_1mw_1_1com_1_1impl_1_1FindServiceHandle.xml"
 
         # Split on the last occurrence of _1 followed by a lowercase letter
-        match = re.match(
-            r'((?:namespace|class|struct)[^_]+(?:_1_1[^_]+)*?)_1[a-f0-9]',
-            refid
-        )
+        match = re.match(self._COMPOUND_REFID_RE, refid)
         if match:
             compound_name = match.group(1)
             xml_file = Path(self.xml_dir) / f"{compound_name}.xml"
@@ -530,14 +599,34 @@ This section contains all {category} tagged with @api.
         # Reconstruct the signature
         simplified = f"{base_name}({', '.join(simplified_params)})"
 
-        # Check for const qualifier after the closing parenthesis
-        # Look for "const" keyword after the parameters
-        # but before other qualifiers
+        # Check for const/ref qualifiers after the closing parenthesis.
+        # Breathe requires an exact signature match, so a ref-qualified
+        # member function (e.g. "GetHandle() const &") must keep its "&"/
+        # "&&" -- dropping it (as before) made Breathe unable to resolve
+        # functions like ProxyBase::GetHandle, which is only declared as
+        # "const HandleType &GetHandle() const & noexcept". Other
+        # qualifiers (noexcept, override, final, =default) are still
+        # intentionally dropped since Breathe's signature matching
+        # ignores them.
         remainder = signature[paren_end+1:].strip()
-        if remainder.startswith('const'):
-            # Add const to the signature, but remove other qualifiers
-            # like noexcept, override, final, =default
-            simplified += " const"
+        remainder_tokens = remainder.split()
+        qualifiers = []
+        idx = 0
+        if remainder_tokens and remainder_tokens[0] == 'const':
+            qualifiers.append('const')
+            idx += 1
+        if idx < len(remainder_tokens):
+            # Doxygen sometimes emits the ref-qualifier glued directly to
+            # the following keyword with no separating space (e.g.
+            # "&noexcept" or "&&noexcept"), so check for a prefix match
+            # rather than requiring the token to be exactly "&"/"&&".
+            token = remainder_tokens[idx]
+            if token.startswith('&&'):
+                qualifiers.append('&&')
+            elif token.startswith('&'):
+                qualifiers.append('&')
+        if qualifiers:
+            simplified += ' ' + ' '.join(qualifiers)
 
         return simplified
 

--- a/score/mw/com/BUILD
+++ b/score/mw/com/BUILD
@@ -17,11 +17,11 @@ load("//quality/api_surface:api_surface.bzl", "api_surface_test")
 load("//quality/unit_testing:unit_testing.bzl", "cc_unit_test")
 load("//score/mw:common_features.bzl", "COMPILER_WARNING_FEATURES")
 
-# Capture README.md for Sphinx documentation at convenient location
+# Capture README.md for Sphinx documentation.
 sphinx_docs_library(
     name = "readme_md",
     srcs = ["README.md"],
-    prefix = "docs/sphinx/",  # Place under sphinx out folder
+    prefix = "score/mw/com/",
     visibility = ["//docs/sphinx:__pkg__"],
 )
 

--- a/score/mw/com/doc/tutorial/BUILD
+++ b/score/mw/com/doc/tutorial/BUILD
@@ -34,7 +34,7 @@ sphinx_docs_library(
         "//score/mw/com/doc/tutorial/chapter_8:doc_files",
         "//score/mw/com/doc/tutorial/chapter_9:doc_files",
     ],
-    prefix = "docs/sphinx/tutorial/",
+    prefix = "score/mw/com/doc/tutorial/",
     visibility = ["//docs/sphinx:__pkg__"],
 )
 

--- a/score/mw/com/doc/tutorial/README.md
+++ b/score/mw/com/doc/tutorial/README.md
@@ -2,4 +2,4 @@
 
 We have a very detailed tutorial of how to use `score::mw::com` as an application developer.
 The documentation is done in `Sphinx reStructuredText (RST)` format and the rendered documentation can be found
-[here](https://eclipse-score.github.io/communication/latest/tutorial/README.html).
+[here](https://eclipse-score.github.io/communication/latest/score/mw/com/doc/tutorial/README.html).

--- a/score/mw/com/doc/tutorial/chapter_1/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_1/README.rst
@@ -149,7 +149,7 @@ implementation of the service interface gets generated via instantiation of the 
 corresponding proxy/skeleton trait. Thus, also the line `using Trait::Base::Base;` is mandatory for each service
 interface a user designs.
 What is specific to our `HelloWorldInterface` is only the datatype declaration for a `FixedSizeString` and the line:
-typename Trait::template Event<FixedSizeString> message{*this, "message"};
+``typename Trait::template Event<FixedSizeString> message{*this, "message"};``
 
 This line expresses, that our service interface `HelloWorldInterface` contains an event with name "message".
 The datatype of the event is `FixedSizeString`, which we declared in the line above.
@@ -440,16 +440,16 @@ A short summary of what we have learned in this chapter:
 - The service interface is defined in terms of a C++ struct, which has to follow a certain pattern, which is documented
   in `traits.h <https://github.com/eclipse-score/communication/blob/main/score/mw/com/impl/traits.h>`__.
 - The provider side skeleton data type is generated via the `AsSkeleton` template, which is instantiated with the service
-interface.
+  interface.
 - The consumer side proxy data type is generated via the `AsProxy` template, which is instantiated with the service
-interface.
+  interface.
 - For both, the provider and the consumer, the service instance is identified via an `instance specifier`, which is a
   string that is used for a configuration lookup.
 - The provider creates a skeleton instance via the `Create` method of the skeleton data type and then offers the service
-instance via the `OfferService` method.
+  instance via the `OfferService` method.
 - The consumer finds the service instance via the `FindService` method of the proxy data type and then creates a proxy
-instance via the `Create` method of the proxy data type.
+  instance via the `Create` method of the proxy data type.
 - The consumer, which wants to receive event samples, the provider sends out, 1st needs to subscribe to the event via
-the `Subscribe` method of the proxy event data type.
+  the `Subscribe` method of the proxy event data type.
 - The consumer then can retrieve new samples via the `GetNewSamples` method of the proxy event data type, which takes a
-callback as argument, which is called for each new sample.
+  callback as argument, which is called for each new sample.

--- a/score/mw/com/doc/tutorial/chapter_10/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_10/README.rst
@@ -42,16 +42,16 @@ These basic building blocks can also be seen in the high-level architecture docu
    shared-memory objects.
 
 Access control is configured at the level of a **service instance** in the ``score::mw::com`` configuration file. For a
-specific service instance you can define two properties, each carrying a list of ``uid``s separated by ASIL level:
+specific service instance you can define two properties, each carrying a list of ``uid``\s separated by ASIL level:
 
 - **allowedConsumer** defines which applications, in the role of a **consumer** (proxy), are allowed to access the
   service instance. This is defined at the **provider side** (provider-side configuration). In the LoLa binding the
-  provider uses this list to restrict access to its shared-memory objects (via ACLs) to exactly the given ``uid``s.
+  provider uses this list to restrict access to its shared-memory objects (via ACLs) to exactly the given ``uid``\s.
 - **allowedProvider** defines which applications are expected/allowed, in the role of a **provider** (skeleton), to
   provide the service instance. This is defined at the **consumer side** (consumer-side configuration). With this
   setting a consumer can make sure that it only accepts a verified/specific provider to consume the service from: when
   opening/mapping the shared-memory objects, the consumer checks that they are owned by one of the configured
-  ``allowedProvider`` ``uid``s and terminates if that is not the case.
+  ``allowedProvider`` ``uid``\s and terminates if that is not the case.
 
 A few important rules:
 
@@ -59,7 +59,7 @@ A few important rules:
   given. If a service instance is tagged with ``asil-level`` = ``QM``, only a ``QM`` list may be given in
   ``allowedConsumer`` / ``allowedProvider``.
 - If a property ``allowedConsumer`` or ``allowedProvider`` is **omitted**, this means **no restrictions** regarding
-  ``uid``s.
+  ``uid``\s.
 - If a property ``allowedConsumer`` or ``allowedProvider`` is an **empty list**, the meaning depends on the
   ``permission-checks`` property of the service instance (``file-permissions-on-empty`` – the default – falls back to
   basic ``ugo`` file-system rights; ``strict`` means really no-one is allowed). See the
@@ -171,10 +171,10 @@ Extract both archives (e.g. in a tmp-directory):
 
 
 Unlike the previous chapters, we now need to start the provider and consumer under **specific user-ids**, matching the
-``uid``s we configured (``777`` for the provider, ``778`` for the consumer). The following steps require **root**
+``uid``\s we configured (``777`` for the provider, ``778`` for the consumer). The following steps require **root**
 privileges (to create the users and to run a program as another user).
 
-Create the two users with exactly the ``uid``s used in the configuration:
+Create the two users with exactly the ``uid``\s used in the configuration:
 
 .. code-block:: bash
 
@@ -239,12 +239,12 @@ A short summary of what we have learned in this chapter:
   **shared-memory objects** (the message-passing layer currently has no access control).
 - Access control is configured per **service instance** via two properties:
 
-  - ``allowedConsumer`` (provider-side): the ``uid``s allowed to *consume* the instance; enforced via ACLs on the
+  - ``allowedConsumer`` (provider-side): the ``uid``\s allowed to *consume* the instance; enforced via ACLs on the
     provider's shared-memory objects.
-  - ``allowedProvider`` (consumer-side): the ``uid``s the consumer accepts as *provider*; the consumer checks the
+  - ``allowedProvider`` (consumer-side): the ``uid``\s the consumer accepts as *provider*; the consumer checks the
     ownership of the shared-memory objects and terminates on a mismatch.
 
 - The ``uid`` lists are given per ASIL level (``QM``, and ``B`` only for ASIL-B service instances). An **omitted**
   property means *no restriction*; an **empty** list is interpreted according to the ``permission-checks`` property.
-- If the running ``uid``s do not match the configured lists on either side, the consumer cannot create a proxy and
+- If the running ``uid``\s do not match the configured lists on either side, the consumer cannot create a proxy and
   communication is denied.

--- a/score/mw/com/doc/tutorial/chapter_12/BUILD
+++ b/score/mw/com/doc/tutorial/chapter_12/BUILD
@@ -169,6 +169,12 @@ filegroup(
         "**/*.cpp",
         "**/*.h",
         "**/*.json",
-    ]),
+    ]) + [
+        # README.rst literalincludes this chapter's own BUILD file (to show
+        # the cc_unit_test target definitions); the default glob above
+        # doesn't match "BUILD" so it must be added explicitly, or the
+        # literalinclude silently can't find it in the merged Sphinx tree.
+        "BUILD",
+    ],
     visibility = ["//score/mw/com/doc/tutorial:__pkg__"],
 )

--- a/score/mw/com/doc/tutorial/chapter_2/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_2/README.rst
@@ -154,8 +154,9 @@ run into an error like this, when starting the consumer app:
 So here are some best practices regarding configuration files for `score::mw::com` applications:
 
 - typically go for the default/implicit approach: Put the configuration file `mw_com_config.json` in the `./etc` path
-relative to the current working directory of the application.
+  relative to the current working directory of the application.
 - if you have a strong reason to have a different configuration file name or path, then go for the explicit approach:
+
   - either call `score::mw::com::runtime::InitializeRuntime(argc, argv)` in your application and provide the path to the
     configuration file via the `--service_instance_manifest` command line argument.
   - or - for the real "power-user" - call `score::mw::com::runtime::InitializeRuntime(const RuntimeConfiguration& runtime_configuration)`,

--- a/score/mw/com/doc/tutorial/chapter_6/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_6/README.rst
@@ -9,11 +9,11 @@ This chapter is about correctly sizing the `numberOfSampleSlots` property of an 
 depend on the provider alone – it depends on the **consumers**: on *how many* consumers (proxy instances) subscribe
 to the event and with which `max_sample_count` they subscribe.
 
-The `max_sample_count` a subscriber passes to `Subscribe()` expresses how many samples (in the form of `SamplePtr`s) that
+The `max_sample_count` a subscriber passes to `Subscribe()` expresses how many samples (in the form of `SamplePtr`\s) that
 subscriber wants to be able to **hold in parallel**.
 
-Why the sum of all `max_sample_count`s?
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+Why the sum of all `max_sample_count`\s?
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 
 Consumers are, in general, **completely independent** of each other. The point in time when a consumer calls
@@ -25,7 +25,7 @@ parallel, subscriber 2 up to **three**. Then, because the two can hold their sam
 points in time, the provider must provide at least `2 + 3 = 5` sample slots. Consider these two extreme situations for
 the underlying control-slot-vector (of size 5):
 
-1. **Closely coupled:** consumer 1 acquires new samples and keeps the `SamplePtr`s; shortly after, consumer 2
+1. **Closely coupled:** consumer 1 acquires new samples and keeps the `SamplePtr`\s; shortly after, consumer 2
    does the same and ends up referencing largely the *same* slots. We might then have two slots with a reference count of
    2 (referenced by both consumers), one slot with a reference count of 1 (only consumer 2), and two remaining slots
    that are not referenced by either consumer. Such a not-referenced slot is either *uninitialized* (does not yet contain
@@ -74,7 +74,7 @@ The `bazel` project for this chapter is located in `score/mw/com/doc/tutorial/ch
    * - `BUILD <https://github.com/eclipse-score/communication/blob/main/score/mw/com/doc/tutorial/chapter_6/BUILD>`__
      - This file contains bazel targets for this example.
    * - `consumer/consumer.cpp <https://github.com/eclipse-score/communication/blob/main/score/mw/com/doc/tutorial/chapter_6/consumer/consumer.cpp>`__
-     - Implementation of the service consumer app (polling, keeps `SamplePtr`s).
+     - Implementation of the service consumer app (polling, keeps `SamplePtr`\s).
    * - `consumer/consumer.h <https://github.com/eclipse-score/communication/blob/main/score/mw/com/doc/tutorial/chapter_6/consumer/consumer.h>`__
      - Header (empty - we just always want to have cpp/h pairs) of the service consumer.
    * - `consumer/logging.json <https://github.com/eclipse-score/communication/blob/main/score/mw/com/doc/tutorial/chapter_6/consumer/logging.json>`__
@@ -130,7 +130,7 @@ end of the `GetNewSamples()` callback, so they effectively never held more than 
 this chapter is more realistic:
 
 - It uses the **polling** approach again (cyclically calling `GetNewSamples()`).
-- It **keeps** the received `SamplePtr`s by *moving* them out of the callback into a container (`std::deque`) that lives
+- It **keeps** the received `SamplePtr`\s by *moving* them out of the callback into a container (`std::deque`) that lives
   in `main()`. It therefore holds up to `max_sample_count` samples in parallel.
 - It takes the `max_sample_count` to use as a **command-line argument**.
 - Whenever it already holds `max_sample_count` samples, it releases the **oldest** one before calling `GetNewSamples()`
@@ -203,7 +203,7 @@ Playing with the sizing
 
 With `numberOfSampleSlots` fixed at **10**, you can now explore the three interesting variations:
 
-- **`4` and `5` – rule of thumb satisfied.** The sum of the `max_sample_count`s is `4 + 5 = 9`, plus the safety
+- **`4` and `5` – rule of thumb satisfied.** The sum of the `max_sample_count`\s is `4 + 5 = 9`, plus the safety
   margin of 1 gives 10, which is exactly `numberOfSampleSlots`. In this configuration you should **never** see the
   provider log that it could not allocate a sample slot.
 - **`5` and `5` – missing the `+ 1`.** Both consumers can still subscribe (`5 + 5 = 10 =
@@ -231,7 +231,7 @@ A short summary of what we have learned in this chapter:
 
 - `numberOfSampleSlots` is configured by the **provider**, but its correct value is dictated by the **consumers**: by
   how many subscribe and with which `max_sample_count`.
-- `max_sample_count` (passed to `Subscribe()`) is the number of `SamplePtr`s a subscriber wants to be able to hold in
+- `max_sample_count` (passed to `Subscribe()`) is the number of `SamplePtr`\s a subscriber wants to be able to hold in
   parallel. Because subscribers are independent, in the worst case all of them hold their maximum at disjoint slots at
   the same time.
 - Rule of thumb: **`numberOfSampleSlots = Sum of (max_sample_count of all subscribers) + 1`**. The `+ 1` guarantees the

--- a/score/mw/com/doc/tutorial/chapter_8/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_8/README.rst
@@ -296,8 +296,9 @@ A short summary of what we have learned in this chapter:
   **first argument by (mutable) reference** (an out-parameter), followed by the input arguments by const-reference –
   i.e. the expected handler signature for `ReturnType(ArgTypes...)` is `void(ReturnType&, const ArgTypes&...)`.
 - On the **consumer** side a method member is callable via `operator()`. There are two variants:
+
   - the **copy** call operator `proxy.method(args...)` – convenient for small, cheap-to-copy arguments (it
-    internally `Allocate()`s, copies the arguments in and calls);
+    internally `Allocate()`\s, copies the arguments in and calls);
   - the **zero-copy** call operator `proxy.method(MethodInArgPtr...)` – for (potentially large) arguments: first
     `Allocate()` the argument directly in the shared-memory slot, fill it **in place**, then invoke the method with the
     obtained pointer(s), avoiding an extra copy.


### PR DESCRIPTION
sphinx_docs_library targets used a prefix that placed files at an arbitrary location inside the merged Sphinx source tree, unrelated to where the consuming .rst files expected them. This caused:

- docs/sphinx/lola.rst's `.. include:: README.md` to silently resolve to empty content (no warning), losing the entire mw::com README page from the built/deployed docs.
- The `tutorial/README` and `mw_com_index/index` toctree entries in lola.rst, and the `CONTRIBUTING` toctree entry in index.rst, to be orphaned from site navigation.

Fix: adopt the convention that `prefix` mirrors the target's own source package path, so files keep their real repo-relative path inside the merged Sphinx tree. This makes include/toctree references predictable and avoids collisions between same-named files from different packages. Updated the affected BUILD targets and the lola.rst references accordingly.