### PR TITLE
feat(docs): add clickable_plantuml sphinx extension

### DIFF
--- a/bazel/toolchains/template/conf.template.py
+++ b/bazel/toolchains/template/conf.template.py
@@ -42,6 +42,7 @@ extensions = [
     "sphinx_design",
     "myst_parser",
     "sphinxcontrib.plantuml",
+    "clickable_plantuml",
     "breathe",
     "trlc",
 ]


### PR DESCRIPTION
Added the clickable_plantuml extension to the Sphinx configuration template, enabling PlantUML diagrams in the generated documentation to be interactive/clickable.