### PR TITLE
mw/com: expose public assumptions_of_use target for safety analysis AoUs

### DIFF
--- a/score/mw/com/dependability/BUILD
+++ b/score/mw/com/dependability/BUILD
@@ -15,7 +15,9 @@ load("@score_tooling//bazel/rules/rules_score:rules_score.bzl", "dependable_elem
 dependable_element(
     name = "mw_com",
     architectural_design = ["//score/mw/com/dependability/software_architectural_design/static_design:software_architectural_design"],
-    assumptions_of_use = [],
+    assumptions_of_use = [
+        "//score/mw/com/dependability/safety_analysis:assumptions_of_use",
+    ],
     components = [
         "//score/mw/com/impl:frontend_component",
         "//score/mw/com/impl/bindings",

--- a/score/mw/com/dependability/safety_analysis/BUILD
+++ b/score/mw/com/dependability/safety_analysis/BUILD
@@ -13,6 +13,7 @@
 
 load(
     "@score_tooling//bazel/rules/rules_score:rules_score.bzl",
+    "assumptions_of_use",
     "fmea",
 )
 
@@ -31,8 +32,14 @@ filegroup(
 fmea(
     name = "mw_com_fmea",
     arch_design = "//score/mw/com/dependability/software_architectural_design/static_design:software_architectural_design",
-    controlmeasures = ["aou.trlc"],
+    controlmeasures = [":assumptions_of_use"],
     failuremodes = ["failure_modes.trlc"],
     root_causes = [":root_causes"],
     visibility = ["//score/mw/com/dependability:__subpackages__"],
+)
+
+assumptions_of_use(
+    name = "assumptions_of_use",
+    srcs = ["aou.trlc"],
+    visibility = ["//visibility:public"],
 )


### PR DESCRIPTION
Adds a public assumptions_of_use Bazel target wrapping aou.trlc under score/mw/com/dependability/safety_analysis