### PR TITLE
Avoid blocking workflow on cancellation

### DIFF
--- a/.github/workflows/build_and_test_qnx.yml
+++ b/.github/workflows/build_and_test_qnx.yml
@@ -120,7 +120,7 @@ jobs:
       needs:
         - precheck
         - approval
-      if: ${{ always() && needs.precheck.outputs.should-run == 'true' && (needs.approval.result == 'success' || needs.approval.result == 'skipped') }}
+      if: ${{ !cancelled() && needs.precheck.outputs.should-run == 'true' && (needs.approval.result == 'success' || needs.approval.result == 'skipped') }}
       runs-on: ubuntu-24.04
       permissions:
         contents: read


### PR DESCRIPTION
Cancellation does not work nicely with always().
Github documentation notes that !cancelled() should be used instead.