### PR TITLE
test: CI clang-tidy lint gating check (do not merge)

### DIFF
--- a/score/mw/com/test/ci_clang_tidy_probe/BUILD
+++ b/score/mw/com/test/ci_clang_tidy_probe/BUILD
@@ -1,0 +1,25 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:defs.bzl", "cc_library")
+
+# Temporary probe used to verify that the CI clang-tidy lint job still gates
+# pull requests as expected. This target intentionally contains a
+# readability-magic-numbers violation (see probe.cpp). Remove this whole
+# directory once the CI validation is complete.
+cc_library(
+    name = "ci_clang_tidy_probe",
+    srcs = ["probe.cpp"],
+    hdrs = ["probe.h"],
+    visibility = ["//score/mw/com:__subpackages__"],
+)

--- a/score/mw/com/test/ci_clang_tidy_probe/probe.cpp
+++ b/score/mw/com/test/ci_clang_tidy_probe/probe.cpp
@@ -1,0 +1,25 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/test/ci_clang_tidy_probe/probe.h"
+
+namespace score::mw::com::test::ci_clang_tidy_probe
+{
+
+int AddMagicOffset(int value)
+{
+    // Intentional clang-tidy violation (readability-magic-numbers): 4217 is an
+    // unexplained literal used directly in an expression.
+    return value + 4217;
+}
+
+}  // namespace score::mw::com::test::ci_clang_tidy_probe

--- a/score/mw/com/test/ci_clang_tidy_probe/probe.h
+++ b/score/mw/com/test/ci_clang_tidy_probe/probe.h
@@ -1,0 +1,26 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_TEST_CI_CLANG_TIDY_PROBE_PROBE_H
+#define SCORE_MW_COM_TEST_CI_CLANG_TIDY_PROBE_PROBE_H
+
+namespace score::mw::com::test::ci_clang_tidy_probe
+{
+
+// This function only exists to intentionally trigger a clang-tidy finding
+// (readability-magic-numbers) so that CI linting behavior can be validated.
+// Remove this whole directory once the validation is done.
+int AddMagicOffset(int value);
+
+}  // namespace score::mw::com::test::ci_clang_tidy_probe
+
+#endif  // SCORE_MW_COM_TEST_CI_CLANG_TIDY_PROBE_PROBE_H


### PR DESCRIPTION
## Purpose
This is a **throwaway test PR** to verify that our CI clang-tidy lint job still correctly runs and gates pull requests after the Eclipse Foundation changed the code review behavior for this repository.

## What this PR does
Adds an isolated probe library (`score/mw/com/test/ci_clang_tidy_probe`) containing one deliberate `readability-magic-numbers` clang-tidy violation. It does not touch any production code.

Locally reproduced with:
```
aspect lint --bazel-flag=--config=ci --bazel-flag=--config=clang-tidy -- //score/mw/com/test/ci_clang_tidy_probe/...
```
which correctly reports:
```
probe.cpp:22:20: warning: 4217 is a magic number; consider replacing it with a named constant [readability-magic-numbers]
```

## Expected CI outcome
The `Linter Checks / clang-tidy` workflow job should fail (hold-the-line strategy) and/or surface a Code Scanning alert for this finding on this PR.

## Cleanup
This branch/PR and the probe directory should be deleted once CI behavior is confirmed. **Do not merge.**