### PR TITLE
Avoid blocking workflows

### DIFF
--- a/.github/actions/00_infrastructure/setup_bazel_cache/action.yml
+++ b/.github/actions/00_infrastructure/setup_bazel_cache/action.yml
@@ -15,7 +15,7 @@ name: "Bazel Post Cache Save"
 description: >
   Internal action: registers a post step that saves Bazel caches.
   Called from within prepare_bazel_environment composite action to ensure cache save
-  runs even on job failure (via post-if: always()).
+  runs even on job failure (via post-if: !cancelled()).
 
 inputs:
   cache-mode:
@@ -34,4 +34,4 @@ runs:
   using: "node24"
   main: "dist/main/index.js"
   post: "dist/post/index.js"
-  post-if: "always()"
+  post-if: "!cancelled()"

--- a/.github/actions/00_infrastructure/setup_qnx_environment/action.yml
+++ b/.github/actions/00_infrastructure/setup_qnx_environment/action.yml
@@ -27,4 +27,4 @@ runs:
   using: "node24"
   main: "main.js"
   post: "post.js"
-  post-if: "always()"
+  post-if: "!cancelled()"

--- a/.github/actions/00_infrastructure/upload_bazel_testlogs_on_failure/action.yml
+++ b/.github/actions/00_infrastructure/upload_bazel_testlogs_on_failure/action.yml
@@ -64,7 +64,7 @@ runs:
         echo "log-count=${COUNT}" >> "${GITHUB_OUTPUT}"
 
     - name: Upload Bazel test logs artifact
-      if: always()
+      if: ${{ !cancelled() }}
       uses: actions/upload-artifact@v4
       with:
         name: ${{ inputs.artifact-name }}

--- a/.github/cache-strategy.md
+++ b/.github/cache-strategy.md
@@ -194,7 +194,7 @@ A Node.js action (`using: node24`) with main/post lifecycle:
 - **`main`**: Saves inputs to action state, creates cache directories,
   restores caches via `@actions/cache` npm library, writes `~/.bazelrc`
   with `--repository_cache` and `--disk_cache` flags.
-- **`post`** (`post-if: always()`): Saves disk cache (if name non-empty),
+- **`post`** (`post-if: !cancelled()`): Saves disk cache (if name non-empty),
   saves repository cache (if mode is `recreate`/`recreate-update`),
   deletes old entries via GitHub API. Guaranteed to run even on
   job cancellation.

--- a/.github/workflows/_codeql.yml
+++ b/.github/workflows/_codeql.yml
@@ -98,7 +98,7 @@ jobs:
           retention-days: 1
 
       - name: Upload MISRA compliance reports (Linux)
-        if: inputs.fetch-only != 'true' && always()
+        if: ${{ !cancelled() && inputs.fetch-only != 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: codeql-misra-reports
@@ -164,7 +164,7 @@ jobs:
   merge:
     name: Merge & deduplicate findings (Linux ∪ QNX union)
     needs: [determine-qnx, codeql-linux, codeql-qnx]
-    if: always() && inputs.fetch-only != 'true' && needs.codeql-linux.result == 'success'
+    if: ${{ !cancelled() && inputs.fetch-only != 'true' && needs.codeql-linux.result == 'success' }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -211,7 +211,7 @@ jobs:
       # and QNX findings (or just the deduplicated Linux findings when QNX was
       # not run).
       - name: Upload SARIF to GitHub Code Scanning
-        if: always() && steps.merge-codeql.outcome == 'success'
+        if: ${{ !cancelled() && steps.merge-codeql.outcome == 'success' }}
         continue-on-error: true
         uses: github/codeql-action/upload-sarif@v4
         with:
@@ -219,7 +219,7 @@ jobs:
           category: codeql-nightly
 
       - name: Upload SARIF results
-        if: always() && steps.merge-codeql.outcome == 'success'
+        if: ${{ !cancelled() && steps.merge-codeql.outcome == 'success' }}
         uses: actions/upload-artifact@v4
         with:
           name: codeql-sarif-results

--- a/.github/workflows/_linter.yml
+++ b/.github/workflows/_linter.yml
@@ -123,7 +123,7 @@ jobs:
             -- //... 2>&1 | tee "${{ matrix.id }}_raw.log"
 
       - name: Collect SARIF reports
-        if: always() && inputs.fetch-only != 'true'
+        if: ${{ !cancelled() && inputs.fetch-only != 'true' }}
         id: sarif
         uses: ./.github/actions/00_infrastructure/merge_sarif_reports
         with:
@@ -131,7 +131,7 @@ jobs:
           output-file: ${{ matrix.id }}.sarif
 
       - name: Upload SARIF reports to GitHub Code Scanning
-        if: always() && inputs.fetch-only != 'true'
+        if: ${{ !cancelled() && inputs.fetch-only != 'true' }}
         uses: github/codeql-action/upload-sarif@v4
         with:
           sarif_file: ${{ matrix.id }}.sarif
@@ -143,7 +143,7 @@ jobs:
           wait-for-processing: true
 
       - name: Upload ${{ matrix.id }} findings as artifact
-        if: always() && inputs.fetch-only != 'true'
+        if: ${{ !cancelled() && inputs.fetch-only != 'true' }}
         uses: actions/upload-artifact@v4
         with:
           name: ${{ matrix.id }}-findings

--- a/.github/workflows/_nightly_flaky_detection_runner.yml
+++ b/.github/workflows/_nightly_flaky_detection_runner.yml
@@ -157,7 +157,7 @@ jobs:
 
       - name: Collect flaky summary
         id: summary
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           REPORT_DIR="${RUNNER_TEMP}/nightly-flaky/${{ inputs.config-name }}"
           bazel run --config=ci //quality/scripts:collect_flaky_tests -- \
@@ -170,7 +170,7 @@ jobs:
             --github-output "${GITHUB_OUTPUT}"
 
       - name: Upload per-config flaky report
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: nightly-flaky-${{ inputs.config-name }}-${{ github.run_id }}

--- a/.github/workflows/nightly_flaky_detection.yml
+++ b/.github/workflows/nightly_flaky_detection.yml
@@ -138,7 +138,7 @@ jobs:
       - flaky-tsan
       - flaky-qnx-unit
       - flaky-qnx-integration
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -165,11 +165,11 @@ jobs:
             --github-output "${GITHUB_OUTPUT}"
 
       - name: Add summary to workflow
-        if: always()
+        if: ${{ !cancelled() }}
         run: cat /tmp/nightly_flaky/merged/summary.md >> "$GITHUB_STEP_SUMMARY"
 
       - name: Sync flaky test issues
-        if: always()
+        if: ${{ !cancelled() }}
         env:
           GITHUB_TOKEN: ${{ github.token }}
         run: |
@@ -184,7 +184,7 @@ jobs:
             --run-url "${{ github.server_url }}/${{ github.repository }}/actions/runs/${{ github.run_id }}"
 
       - name: Upload consolidated artifact
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: nightly-flaky-summary-${{ github.run_id }}

--- a/.github/workflows/nightly_quality.yml
+++ b/.github/workflows/nightly_quality.yml
@@ -90,7 +90,7 @@ jobs:
     needs: [run-coverage, run-linters, run-codeql]
     # Always run even if individual quality jobs fail, so the dashboard
     # still reflects which jobs passed and which failed.
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
     permissions:
       contents: write
@@ -134,7 +134,7 @@ jobs:
       # Download clang-tidy findings artifact
       # ------------------------------------------------------------------
       - name: Download clang-tidy findings
-        if: always()
+        if: ${{ !cancelled() }}
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
@@ -142,7 +142,7 @@ jobs:
           path: /tmp/clang_tidy
 
       - name: Copy clang-tidy SARIF into quality output
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/_quality"
           if [[ -f /tmp/clang_tidy/clang-tidy.sarif ]]; then
@@ -156,7 +156,7 @@ jobs:
       # Download clippy findings artifact
       # ------------------------------------------------------------------
       - name: Download clippy findings
-        if: always()
+        if: ${{ !cancelled() }}
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
@@ -164,7 +164,7 @@ jobs:
           path: /tmp/clippy
 
       - name: Copy clippy SARIF into quality output
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/_quality"
           if [[ -f /tmp/clippy/clippy.sarif ]]; then
@@ -178,7 +178,7 @@ jobs:
       # Download CodeQL SARIF artifact
       # ------------------------------------------------------------------
       - name: Download CodeQL SARIF artifact
-        if: always()
+        if: ${{ !cancelled() }}
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
@@ -186,7 +186,7 @@ jobs:
           path: /tmp/codeql
 
       - name: Copy CodeQL SARIF into quality output
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/_quality"
           if [[ -f /tmp/codeql/codeql-nightly.sarif ]]; then
@@ -198,7 +198,7 @@ jobs:
       # Download CodeQL MISRA compliance reports artifact
       # ------------------------------------------------------------------
       - name: Download CodeQL MISRA reports artifact
-        if: always()
+        if: ${{ !cancelled() }}
         continue-on-error: true
         uses: actions/download-artifact@v4
         with:
@@ -206,7 +206,7 @@ jobs:
           path: /tmp/codeql_reports
 
       - name: Copy CodeQL MISRA reports into quality output
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           mkdir -p "${GITHUB_WORKSPACE}/_quality/codeql"
           find /tmp/codeql_reports -name '*.md' -type f -exec cp {} "${GITHUB_WORKSPACE}/_quality/codeql/" \;
@@ -215,7 +215,7 @@ jobs:
       # Generate coverage KPI dashboard via generate_dashboard py_binary
       # ------------------------------------------------------------------
       - name: Generate quality dashboard
-        if: always() && steps.setup.outcome == 'success'
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         run: |
           # Pass LCOV data and SARIF findings; generate_dashboard handles
           # absent files gracefully (shows N/A for that metric).
@@ -232,7 +232,7 @@ jobs:
       # pick up and deploy as part of the unified Sphinx site.
       # ------------------------------------------------------------------
       - name: Upload quality reports artifact
-        if: always() && steps.setup.outcome == 'success'
+        if: ${{ !cancelled() && steps.setup.outcome == 'success' }}
         uses: actions/upload-artifact@v4
         with:
           name: nightly-quality-reports
@@ -240,7 +240,7 @@ jobs:
           retention-days: 7
 
       - name: Print dashboard URL
-        if: always()
+        if: ${{ !cancelled() }}
         run: |
           OWNER="${{ github.repository_owner }}"
           REPO="${{ github.event.repository.name }}"

--- a/.github/workflows/test_dependency_version_combinations.yml
+++ b/.github/workflows/test_dependency_version_combinations.yml
@@ -108,7 +108,7 @@ jobs:
           fi
 
       - name: Write result JSON
-        if: always()
+        if: ${{ !cancelled() }}
         env:
           COMBO: ${{ toJSON(matrix) }}
         run: |
@@ -132,7 +132,7 @@ jobs:
           PY
 
       - name: Upload result
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: result-${{ matrix.index }}
@@ -143,7 +143,7 @@ jobs:
 
   report:
     needs: build-and-test
-    if: always()
+    if: ${{ !cancelled() }}
     runs-on: ubuntu-24.04
     permissions:
       contents: read
@@ -171,7 +171,7 @@ jobs:
             --fail-on never
 
       - name: Upload report
-        if: always()
+        if: ${{ !cancelled() }}
         uses: actions/upload-artifact@v4
         with:
           name: compatibility-report


### PR DESCRIPTION
always() leads to blocking workflows when cancelled.

Instead, use !cancelled() as suggested by GitHub.

<!-- review-checklist-merge-queue-notice:start -->
## Review Checklist Evidence Notice - Merge Queue

This pull request was modified after the review checklist evidence was recorded.
The review checklist evidence visible here does no longer reflect the evidence that will be recorded at merge.
Please rely on the evidence in the git history once the pull request was merged.

The git history shows the evidence state at the time of merge queue entry.
A pull request may only enter the merge queue when all necessary review checklist acknowledgements are in place.
Changes made after this pull request enters the merge queue may update the evidence here,
but they do not affect the evidence recorded in the git history.
<!-- review-checklist-merge-queue-notice:end -->