### PR TITLE
Add clippy and ruff to CI.md

### DIFF
--- a/CI.md
+++ b/CI.md
@@ -110,6 +110,11 @@ Also, it lints the files to ensure the basic Bazel best practices.
 Ensure that the modified C++ files are formatted following our decided style.
 The goal is not to ensure a specific format but to have consistency in the project.
 
+#### Formatting of Python files
+
+Ensure that the modified Python files are formatted following our decided style.
+The goal is not to ensure a specific format but to have consistency in the project.
+
 #### Build everything and run unit tests (x86-64 linux)
 
 Builds everything and runs all unit tests for all languages (C++, Rust, Python, etc.).
@@ -173,6 +178,16 @@ Runs the [clang-tidy checks](./.clang-tidy) for the host.
 Runs the [clang-tidy checks](./.clang-tidy) for the target.
 
 Note: Not yet implemented, it will be done with https://github.com/eclipse-score/communication/issues/790.
+
+#### Linting for Rust (x86-64 linux)
+
+Runs the [default clippy checks](https://rust-lang.github.io/rust-clippy/master/index.html) for the host.
+
+#### Linting for Python (x86-64 linux)
+
+There are many linters for Python with no clear recommendation.
+We chose ruff because it is fast, and it has a good set of default checks.
+Runs the [ruff checks](./.ruff.toml) for the host.
 
 #### API checks
 


### PR DESCRIPTION
We introduced clippy and ruff in the CI.

Adds them to the documentation to keep it up to date.