### PR TITLE
Event sample data type alignment fix

### DIFF
--- a/score/mw/com/api_surface.lock.json
+++ b/score/mw/com/api_surface.lock.json
@@ -802,6 +802,12 @@
       "signature": "GenericProxyEvent : void (ProxyBase &, const std::string_view)"
     },
     {
+      "name": "GetDataTypeSizeInfo",
+      "qualified_name": "score::mw::com::GenericProxyEvent::GetDataTypeSizeInfo",
+      "kind": "method",
+      "signature": "GetDataTypeSizeInfo : memory::DataTypeSizeInfo () const"
+    },
+    {
       "name": "GetNewSamples",
       "qualified_name": "score::mw::com::GenericProxyEvent::GetNewSamples",
       "kind": "template_function",
@@ -817,7 +823,7 @@
       "name": "GetSampleSize",
       "qualified_name": "score::mw::com::GenericProxyEvent::GetSampleSize",
       "kind": "method",
-      "signature": "GetSampleSize : std::size_t () const noexcept"
+      "signature": "GetSampleSize : std::size_t () const noexcept [[deprecated]]"
     },
     {
       "name": "HasSerializedFormat",

--- a/score/mw/com/dependability/requirements/component_requirements/component_requirements_ipc_generic_proxy.trlc
+++ b/score/mw/com/dependability/requirements/component_requirements/component_requirements_ipc_generic_proxy.trlc
@@ -510,6 +510,7 @@ section "com" {
                 }
 
                 /* broken_link_c/issue/14035184 */
+                /* GetSampleSize is deprecated in favor of GetDataTypeSizeInfo (see GenericProxyEventGetDataTypeSizeInfo), it will be removed in https://github.com/eclipse-score/communication/issues/975 */
                 ScoreReq.CompReq GenericProxyEventGetSampleSize {
                     description = '''The {{GenericProxyEvent}} shall provide a public method:
 
@@ -518,6 +519,19 @@ section "com" {
                     Behaviour: {{GetSampleSize}} shall adhere to the re-entrancy and thread-safety specifications described in Re-entrancy and Thread-safety.
 
                     Return value: returns the aligned size in bytes of the underlying event sample data type. I.e. in case the underlying data type is T, it shall return {{sizeof(T)}}.'''
+                    safety = ScoreReq.Asil.B
+                    derived_from = [Communication.EventType@1]
+                    version = 1
+                }
+
+                ScoreReq.CompReq GenericProxyEventGetDataTypeSizeInfo {
+                    description = '''The {{GenericProxyEvent}} shall provide a public method:
+
+                    {{{memory::DataTypeSizeInfo GetDataTypeSizeInfo() const noexcept}}}
+
+                    Behaviour: {{GetDataTypeSizeInfo}} shall adhere to the re-entrance and thread-safety specifications described in Re-entrance and Thread-safety.
+
+                    Return value: returns the data type size info (size in bites and alignment in bytes) of the underlying event sample data type.'''
                     safety = ScoreReq.Asil.B
                     derived_from = [Communication.EventType@1]
                     version = 1

--- a/score/mw/com/dependability/software_architectural_design/mw_com_dii/README.md
+++ b/score/mw/com/dependability/software_architectural_design/mw_com_dii/README.md
@@ -164,8 +164,7 @@ These are the deviations:
 3. For this obviously a void specialization of `mw::com::SamplePtr` is needed. This specialization removes the
    following members:
     - `T& operator*() const noexcept`
-4. `GenericProxyEvent` gets a new member function: `std::size_t GetSampleSize()`, which returns the "static" size of the sample
-   type in bytes.
+4. `GenericProxyEvent` gets new member function: `memory::DataTypeSizeInfo GenericProxyEvent::GetDataTypeSizeInfo()` which returns the "static" size and alignment of the sample type in bytes.
 5. `GenericProxyEvent` gets a new member function: `bool HasSerializedFormat()`, which returns `true` in case the
    representation of the event provided by the implementation is some serialized format or `false` in case the
    representation is that of the expected C++ type. (see [here](#binary-representation-of-untyped-form))

--- a/score/mw/com/design/skeleton_proxy/generic_proxy/generic_proxy_model.puml
+++ b/score/mw/com/design/skeleton_proxy/generic_proxy/generic_proxy_model.puml
@@ -143,6 +143,7 @@ abstract class "mw::com::impl::ProxyEventBase" #yellow {
 
 class "mw::com::impl::GenericProxyEvent" #yellow {
   +GetSampleSize() const : std::size_t
+  +GetDataTypeSizeInfo() const : memory::DataTypeSizeInfo
   +HasSerializedFormat() const : bool
   +GetNewSamples(F&& receiver, size_t max_num_samples): Result<size_t>
 }
@@ -151,6 +152,7 @@ abstract class "GenericProxyEventBinding" #yellow {
   using Callback = score::cpp::callback<void(SamplePtr<void>) noexcept>
   ..
   +GetSampleSize() const : std::size_t
+  +GetDataTypeSizeInfo() const : memory::DataTypeSizeInfo
   +HasSerializedFormat() const : bool
   +{abstract} GetNewSamples(Callback&&, size_t max_num_samples) = 0: Result<size_t>
 }

--- a/score/mw/com/gateway/gateway_application/gateway_application.cpp
+++ b/score/mw/com/gateway/gateway_application/gateway_application.cpp
@@ -203,9 +203,9 @@ void GatewayApplication::PropagateService(const std::string& specifier_str)
     const auto& event_map = proxy_it->second.GetEvents();
     for (const auto& [event_name, event] : std::as_const(event_map))
     {
-        const auto sample_size = event.GetSampleSize();
-        elements.push_back(
-            score::mw::com::impl::EventInfo{event_name, score::mw::com::impl::DataTypeMetaInfo{sample_size, 0U}});
+        const auto sample_size_info = event.GetDataTypeSizeInfo();
+        elements.push_back(score::mw::com::impl::EventInfo{
+            event_name, score::mw::com::impl::DataTypeMetaInfo{sample_size_info.Size(), sample_size_info.Alignment()}});
     }
 
     auto provide_result = transport_layer_->ProvideService(std::move(specifier_result).value(), std::move(elements));

--- a/score/mw/com/gateway/gateway_application/gateway_application_test.cpp
+++ b/score/mw/com/gateway/gateway_application/gateway_application_test.cpp
@@ -676,6 +676,9 @@ class GatewayApplicationFlowTest : public ::testing::Test
                 ON_CALL(*mock, GetSubscriptionState()).WillByDefault(::testing::Invoke([state]() {
                     return *state;
                 }));
+                // Provide a sensible default DataTypeSizeInfo so PropagateService can build EventInfo
+                ON_CALL(*mock, GetDataTypeSizeInfo())
+                    .WillByDefault(::testing::Return(score::memory::DataTypeSizeInfo{1U, 1U}));
                 ON_CALL(*mock, Subscribe(::testing::_)).WillByDefault(::testing::Invoke([state](std::size_t) {
                     *state = impl::SubscriptionState::kSubscribed;
                     return score::Result<void>{};

--- a/score/mw/com/impl/bindings/lola/generic_proxy_event.cpp
+++ b/score/mw/com/impl/bindings/lola/generic_proxy_event.cpp
@@ -82,6 +82,11 @@ std::size_t GenericProxyEvent::GetSampleSize() const noexcept
     return meta_info_.data_type_info_.Size();
 }
 
+memory::DataTypeSizeInfo GenericProxyEvent::GetDataTypeSizeInfo() const
+{
+    return meta_info_.data_type_info_;
+}
+
 bool GenericProxyEvent::HasSerializedFormat() const noexcept
 {
     // our shared-memory based binding does no serialization at all!

--- a/score/mw/com/impl/bindings/lola/generic_proxy_event.h
+++ b/score/mw/com/impl/bindings/lola/generic_proxy_event.h
@@ -64,6 +64,7 @@ class GenericProxyEvent final : public GenericProxyEventBinding
     Result<std::size_t> GetNumNewSamplesAvailable() const override;
     Result<std::size_t> GetNewSamples(Callback&& receiver, TrackerGuardFactory& tracker) override;
     std::size_t GetSampleSize() const noexcept override;
+    memory::DataTypeSizeInfo GetDataTypeSizeInfo() const override;
     bool HasSerializedFormat() const noexcept override;
 
     Result<void> SetReceiveHandler(std::weak_ptr<ScopedEventReceiveHandler> handler) noexcept override;

--- a/score/mw/com/impl/bindings/lola/generic_proxy_event_test.cpp
+++ b/score/mw/com/impl/bindings/lola/generic_proxy_event_test.cpp
@@ -77,6 +77,25 @@ TEST_F(LolaGenericProxyEventFixture, GetSampleSize)
     EXPECT_EQ(generic_proxy_event_->GetSampleSize(), sizeof(SampleType));
 }
 
+TEST_F(LolaGenericProxyEventFixture, GetDataTypeSizeInfo)
+{
+    RecordProperty("lobster-tracing", "GenericProxyEventGetDataTypeSizeInfo");
+    RecordProperty(
+        "Description",
+        "Checks that GetDataTypeSizeInfo will return the data type size info of the underlying event data type.");
+    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("Priority", "1");
+    RecordProperty("DerivationTechnique", "Analysis of requirements");
+
+    // Given a valid GenericProxyEvent
+    WithAGenericProxyEvent(element_fq_id_, event_name_);
+
+    // Expect, that asking about the Sample size, we get the sizeof the underlying event data type (which is
+    // std::uint32_t in case of LolaProxyEventResources)
+    EXPECT_EQ(generic_proxy_event_->GetDataTypeSizeInfo().Alignment(), alignof(SampleType));
+    EXPECT_EQ(generic_proxy_event_->GetDataTypeSizeInfo().Size(), sizeof(SampleType));
+}
+
 TEST_F(LolaGenericProxyEventFixture, HasSerializedFormat)
 {
     RecordProperty("Verifies", "SCR-14035199");

--- a/score/mw/com/impl/bindings/mock_binding/generic_proxy_event.h
+++ b/score/mw/com/impl/bindings/mock_binding/generic_proxy_event.h
@@ -49,6 +49,7 @@ class GenericProxyEvent : public GenericProxyEventBinding
     MOCK_METHOD(Result<void>, Subscribe, (std::size_t), (noexcept, override));
     MOCK_METHOD(Result<std::size_t>, GetNumNewSamplesAvailable, (), (const, noexcept, override));
     MOCK_METHOD(std::size_t, GetSampleSize, (), (const, noexcept, override));
+    MOCK_METHOD(memory::DataTypeSizeInfo, GetDataTypeSizeInfo, (), (const, noexcept, override));
     MOCK_METHOD(bool, HasSerializedFormat, (), (const, noexcept, override));
     MOCK_METHOD(Result<std::size_t>,
                 GetNewSamples,

--- a/score/mw/com/impl/generic_proxy_event.cpp
+++ b/score/mw/com/impl/generic_proxy_event.cpp
@@ -45,6 +45,14 @@ std::size_t GenericProxyEvent::GetSampleSize() const noexcept
     return proxy_event_binding->GetSampleSize();
 }
 
+memory::DataTypeSizeInfo GenericProxyEvent::GetDataTypeSizeInfo() const
+{
+    auto* const proxy_event_binding = dynamic_cast<GenericProxyEventBinding*>(binding_base_.get());
+    SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(proxy_event_binding != nullptr,
+                                                "Downcast to GenericProxyEventBinding failed!");
+    return proxy_event_binding->GetDataTypeSizeInfo();
+}
+
 bool GenericProxyEvent::HasSerializedFormat() const noexcept
 {
     auto* const proxy_event_binding = dynamic_cast<GenericProxyEventBinding*>(binding_base_.get());

--- a/score/mw/com/impl/generic_proxy_event.h
+++ b/score/mw/com/impl/generic_proxy_event.h
@@ -80,7 +80,11 @@ class GenericProxyEvent : public ProxyEventBase
 
     /// \brief return the (aligned) size in bytes of the underlying event sample data type.
     /// \return size in bytes.
+    [[deprecated("Use GetDataTypeSizeInfo() for size and alignment information, issue #975")]]
     std::size_t GetSampleSize() const noexcept;
+
+    /// \brief return the size and alignment information of the underlying event sample data type.
+    memory::DataTypeSizeInfo GetDataTypeSizeInfo() const;
 
     /// \brief reports, whether the event sample data the SamplePtr<void> points to is in some internal serialized
     ///        format (true) or it is the binary representation of the underlying C++ data type (false).

--- a/score/mw/com/impl/generic_proxy_event_binding.h
+++ b/score/mw/com/impl/generic_proxy_event_binding.h
@@ -52,7 +52,11 @@ class GenericProxyEventBinding : public ProxyEventBindingBase
 
     /// \brief return the (aligned) size in bytes of the underlying event sample data type.
     /// \return size in bytes.
+    [[deprecated("Use GetDataTypeSizeInfo() for size and alignment information, issue #975")]]
     virtual std::size_t GetSampleSize() const noexcept = 0;
+
+    /// \brief return the size and alignment information of the underlying event sample data type.
+    virtual memory::DataTypeSizeInfo GetDataTypeSizeInfo() const = 0;
 
     /// \brief reports, whether the event sample data the SamplePtr<void> points to is in some internal serialized
     ///        format (true) or it is the binary representation of the underlying C++ data type (false).

--- a/score/mw/com/impl/generic_proxy_event_test.cpp
+++ b/score/mw/com/impl/generic_proxy_event_test.cpp
@@ -162,6 +162,33 @@ TEST(GenericProxyEventGetSampleSizeTest, GetSampleSizeDispatchesToBinding)
     EXPECT_EQ(sample_size, expected_sample_size);
 }
 
+TEST(GenericProxyEventGetDataTypeSizeInfoTest, GetDataTypeSizeInfoDispatchesToBinding)
+{
+    RecordProperty("lobster-tracing", "GenericProxyEventGetDataTypeSizeInfo");
+    RecordProperty("Description",
+                   "Checks that GetDataTypeSizeInfo will return the data type size info from the binding");
+    RecordProperty("TestType", "Requirements-based test");
+    RecordProperty("Priority", "1");
+    RecordProperty("DerivationTechnique", "Analysis of requirements");
+
+    const score::memory::DataTypeSizeInfo expected_data_type_size_info{12U, 4U};
+
+    // Given a generic proxy event based on a mock binding
+    auto mock_proxy_event_ptr = std::make_unique<StrictMock<mock_binding::GenericProxyEvent>>();
+    auto& mock_proxy_event = *mock_proxy_event_ptr;
+    GenericProxyEvent proxy_event{kEventName,
+                                  std::unique_ptr<GenericProxyEventBinding>{std::move(mock_proxy_event_ptr)}};
+
+    // Expect that GetDataTypeSizeInfo is called once on the binding
+    EXPECT_CALL(mock_proxy_event, GetDataTypeSizeInfo()).WillOnce(Return(expected_data_type_size_info));
+
+    // When GetDataTypeSizeInfo is called on the proxy_event
+    const auto data_type_size_info = proxy_event.GetDataTypeSizeInfo();
+
+    // Then the data type size info will be the same value returned by the binding
+    EXPECT_EQ(data_type_size_info, expected_data_type_size_info);
+}
+
 TEST(GenericProxyEventHasSerializedFormatTest, HasSerializedFormatDispatchesToBinding)
 {
     RecordProperty("Verifies", "SCR-14035199");


### PR DESCRIPTION
Added API for getting alignment of event data type.
Issue #852 

Also fixed alignment of event data type in GatewayApplication.
Alignment was hardcoded to `0U`, now it is collected from `memory::DataTypeSizeInfo`.
Issue #387 

Documentation updated
- `score/mw/com/dependability/software_architectural_design/mw_com_dii/README.md`
- `score/mw/com/design/skeleton_proxy/generic_proxy/generic_proxy_model.puml`

Implementation extended:
- `score/mw/com/gateway/gateway_application/gateway_application.cpp`
- `score/mw/com/impl/bindings/lola/generic_proxy_event.cpp`
- `score/mw/com/impl/bindings/lola/generic_proxy_event.h`
- `score/mw/com/impl/generic_proxy_event.cpp`
- `score/mw/com/impl/generic_proxy_event.h`
- `score/mw/com/impl/generic_proxy_event_binding.h`

Tests updated:

- `score/mw/com/impl/bindings/lola/generic_proxy_event_test.cpp`
- `score/mw/com/impl/bindings/mock_binding/generic_proxy_event.h`
- `score/mw/com/impl/generic_proxy_event_test.cpp`

