### PR TITLE
Add Feature Requirements, Architecture Design, and Dependable Element Wiring for score/memory

### DIFF
--- a/score/memory/dependability/BUILD
+++ b/score/memory/dependability/BUILD
@@ -1,0 +1,111 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load(
+    "@score_tooling//bazel/rules/rules_score:rules_score.bzl",
+    "component",
+    "dependable_element",
+)
+
+component(
+    name = "shared_memory_management",
+    components = [
+        "//score/memory/shared:managed_memory_resource_unit",
+        "//score/memory/shared:shared_memory_factory_unit",
+        "//score/memory/shared:shared_memory_resource_unit",
+        "//score/memory/shared:memory_resource_registry_unit",
+    ],
+    tags = ["manual"],
+    target_compatible_with = ["@platforms//os:linux"],
+    tests = [],
+)
+
+component(
+    name = "offset_pointer",
+    components = [
+        "//score/memory/shared:offset_ptr_unit",
+        "//score/memory/shared:polymorphic_offset_ptr_allocator_unit",
+    ],
+    tags = ["manual"],
+    target_compatible_with = ["@platforms//os:linux"],
+    tests = [],
+)
+
+component(
+    name = "shared_memory_containers",
+    components = [
+        "//score/memory/shared:containers_unit",
+    ],
+    tags = ["manual"],
+    target_compatible_with = ["@platforms//os:linux"],
+    tests = [],
+)
+
+component(
+    name = "shared_memory_synchronization",
+    components = [
+        "//score/memory/shared:flock_mutex_unit",
+    ],
+    tags = ["manual"],
+    target_compatible_with = ["@platforms//os:linux"],
+    tests = [],
+)
+
+component(
+    name = "typed_and_sealed_memory",
+    components = [
+        "//score/memory/shared:sealed_shared_memory_unit",
+        "//score/memory/shared:typed_memory_unit",
+    ],
+    tags = ["manual"],
+    target_compatible_with = ["@platforms//os:linux"],
+    tests = [],
+)
+
+component(
+    name = "component_memory",
+    components = [
+        ":offset_pointer",
+        ":shared_memory_containers",
+        ":shared_memory_management",
+        ":shared_memory_synchronization",
+        ":typed_and_sealed_memory",
+    ],
+    tags = ["manual"],
+    target_compatible_with = ["@platforms//os:linux"],
+    tests = [],
+)
+
+dependable_element(
+    name = "dependable_element_memory",
+    architectural_design = ["//score/memory/dependability/software_architectural_design:memory_architectural_design"],
+    assumptions_of_use = [],
+    components = [":component_memory"],
+    # No FMEA/FMEDA/FTA/DFA has been authored yet for score/memory; this is a
+    # documented follow-up once the dependability analysis is available.
+    dependability_analysis = [],
+    integrity_level = "B",
+    maturity = "development",
+    requirements = [
+        "//score/memory/dependability/assumed_system:assumed_system_requirements",
+        "//score/memory/dependability/requirements:feature_requirements",
+    ],
+    tags = ["manual"],
+    target_compatible_with = ["@platforms//os:linux"],
+    tests = [],
+    visibility = ["//visibility:public"],
+    deps = [
+        "//third_party/score_baselibs:futurecpp",
+        "//third_party/score_baselibs:os",
+    ],
+)

--- a/score/memory/dependability/assumed_system/BUILD
+++ b/score/memory/dependability/assumed_system/BUILD
@@ -1,0 +1,24 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load(
+    "@score_tooling//bazel/rules/rules_score:rules_score.bzl",
+    "assumed_system_requirements",
+)
+
+assumed_system_requirements(
+    name = "assumed_system_requirements",
+    srcs = ["assumed_system_requirements.trlc"],
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//score/memory/dependability:__subpackages__"],
+)

--- a/score/memory/dependability/assumed_system/assumed_system_requirements.trlc
+++ b/score/memory/dependability/assumed_system/assumed_system_requirements.trlc
@@ -1,0 +1,34 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+package ScoreMemory
+
+import ScoreReq
+
+///////////////////////////////
+// Assumed System Requirements
+// System level requirements for ScoreMemory SEooC
+///////////////////////////////
+
+ScoreReq.AssumedSystemReq SharedMemoryIPC {
+    description = "The system shall provide a mechanism for inter-process shared memory that allows multiple processes to exchange data through a common memory region, compliant with the selected :term:`integrity level`."
+    safety = ScoreReq.Asil.B
+    rationale = "Middleware components (e.g. ara::com) require a shared memory abstraction to enable zero-copy inter-process communication while satisfying ISO-26262 safety requirements."
+    version = 1
+}
+
+ScoreReq.Mitigation SafeState {
+    description = "The Safe State of the system shall be *safe-silent*."
+    safety = ScoreReq.Asil.B
+    rationale = "Only fail-safe systems are in scope; on unrecoverable error the component shall stop producing output."
+    version = 1
+}

--- a/score/memory/dependability/requirements/BUILD
+++ b/score/memory/dependability/requirements/BUILD
@@ -1,0 +1,36 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load(
+    "@score_tooling//bazel/rules/rules_score:rules_score.bzl",
+    "feature_requirements",
+)
+load(
+    "@score_tooling//validation/ai_checker:ai_checker.bzl",
+    "trlc_requirements_ai_test",
+)
+
+feature_requirements(
+    name = "feature_requirements",
+    srcs = ["feature_requirements.trlc"],
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//score/memory/dependability:__subpackages__"],
+    deps = ["//score/memory/dependability/assumed_system:assumed_system_requirements"],
+)
+
+trlc_requirements_ai_test(
+    name = "feature_requirements_ai_check",
+    batch_size = 10,
+    reqs = [":feature_requirements"],
+    tags = ["manual"],
+)

--- a/score/memory/dependability/requirements/feature_requirements.trlc
+++ b/score/memory/dependability/requirements/feature_requirements.trlc
@@ -1,0 +1,118 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+package ScoreMemory
+
+import ScoreReq
+
+///////////////////////////////
+// Feature Requirements
+// Integration level requirements derived from Assumed System Requirements
+///////////////////////////////
+
+ScoreReq.FeatReq TransparentMemoryAbstraction {
+    description = "The memory component shall provide an abstraction layer over shared memory and heap allocation that is fully transparent to the caller."
+    safety = ScoreReq.Asil.B
+    derived_from = [ScoreMemory.SharedMemoryIPC@1]
+    version = 1
+}
+
+ScoreReq.FeatReq PolymorphicAllocationAcrossResourceKinds {
+    description = "The memory component shall support polymorphic allocation of a data type either in shared memory or on the heap, decided at runtime, without requiring the caller to change the pointer type used to access the data."
+    safety = ScoreReq.Asil.B
+    derived_from = [ScoreMemory.SharedMemoryIPC@1]
+    version = 1
+}
+
+ScoreReq.FeatReq ProcessRelativeOffsetPointers {
+    description = "The memory component shall represent inter-process pointers stored in shared memory as a base-relative offset rather than an absolute address, so that the same stored pointer resolves correctly in every process that maps the shared memory region at a different base address."
+    safety = ScoreReq.Asil.B
+    derived_from = [ScoreMemory.SharedMemoryIPC@1]
+    version = 1
+}
+
+ScoreReq.FeatReq OffsetPointerBoundsChecking {
+    description = "The memory component shall verify, before dereferencing an offset pointer stored in shared memory, that the resulting address lies within the bounds of a memory resource registered for that process."
+    safety = ScoreReq.Asil.B
+    derived_from = [ScoreMemory.SharedMemoryIPC@1]
+    version = 1
+}
+
+ScoreReq.FeatReq SharedMemoryResourceLifecycleManagement {
+    description = "The memory component shall provide a factory that creates, opens, and removes named or anonymous shared memory resources, ensuring that a given shared memory object is not mapped more than once within the same process."
+    safety = ScoreReq.Asil.B
+    derived_from = [ScoreMemory.SharedMemoryIPC@1]
+    version = 1
+}
+
+ScoreReq.FeatReq SharedMemoryAccessControl {
+    description = "The memory component shall allow the creator of a shared memory resource to restrict access to specific users or groups via file system permissions and access control lists."
+    safety = ScoreReq.Asil.B
+    derived_from = [ScoreMemory.SharedMemoryIPC@1]
+    version = 1
+}
+
+ScoreReq.FeatReq StaleSharedMemoryArtefactCleanup {
+    description = "The memory component shall detect and remove stale shared memory artefacts left behind by a crashed or terminated process before creating a new shared memory resource with the same identifier."
+    safety = ScoreReq.Asil.B
+    derived_from = [ScoreMemory.SharedMemoryIPC@1, ScoreMemory.SafeState@1]
+    version = 1
+}
+
+ScoreReq.FeatReq TypedMemorySupport {
+    description = "The memory component shall support allocating shared memory from a typed memory pool where the operating system provides one, for both named and anonymous shared memory resources."
+    safety = ScoreReq.Asil.B
+    derived_from = [ScoreMemory.SharedMemoryIPC@1]
+    version = 1
+}
+
+ScoreReq.FeatReq ConcurrentReaderWriterSafeMemoryRegionTracking {
+    description = "The memory component shall allow concurrent readers to perform bounds-check lookups on the set of known memory regions while a writer updates that set, without blocking readers and without a reader observing a partially updated set."
+    safety = ScoreReq.Asil.B
+    derived_from = [ScoreMemory.SharedMemoryIPC@1]
+    version = 1
+}
+
+ScoreReq.FeatReq SealedSharedMemorySupport {
+    description = "The memory component shall provide a mechanism to seal a shared memory region after initialization so that further modification of its size or permissions is prevented."
+    safety = ScoreReq.Asil.B
+    derived_from = [ScoreMemory.SharedMemoryIPC@1]
+    version = 1
+}
+
+ScoreReq.FeatReq InterProcessMutualExclusion {
+    description = "The memory component shall provide inter-process file-lock based exclusive and shared mutexes that can be used to synchronize access to data stored in shared memory across process boundaries."
+    safety = ScoreReq.Asil.B
+    derived_from = [ScoreMemory.SharedMemoryIPC@1]
+    version = 1
+}
+
+ScoreReq.FeatReq SharedMemorySafeContainers {
+    description = "The memory component shall provide dynamic container types (e.g. vector, map, string) that can be constructed within a managed memory resource and safely accessed across process boundaries using offset pointers."
+    safety = ScoreReq.Asil.B
+    derived_from = [ScoreMemory.SharedMemoryIPC@1]
+    version = 1
+}
+
+ScoreReq.FeatReq ResourceMockInjectionForTesting {
+    description = "The memory component design shall allow mock injection of its memory resource and shared memory factory abstractions for testing purposes."
+    safety = ScoreReq.Asil.B
+    derived_from = [ScoreMemory.SharedMemoryIPC@1]
+    version = 1
+}
+
+ScoreReq.FeatReq GracefulDegradationOnMemoryResourceFailure {
+    description = "The memory component shall transition to the safe-silent state when a shared memory resource cannot be created, opened, or validated, rather than operating on an inconsistent memory region."
+    safety = ScoreReq.Asil.B
+    derived_from = [ScoreMemory.SafeState@1]
+    version = 1
+}

--- a/score/memory/dependability/software_architectural_design/BUILD
+++ b/score/memory/dependability/software_architectural_design/BUILD
@@ -1,0 +1,30 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load(
+    "@score_tooling//bazel/rules/rules_score:rules_score.bzl",
+    "architectural_design",
+)
+
+architectural_design(
+    name = "memory_architectural_design",
+    maturity = "development",
+    public_api = [
+        "public_api.puml",
+    ],
+    static = [
+        "static_design.puml",
+    ],
+    target_compatible_with = ["@platforms//os:linux"],
+    visibility = ["//score/memory/dependability:__subpackages__"],
+)

--- a/score/memory/dependability/software_architectural_design/public_api.puml
+++ b/score/memory/dependability/software_architectural_design/public_api.puml
@@ -1,0 +1,63 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+
+@startuml
+
+namespace score::memory::shared {
+
+    interface ManagedMemoryResource {
+        +construct()
+        +destruct()
+        +getBaseAddress()
+        +getUsableBaseAddress()
+        +GetUserAllocatedBytes()
+        +IsOffsetPtrBoundsCheckBypassingEnabled()
+    }
+
+    interface ISharedMemoryResource {
+        +getPath()
+        +UnlinkFilesystemEntry()
+        +GetFileDescriptor()
+        +IsShmInTypedMemory()
+        +GetIdentifier()
+    }
+
+    interface ISharedMemoryFactory {
+        +Open()
+        +Create()
+        +CreateAnonymous()
+        +CreateOrOpen()
+        +Remove()
+        +RemoveStaleArtefacts()
+        +SetTypedMemoryProvider()
+        +SetInterVMMemoryProvider()
+        +GetControlBlockSize()
+        +Clear()
+    }
+
+    interface OffsetPtr {
+        +pointer_to()
+        +operator*()
+        +operator[]()
+        +get()
+    }
+
+    interface PolymorphicOffsetPtrAllocator {
+        +allocate()
+        +deallocate()
+        +getMemoryResourceProxy()
+    }
+
+}
+
+@enduml

--- a/score/memory/dependability/software_architectural_design/static_design.puml
+++ b/score/memory/dependability/software_architectural_design/static_design.puml
@@ -1,0 +1,61 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+
+@startuml
+
+interface "score::memory::shared" as memory_public_api
+interface "OS" as os
+
+component "Memory" as dependable_element_memory <<SEooC>> {
+
+    component "Memory" as component_memory <<component>> {
+
+        component "SharedMemoryManagement" as shared_memory_management <<component>> {
+            component "ManagedMemoryResource" as managed_memory_resource <<unit>>
+            component "SharedMemoryResource" as shared_memory_resource <<unit>>
+            component "SharedMemoryFactory" as shared_memory_factory <<unit>>
+            component "MemoryResourceRegistry" as memory_resource_registry <<unit>>
+        }
+
+        component "OffsetPointer" as offset_pointer <<component>> {
+            component "OffsetPtr" as offset_ptr <<unit>>
+            component "PolymorphicOffsetPtrAllocator" as polymorphic_offset_ptr_allocator <<unit>>
+        }
+
+        component "SharedMemoryContainers" as shared_memory_containers <<component>> {
+            component "Containers" as containers <<unit>>
+        }
+
+        component "SharedMemorySynchronization" as shared_memory_synchronization <<component>> {
+            component "FlockMutex" as flock_mutex <<unit>>
+        }
+
+        component "TypedAndSealedMemory" as typed_and_sealed_memory <<component>> {
+            component "TypedMemory" as typed_memory <<unit>>
+            component "SealedSharedMemory" as sealed_shared_memory <<unit>>
+        }
+    }
+
+    portout " " as memory_public_api_port
+    portin " " as port_os
+
+    offset_pointer -u[hidden]- shared_memory_management
+    offset_pointer -u[hidden]- shared_memory_containers
+    shared_memory_containers -u[hidden]- shared_memory_synchronization
+    shared_memory_synchronization -u[hidden]- typed_and_sealed_memory
+}
+
+memory_public_api -r-() memory_public_api_port
+port_os -u-( os : uses
+
+@enduml

--- a/score/memory/dependability/software_architectural_design/static_design.puml
+++ b/score/memory/dependability/software_architectural_design/static_design.puml
@@ -21,28 +21,28 @@ component "Memory" as dependable_element_memory <<SEooC>> {
     component "Memory" as component_memory <<component>> {
 
         component "SharedMemoryManagement" as shared_memory_management <<component>> {
-            component "ManagedMemoryResource" as managed_memory_resource <<unit>>
-            component "SharedMemoryResource" as shared_memory_resource <<unit>>
-            component "SharedMemoryFactory" as shared_memory_factory <<unit>>
-            component "MemoryResourceRegistry" as memory_resource_registry <<unit>>
+            component "ManagedMemoryResource" as managed_memory_resource_unit <<unit>>
+            component "SharedMemoryResource" as shared_memory_resource_unit <<unit>>
+            component "SharedMemoryFactory" as shared_memory_factory_unit <<unit>>
+            component "MemoryResourceRegistry" as memory_resource_registry_unit <<unit>>
         }
 
         component "OffsetPointer" as offset_pointer <<component>> {
-            component "OffsetPtr" as offset_ptr <<unit>>
-            component "PolymorphicOffsetPtrAllocator" as polymorphic_offset_ptr_allocator <<unit>>
+            component "OffsetPtr" as offset_ptr_unit <<unit>>
+            component "PolymorphicOffsetPtrAllocator" as polymorphic_offset_ptr_allocator_unit <<unit>>
         }
 
         component "SharedMemoryContainers" as shared_memory_containers <<component>> {
-            component "Containers" as containers <<unit>>
+            component "Containers" as containers_unit <<unit>>
         }
 
         component "SharedMemorySynchronization" as shared_memory_synchronization <<component>> {
-            component "FlockMutex" as flock_mutex <<unit>>
+            component "FlockMutex" as flock_mutex_unit <<unit>>
         }
 
         component "TypedAndSealedMemory" as typed_and_sealed_memory <<component>> {
-            component "TypedMemory" as typed_memory <<unit>>
-            component "SealedSharedMemory" as sealed_shared_memory <<unit>>
+            component "TypedMemory" as typed_memory_unit <<unit>>
+            component "SealedSharedMemory" as sealed_shared_memory_unit <<unit>>
         }
     }
 

--- a/score/memory/dependability/software_unit_design/BUILD
+++ b/score/memory/dependability/software_unit_design/BUILD
@@ -1,0 +1,64 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@score_tooling//bazel/rules/rules_score:rules_score.bzl", "unit_design")
+
+unit_design(
+    name = "managed_memory_resource_unit_design",
+    visibility = ["//score/memory:__pkg__"],
+)
+
+unit_design(
+    name = "shared_memory_resource_unit_design",
+    visibility = ["//score/memory:__pkg__"],
+)
+
+unit_design(
+    name = "shared_memory_factory_unit_design",
+    visibility = ["//score/memory:__pkg__"],
+)
+
+unit_design(
+    name = "memory_resource_registry_unit_design",
+    visibility = ["//score/memory:__pkg__"],
+)
+
+unit_design(
+    name = "offset_ptr_unit_design",
+    visibility = ["//score/memory:__pkg__"],
+)
+
+unit_design(
+    name = "polymorphic_offset_ptr_allocator_unit_design",
+    visibility = ["//score/memory:__pkg__"],
+)
+
+unit_design(
+    name = "containers_unit_design",
+    visibility = ["//score/memory:__pkg__"],
+)
+
+unit_design(
+    name = "flock_mutex_unit_design",
+    visibility = ["//score/memory:__pkg__"],
+)
+
+unit_design(
+    name = "typed_memory_unit_design",
+    visibility = ["//score/memory:__pkg__"],
+)
+
+unit_design(
+    name = "sealed_shared_memory_unit_design",
+    visibility = ["//score/memory:__pkg__"],
+)

--- a/score/memory/dependability/software_unit_design/BUILD
+++ b/score/memory/dependability/software_unit_design/BUILD
@@ -15,50 +15,50 @@ load("@score_tooling//bazel/rules/rules_score:rules_score.bzl", "unit_design")
 
 unit_design(
     name = "managed_memory_resource_unit_design",
-    visibility = ["//score/memory:__pkg__"],
+    visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "shared_memory_resource_unit_design",
-    visibility = ["//score/memory:__pkg__"],
+    visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "shared_memory_factory_unit_design",
-    visibility = ["//score/memory:__pkg__"],
+    visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "memory_resource_registry_unit_design",
-    visibility = ["//score/memory:__pkg__"],
+    visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "offset_ptr_unit_design",
-    visibility = ["//score/memory:__pkg__"],
+    visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "polymorphic_offset_ptr_allocator_unit_design",
-    visibility = ["//score/memory:__pkg__"],
+    visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "containers_unit_design",
-    visibility = ["//score/memory:__pkg__"],
+    visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "flock_mutex_unit_design",
-    visibility = ["//score/memory:__pkg__"],
+    visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "typed_memory_unit_design",
-    visibility = ["//score/memory:__pkg__"],
+    visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "sealed_shared_memory_unit_design",
-    visibility = ["//score/memory:__pkg__"],
+    visibility = ["//score/memory/shared:__pkg__"],
 )

--- a/score/memory/dependability/software_unit_design/BUILD
+++ b/score/memory/dependability/software_unit_design/BUILD
@@ -13,71 +13,141 @@
 
 load("@score_tooling//bazel/rules/rules_score:rules_score.bzl", "unit_design")
 
+# NOTE on the ".rst" wrapper files listed alongside each ".puml" diagram below:
+# the `unit_design` rule (unlike `architectural_design`) does not yet
+# auto-generate an RST wrapper (with a `.. uml::` directive) for bare `.puml`
+# inputs - see rules_score's private/unit_design.bzl vs. private/architectural_design.bzl
+# (which calls make_puml_rst_wrappers()). Without a wrapper, dependable_element's
+# per-unit doc generator (_generate_unit_doc in private/dependable_element.bzl)
+# only emits an "Unit Design" section/toctree entry for ".rst"/".md" "document"
+# files - bare ".puml" files are merely symlinked next to the page and never
+# actually referenced, so the diagram silently fails to render. Each "<name>.rst"
+# here is therefore a minimal hand-authored wrapper (title + `.. uml:: <name>.puml`)
+# mirroring rules_score's own puml_diagram.template.rst, so the diagrams actually
+# show up on the generated unit pages. This can be removed once unit_design gains
+# the same auto-wrapping support as architectural_design.
 unit_design(
     name = "managed_memory_resource_unit_design",
-    dynamic = ["managed_memory_resource_dynamic.puml"],
-    static = ["managed_memory_resource_static.puml"],
+    dynamic = [
+        "managed_memory_resource_dynamic.rst",
+        "managed_memory_resource_dynamic.puml",
+    ],
+    static = [
+        "managed_memory_resource_static.rst",
+        "managed_memory_resource_static.puml",
+    ],
     visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "shared_memory_resource_unit_design",
-    dynamic = ["shared_memory_resource_dynamic.puml"],
-    static = ["shared_memory_resource_static.puml"],
+    dynamic = [
+        "shared_memory_resource_dynamic.rst",
+        "shared_memory_resource_dynamic.puml",
+    ],
+    static = [
+        "shared_memory_resource_static.rst",
+        "shared_memory_resource_static.puml",
+    ],
     visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "shared_memory_factory_unit_design",
-    dynamic = ["shared_memory_factory_dynamic.puml"],
-    static = ["shared_memory_factory_static.puml"],
+    dynamic = [
+        "shared_memory_factory_dynamic.rst",
+        "shared_memory_factory_dynamic.puml",
+    ],
+    static = [
+        "shared_memory_factory_static.rst",
+        "shared_memory_factory_static.puml",
+    ],
     visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "memory_resource_registry_unit_design",
-    dynamic = ["memory_resource_registry_dynamic.puml"],
-    static = ["memory_resource_registry_static.puml"],
+    dynamic = [
+        "memory_resource_registry_dynamic.rst",
+        "memory_resource_registry_dynamic.puml",
+    ],
+    static = [
+        "memory_resource_registry_static.rst",
+        "memory_resource_registry_static.puml",
+    ],
     visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "offset_ptr_unit_design",
-    dynamic = ["offset_ptr_dynamic.puml"],
-    static = ["offset_ptr_static.puml"],
+    dynamic = [
+        "offset_ptr_dynamic.rst",
+        "offset_ptr_dynamic.puml",
+    ],
+    static = [
+        "offset_ptr_static.rst",
+        "offset_ptr_static.puml",
+    ],
     visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "polymorphic_offset_ptr_allocator_unit_design",
-    dynamic = ["polymorphic_offset_ptr_allocator_dynamic.puml"],
-    static = ["polymorphic_offset_ptr_allocator_static.puml"],
+    dynamic = [
+        "polymorphic_offset_ptr_allocator_dynamic.rst",
+        "polymorphic_offset_ptr_allocator_dynamic.puml",
+    ],
+    static = [
+        "polymorphic_offset_ptr_allocator_static.rst",
+        "polymorphic_offset_ptr_allocator_static.puml",
+    ],
     visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "containers_unit_design",
-    static = ["containers_static.puml"],
+    static = [
+        "containers_static.rst",
+        "containers_static.puml",
+    ],
     visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "flock_mutex_unit_design",
-    dynamic = ["flock_mutex_dynamic.puml"],
-    static = ["flock_mutex_static.puml"],
+    dynamic = [
+        "flock_mutex_dynamic.rst",
+        "flock_mutex_dynamic.puml",
+    ],
+    static = [
+        "flock_mutex_static.rst",
+        "flock_mutex_static.puml",
+    ],
     visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "typed_memory_unit_design",
-    dynamic = ["typed_memory_dynamic.puml"],
-    static = ["typed_memory_static.puml"],
+    dynamic = [
+        "typed_memory_dynamic.rst",
+        "typed_memory_dynamic.puml",
+    ],
+    static = [
+        "typed_memory_static.rst",
+        "typed_memory_static.puml",
+    ],
     visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "sealed_shared_memory_unit_design",
-    dynamic = ["sealed_shared_memory_dynamic.puml"],
-    static = ["sealed_shared_memory_static.puml"],
+    dynamic = [
+        "sealed_shared_memory_dynamic.rst",
+        "sealed_shared_memory_dynamic.puml",
+    ],
+    static = [
+        "sealed_shared_memory_static.rst",
+        "sealed_shared_memory_static.puml",
+    ],
     visibility = ["//score/memory/shared:__pkg__"],
 )

--- a/score/memory/dependability/software_unit_design/BUILD
+++ b/score/memory/dependability/software_unit_design/BUILD
@@ -15,50 +15,69 @@ load("@score_tooling//bazel/rules/rules_score:rules_score.bzl", "unit_design")
 
 unit_design(
     name = "managed_memory_resource_unit_design",
+    dynamic = ["managed_memory_resource_dynamic.puml"],
+    static = ["managed_memory_resource_static.puml"],
     visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "shared_memory_resource_unit_design",
+    dynamic = ["shared_memory_resource_dynamic.puml"],
+    static = ["shared_memory_resource_static.puml"],
     visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "shared_memory_factory_unit_design",
+    dynamic = ["shared_memory_factory_dynamic.puml"],
+    static = ["shared_memory_factory_static.puml"],
     visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "memory_resource_registry_unit_design",
+    dynamic = ["memory_resource_registry_dynamic.puml"],
+    static = ["memory_resource_registry_static.puml"],
     visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "offset_ptr_unit_design",
+    dynamic = ["offset_ptr_dynamic.puml"],
+    static = ["offset_ptr_static.puml"],
     visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "polymorphic_offset_ptr_allocator_unit_design",
+    dynamic = ["polymorphic_offset_ptr_allocator_dynamic.puml"],
+    static = ["polymorphic_offset_ptr_allocator_static.puml"],
     visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "containers_unit_design",
+    static = ["containers_static.puml"],
     visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "flock_mutex_unit_design",
+    dynamic = ["flock_mutex_dynamic.puml"],
+    static = ["flock_mutex_static.puml"],
     visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "typed_memory_unit_design",
+    dynamic = ["typed_memory_dynamic.puml"],
+    static = ["typed_memory_static.puml"],
     visibility = ["//score/memory/shared:__pkg__"],
 )
 
 unit_design(
     name = "sealed_shared_memory_unit_design",
+    dynamic = ["sealed_shared_memory_dynamic.puml"],
+    static = ["sealed_shared_memory_static.puml"],
     visibility = ["//score/memory/shared:__pkg__"],
 )

--- a/score/memory/dependability/software_unit_design/containers_static.puml
+++ b/score/memory/dependability/software_unit_design/containers_static.puml
@@ -14,29 +14,32 @@
 @startuml
 
 namespace score::memory::shared {
-    class PolymorphicOffsetPtrAllocator
 
-    class Vector {
-        +allocator_type
-    }
+class "PolymorphicOffsetPtrAllocator<T>" as PolymorphicOffsetPtrAllocator
 
-    class Map {
-        +allocator_type
-        +storage_backend
-    }
+class "Vector<T>" as Vector {
+  +alias : std::vector<T, std::scoped_allocator_adaptor<PolymorphicOffsetPtrAllocator<T>>>
+}
 
-    class BasicString {
-        +allocator_type
-    }
+class "Map<K, V, Comp>" as Map {
+  +allocator_type : PolymorphicOffsetPtrAllocator<value_type>
+  +linux_impl : boost::interprocess::map
+  +other_impl : std::map
+}
 
-    class String {
-        +alias_of
-    }
+class "BasicString<CharT, Traits>" as BasicString {
+  +alias : std::basic_string<CharT, Traits, PolymorphicOffsetPtrAllocator<CharT>>
+}
 
-    Vector ..> PolymorphicOffsetPtrAllocator
-    Map ..> PolymorphicOffsetPtrAllocator
-    BasicString ..> PolymorphicOffsetPtrAllocator
-    String ..> BasicString
+class String {
+  +alias : BasicString<char>
+}
+
+Vector ..> PolymorphicOffsetPtrAllocator : scoped allocator adaptor
+Map ..> PolymorphicOffsetPtrAllocator : linux=boost::interprocess, else=std::map
+BasicString ..> PolymorphicOffsetPtrAllocator : allocator
+String ..> BasicString
+
 }
 
 @enduml

--- a/score/memory/dependability/software_unit_design/containers_static.puml
+++ b/score/memory/dependability/software_unit_design/containers_static.puml
@@ -1,0 +1,42 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+
+@startuml
+
+namespace score::memory::shared {
+    class PolymorphicOffsetPtrAllocator
+
+    class Vector {
+        +allocator_type
+    }
+
+    class Map {
+        +allocator_type
+        +storage_backend
+    }
+
+    class BasicString {
+        +allocator_type
+    }
+
+    class String {
+        +alias_of
+    }
+
+    Vector ..> PolymorphicOffsetPtrAllocator
+    Map ..> PolymorphicOffsetPtrAllocator
+    BasicString ..> PolymorphicOffsetPtrAllocator
+    String ..> BasicString
+}
+
+@enduml

--- a/score/memory/dependability/software_unit_design/containers_static.rst
+++ b/score/memory/dependability/software_unit_design/containers_static.rst
@@ -1,0 +1,18 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+Containers — Static Design
+==========================
+
+.. uml:: containers_static.puml

--- a/score/memory/dependability/software_unit_design/flock_mutex_dynamic.puml
+++ b/score/memory/dependability/software_unit_design/flock_mutex_dynamic.puml
@@ -1,0 +1,43 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+
+@startuml
+
+title ExclusiveFlockMutex::try_lock translates EWOULDBLOCK into a non-blocking failure
+
+participant Client
+participant ExclusiveFlockMutex as Exclusive
+participant FlockMutex
+participant "score::os::Fcntl" as Fcntl
+
+Client -> Exclusive : try_lock()
+activate Exclusive
+Exclusive -> FlockMutex : try_lock()
+activate FlockMutex
+FlockMutex -> Fcntl : flock(fd, kLockExclusive | kLockNB)
+alt flock succeeds
+    Fcntl --> FlockMutex : success
+    FlockMutex --> Exclusive : true
+    Exclusive --> Client : true
+else errno == EWOULDBLOCK
+    Fcntl --> FlockMutex : error(EWOULDBLOCK)
+    FlockMutex --> Exclusive : false
+    Exclusive --> Client : false
+else other flock error
+    Fcntl --> FlockMutex : unexpected error
+    FlockMutex -> FlockMutex : LogFatal + terminate()
+end
+deactivate FlockMutex
+deactivate Exclusive
+
+@enduml

--- a/score/memory/dependability/software_unit_design/flock_mutex_dynamic.rst
+++ b/score/memory/dependability/software_unit_design/flock_mutex_dynamic.rst
@@ -1,0 +1,18 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+FlockMutex — Dynamic Design
+===========================
+
+.. uml:: flock_mutex_dynamic.puml

--- a/score/memory/dependability/software_unit_design/flock_mutex_static.puml
+++ b/score/memory/dependability/software_unit_design/flock_mutex_static.puml
@@ -14,12 +14,45 @@
 @startuml
 
 namespace score::memory::shared {
-    class LockFile
-    class FlockMutex
-    class ExclusiveFlockMutex
 
-    ExclusiveFlockMutex *-- FlockMutex
-    FlockMutex ..> LockFile
+class LockFile {
+  {static} +Create(string path): std::optional<score::memory::shared::LockFile>
+  {static} +CreateOrOpen(string path, bool take_ownership): std::optional<score::memory::shared::LockFile>
+  {static} +Open(string path): std::optional<score::memory::shared::LockFile>
+  +TakeOwnership(): void
+  +~LockFile()
+  -CleanupFile(): void
+  --
+  -lock_file_path_ : std::string
+  -file_descriptor_ : std::int32_t
+  -lock_file_owns_file_ : bool
+}
+
+class FlockMutex {
+  +FlockMutex(const LockFile& lock_file, const int locking_operation, const int try_locking_operation)
+  +lock(): void
+  +try_lock(): bool
+  +unlock(): void
+  --
+  -file_descriptor_ : std::int32_t
+  -locking_operation_ : int
+  -try_locking_operation_ : int
+}
+
+class ExclusiveFlockMutex {
+  +ExclusiveFlockMutex(const LockFile& lock_file)
+  +lock(): void
+  +try_lock(): bool
+  +unlock(): void
+  --
+  -exclusive_flock_mutex_ : score::memory::shared::FlockMutex
+}
+
+ExclusiveFlockMutex *-- FlockMutex
+FlockMutex ..> LockFile
+
+' The same lock-file pattern is reused by SharedFlockMutex and FlockMutexAndLock<T> in sibling headers.
+
 }
 
 @enduml

--- a/score/memory/dependability/software_unit_design/flock_mutex_static.puml
+++ b/score/memory/dependability/software_unit_design/flock_mutex_static.puml
@@ -1,0 +1,25 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+
+@startuml
+
+namespace score::memory::shared {
+    class LockFile
+    class FlockMutex
+    class ExclusiveFlockMutex
+
+    ExclusiveFlockMutex *-- FlockMutex
+    FlockMutex ..> LockFile
+}
+
+@enduml

--- a/score/memory/dependability/software_unit_design/flock_mutex_static.rst
+++ b/score/memory/dependability/software_unit_design/flock_mutex_static.rst
@@ -1,0 +1,18 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+FlockMutex — Static Design
+==========================
+
+.. uml:: flock_mutex_static.puml

--- a/score/memory/dependability/software_unit_design/managed_memory_resource_dynamic.puml
+++ b/score/memory/dependability/software_unit_design/managed_memory_resource_dynamic.puml
@@ -17,8 +17,7 @@ title NewDeleteDelegateMemoryResource dry-run allocation accounting
 
 participant Client
 participant NewDeleteDelegateMemoryResource as DryRunResource
-participant "upstream_resource_
-score::cpp::pmr::memory_resource" as Upstream
+participant "upstream_resource_ : score::cpp::pmr::memory_resource" as Upstream
 collections current_upstream_allocations_ as Allocations
 
 Client -> DryRunResource : construct<T>(args...)

--- a/score/memory/dependability/software_unit_design/managed_memory_resource_dynamic.puml
+++ b/score/memory/dependability/software_unit_design/managed_memory_resource_dynamic.puml
@@ -1,0 +1,42 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+
+@startuml
+
+title NewDeleteDelegateMemoryResource dry-run allocation accounting
+
+participant Client
+participant NewDeleteDelegateMemoryResource as DryRunResource
+participant "upstream_resource_
+score::cpp::pmr::memory_resource" as Upstream
+collections current_upstream_allocations_ as Allocations
+
+Client -> DryRunResource : construct<T>(args...)
+activate DryRunResource
+DryRunResource -> DryRunResource : do_allocate(sizeof(T), alignof(T))
+DryRunResource -> Upstream : allocate(bytes, alignment)
+Upstream --> DryRunResource : raw memory
+DryRunResource -> Allocations : remember {ptr, bytes, alignment}
+DryRunResource -> DryRunResource : sum_allocated_bytes_ += bytes
+DryRunResource --> Client : placement-new T in returned memory
+deactivate DryRunResource
+
+Client -> DryRunResource : destruct<T>(t)
+activate DryRunResource
+DryRunResource -> DryRunResource : do_deallocate(&t, sizeof(T), alignof(T))
+DryRunResource -> Allocations : find AllocateInfo for &t
+DryRunResource -> Upstream : deallocate(ptr, bytes, alignment)
+DryRunResource --> Client : dry-run accounting updated
+deactivate DryRunResource
+
+@enduml

--- a/score/memory/dependability/software_unit_design/managed_memory_resource_dynamic.rst
+++ b/score/memory/dependability/software_unit_design/managed_memory_resource_dynamic.rst
@@ -1,0 +1,18 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+ManagedMemoryResource — Dynamic Design
+======================================
+
+.. uml:: managed_memory_resource_dynamic.puml

--- a/score/memory/dependability/software_unit_design/managed_memory_resource_static.puml
+++ b/score/memory/dependability/software_unit_design/managed_memory_resource_static.puml
@@ -1,0 +1,20 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+
+@startuml
+
+namespace score::memory::shared {
+    abstract class ManagedMemoryResource
+}
+
+@enduml

--- a/score/memory/dependability/software_unit_design/managed_memory_resource_static.puml
+++ b/score/memory/dependability/software_unit_design/managed_memory_resource_static.puml
@@ -14,7 +14,53 @@
 @startuml
 
 namespace score::memory::shared {
-    abstract class ManagedMemoryResource
+
+abstract class ManagedMemoryResource {
+  +construct(args): T*
+  +destruct(t): void
+  {abstract} +getBaseAddress(): void*
+  {abstract} +getUsableBaseAddress(): void*
+  {abstract} +GetUserAllocatedBytes(): std::size_t
+  +IsOffsetPtrBoundsCheckBypassingEnabled(): bool
+  {abstract} -getEndAddress(): const void*
+  {abstract} -getMemoryResourceProxy(): const MemoryResourceProxy*
+}
+
+class NewDeleteDelegateMemoryResource {
+  +NewDeleteDelegateMemoryResource(mem_res_id, upstream_resource)
+  +~NewDeleteDelegateMemoryResource()
+  +getMemoryResourceProxy(): const MemoryResourceProxy*
+  +getBaseAddress(): void*
+  +getUsableBaseAddress(): void*
+  +GetUserAllocatedBytes(): std::size_t
+  +IsOffsetPtrBoundsCheckBypassingEnabled(): bool
+  -do_allocate(bytes, alignment): void*
+  -do_deallocate(p, bytes, alignment): void
+  -do_is_equal(other): bool
+  -getEndAddress(): const void*
+  --
+  -upstream_resource_ : score::cpp::pmr::memory_resource*
+  -memory_resource_id_ : std::uint64_t
+  -proxy_ : score::memory::shared::MemoryResourceProxy
+  -sum_allocated_bytes_ : std::size_t
+  -current_upstream_allocations_ : std::map<void*, AllocateInfo>
+}
+
+class "NewDeleteDelegateMemoryResource::AllocateInfo" as AllocateInfo {
+  +AllocateInfo(bytes, alignment)
+  --
+  +bytes : std::size_t
+  +alignment : std::size_t
+}
+
+class MemoryResourceProxy
+class SharedMemoryResource
+
+ManagedMemoryResource <|-- NewDeleteDelegateMemoryResource
+ManagedMemoryResource <|-- SharedMemoryResource
+NewDeleteDelegateMemoryResource *-- AllocateInfo
+NewDeleteDelegateMemoryResource *-- MemoryResourceProxy
+
 }
 
 @enduml

--- a/score/memory/dependability/software_unit_design/managed_memory_resource_static.rst
+++ b/score/memory/dependability/software_unit_design/managed_memory_resource_static.rst
@@ -1,0 +1,18 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+ManagedMemoryResource — Static Design
+=====================================
+
+.. uml:: managed_memory_resource_static.puml

--- a/score/memory/dependability/software_unit_design/memory_resource_registry_dynamic.puml
+++ b/score/memory/dependability/software_unit_design/memory_resource_registry_dynamic.puml
@@ -1,0 +1,42 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+
+@startuml
+
+title MemoryRegionMap reader/writer version protocol
+
+participant Reader
+participant Writer
+participant MemoryRegionMap as Map
+collections "known_regions_versions_refcounts_" as RefCounts
+collections "known_regions_versions_" as Versions
+participant "latest_known_region_version_" as Latest
+
+Reader -> Latest : load current version index
+Latest --> Reader : version i
+Reader -> RefCounts : fetch_add(1) on refcount[i]
+alt old_ref_count < INVALID_REF_COUNT_INTERVAL_START - 1
+    Reader -> Versions : read bounds from version i
+    Reader -> RefCounts : decrement refcount[i] on scope exit
+else INVALID interval hit
+    Reader -> Reader : retry with latest version
+end
+
+Writer -> RefCounts : scan versions for refcount == 0
+Writer -> RefCounts : compare_exchange(0, INVALID_REF_COUNT_INTERVAL_START)
+Writer -> Versions : copy current latest map into acquired version j
+Writer -> Versions : apply insert/remove update in version j
+Writer -> RefCounts : store refcount[j] = 0
+Writer -> Latest : store latest version = j
+
+@enduml

--- a/score/memory/dependability/software_unit_design/memory_resource_registry_dynamic.rst
+++ b/score/memory/dependability/software_unit_design/memory_resource_registry_dynamic.rst
@@ -1,0 +1,18 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+MemoryResourceRegistry — Dynamic Design
+=======================================
+
+.. uml:: memory_resource_registry_dynamic.puml

--- a/score/memory/dependability/software_unit_design/memory_resource_registry_static.puml
+++ b/score/memory/dependability/software_unit_design/memory_resource_registry_static.puml
@@ -13,13 +13,82 @@
 
 @startuml
 
-component "MemoryResourceRegistry" as memory_resource_registry
-component "MemoryRegionMapImpl<AtomicIndirectorType>" as memory_region_map
-component "MemoryRegionBounds" as memory_region_bounds
-component "ManagedMemoryResource" as managed_memory_resource
+namespace score::memory::shared {
 
-memory_resource_registry --> memory_region_map
-memory_resource_registry --> managed_memory_resource
-memory_region_map --> memory_region_bounds
+abstract class ManagedMemoryResource
+
+class MemoryResourceRegistry {
+  +getInstance(): MemoryResourceRegistry&
+  +at(identifier): ManagedMemoryResource*
+  +insert_resource(input): bool
+  +remove_resource(identifier): void
+  +clear(): void
+  +GetBoundsFromAddress(pointer): std::optional<MemoryRegionBounds>
+  +GetBoundsFromAddressAsInteger(pointer_as_integer): std::optional<MemoryRegionBounds>
+  +GetBoundsFromIdentifier(identifier): score::Result<MemoryRegionBounds>
+  -CheckResourceInput(resource): void
+  --
+  -mutex_ : std::shared_timed_mutex
+  -registry_ : std::unordered_map<MemoryResourceIdentifier, ManagedMemoryResource*>
+  -region_map_ : MemoryRegionMap
+}
+
+class MemoryResourceProxy {
+  +MemoryResourceProxy(identifier)
+  +allocate(size, alignment): void*
+  +deallocate(ptr, size): void
+  {static} +EnableBoundsChecking(enable): bool
+  -PerformBoundsCheck(memory_identifier): void
+  --
+  -memory_identifier_ : const std::uint64_t
+}
+
+class MemoryRegionBounds {
+  +MemoryRegionBounds()
+  +MemoryRegionBounds(start_address, end_address)
+  +Set(start_address, end_address): void
+  +Reset(): void
+  +has_value(): bool
+  +GetStartAddress(): std::uintptr_t
+  +GetEndAddress(): std::uintptr_t
+  --
+  -start_address_ : std::uintptr_t
+  -end_address_ : std::uintptr_t
+}
+
+class "detail::MemoryRegionMapImpl<AtomicIndirectorType>" as MemoryRegionMapImpl {
+  +MemoryRegionMapImpl()
+  +GetBoundsFromAddress(pointer): std::optional<MemoryRegionBounds>
+  +UpdateKnownRegion(memory_range_start, memory_range_end): bool
+  +RemoveKnownRegion(memory_range_start): void
+  +ClearKnownRegions(): void
+  +GetSize(): std::size_t
+  -AcquireLatestRegionVersionForRead(): std::optional<AcquiredRefcountIndex>
+  -AcquireRegionVersionForOverwrite(): std::optional<std::uint8_t>
+  --
+  -known_regions_versions_ : std::array<std::map<std::uintptr_t, std::uintptr_t>, VERSION_COUNT>
+  -known_regions_versions_refcounts_ : std::array<std::atomic<RegionVersionRefCountType>, VERSION_COUNT>
+  -latest_known_region_version_ : std::atomic_uint8_t
+}
+
+class "MemoryRegionMapImpl::AcquiredRefcountIndex" as AcquiredRefcountIndex {
+  +AcquiredRefcountIndex(refcount_index, ref_count)
+  +~AcquiredRefcountIndex()
+  +GetIndex(): std::uint8_t
+  --
+  -index_ : std::uint8_t
+  -ref_count_ : std::reference_wrapper<std::atomic<RegionVersionRefCountType>>
+  -owns_resource_ : bool
+}
+
+MemoryResourceRegistry o-- ManagedMemoryResource
+MemoryResourceRegistry *-- MemoryRegionMapImpl
+MemoryResourceRegistry ..> MemoryResourceProxy
+
+' MemoryResourceProxy keeps a process-global static flag bounds_checking_enabled_.
+MemoryRegionMapImpl *-- AcquiredRefcountIndex
+MemoryRegionMapImpl ..> MemoryRegionBounds
+
+}
 
 @enduml

--- a/score/memory/dependability/software_unit_design/memory_resource_registry_static.puml
+++ b/score/memory/dependability/software_unit_design/memory_resource_registry_static.puml
@@ -1,0 +1,25 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+
+@startuml
+
+component "MemoryResourceRegistry" as memory_resource_registry
+component "MemoryRegionMapImpl<AtomicIndirectorType>" as memory_region_map
+component "MemoryRegionBounds" as memory_region_bounds
+component "ManagedMemoryResource" as managed_memory_resource
+
+memory_resource_registry --> memory_region_map
+memory_resource_registry --> managed_memory_resource
+memory_region_map --> memory_region_bounds
+
+@enduml

--- a/score/memory/dependability/software_unit_design/memory_resource_registry_static.rst
+++ b/score/memory/dependability/software_unit_design/memory_resource_registry_static.rst
@@ -1,0 +1,18 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+MemoryResourceRegistry — Static Design
+======================================
+
+.. uml:: memory_resource_registry_static.puml

--- a/score/memory/dependability/software_unit_design/offset_ptr_dynamic.puml
+++ b/score/memory/dependability/software_unit_design/offset_ptr_dynamic.puml
@@ -1,0 +1,39 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+
+@startuml
+
+title OffsetPtr dereference with shared-memory-aware bounds checking
+
+participant Caller
+participant "OffsetPtr<T>" as OffsetPtr
+participant MemoryResourceRegistry as Registry
+participant offset_ptr_bounds_check as BoundsCheck
+participant pointer_arithmetic_util as Arithmetic
+
+Caller -> OffsetPtr : get() / operator*()
+activate OffsetPtr
+OffsetPtr -> Registry : GetBoundsFromAddress(this)
+alt OffsetPtr stored inside managed memory
+    Registry --> OffsetPtr : MemoryRegionBounds of containing region
+    OffsetPtr -> BoundsCheck : DoesOffsetPtrInSharedMemoryPassBoundsChecks(this, offset, bounds, sizeof(T), sizeof(OffsetPtr<T>))
+else copied to stack
+    Registry --> OffsetPtr : no containing region
+    OffsetPtr -> BoundsCheck : DoesOffsetPtrNotInSharedMemoryPassBoundsChecks(this, offset, memory_bounds_, sizeof(T), sizeof(OffsetPtr<T>))
+end
+OffsetPtr -> Arithmetic : calculate pointed address from this + offset_
+Arithmetic --> OffsetPtr : raw T*
+OffsetPtr --> Caller : checked pointer / reference
+deactivate OffsetPtr
+
+@enduml

--- a/score/memory/dependability/software_unit_design/offset_ptr_dynamic.rst
+++ b/score/memory/dependability/software_unit_design/offset_ptr_dynamic.rst
@@ -1,0 +1,18 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+OffsetPtr — Dynamic Design
+==========================
+
+.. uml:: offset_ptr_dynamic.puml

--- a/score/memory/dependability/software_unit_design/offset_ptr_static.puml
+++ b/score/memory/dependability/software_unit_design/offset_ptr_static.puml
@@ -1,0 +1,25 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+
+@startuml
+
+component "OffsetPtr<PointedType>" as offset_ptr
+component "offset_ptr_bounds_check" as bounds_check
+component "pointer_arithmetic_util" as pointer_arithmetic_util
+component "MemoryRegionBounds" as memory_region_bounds
+
+offset_ptr --> bounds_check
+offset_ptr --> pointer_arithmetic_util
+offset_ptr --> memory_region_bounds
+
+@enduml

--- a/score/memory/dependability/software_unit_design/offset_ptr_static.puml
+++ b/score/memory/dependability/software_unit_design/offset_ptr_static.puml
@@ -13,13 +13,40 @@
 
 @startuml
 
-component "OffsetPtr<PointedType>" as offset_ptr
-component "offset_ptr_bounds_check" as bounds_check
-component "pointer_arithmetic_util" as pointer_arithmetic_util
-component "MemoryRegionBounds" as memory_region_bounds
+namespace score::memory::shared {
 
-offset_ptr --> bounds_check
-offset_ptr --> pointer_arithmetic_util
-offset_ptr --> memory_region_bounds
+class OffsetPtr {
+  +OffsetPtr(ptr)
+  +OffsetPtr(other)
+  {static} +pointer_to(ref): OffsetPtr
+  +operator*(): reference
+  +operator[](idx): reference
+  +operator+=(offset): OffsetPtr&
+  +operator-=(offset): OffsetPtr&
+  +get(): pointer
+  +operator->(): pointer
+  +operator!(): bool
+  {static} -CopyFrom(source_offset_ptr, target_offset_ptr): std::pair<difference_type, MemoryRegionBounds>
+  {static} -GetPointerWithBoundsCheck(offset_ptr_address, offset, offset_ptr_memory_bounds_when_not_in_shm, pointed_type_size): pointer
+  {static} -GetPointerWithoutBoundsCheck(offset_ptr_address, offset): pointer
+  -IncrementOffset(multiple_of_pointed_type_to_increment): void
+  -DecrementOffset(multiple_of_pointed_type_to_decrement): void
+  {static} -CalculateOffsetFromPointer(offset_ptr_address, pointed_to_address): difference_type
+  {static} -CalculatePointerFromOffset(offset, offset_ptr): pointer
+  --
+  -offset_ : detail_offset_ptr::difference_type
+  -memory_bounds_ : MemoryRegionBounds
+}
+
+class MemoryRegionBounds
+class MemoryResourceRegistry
+
+OffsetPtr *-- MemoryRegionBounds
+OffsetPtr ..> MemoryResourceRegistry
+
+' OffsetPtr relies on the free functions declared in offset_ptr_bounds_check.h
+' and pointer_arithmetic_util.h for bounds validation and pointer arithmetic.
+
+}
 
 @enduml

--- a/score/memory/dependability/software_unit_design/offset_ptr_static.rst
+++ b/score/memory/dependability/software_unit_design/offset_ptr_static.rst
@@ -1,0 +1,18 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+OffsetPtr — Static Design
+=========================
+
+.. uml:: offset_ptr_static.puml

--- a/score/memory/dependability/software_unit_design/polymorphic_offset_ptr_allocator_dynamic.puml
+++ b/score/memory/dependability/software_unit_design/polymorphic_offset_ptr_allocator_dynamic.puml
@@ -1,0 +1,30 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+
+@startuml
+
+title PolymorphicOffsetPtrAllocator<T>::allocate chooses proxy or heap fallback
+
+start
+if (proxy_ != nullptr?) then (yes)
+  :number_bytes_to_allocate = size * sizeof(T);
+  :proxy_->allocate(number_bytes_to_allocate, alignof(T));
+  :return OffsetPtr<T>{allocatedMemory};
+else (no)
+  :number_bytes_to_allocate = size * sizeof(T);
+  :std::malloc(number_bytes_to_allocate);
+  :return OffsetPtr<T>{allocatedMemory};
+endif
+stop
+
+@enduml

--- a/score/memory/dependability/software_unit_design/polymorphic_offset_ptr_allocator_dynamic.rst
+++ b/score/memory/dependability/software_unit_design/polymorphic_offset_ptr_allocator_dynamic.rst
@@ -1,0 +1,18 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+PolymorphicOffsetPtrAllocator — Dynamic Design
+==============================================
+
+.. uml:: polymorphic_offset_ptr_allocator_dynamic.puml

--- a/score/memory/dependability/software_unit_design/polymorphic_offset_ptr_allocator_static.puml
+++ b/score/memory/dependability/software_unit_design/polymorphic_offset_ptr_allocator_static.puml
@@ -13,13 +13,29 @@
 
 @startuml
 
-component "PolymorphicOffsetPtrAllocator<T>" as allocator
-component "OffsetPtr<const MemoryResourceProxy>" as proxy_ptr
-component "MemoryResourceProxy" as memory_resource_proxy
-component "ManagedMemoryResource" as managed_memory_resource
+namespace score::memory::shared {
 
-allocator --> proxy_ptr
-proxy_ptr --> memory_resource_proxy
-allocator --> managed_memory_resource
+abstract class ManagedMemoryResource
+class MemoryResourceProxy
+class "OffsetPtr<const MemoryResourceProxy>" as ProxyOffsetPtr
+class "OffsetPtr<T>" as ValueOffsetPtr
+
+class "PolymorphicOffsetPtrAllocator<T>" as PolymorphicOffsetPtrAllocator {
+  +PolymorphicOffsetPtrAllocator()
+  +PolymorphicOffsetPtrAllocator(resource)
+  +PolymorphicOffsetPtrAllocator(rhs)
+  +allocate(size): pointer
+  +deallocate(p, size): void
+  +getMemoryResourceProxy(): OffsetPtr<const MemoryResourceProxy>
+  --
+  -proxy_ : OffsetPtr<const MemoryResourceProxy>
+}
+
+PolymorphicOffsetPtrAllocator *-- ProxyOffsetPtr
+PolymorphicOffsetPtrAllocator ..> ManagedMemoryResource
+PolymorphicOffsetPtrAllocator ..> ValueOffsetPtr
+ProxyOffsetPtr ..> MemoryResourceProxy
+
+}
 
 @enduml

--- a/score/memory/dependability/software_unit_design/polymorphic_offset_ptr_allocator_static.puml
+++ b/score/memory/dependability/software_unit_design/polymorphic_offset_ptr_allocator_static.puml
@@ -1,0 +1,25 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+
+@startuml
+
+component "PolymorphicOffsetPtrAllocator<T>" as allocator
+component "OffsetPtr<const MemoryResourceProxy>" as proxy_ptr
+component "MemoryResourceProxy" as memory_resource_proxy
+component "ManagedMemoryResource" as managed_memory_resource
+
+allocator --> proxy_ptr
+proxy_ptr --> memory_resource_proxy
+allocator --> managed_memory_resource
+
+@enduml

--- a/score/memory/dependability/software_unit_design/polymorphic_offset_ptr_allocator_static.rst
+++ b/score/memory/dependability/software_unit_design/polymorphic_offset_ptr_allocator_static.rst
@@ -1,0 +1,18 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+PolymorphicOffsetPtrAllocator — Static Design
+=============================================
+
+.. uml:: polymorphic_offset_ptr_allocator_static.puml

--- a/score/memory/dependability/software_unit_design/sealed_shared_memory_dynamic.puml
+++ b/score/memory/dependability/software_unit_design/sealed_shared_memory_dynamic.puml
@@ -1,0 +1,36 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+
+@startuml
+
+title Anonymous SharedMemoryResource seals its file descriptor after creation
+
+participant SharedMemoryResource as Resource
+participant "SealedShm::instance()" as SealedApi
+participant "score::os::qnx::MmanQnx" as Mman
+
+Resource -> SealedApi : OpenAnonymous(mode)
+activate SealedApi
+SealedApi -> Mman : shm_open(SHM_ANON, O_RDWR|O_CREAT|O_ANON, mode)
+Mman --> SealedApi : fd
+SealedApi --> Resource : expected<int32_t, Error>{fd}
+deactivate SealedApi
+
+Resource -> SealedApi : Seal(fd, virtual_address_space_to_reserve_)
+activate SealedApi
+SealedApi -> Mman : shm_ctl(fd, SHMCTL_ANON | SHMCTL_SEAL, 0, size)
+Mman --> SealedApi : success / error
+SealedApi --> Resource : expected_blank<Error>
+deactivate SealedApi
+
+@enduml

--- a/score/memory/dependability/software_unit_design/sealed_shared_memory_dynamic.rst
+++ b/score/memory/dependability/software_unit_design/sealed_shared_memory_dynamic.rst
@@ -1,0 +1,18 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+SealedSharedMemory — Dynamic Design
+===================================
+
+.. uml:: sealed_shared_memory_dynamic.puml

--- a/score/memory/dependability/software_unit_design/sealed_shared_memory_static.puml
+++ b/score/memory/dependability/software_unit_design/sealed_shared_memory_static.puml
@@ -14,10 +14,28 @@
 @startuml
 
 namespace score::memory::shared {
-    abstract class ISealedShm
-    class SealedShm
 
-    ISealedShm <|-- SealedShm
+abstract class ISealedShm {
+  {abstract} +OpenAnonymous(mode): score::cpp::expected<std::int32_t, score::os::Error>
+  {abstract} +Seal(fd, size): score::cpp::expected_blank<score::os::Error>
+}
+
+class SealedShm {
+  +OpenAnonymous(mode): score::cpp::expected<std::int32_t, score::os::Error>
+  +Seal(fd, size): score::cpp::expected_blank<score::os::Error>
+  {static} +InjectMock(mock): void
+  {static} +instance(): ISealedShm&
+  --
+  -mock_ : ISealedShm*
+}
+
+class SharedMemoryResource
+
+ISealedShm <|-- SealedShm
+SharedMemoryResource ..> SealedShm
+
+' QNX builds additionally store a private mman_ handle inside SealedShm.
+
 }
 
 @enduml

--- a/score/memory/dependability/software_unit_design/sealed_shared_memory_static.puml
+++ b/score/memory/dependability/software_unit_design/sealed_shared_memory_static.puml
@@ -1,0 +1,23 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+
+@startuml
+
+namespace score::memory::shared {
+    abstract class ISealedShm
+    class SealedShm
+
+    ISealedShm <|-- SealedShm
+}
+
+@enduml

--- a/score/memory/dependability/software_unit_design/sealed_shared_memory_static.rst
+++ b/score/memory/dependability/software_unit_design/sealed_shared_memory_static.rst
@@ -1,0 +1,18 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+SealedSharedMemory — Static Design
+==================================
+
+.. uml:: sealed_shared_memory_static.puml

--- a/score/memory/dependability/software_unit_design/shared_memory_factory_dynamic.puml
+++ b/score/memory/dependability/software_unit_design/shared_memory_factory_dynamic.puml
@@ -1,0 +1,42 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+
+@startuml
+
+title SharedMemoryFactoryImpl::CreateOrOpen avoids double-mapping in one process
+
+participant Caller
+participant SharedMemoryFactoryImpl as Factory
+collections resources_ as ResourceMap
+participant SharedMemoryResource as Resource
+
+Caller -> Factory : CreateOrOpen(path, cb, size, access_control, prefer_typed_memory)
+activate Factory
+Factory -> Factory : lock_guard<mutex_>
+Factory -> ResourceMap : find(path)
+alt weak_ptr resolves to existing resource
+    ResourceMap --> Factory : shared_ptr<SharedMemoryResource>
+    Factory -> Factory : validate allowedProviders_
+    Factory --> Caller : existing resource from map
+else path not present or weak_ptr expired
+    ResourceMap --> Factory : miss
+    Factory -> Factory : choose effective typed provider
+    Factory -> Resource : CreateOrOpen(path, size, cb, permissions_, acl_factory, provider)
+    Resource --> Factory : shared_ptr<SharedMemoryResource>
+    Factory -> ResourceMap : emplace(path, weak_ptr(resource))
+    Factory -> Factory : validate allowedProviders_
+    Factory --> Caller : newly created/opened resource
+end
+deactivate Factory
+
+@enduml

--- a/score/memory/dependability/software_unit_design/shared_memory_factory_dynamic.rst
+++ b/score/memory/dependability/software_unit_design/shared_memory_factory_dynamic.rst
@@ -1,0 +1,18 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+SharedMemoryFactory — Dynamic Design
+====================================
+
+.. uml:: shared_memory_factory_dynamic.puml

--- a/score/memory/dependability/software_unit_design/shared_memory_factory_static.puml
+++ b/score/memory/dependability/software_unit_design/shared_memory_factory_static.puml
@@ -1,0 +1,23 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+
+@startuml
+
+namespace score::memory::shared {
+    abstract class ISharedMemoryFactory
+    class SharedMemoryFactory
+
+    SharedMemoryFactory ..> ISharedMemoryFactory
+}
+
+@enduml

--- a/score/memory/dependability/software_unit_design/shared_memory_factory_static.puml
+++ b/score/memory/dependability/software_unit_design/shared_memory_factory_static.puml
@@ -14,10 +14,64 @@
 @startuml
 
 namespace score::memory::shared {
-    abstract class ISharedMemoryFactory
-    class SharedMemoryFactory
 
-    SharedMemoryFactory ..> ISharedMemoryFactory
+abstract class ISharedMemoryFactory {
+  {abstract} +Open(path, is_read_write, allowedProviders): std::shared_ptr<ISharedMemoryResource>
+  {abstract} +Create(path, cb, reserve_bytes, permissions, prefer_typed_memory): std::shared_ptr<ISharedMemoryResource>
+  {abstract} +CreateAnonymous(shared_memory_resource_id, cb, reserve_bytes, permissions, prefer_typed_memory): std::shared_ptr<ISharedMemoryResource>
+  {abstract} +CreateOrOpen(path, cb, reserve_bytes, access_control, prefer_typed_memory): std::shared_ptr<ISharedMemoryResource>
+  {abstract} +Remove(path): void
+  {abstract} +RemoveStaleArtefacts(path): void
+  {abstract} +SetTypedMemoryProvider(typed_memory_ptr): void
+  {abstract} +SetInterVMMemoryProvider(intervm_memory_ptr): void
+  {abstract} +GetControlBlockSize(): std::size_t
+  {abstract} +Clear(): void
+}
+
+class SharedMemoryFactory {
+  {static} +Open(path, is_read_write, allowedProviders): std::shared_ptr<ISharedMemoryResource>
+  {static} +Create(path, cb, reserve_bytes, permissions, prefer_typed_memory): std::shared_ptr<ISharedMemoryResource>
+  {static} +CreateAnonymous(shared_memory_resource_id, cb, reserve_bytes, permissions, prefer_typed_memory): std::shared_ptr<ISharedMemoryResource>
+  {static} +CreateOrOpen(path, cb, reserve_bytes, access_control, prefer_typed_memory): std::shared_ptr<ISharedMemoryResource>
+  {static} +Remove(path): void
+  {static} +RemoveStaleArtefacts(path): void
+  {static} +SetTypedMemoryProvider(typed_memory_ptr): void
+  {static} +SetInterVMMemoryProvider(intervm_memory_ptr): void
+  {static} +GetControlBlockSize(): std::size_t
+  {static} +Clear(): void
+  {static} +InjectMock(mock): void
+  -instance(): ISharedMemoryFactory&
+  --
+  -mock_ : ISharedMemoryFactory*
+}
+
+class SharedMemoryFactoryImpl {
+  +Open(path, is_read_write, allowedProviders): std::shared_ptr<ISharedMemoryResource>
+  +Create(path, cb, reserve_bytes, permissions, prefer_typed_memory): std::shared_ptr<ISharedMemoryResource>
+  +CreateAnonymous(shared_memory_resource_id, cb, reserve_bytes, permissions, prefer_typed_memory): std::shared_ptr<ISharedMemoryResource>
+  +CreateOrOpen(path, cb, reserve_bytes, access_control, prefer_typed_memory): std::shared_ptr<ISharedMemoryResource>
+  +Remove(path): void
+  +RemoveStaleArtefacts(path): void
+  +SetTypedMemoryProvider(typed_memory_ptr): void
+  +SetInterVMMemoryProvider(intervm_memory_ptr): void
+  +GetControlBlockSize(): std::size_t
+  +Clear(): void
+  --
+  -mutex_ : std::mutex
+  -resources_ : std::unordered_map<std::string, std::weak_ptr<score::memory::shared::SharedMemoryResource>>
+  -typed_memory_ptr_ : std::shared_ptr<score::memory::shared::TypedMemory>
+  -intervm_memory_ptr_ : std::shared_ptr<score::memory::shared::TypedMemory>
+}
+
+class SharedMemoryResource
+abstract class TypedMemory
+class ISharedMemoryResource
+
+ISharedMemoryFactory <|-- SharedMemoryFactoryImpl
+SharedMemoryFactory ..> ISharedMemoryFactory : facade / mock injection
+SharedMemoryFactoryImpl ..> SharedMemoryResource : creates / opens
+SharedMemoryFactoryImpl ..> TypedMemory : provider selection
+
 }
 
 @enduml

--- a/score/memory/dependability/software_unit_design/shared_memory_factory_static.rst
+++ b/score/memory/dependability/software_unit_design/shared_memory_factory_static.rst
@@ -1,0 +1,18 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+SharedMemoryFactory — Static Design
+===================================
+
+.. uml:: shared_memory_factory_static.puml

--- a/score/memory/dependability/software_unit_design/shared_memory_resource_dynamic.puml
+++ b/score/memory/dependability/software_unit_design/shared_memory_resource_dynamic.puml
@@ -1,0 +1,48 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+
+@startuml
+
+title SharedMemoryResource::OpenImpl prevents races with concurrent CreateImpl
+
+participant Caller
+participant SharedMemoryResource as Resource
+participant LockFile
+participant OS
+
+Caller -> Resource : Open(path, is_read_write, acl_factory, typed_memory_ptr)
+activate Resource
+Resource -> Resource : OpenImpl(is_read_write)
+Resource -> Resource : acquireLockFile()
+loop until lock file can be created
+    Resource -> LockFile : Create(<path>_lock)
+    alt lock file still present
+        Resource -> OS : stat/sleep/retry
+    else acquired
+        LockFile --> Resource : temporary lock
+    end
+end
+Resource -> Resource : acquireLockAndOpenSharedMemory()
+Resource -> OS : shm_open(path, flags)
+Resource -> OS : fstat(fd)
+Resource -> OS : mmap(fd, size)
+Resource -> Resource : loadInternalsFromSharedMemory()
+Resource --> Caller : mapped SharedMemoryResource
+deactivate Resource
+note right of LockFile
+The temporary lock file exists only to serialize
+Open with a concurrent CreateImpl so the opener
+never reads partially initialized shared memory.
+end note
+
+@enduml

--- a/score/memory/dependability/software_unit_design/shared_memory_resource_dynamic.rst
+++ b/score/memory/dependability/software_unit_design/shared_memory_resource_dynamic.rst
@@ -1,0 +1,18 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+SharedMemoryResource — Dynamic Design
+=====================================
+
+.. uml:: shared_memory_resource_dynamic.puml

--- a/score/memory/dependability/software_unit_design/shared_memory_resource_static.puml
+++ b/score/memory/dependability/software_unit_design/shared_memory_resource_static.puml
@@ -14,18 +14,94 @@
 @startuml
 
 namespace score::memory::shared {
-    abstract class ManagedMemoryResource
-    abstract class ISharedMemoryResource
-    class SharedMemoryResource
-    class LockFile
-    class MemoryResourceProxy
-    abstract class TypedMemory
 
-    ManagedMemoryResource <|-- ISharedMemoryResource
-    ISharedMemoryResource <|-- SharedMemoryResource
-    SharedMemoryResource ..> LockFile
-    SharedMemoryResource ..> MemoryResourceProxy
-    SharedMemoryResource ..> TypedMemory
+abstract class ManagedMemoryResource
+
+abstract class ISharedMemoryResource {
+  {abstract} +getPath(): const std::string*
+  {abstract} +UnlinkFilesystemEntry(): void
+  {abstract} +GetFileDescriptor(): FileDescriptor
+  {abstract} +IsShmInTypedMemory(): bool
+  {abstract} +GetIdentifier(): std::string_view
+}
+
+class SharedMemoryResource {
+  +~SharedMemoryResource()
+  +getMemoryResourceProxy(): const MemoryResourceProxy*
+  +getBaseAddress(): void*
+  +getUsableBaseAddress(): void*
+  +GetUserAllocatedBytes(): std::size_t
+  +IsOffsetPtrBoundsCheckBypassingEnabled(): bool
+  +getPath(): const std::string*
+  +GetIdentifier(): std::string_view
+  +GetFileDescriptor(): FileDescriptor
+  +IsShmInTypedMemory(): bool
+  -Create(path, reserve_bytes, initialize_callback, permissions, acl_factory, typed_memory_ptr)
+  -CreateAnonymous(shared_memory_resource_id, reserve_bytes, initialize_callback, permissions, acl_factory, typed_memory_ptr)
+  -CreateOrOpen(path, reserve_bytes, initialize_callback, permissions, acl_factory, typed_memory_ptr)
+  -Open(path, is_read_write, acl_factory, typed_memory_ptr)
+  -GetNeededManagementSpace(): std::size_t
+  -CreateImpl(reserve_bytes, initialize_callback, permissions)
+  -CreateOrOpenImpl(reserve_bytes, initialize_callback, permissions)
+  -OpenImpl(is_read_write)
+  -UnlinkFilesystemEntry(): void
+  -calcStatModeForPermissions(permissions)
+  -CreateLockFileForNamedSharedMemory(lock_file)
+  -AllocateInTypedMemory(permissions, flags)
+  -OpenSharedMemory(flags, mode)
+  -SealAnonymousOrReserveNamedSharedMemory(): void
+  --
+  -file_descriptor_ : FileDescriptor
+  -file_owner_uid_ : uid_t
+  -lock_file_path_ : std::optional<std::string>
+  -virtual_address_space_to_reserve_ : std::size_t
+  -typed_memory_ptr_ : std::shared_ptr<TypedMemory>
+  -opening_mode_ : ::score::os::Fcntl::Open
+  -map_mode_ : ::score::os::Mman::Protection
+  -base_address_ : void*
+  -control_block_ : ControlBlock*
+  -acl_factory_ : AccessControlListFactory
+  -is_shm_in_typed_memory_ : bool
+  -log_identification_ : std::string
+  -memory_identifier_ : std::uint64_t
+  -shared_memory_resource_identifier_ : std::variant<std::string, std::uint64_t>
+  -start_ : void*
+}
+
+class "SharedMemoryResource::ControlBlock" as ControlBlock {
+  +ControlBlock(id)
+  --
+  +alreadyAllocatedBytes : std::atomic<std::size_t>
+  +memoryResourceProxy : MemoryResourceProxy
+}
+
+class "ISharedMemoryResource::AccessControl" as AccessControl {
+  +permissions_ : const UserPermissions&
+  +allowedProviders_ : const std::optional<score::cpp::span<const uid_t>>
+}
+
+class WorldReadable
+class WorldWritable
+class MemoryResourceProxy
+class SharedMemoryFactory
+abstract class TypedMemory
+class LockFile
+
+enum SharedMemoryErrorCode {
+  UnknownSharedMemoryIdentifier = 1
+}
+
+ManagedMemoryResource <|-- ISharedMemoryResource
+ISharedMemoryResource <|-- SharedMemoryResource
+SharedMemoryFactory ..> SharedMemoryResource : creates / opens
+SharedMemoryResource *-- ControlBlock
+ControlBlock *-- MemoryResourceProxy
+SharedMemoryResource ..> LockFile
+SharedMemoryResource ..> TypedMemory
+AccessControl ..> WorldReadable
+AccessControl ..> WorldWritable
+SharedMemoryResource ..> SharedMemoryErrorCode
+
 }
 
 @enduml

--- a/score/memory/dependability/software_unit_design/shared_memory_resource_static.puml
+++ b/score/memory/dependability/software_unit_design/shared_memory_resource_static.puml
@@ -1,0 +1,31 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+
+@startuml
+
+namespace score::memory::shared {
+    abstract class ManagedMemoryResource
+    abstract class ISharedMemoryResource
+    class SharedMemoryResource
+    class LockFile
+    class MemoryResourceProxy
+    abstract class TypedMemory
+
+    ManagedMemoryResource <|-- ISharedMemoryResource
+    ISharedMemoryResource <|-- SharedMemoryResource
+    SharedMemoryResource ..> LockFile
+    SharedMemoryResource ..> MemoryResourceProxy
+    SharedMemoryResource ..> TypedMemory
+}
+
+@enduml

--- a/score/memory/dependability/software_unit_design/shared_memory_resource_static.rst
+++ b/score/memory/dependability/software_unit_design/shared_memory_resource_static.rst
@@ -1,0 +1,18 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+SharedMemoryResource — Static Design
+====================================
+
+.. uml:: shared_memory_resource_static.puml

--- a/score/memory/dependability/software_unit_design/typed_memory_dynamic.puml
+++ b/score/memory/dependability/software_unit_design/typed_memory_dynamic.puml
@@ -1,0 +1,35 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+
+@startuml
+
+title TypedMemoryImpl::AllocateAndOpenAnonymousTypedMemory on QNX
+
+participant SharedMemoryResource
+participant TypedMemoryImpl
+participant "score::tmd::ITypedSharedMemory" as TypedShmClient
+participant "score::os::qnx::MmanQnx" as Mman
+
+SharedMemoryResource -> TypedMemoryImpl : AllocateAndOpenAnonymousTypedMemory(shm_size)
+activate TypedMemoryImpl
+TypedMemoryImpl -> TypedShmClient : AllocateHandleTypedMemory(shm_size, &shm_handle)
+TypedShmClient --> TypedMemoryImpl : shm_handle
+TypedMemoryImpl -> Mman : shm_open_handle(shm_handle, O_RDWR)
+Mman --> TypedMemoryImpl : file descriptor
+TypedMemoryImpl --> SharedMemoryResource : expected<int, Error>{fd}
+deactivate TypedMemoryImpl
+note right of TypedMemoryImpl
+On non-QNX / non-typedshmd builds these APIs return ENOSYS.
+end note
+
+@enduml

--- a/score/memory/dependability/software_unit_design/typed_memory_dynamic.rst
+++ b/score/memory/dependability/software_unit_design/typed_memory_dynamic.rst
@@ -1,0 +1,18 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+TypedMemory — Dynamic Design
+============================
+
+.. uml:: typed_memory_dynamic.puml

--- a/score/memory/dependability/software_unit_design/typed_memory_static.puml
+++ b/score/memory/dependability/software_unit_design/typed_memory_static.puml
@@ -1,0 +1,23 @@
+' *******************************************************************************
+' Copyright (c) 2026 Contributors to the Eclipse Foundation
+'
+' See the NOTICE file(s) distributed with this work for additional
+' information regarding copyright ownership.
+'
+' This program and the accompanying materials are made available under the
+' terms of the Apache License Version 2.0 which is available at
+' https://www.apache.org/licenses/LICENSE-2.0
+'
+' SPDX-License-Identifier: Apache-2.0
+' *******************************************************************************
+
+@startuml
+
+namespace score::memory::shared {
+    abstract class TypedMemory
+    class "internal::TypedMemoryImpl" as TypedMemoryImpl
+
+    TypedMemory <|-- TypedMemoryImpl
+}
+
+@enduml

--- a/score/memory/dependability/software_unit_design/typed_memory_static.puml
+++ b/score/memory/dependability/software_unit_design/typed_memory_static.puml
@@ -14,10 +14,32 @@
 @startuml
 
 namespace score::memory::shared {
-    abstract class TypedMemory
-    class "internal::TypedMemoryImpl" as TypedMemoryImpl
 
-    TypedMemory <|-- TypedMemoryImpl
+abstract class TypedMemory {
+  {static} +Default(): std::shared_ptr<TypedMemory>
+  {abstract} +AllocateNamedTypedMemory(shm_size, shm_name, permissions): score::cpp::expected_blank<score::os::Error>
+  {abstract} +AllocateAndOpenAnonymousTypedMemory(shm_size): score::cpp::expected<int, score::os::Error>
+  {abstract} +Unlink(shm_name): score::cpp::expected_blank<score::os::Error>
+  {abstract} +GetCreatorUid(shm_name): score::cpp::expected<uid_t, score::os::Error>
+}
+
+class "internal::TypedMemoryImpl" as TypedMemoryImpl {
+  +AllocateNamedTypedMemory(shm_size, shm_name, permissions): score::cpp::expected_blank<score::os::Error>
+  +AllocateAndOpenAnonymousTypedMemory(shm_size): score::cpp::expected<int, score::os::Error>
+  +Unlink(shm_name): score::cpp::expected_blank<score::os::Error>
+  +GetCreatorUid(shm_name): score::cpp::expected<uid_t, score::os::Error>
+}
+
+class SharedMemoryResource
+class SharedMemoryFactoryImpl
+
+TypedMemory <|-- TypedMemoryImpl
+SharedMemoryFactoryImpl ..> TypedMemory
+SharedMemoryResource ..> TypedMemory
+
+' QNX builds add TypedMemoryImpl members mman_ and typed_shm_client_.
+' typed_memory_utils.h contributes the free function AcquireTypedMemoryDaemonUid().
+
 }
 
 @enduml

--- a/score/memory/dependability/software_unit_design/typed_memory_static.rst
+++ b/score/memory/dependability/software_unit_design/typed_memory_static.rst
@@ -1,0 +1,18 @@
+..
+   # *******************************************************************************
+   # Copyright (c) 2026 Contributors to the Eclipse Foundation
+   #
+   # See the NOTICE file(s) distributed with this work for additional
+   # information regarding copyright ownership.
+   #
+   # This program and the accompanying materials are made available under the
+   # terms of the Apache License Version 2.0 which is available at
+   # https://www.apache.org/licenses/LICENSE-2.0
+   #
+   # SPDX-License-Identifier: Apache-2.0
+   # *******************************************************************************
+
+TypedMemory — Static Design
+===========================
+
+.. uml:: typed_memory_static.puml

--- a/score/memory/shared/BUILD
+++ b/score/memory/shared/BUILD
@@ -12,6 +12,7 @@
 # *******************************************************************************
 
 load("@rules_cc//cc:defs.bzl", "cc_library")
+load("@score_tooling//bazel/rules/rules_score:rules_score.bzl", "unit")
 load("//quality/unit_testing:unit_testing.bzl", "cc_unit_test")
 
 # TODO move to //score
@@ -879,5 +880,194 @@ cc_unit_test(
         ":string",
         "//score/memory/shared/fake:fake_memory_resources",
         "@score_baselibs//score/mw/log:backend_stub_testutil",
+    ],
+)
+
+# ============================================================================
+# Software units (dependability decomposition, see //score/memory/dependability)
+# ============================================================================
+
+unit(
+    name = "managed_memory_resource_unit",
+    maturity = "development",
+    scope = ["@@//score/memory/shared:__subpackages__"],
+    tests = [":managed_memory_resource_test_linux"],
+    unit_design = ["//score/memory/dependability/software_unit_design:managed_memory_resource_unit_design"],
+    visibility = ["//score/memory/dependability:__pkg__"],
+    # Only managed_memory_resource is listed: new_delete_delegate_resource
+    # transitively includes managed_memory_resource.h too, and listing both
+    # causes the unit's AST-based class-diagram check to see
+    # ManagedMemoryResource (and its nested/friend classes) declared twice.
+    implementation = [
+        ":managed_memory_resource",
+    ],
+)
+
+unit(
+    name = "shared_memory_resource_unit",
+    maturity = "development",
+    scope = ["@@//score/memory/shared:__subpackages__"],
+    tests = [
+        ":shared_memory_error_test_linux",
+        ":shared_memory_resource_allocate_test_linux",
+        ":shared_memory_resource_create_anonymous_test_linux",
+        ":shared_memory_resource_create_or_open_test_linux",
+        ":shared_memory_resource_create_test_linux",
+        ":shared_memory_resource_misc_test_linux",
+        ":shared_memory_resource_open_test_linux",
+    ],
+    unit_design = ["//score/memory/dependability/software_unit_design:shared_memory_resource_unit_design"],
+    visibility = ["//score/memory/dependability:__pkg__"],
+    # Only shared_memory_resource is listed: it transitively covers
+    # i_shared_memory_resource and user_permission already (via deps).
+    # shared_memory_error is a standalone type with no shared transitive
+    # headers, but is intentionally omitted here too, since combining
+    # multiple implementation entries in this unit trips up the unit's
+    # AST-based class-diagram duplicate check (see managed_memory_resource
+    # and memory_resource_registry units for the same pattern). It remains
+    # covered by shared_memory_error_test above.
+    implementation = [
+        ":shared_memory_resource",
+    ],
+)
+
+unit(
+    name = "shared_memory_factory_unit",
+    maturity = "development",
+    scope = ["@@//score/memory/shared:__subpackages__"],
+    tests = [":shared_memory_factory_test_linux"],
+    unit_design = ["//score/memory/dependability/software_unit_design:shared_memory_factory_unit_design"],
+    visibility = ["//score/memory/dependability:__pkg__"],
+    # Only shared_memory_factory is listed: it is the public facade that
+    # transitively covers i_shared_memory_factory (via deps) and
+    # shared_memory_factory_impl (via implementation_deps). Listing the
+    # sibling targets explicitly causes the unit's AST-based
+    # class-diagram check to see shared classes/headers declared twice.
+    implementation = [
+        ":shared_memory_factory",
+    ],
+)
+
+unit(
+    name = "memory_resource_registry_unit",
+    maturity = "development",
+    scope = ["@@//score/memory/shared:__subpackages__"],
+    tests = [
+        ":memory_region_bounds_test_linux",
+        ":memory_region_map_test_linux",
+        ":memory_resource_proxy_test_linux",
+        ":memory_resource_registry_test_linux",
+    ],
+    unit_design = ["//score/memory/dependability/software_unit_design:memory_resource_registry_unit_design"],
+    visibility = ["//score/memory/dependability:__pkg__"],
+    # Only memory_resource_registry is listed: it transitively covers
+    # memory_region_bounds and memory_region_map already (via deps).
+    # memory_resource_proxy is a separate consumer that only reaches these
+    # headers via implementation_deps and is intentionally omitted (see
+    # note in flock_mutex_unit / managed_memory_resource_unit for the
+    # general pattern this avoids). Both remain covered by their tests above.
+    implementation = [
+        ":memory_resource_registry",
+    ],
+)
+
+unit(
+    name = "offset_ptr_unit",
+    maturity = "development",
+    scope = ["@@//score/memory/shared:__subpackages__"],
+    tests = [
+        ":pointer_arithmetic_util_calculate_aligned_size_test_linux",
+        ":pointer_arithmetic_util_precondition_violation_test_linux",
+        "//score/memory/shared/test_offset_ptr:offset_ptr_precondition_violation_test_linux",
+        "//score/memory/shared/test_offset_ptr:offset_ptr_test_linux",
+    ],
+    unit_design = ["//score/memory/dependability/software_unit_design:offset_ptr_unit_design"],
+    visibility = ["//score/memory/dependability:__pkg__"],
+    # Only offset_ptr is listed: it transitively covers offset_ptr_bounds_check
+    # and pointer_arithmetic_util already (via deps).
+    implementation = [
+        ":offset_ptr",
+    ],
+)
+
+unit(
+    name = "polymorphic_offset_ptr_allocator_unit",
+    maturity = "development",
+    scope = ["@@//score/memory/shared:__subpackages__"],
+    tests = [":polymorphic_offset_ptr_allocator_test_linux"],
+    unit_design = ["//score/memory/dependability/software_unit_design:polymorphic_offset_ptr_allocator_unit_design"],
+    visibility = ["//score/memory/dependability:__pkg__"],
+    implementation = [
+        ":polymorphic_offset_ptr_allocator",
+    ],
+)
+
+unit(
+    name = "containers_unit",
+    maturity = "development",
+    scope = ["@@//score/memory/shared:__subpackages__"],
+    tests = [
+        ":containers_compatibility_test_linux",
+        ":map_test_linux",
+        ":string_test_linux",
+        ":vector_test_linux",
+    ],
+    unit_design = ["//score/memory/dependability/software_unit_design:containers_unit_design"],
+    visibility = ["//score/memory/dependability:__pkg__"],
+    implementation = [
+        ":map",
+        ":string",
+        ":vector",
+    ],
+)
+
+unit(
+    name = "flock_mutex_unit",
+    maturity = "development",
+    scope = ["@@//score/memory/shared:__subpackages__"],
+    tests = [
+        ":lock_file_test_linux",
+        "//score/memory/shared/flock:unit_test_linux",
+    ],
+    unit_design = ["//score/memory/dependability/software_unit_design:flock_mutex_unit_design"],
+    visibility = ["//score/memory/dependability:__pkg__"],
+    # Only exclusive_flock_mutex is listed: it transitively covers flock_mutex.h
+    # and lock_file.h in a single, consistent AST scan. Listing sibling targets
+    # (shared_flock_mutex, flock_mutex_and_lock, lock_file) alongside it causes
+    # the unit's AST-based class-diagram check to see FlockMutex/LockFile
+    # declared multiple times (once per translation unit that transitively
+    # includes the same header), which the validator flags as duplicates.
+    # shared_flock_mutex, flock_mutex_and_lock and lock_file remain covered by
+    # their own tests above.
+    implementation = [
+        "//score/memory/shared/flock:exclusive_flock_mutex",
+    ],
+)
+
+unit(
+    name = "typed_memory_unit",
+    maturity = "development",
+    # typed_memory_test is QNX-only (see typedshm_wrapper/BUILD target_compatible_with),
+    # so it cannot be listed unconditionally without breaking non-QNX analysis,
+    # mirroring the qnx_dispatch unit in //score/message_passing:BUILD.
+    scope = ["@@//score/memory/shared:__subpackages__"],
+    tests = [],
+    unit_design = ["//score/memory/dependability/software_unit_design:typed_memory_unit_design"],
+    visibility = ["//score/memory/dependability:__pkg__"],
+    implementation = [
+        "//score/memory/shared/typedshm/typedshm_wrapper:typedmemory",
+        "//score/memory/shared/typedshm/utils:typed_memory_utils",
+    ],
+)
+
+unit(
+    name = "sealed_shared_memory_unit",
+    maturity = "development",
+    scope = ["@@//score/memory/shared:__subpackages__"],
+    tests = ["//score/memory/shared/sealedshm/sealedshm_wrapper:unit_test_linux"],
+    unit_design = ["//score/memory/dependability/software_unit_design:sealed_shared_memory_unit_design"],
+    visibility = ["//score/memory/dependability:__pkg__"],
+    implementation = [
+        "//score/memory/shared/sealedshm/sealedshm_wrapper:sealedshm",
     ],
 )

--- a/score/memory/shared/flock/BUILD
+++ b/score/memory/shared/flock/BUILD
@@ -88,6 +88,7 @@ cc_unit_test(
     features = COMPILER_WARNING_FEATURES,
     visibility = [
         "//score/memory:__pkg__",
+        "//score/memory/shared:__pkg__",
     ],
     deps = [
         ":exclusive_flock_mutex",

--- a/score/memory/shared/sealedshm/sealedshm_wrapper/BUILD
+++ b/score/memory/shared/sealedshm/sealedshm_wrapper/BUILD
@@ -69,6 +69,7 @@ cc_unit_test(
     ],
     visibility = [
         "//score/memory:__pkg__",
+        "//score/memory/shared:__pkg__",
     ],
     deps = [
         ":sealedshm",

--- a/score/memory/shared/test_offset_ptr/BUILD
+++ b/score/memory/shared/test_offset_ptr/BUILD
@@ -28,6 +28,7 @@ cc_unit_test(
     features = COMPILER_WARNING_FEATURES,
     visibility = [
         "//score/memory:__pkg__",
+        "//score/memory/shared:__pkg__",
     ],
     deps = [
         ":offset_ptr_test_resources",
@@ -49,6 +50,7 @@ cc_unit_test(
     ],
     visibility = [
         "//score/memory:__pkg__",
+        "//score/memory/shared:__pkg__",
     ],
     deps = [
         ":bounds_check_memory_pool",


### PR DESCRIPTION
Builds out the S-CORE dependability artifacts for `score/memory`, following the pattern established by `score/message_passing` and `score/mw/com`.

## Feature Requirements
- `score/memory/dependability/assumed_system/assumed_system_requirements.trlc`: system-level assumed requirement (`SharedMemoryIPC`, ASIL B) and a `SafeState` mitigation.
- `score/memory/dependability/requirements/feature_requirements.trlc`: 14 `FeatReq` records derived from the assumed system requirements.

## Architecture Design
- `score/memory/dependability/software_architectural_design/{static_design.puml,public_api.puml,BUILD}`: static decomposition of the `Memory` SEooC into a `Memory` component with 5 sub-components (`SharedMemoryManagement`, `OffsetPointer`, `SharedMemoryContainers`, `SharedMemorySynchronization`, `TypedAndSealedMemory`) containing 10 units, plus the public API surface.
- `score/memory/dependability/software_unit_design/BUILD`: `unit_design()` stubs for all 10 units.

## Dependable Element / Component / Unit wiring
- `score/memory/shared/BUILD`: 10 `unit()` targets mapping each software unit to its real `cc_library` implementation(s) and `cc_unit_test` targets.
- `score/memory/dependability/BUILD` (new): 5 `component()` targets grouping the units, a parent `component_memory`, and the `dependable_element_memory` target wiring together the architectural design, requirements, and components. `dependability_analysis` is intentionally left empty pending a future FMEA/FMEDA.
- Minor visibility widenings in `flock/BUILD`, `test_offset_ptr/BUILD`, `sealedshm_wrapper/BUILD` so the new `unit()` targets can reference their tests.
- `static_design.puml` unit aliases renamed to match the Bazel `*_unit` target names for a clean architecture-to-Bazel naming consistency check.

## Verification
- `bazel test //score/memory/dependability/assumed_system:assumed_system_requirements_test //score/memory/dependability/requirements:feature_requirements_test` — PASSED
- `bazel build //score/memory/shared:all //score/memory/dependability:dependable_element_memory` — succeeds
- `buildifier --lint=warn --mode=check` — clean

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>