### PR TITLE
Drop Bazel 8.5.1 from support window

### DIFF
--- a/quality/dependency_compatibility_checker/config.yaml
+++ b/quality/dependency_compatibility_checker/config.yaml
@@ -17,7 +17,6 @@
 dependencies:
   bazel:                       # special: drives USE_BAZEL_VERSION, not a MODULE dep
     versions:
-      - version: "8.5.1"
       - version: "8.6.0"
       - version: "8.7.0"
       - version: "9.0.2"


### PR DESCRIPTION
Bazel 8.5.1 relies on compatibility_level checks
in bzlmod dependency resolution.
Many of our dependencies do no longer update the
compatibility_level correctly.
This breaks the build fully and irreversible.

Thus, we drop Bazel 8.5.1 from our support window.