### PR TITLE
Fix serialization and deserialization for ProvideServiceRequest in Gateway

### DIFF
--- a/score/mw/com/gateway/transport_layer/sample/messages/serialization.h
+++ b/score/mw/com/gateway/transport_layer/sample/messages/serialization.h
@@ -20,6 +20,7 @@
 #include <cstring>
 #include <limits>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <type_traits>
 #include <vector>
@@ -49,6 +50,30 @@ struct is_std_string<std::string> : std::true_type
 {
 };
 
+// Helper to detect std::string_view
+template <typename T>
+struct is_std_string_view : std::false_type
+{
+};
+
+template <>
+struct is_std_string_view<std::string_view> : std::true_type
+{
+};
+
+// Helper to detect types that opt into member-wise (de)serialization via GetSerializeMembers(),
+// so they are not accidentally routed to a raw memcpy just because they happen to be trivially
+// copyable (e.g. a struct holding a std::string_view).
+template <typename T, typename = void>
+struct has_get_serialize_members : std::false_type
+{
+};
+
+template <typename T>
+struct has_get_serialize_members<T, std::void_t<decltype(std::declval<T&>().GetSerializeMembers())>> : std::true_type
+{
+};
+
 // Tag types for dispatch
 struct trivially_copyable_tag
 {
@@ -57,6 +82,9 @@ struct std_vector_tag
 {
 };
 struct std_string_tag
+{
+};
+struct std_string_view_tag
 {
 };
 struct non_trivial_tag
@@ -70,6 +98,14 @@ constexpr auto serialization_tag()
     if constexpr (is_std_string<std::decay_t<T>>::value)
     {
         return std_string_tag{};
+    }
+    else if constexpr (is_std_string_view<std::decay_t<T>>::value)
+    {
+        return std_string_view_tag{};
+    }
+    else if constexpr (has_get_serialize_members<T>::value)
+    {
+        return non_trivial_tag{};
     }
     else if constexpr (std::is_trivially_copyable_v<T>)
     {
@@ -147,6 +183,28 @@ score::Result<uint32_t> Serialize(const T& string, score::cpp::span<std::byte> t
     // NOLINTNEXTLINE(bugprone-suspicious-stringview-data-usage): This is no string_view.
     std::memcpy(target_buffer.data(), string.data(), string.size());
     std::memset(&target_buffer[string.size()], 0, 1U);
+    return static_cast<uint32_t>(required_size);
+}
+
+/**
+ * @brief Serialize implementation for std::string_view.
+ * @details See above in the main Serialize function. Uses the same wire format as std::string: the
+ * viewed characters followed by a null terminator. Necessary because std::string_view is trivially
+ * copyable as an object (pointer + length), which would otherwise cause it to be serialized as a raw
+ * copy of the pointer/length rather than of the characters it views.
+ */
+template <typename T>
+score::Result<uint32_t> Serialize(const T& string_view_value,
+                                  score::cpp::span<std::byte> target_buffer,
+                                  std_string_view_tag)
+{
+    const auto required_size = string_view_value.size() + 1U;
+    if (target_buffer.size() < required_size)
+    {
+        return score::MakeUnexpected(score::mw::com::gateway::MessageErrorc::kBufferTooSmall);
+    }
+    std::memcpy(target_buffer.data(), string_view_value.data(), string_view_value.size());
+    std::memset(&target_buffer[string_view_value.size()], 0, 1U);
     return static_cast<uint32_t>(required_size);
 }
 
@@ -254,6 +312,12 @@ std::size_t ComputeSerializedSize(const T& value, std_string_tag)
 }
 
 template <typename T>
+std::size_t ComputeSerializedSize(const T& value, std_string_view_tag)
+{
+    return value.size() + 1U;
+}
+
+template <typename T>
 std::size_t ComputeSerializedSize(const T&, trivially_copyable_tag)
 {
     return sizeof(T);
@@ -304,6 +368,28 @@ score::Result<uint32_t> Deserialize(T& target_string, score::cpp::span<const std
         return score::MakeUnexpected(score::mw::com::gateway::MessageErrorc::kPayloadInvalid);
     }
     target_string.assign(string_start, string_len);
+    return static_cast<uint32_t>(string_len + 1U);
+}
+
+/**
+ * @brief Deserialize implementation for std::string_view.
+ * @details See above in the main Deserialize function. Unlike std::string, std::string_view cannot own a copy of
+ * the data, so the deserialized view points back into source_buffer; the caller is responsible for keeping the
+ * buffer alive for as long as the view is used.
+ */
+template <typename T>
+score::Result<uint32_t> Deserialize(T& target_string_view,
+                                    score::cpp::span<const std::byte> source_buffer,
+                                    std_string_view_tag)
+{
+    auto string_start = reinterpret_cast<const char*>(source_buffer.data());
+    const auto string_len = strnlen(string_start, source_buffer.size());
+    const auto remaining_size = source_buffer.size();
+    if (string_len == remaining_size || string_len == 0)
+    {
+        return score::MakeUnexpected(score::mw::com::gateway::MessageErrorc::kPayloadInvalid);
+    }
+    target_string_view = T(string_start, string_len);
     return static_cast<uint32_t>(string_len + 1U);
 }
 

--- a/score/mw/com/gateway/transport_layer/sample/messages/serialization_test.cpp
+++ b/score/mw/com/gateway/transport_layer/sample/messages/serialization_test.cpp
@@ -135,6 +135,71 @@ TEST(SerializationTest, SerializeAndDeserializeVectorOfStringsProducesOriginalVa
     EXPECT_EQ(out, original);
 }
 
+TEST(SerializationTest, SerializeAndDeserializeVectorOfEventInfoProducesOriginalValues)
+{
+    // Expected values captured as independent std::strings, not string_views --
+    // so the final comparison can't accidentally succeed by reading through a
+    // stale/dangling view into memory we're about to free.
+    const std::string kExpectedSpeedName = "SpeedEvent_LongEnoughToDefeatSSO_AAAAAAAAAA";
+    const std::string kExpectedBrakeName = "BrakeEvent_LongEnoughToDefeatSSO_BBBBBBBBBB";
+    const impl::DataTypeMetaInfo kExpectedSpeedMeta{64U, 8U};
+    const impl::DataTypeMetaInfo kExpectedBrakeMeta{32U, 4U};
+
+    std::array<std::byte, 256> buf{};
+    score::Result<uint32_t> written;
+    score::Result<uint32_t> consumed;
+    std::vector<impl::EventInfo> out;
+
+    {
+        // Heap-allocate the source strings explicitly (not literals, not SSO-sized)
+        // so their backing memory is a real, freeable heap block, and so we control
+        // exactly when it's destroyed.
+        auto speed_name = std::make_unique<std::string>(kExpectedSpeedName);
+        auto brake_name = std::make_unique<std::string>(kExpectedBrakeName);
+
+        std::vector<impl::EventInfo> original = {{std::string_view(*speed_name), kExpectedSpeedMeta},
+                                                 {std::string_view(*brake_name), kExpectedBrakeMeta}};
+
+        written = Serialize(original, score::cpp::span<std::byte>(buf.data(), buf.size()));
+        ASSERT_TRUE(written.has_value());
+
+        // original's string_views are only needed until Serialize() has copied
+        // their bytes into buf -- drop the vector now.
+        original.clear();
+        original.shrink_to_fit();
+
+        // Poison and free the actual string backing memory original's
+        // string_views pointed at, BEFORE Deserialize is even called.
+        std::memset(speed_name->data(), 0xCD, speed_name->size());
+        std::memset(brake_name->data(), 0xCD, brake_name->size());
+        speed_name.reset();
+        brake_name.reset();
+
+        // Nudge the allocator into reusing those freed blocks with different
+        // content, so an accidental dependency on the old memory is more likely
+        // to surface as a wrong value instead of coincidentally-correct leftovers.
+        std::vector<std::unique_ptr<std::string>> heap_pressure;
+        heap_pressure.reserve(64);
+        for (int i = 0; i < 64; ++i)
+        {
+            heap_pressure.push_back(std::make_unique<std::string>(kExpectedSpeedName.size(), 'X'));
+        }
+
+        // Deserialize now runs with the original source strings already gone --
+        // out[i].name can only be valid if it was built from buf, not from them.
+        consumed = Deserialize(out, score::cpp::span<const std::byte>(buf.data(), written.value()));
+    }
+
+    ASSERT_TRUE(consumed.has_value());
+    ASSERT_EQ(out.size(), 2U);
+    EXPECT_EQ(out[0].name, kExpectedSpeedName);
+    EXPECT_EQ(out[1].name, kExpectedBrakeName);
+    EXPECT_EQ(out[0].data_type_meta_info.size, kExpectedSpeedMeta.size);
+    EXPECT_EQ(out[0].data_type_meta_info.alignment, kExpectedSpeedMeta.alignment);
+    EXPECT_EQ(out[1].data_type_meta_info.size, kExpectedBrakeMeta.size);
+    EXPECT_EQ(out[1].data_type_meta_info.alignment, kExpectedBrakeMeta.alignment);
+}
+
 TEST(SerializationTest, VectorSerializeAndDeserializeFailWhenBufferTooSmallForHeader)
 {
     const std::vector<std::uint32_t> original = {1U};

--- a/score/mw/com/impl/generic_skeleton.h
+++ b/score/mw/com/impl/generic_skeleton.h
@@ -25,6 +25,7 @@
 
 #include <memory>
 #include <string_view>
+#include <tuple>
 
 namespace score::mw::com::impl
 {
@@ -33,6 +34,16 @@ struct EventInfo
 {
     std::string_view name;
     DataTypeMetaInfo data_type_meta_info;
+
+    /// @brief Members to be (de)serialized by score::mw::com::gateway serialization, in order.
+    std::tuple<const std::string_view&, const DataTypeMetaInfo&> GetSerializeMembers() const
+    {
+        return {name, data_type_meta_info};
+    }
+    std::tuple<std::string_view&, DataTypeMetaInfo&> GetSerializeMembers()
+    {
+        return {name, data_type_meta_info};
+    }
 };
 
 struct GenericSkeletonServiceElementInfo


### PR DESCRIPTION
The problem was with the deserialization of the field of type` score::mw::com::impl::EventInfo` and its `std::string_view` field name:

```
struct EventInfo
{
    std::string_view name;
    DataTypeMetaInfo data_type_meta_info;
};
```

std::string_view is essentially a pointer into a string, so its (de)serialization requires the string's value to be copied, not just the pointer.

Implementation extended:

- `score/mw/com/gateway/transport_layer/sample/messages/BUILD`
- `score/mw/com/gateway/transport_layer/sample/messages/serialization.h`

Unit tests extended:

- ` score/mw/com/gateway/transport_layer/sample/messages/serialization.h`

Issue #387 