### PR TITLE
quality: justify CodeQL RULE-21-6-3 placement-new findings

### DIFF
--- a/quality/static_analysis/coding-standards.yaml
+++ b/quality/static_analysis/coding-standards.yaml
@@ -4,6 +4,11 @@ deviations:
     justification: "The software is designed for a fail-silent system. The agreed safe-state for a process is the termination. Thus, we do not need to care about not cleaning up the environment, as this is exactly the desired behavior."
     paths:
       - "score/**"
+  - rule-id: "RULE-21-6-3"
+    query-id: "cpp/misra/advanced-memory-management-used"
+    code-identifier: "shared-memory-placement-new"
+    scope: "Applies only to the specific placement-new expressions marked with this code identifier in score/memory/shared/managed_memory_resource.h and score/memory/shared/shared_memory_resource.cpp. This code-identifier must not be used anywhere else in the codebase."
+    justification: "These marked placement-new expressions are part of the shared-memory allocator abstraction layer and must construct objects at a caller-supplied, already-allocated address (e.g. a page mapped via mmap or a slot from a custom memory resource). This requires placement new, i.e. the non-replaceable `operator new(std::size_t, void*)`. The raw new/delete usage is intentionally confined to these two call sites in the abstraction layer so that the rest of the codebase does not need to use advanced memory management directly."
 guideline-recategorizations:
   - rule-id: "RULE-0-1-1"
     category: "disapplied"

--- a/score/memory/shared/managed_memory_resource.h
+++ b/score/memory/shared/managed_memory_resource.h
@@ -77,6 +77,7 @@ class ManagedMemoryResource : public ::score::cpp::pmr::memory_resource
         void* const memory = this->allocate(sizeof(T), alignof(T));
         // Operator \c new doesn't allocate any new resources, instead of that preallocated buffer is
         // NOLINTNEXTLINE(score-no-dynamic-raw-memory): used by placement new
+        // Deviation of MISRA RULE-21-6-3: codeql::misra_deviation_next_line(shared-memory-placement-new)
         return new (memory) T(std::forward<Args>(args)...);
     }
 

--- a/score/memory/shared/shared_memory_resource.cpp
+++ b/score/memory/shared/shared_memory_resource.cpp
@@ -977,6 +977,7 @@ auto SharedMemoryResource::initializeControlBlock() noexcept -> void
     // base_address_ is the address we got back from mmap() call and it is therefore guaranteed to be page aligned!
     // Proper usage of the operator new according to Autosar rule A18-5-10.
     // NOLINTNEXTLINE(score-no-dynamic-raw-memory): Placement new is used.
+    // Deviation of MISRA RULE-21-6-3: codeql::misra_deviation_next_line(shared-memory-placement-new)
     this->control_block_ = new (this->base_address_) ControlBlock(memory_identifier_);
     // we want the memory region, where later further allocations start from, to be "worst case aligned".
     // The main reason: Reproducibility of memory needs for a deterministic set of allocations.


### PR DESCRIPTION
## Summary

Fixes CodeQL findings [#13959](https://github.com/eclipse-score/communication/security/code-scanning/13959) (`score/memory/shared/managed_memory_resource.h`) and [#13958](https://github.com/eclipse-score/communication/security/code-scanning/13958) (`score/memory/shared/shared_memory_resource.cpp`), which flag the use of raw placement `new` in violation of **MISRA RULE-21-6-3** (*Advanced memory management shall not be used*).

## Rationale

Both call sites construct objects at a caller-supplied, already-allocated address (a page mapped via `mmap`, or a slot handed out by a custom memory resource), which requires the non-replaceable placement `operator new(std::size_t, void*)`. This is intentional and confined to the shared-memory allocator abstraction layer, so the rest of the codebase never needs to use advanced memory management directly.

## Change

- Added a `code-identifier`-scoped deviation record for `RULE-21-6-3` in `quality/static_analysis/coding-standards.yaml`.
- Marked the two exact placement-new expressions with the corresponding `codeql::misra_deviation_next_line(shared-memory-placement-new)` in-code marker, so only those specific lines are deviated rather than the whole file (in line with the existing `NOLINTNEXTLINE` comment convention already used at these locations).

## Verification

- Validated `coding-standards.yaml` against the upstream `codeql-coding-standards` JSON schema.
- Rebuilt a fresh, complete CodeQL database (`bazel run //quality/static_analysis:codeql_lint -- --phase create-database ...`) and re-ran `AdvancedMemoryManagementUsed.ql` directly against it: 0 results, and the generated `deviations_report.md` confirms the deviation is applied via the code-identifier marker (not a blanket file/path scope).

Co-authored-by: Copilot <223556219+Copilot@users.noreply.github.com>

<!-- review-checklist-merge-queue-notice:start -->
## Review Checklist Evidence Notice - Merge Queue

This pull request was modified after the review checklist evidence was recorded.
The review checklist evidence visible here does no longer reflect the evidence that will be recorded at merge.
Please rely on the evidence in the git history once the pull request was merged.

The git history shows the evidence state at the time of merge queue entry.
A pull request may only enter the merge queue when all necessary review checklist acknowledgements are in place.
Changes made after this pull request enters the merge queue may update the evidence here,
but they do not affect the evidence recorded in the git history.
<!-- review-checklist-merge-queue-notice:end -->