### PR TITLE
Warning fixes

### DIFF
--- a/score/mw/com/impl/methods/skeleton_method.h
+++ b/score/mw/com/impl/methods/skeleton_method.h
@@ -286,6 +286,8 @@ Result<void> SkeletonMethod<ReturnType(ArgTypes...)>::RegisterHandlerImpl(Callab
                 }
                 else
                 {
+                    // When WithQuality != kYes it does not matter the quality type
+                    std::ignore = quality_type;
                     return stateless_type_erased_handler(
                         user_callback, std::optional<QualityType>{}, type_erased_in_args, type_erased_return);
                 }


### PR DESCRIPTION
These small details were causing warning, that would then lead the builds to fail.