### PR TITLE
message_passing: one way communication integration tests

### DIFF
--- a/score/message_passing/test/client_server_communication_one_way/BUILD
+++ b/score/message_passing/test/client_server_communication_one_way/BUILD
@@ -1,0 +1,65 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@score_baselibs//score/language/safecpp:toolchain_features.bzl", "COMPILER_WARNING_FEATURES")
+load("//bazel/tools:json_schema_validator.bzl", "validate_json_schema_test")
+load("//score/mw/com/test:pkg_application.bzl", "pkg_application")
+
+cc_library(
+    name = "common_resources",
+    srcs = ["common_resources.cpp"],
+    hdrs = ["common_resources.h"],
+    features = COMPILER_WARNING_FEATURES,
+    deps = ["//score/message_passing"],
+)
+
+cc_binary(
+    name = "client",
+    srcs = ["client.cpp"],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        ":common_resources",
+        "//score/message_passing",
+        "@score_baselibs//score/string_manipulation/arguments",
+    ],
+)
+
+cc_binary(
+    name = "server",
+    srcs = ["server.cpp"],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        ":common_resources",
+        "//score/message_passing",
+        "@score_baselibs//score/string_manipulation/arguments",
+    ],
+)
+
+pkg_application(
+    name = "client-pkg",
+    app_name = "ClientApp",
+    bin = [":client"],
+    visibility = [
+        "//score/message_passing/test/client_server_communication_one_way:__subpackages__",
+    ],
+)
+
+pkg_application(
+    name = "server-pkg",
+    app_name = "ServerApp",
+    bin = [":server"],
+    visibility = [
+        "//score/message_passing/test/client_server_communication_one_way:__subpackages__",
+    ],
+)

--- a/score/message_passing/test/client_server_communication_one_way/client.cpp
+++ b/score/message_passing/test/client_server_communication_one_way/client.cpp
@@ -1,0 +1,85 @@
+#include "score/message_passing/client_factory.h"
+#include "score/message_passing/test/client_server_communication_one_way/common_resources.h"
+
+#include "score/string_manipulation/arguments/arguments.h"
+
+#include <score/span.hpp>
+
+#include <unistd.h>
+#include <chrono>
+#include <iostream>
+#include <thread>
+
+namespace
+{
+constexpr std::uint32_t kStateTryAttempts{10U};
+constexpr std::chrono::milliseconds kStateRetryDelay{50};
+}  // namespace
+
+int main(int argc, const char** argv)
+{
+    char message_char{};
+    if (argc > 1)
+    {
+        auto args = score::string_manipulation::GetArguments(argc, argv);
+        message_char = args[1].at(0);
+    }
+    else
+    {
+        std::cout << "A message charachter needs to be provided. This is the charachter that will be transmitted."
+                  << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "Hello from client!" << std::endl;
+    score::message_passing::ClientFactory factory;
+    const score::message_passing::IClientFactory::ClientConfig client_config{0U, 20U, false, true, false};
+
+    auto client_ptr = factory.Create(score::message_passing::test::kTestServiceProtocolConfig, client_config);
+
+    auto state_callback = [](score::message_passing::IClientConnection::State state) {
+        std::cout << "Client state changed: " << static_cast<int>(state) << std::endl;
+    };
+
+    auto notify_callback = [](score::cpp::span<const std::uint8_t> message) {
+        std::cout << "Received notify from server: " << std::endl;
+        for (const auto& byte : message)
+        {
+            std::cout << std::hex << static_cast<int>(byte) << " ";
+        }
+        std::cout << std::dec << std::endl;
+    };
+
+    client_ptr->Start(state_callback, notify_callback);
+
+    for (std::uint32_t try_attempt{0U}; try_attempt < kStateTryAttempts; ++try_attempt)
+    {
+        const auto state = client_ptr->GetState();
+        if (state == score::message_passing::IClientConnection::State::kReady)
+        {
+            std::cout << "Client: Connection is ready!\n" << std::endl;
+            break;
+        }
+        if (state != score::message_passing::IClientConnection::State::kStarting)
+        {
+
+            std::cout << "Client: Connection for " << score::message_passing::test::service_identifier
+                      << " has failed to create, the reason is "
+                      << static_cast<std::uint32_t>(score::cpp::to_underlying(client_ptr->GetStopReason()))
+                      << std::endl;
+
+            return EXIT_FAILURE;
+        }
+        std::this_thread::sleep_for(kStateRetryDelay);
+    }
+
+    std::cout << "Client created successfully!" << std::endl;
+
+    std::array<std::uint8_t, score::message_passing::test::kMaxSendSize> message_to_send{
+        static_cast<unsigned char>(message_char)};
+
+    client_ptr->Send(message_to_send);
+    std::cout << "Client: Message sent!" << std::endl;
+
+    return EXIT_SUCCESS;
+}

--- a/score/message_passing/test/client_server_communication_one_way/common_resources.cpp
+++ b/score/message_passing/test/client_server_communication_one_way/common_resources.cpp
@@ -1,0 +1,1 @@
+#include "score/message_passing/test/client_server_communication_one_way/common_resources.h"

--- a/score/message_passing/test/client_server_communication_one_way/common_resources.h
+++ b/score/message_passing/test/client_server_communication_one_way/common_resources.h
@@ -1,0 +1,20 @@
+#ifndef SCORE_MESSAGE_PASSING_TEST_CLIENT_SERVER_COMMUNICATION_ONE_WAY_COMMON_RESOURCES_H
+#define SCORE_MESSAGE_PASSING_TEST_CLIENT_SERVER_COMMUNICATION_ONE_WAY_COMMON_RESOURCES_H
+#include "score/message_passing/service_protocol_config.h"
+
+namespace score::message_passing::test
+{
+
+constexpr std::string_view service_identifier{"test_server"};
+// we only send and receive one byte for in this tests
+constexpr std::uint32_t kMaxSendSize{1U};
+constexpr std::uint32_t kMaxReplySize{1U};
+
+const score::message_passing::ServiceProtocolConfig kTestServiceProtocolConfig{service_identifier,
+                                                                               kMaxSendSize,
+                                                                               kMaxReplySize,
+                                                                               0U};
+
+}  // namespace score::message_passing::test
+
+#endif  // SCORE_MESSAGE_PASSING_TEST_CLIENT_SERVER_COMMUNICATION_ONE_WAY_COMMON_RESOURCES_H

--- a/score/message_passing/test/client_server_communication_one_way/integration_test/BUILD
+++ b/score/message_passing/test/client_server_communication_one_way/integration_test/BUILD
@@ -1,0 +1,47 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
+load("//quality/integration_testing:integration_testing.bzl", "integration_test")
+
+pkg_filegroup(
+    name = "filesystem",
+    srcs = [
+        "//score/message_passing/test/client_server_communication_one_way:client-pkg",
+        "//score/message_passing/test/client_server_communication_one_way:server-pkg",
+    ],
+)
+
+integration_test(
+    name = "client_server_communication_one_way_test",
+    srcs = [
+        "client_server_communication_one_way_test.py",
+    ],
+    filesystem = ":filesystem",
+)
+
+integration_test(
+    name = "too_many_servers_test",
+    srcs = [
+        "too_many_servers_test.py",
+    ],
+    filesystem = ":filesystem",
+)
+
+integration_test(
+    name = "misconfigured_client_test",
+    srcs = [
+        "misconfigured_client_test.py",
+    ],
+    filesystem = ":filesystem",
+)

--- a/score/message_passing/test/client_server_communication_one_way/integration_test/client_server_communication_one_way_test.py
+++ b/score/message_passing/test/client_server_communication_one_way/integration_test/client_server_communication_one_way_test.py
@@ -1,0 +1,36 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+
+"""
+This is a baseline test which demonstrates the one way communication between a server and a client.
+"""
+
+MESSAGE_CHAR = "1"
+
+
+def client(target, **kwargs):
+    args = [MESSAGE_CHAR]
+    return target.wrap_exec("bin/client", args, cwd="/opt/ClientApp", wait_on_exit=True, **kwargs)
+
+
+def server(target, **kwargs):
+    expecting_message = "1"
+    server_id = "Server"
+    args = [MESSAGE_CHAR, expecting_message, server_id]
+    return target.wrap_exec("bin/server", args, cwd="/opt/ServerApp", wait_on_exit=True, **kwargs)
+
+
+def test_main(target):
+    with client(target, wait_timeout=120), server(target, wait_timeout=120):
+        pass

--- a/score/message_passing/test/client_server_communication_one_way/integration_test/misconfigured_client_test.py
+++ b/score/message_passing/test/client_server_communication_one_way/integration_test/misconfigured_client_test.py
@@ -1,0 +1,51 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+
+"""
+The goal of this test is to demonstrate a failiure mode.
+a misconfigured client, which is running at a time when it shouldn't may cause the server to receive a message and react
+to it, instead of reacting to the message of the correctly configured client.
+"""
+
+
+def client(target, **kwargs):
+    message_char = "a"
+    args = [message_char]
+    return target.wrap_exec("bin/client", args, cwd="/opt/ClientApp", wait_on_exit=True, **kwargs)
+
+
+def misconfigured_client(target, **kwargs):
+    """
+    misconfigured_client in this case referres to the fact that the client runs when it should not be running, and not
+    to the message it sends.
+    for the purposes of this thest this client will send exactly the message that the server is expecting (but not from
+    this client)
+    """
+    message_char = "b"
+    args = [message_char]
+    return target.wrap_exec("bin/client", args, cwd="/opt/ClientApp", wait_on_exit=True, **kwargs)
+
+
+def server(target, **kwargs):
+    expected_message_char = "b"
+    expecting_message = "1"
+    server_id = "Server"
+    args = [expected_message_char, expecting_message, server_id]
+    return target.wrap_exec("bin/server", args, cwd="/opt/ServerApp", wait_on_exit=True, **kwargs)
+
+
+def test_main(target):
+    # this test confirms the failiure mode that a misconfigured client can send communication before the intended client
+    with server(target, wait_timeout=120), misconfigured_client(target, wait_timeout=120), client(target, wait_timeout=120):
+        pass

--- a/score/message_passing/test/client_server_communication_one_way/integration_test/too_many_servers_test.py
+++ b/score/message_passing/test/client_server_communication_one_way/integration_test/too_many_servers_test.py
@@ -1,0 +1,46 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+"""
+The goal of this test is to demonstrate a failiure mode.
+
+An unwanted server which is running at a time when it shouldn't and has the same service_identifier as the intended
+server, may intercept the communication from the client and react to it in an arbitrary way.
+"""
+
+MESSAGE_CHAR = "1"
+
+
+def client(target, **kwargs):
+    args = [MESSAGE_CHAR]
+    return target.wrap_exec("bin/client", args, cwd="/opt/ClientApp", wait_on_exit=True, **kwargs)
+
+
+def server(target, **kwargs):
+    expecting_message = "0"
+    server_id = "Server"
+    args = [MESSAGE_CHAR, expecting_message, server_id]
+    return target.wrap_exec("bin/server", args, cwd="/opt/ServerApp", wait_on_exit=True, **kwargs)
+
+
+def unwanted_server(target, **kwargs):
+    expecting_message = "1"
+    server_id = "Unwanted Server"
+    args = [MESSAGE_CHAR, expecting_message, server_id]
+    return target.wrap_exec("bin/server", args, cwd="/opt/ServerApp", wait_on_exit=True, **kwargs)
+
+
+# gToDo: this test needs to succeed if the normal sever fails to connect
+def test_main(target):
+    with client(target), unwanted_server(target), server(target):
+        pass

--- a/score/message_passing/test/client_server_communication_one_way/server.cpp
+++ b/score/message_passing/test/client_server_communication_one_way/server.cpp
@@ -1,0 +1,147 @@
+#include "score/message_passing/test/client_server_communication_one_way/common_resources.h"
+
+#include "score/message_passing/server_factory.h"
+#include "score/message_passing/server_types.h"
+
+#include "score/string_manipulation/arguments/arguments.h"
+
+#include <atomic>
+#include <chrono>
+#include <cstdlib>
+#include <iostream>
+#include <thread>
+
+int main(int argc, const char** argv)
+{
+    char message_char{};
+    bool expecting_message{};
+    std::string server_id;
+
+    if (argc > 3)
+    {
+        auto args = score::string_manipulation::GetArguments(argc, argv);
+        message_char = args[1].at(0);
+        expecting_message = static_cast<bool>(args[2].at(0));
+        server_id = std::string{args.at(3)};
+    }
+    else
+    {
+        std::cout << "All three arguments need to be provided.\n"
+                     "1. A message charachter that will be compared to the received charachter.\n"
+                     "2. A boolean value (0 or 1) indicating whether the server is expecting a message or not.\n"
+                     "3. A string identifier for the server instance."
+                  << std::endl;
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "Hello from server!" << std::endl;
+
+    const score::message_passing::ServerFactory::ServerConfig server_config{10, 1, 5};
+
+    score::message_passing::ServerFactory factory;
+    auto server_ptr = factory.Create(score::message_passing::test::kTestServiceProtocolConfig, server_config);
+
+    std::cout << server_id << " created successfully!" << std::endl;
+
+    using score::message_passing::ConnectCallback;
+
+    std::atomic_bool wait_for_connection = false;
+    auto connect_callback = [&wait_for_connection,
+                             &server_id](score::message_passing::IServerConnection& /*connection*/) {
+        std::cout << server_id << ": Client connected!" << std::endl;
+
+        wait_for_connection = true;
+        return nullptr;
+    };
+
+    bool stop_listening = false;
+    int exit_code = EXIT_SUCCESS;
+
+    struct ServerState
+    {
+        std::string server_id;
+        bool expecting_message;
+        char message_char;
+        bool& stop_listening;
+        int& exit_code;
+
+    } state{server_id, expecting_message, message_char, stop_listening, exit_code};
+
+    score::message_passing::MessageCallback message_callback =
+        [&state](score::message_passing::IServerConnection& /*connection*/,
+                 score::cpp::span<const std::uint8_t> message) {
+            std::cout << state.server_id << ": Received message from client: ";
+            for (const auto& byte : message)
+            {
+                std::cout << std::hex << static_cast<char>(byte) << " ";
+            }
+
+            std::cout << std::dec << std::endl;
+
+            state.stop_listening = true;
+            if (!state.expecting_message)
+            {
+                std::cout << state.server_id << ": unexpectedly received a message." << std::endl;
+                state.exit_code = EXIT_FAILURE;
+                return score::cpp::expected_blank<score::os::Error>{};
+            }
+
+            if (message[0] != static_cast<std::uint8_t>(state.message_char))
+            {
+                std::cout << state.server_id << ": Received a wrong message. Expected: " << state.message_char
+                          << ", but got: " << static_cast<char>(message[0]) << std::endl;
+                state.exit_code = EXIT_FAILURE;
+            }
+            return score::cpp::expected_blank<score::os::Error>{};
+        };
+    // score::message_passing::DisconnectCallback{};
+    auto disconnect_callback = [&server_id](score::message_passing::IServerConnection& /*connection*/) {
+        std::cout << server_id << ": disconnect Callback" << std::endl;
+        return;
+    };
+
+    server_ptr->StartListening(std::move(connect_callback),
+                               std::move(disconnect_callback),
+                               std::move(message_callback),
+                               score::message_passing::MessageCallback{});
+
+    constexpr auto per_loop_wait_time = std::chrono::milliseconds(10U);
+    constexpr auto long_wait = std::chrono::milliseconds(5000);
+    constexpr auto short_wait = std::chrono::milliseconds(500);
+    const auto wait_time = expecting_message ? long_wait : short_wait;
+
+    auto now = []() {
+        return std::chrono::high_resolution_clock::now();
+    };
+
+    auto not_exceeded_wait_time = [wait_time](std::chrono::high_resolution_clock::time_point start_time,
+                                              std::chrono::high_resolution_clock::time_point now_time) {
+        return std::chrono::duration_cast<std::chrono::milliseconds>(now_time - start_time) < wait_time;
+    };
+
+    for (auto start_time = now(), now_time = now(); not_exceeded_wait_time(start_time, now_time); now_time = now())
+    {
+        if (!wait_for_connection)
+        {
+            break;
+        }
+
+        std::cout << server_id << ": Waiting for client to connect..." << std::endl;
+        std::this_thread::sleep_for(per_loop_wait_time);
+    }
+
+    for (auto start_time = now(), now_time = now(); not_exceeded_wait_time(start_time, now_time); now_time = now())
+    {
+        if (!stop_listening)
+        {
+            break;
+        }
+        std::cout << server_id << ": Waiting for Incoming message..." << std::endl;
+        std::this_thread::sleep_for(per_loop_wait_time);
+    }
+
+    server_ptr->StopListening();
+    std::cout << server_id << ": stopped listening..." << std::endl;
+
+    return EXIT_SUCCESS;
+}


### PR DESCRIPTION
The goal of these tests is to perform simple message_passing behavior and validate liveness, or validate failure modes (depending on if the test is positive or negative)