### PR TITLE
MP: Add explicit stop method to thread runners

### DIFF
--- a/score/message_passing/qnx_dispatch/dispatch_thread_runner.cpp
+++ b/score/message_passing/qnx_dispatch/dispatch_thread_runner.cpp
@@ -119,7 +119,7 @@ void DispatchThreadRunner::StartPostInit() noexcept
     score::cpp::ignore = signal_.PthreadSigMask(SIG_SETMASK, old_set);
 }
 
-DispatchThreadRunner::~DispatchThreadRunner() noexcept
+void DispatchThreadRunner::Stop() noexcept
 {
     if (dispatch_pointer_ == nullptr)
     {
@@ -134,6 +134,12 @@ DispatchThreadRunner::~DispatchThreadRunner() noexcept
     score::cpp::ignore = dispatch_.dispatch_destroy(dispatch_pointer_);
     // NOLINTNEXTLINE(score-banned-function) implementing FFI wrapper
     dispatch_.dispatch_context_free(context_pointer_);
+    dispatch_pointer_ = nullptr;
+}
+
+DispatchThreadRunner::~DispatchThreadRunner() noexcept
+{
+    Stop();
 }
 
 void DispatchThreadRunner::RunOnThread() noexcept

--- a/score/message_passing/qnx_dispatch/dispatch_thread_runner.h
+++ b/score/message_passing/qnx_dispatch/dispatch_thread_runner.h
@@ -69,6 +69,8 @@ class DispatchThreadRunner
         StartPostInit();
     }
 
+    void Stop() noexcept;
+
     dispatch_t* GetDispatchPointer() const noexcept
     {
         return dispatch_pointer_;

--- a/score/message_passing/qnx_dispatch/qnx_dispatch_engine.cpp
+++ b/score/message_passing/qnx_dispatch/qnx_dispatch_engine.cpp
@@ -272,10 +272,14 @@ int QnxDispatchEngine::CoidDeathPulseCallback(message_context_t* ctp,
 
 QnxDispatchEngine::~QnxDispatchEngine() noexcept
 {
+    // enforce joining client and server threads, if they are running
+    // otherwise we would depend on order of destruction of not explicitly related class members
+    server_runner_.Stop();
     if (client_runner_.GetDispatchPointer() != nullptr)
     {
         // client was initialized, which means timer was created
         score::cpp::ignore = os_resources_.timer->TimerDestroy(timer_id_);
+        client_runner_.Stop();
     }
 }
 


### PR DESCRIPTION
In QnxDispatchEngine class, we were relying on implicit shutdown of communication threads by thread runner destructors. That was dangerous because it introduced implicit destruction order dependencies on QnxDispatchEngine members. Now we stop these threads explicitly in the QnxDispatchEngine destructor body.