### PR TITLE
Fix review-checklists bot marking every merged PR as modified

### DIFF
--- a/tools/review-checklists/README.md
+++ b/tools/review-checklists/README.md
@@ -24,9 +24,11 @@ files they're approving.
 It also understands GitHub's merge queue: when the queue runs its checks
 (`merge_group`) it re-validates the originating PR's checklist evidence
 from scratch rather than assuming it is still valid, and while a PR is
-enqueued and subsequently changed (reviewed, commented on, edited) it
-posts a notice explaining that the evidence already recorded is what will
-be carried into the merge commit.
+enqueued it posts a notice on any other checklist-relevant event
+(reviewed, commented on, edited) explaining that the evidence block in
+the PR description is a live, ever-updating view — the authoritative,
+tamper-evident record of what evidence existed is the merge commit's
+message in git history, not this description.
 
 ## How it works
 
@@ -154,6 +156,15 @@ each repository that wants to use it.**
    and this should be reconsidered. You can check your repository's
    configured merge method under the ruleset's `merge_queue` rule
    (`merge_method`).
+
+   Even with `MERGE` selected, GitHub does **not** default to embedding the
+   PR title/description into the merge commit message — by default the
+   merge commit message is a generic "Merge pull request #N from ..."
+   line, which does not capture the evidence block at all. You must also
+   configure the repository so the merge commit message is built from the
+   PR title and body:
+   - `merge_commit_title: "PR_TITLE"`
+   - `merge_commit_message: "PR_BODY"`
 7. **Reviewers must acknowledge by replying `OK`** (exact text,
    case-insensitive) directly in the threaded conversation under the
    bot-posted checklist comment — a general PR approval alone does not

--- a/tools/review-checklists/scripts/check_acknowledgements.py
+++ b/tools/review-checklists/scripts/check_acknowledgements.py
@@ -53,17 +53,15 @@ from typing import Any
 from helpers import (
     build_evidence_block,
     collect_acknowledgement_details,
-    ensure_merge_queue_notice_comment,
-    ensure_merge_queue_notice_description,
     find_existing_checklist_comments,
     find_ok_replies_for_checklists,
     get_approving_reviewers,
     get_changed_files,
     get_github_client,
     get_repo_and_pr,
-    is_pr_in_merge_queue,
     load_checklists,
     match_checklists,
+    refresh_merge_queue_notice,
     set_commit_status,
     update_pr_description_with_evidence,
 )
@@ -186,6 +184,8 @@ def main() -> None:
 
     repo, pr = get_repo_and_pr(gh)
 
+    existing = find_existing_checklist_comments(pr)
+
     # Note this is intentionally separate from the `merge_group` branch
     # above (which already implies the PR is in the queue and instead
     # re-validates evidence and returns/exits). This check instead covers
@@ -193,9 +193,7 @@ def main() -> None:
     # comment posted on a PR that happens to still be enqueued) fires while
     # the PR is enqueued, so we can (re-)post the advisory merge-queue
     # notice for it.
-    if is_pr_in_merge_queue(pr):
-        ensure_merge_queue_notice_comment(pr)
-        ensure_merge_queue_notice_description(pr)
+    refresh_merge_queue_notice(pr, existing)
 
     checklists = load_checklists(args.config_path)
     changed_files = get_changed_files(pr)
@@ -205,7 +203,6 @@ def main() -> None:
         set_commit_status(repo, pr.head.sha, "success", "No checklists applicable")
         return
 
-    existing = find_existing_checklist_comments(pr)
     posted_relevant_ids = [checklist["id"] for checklist in relevant_checklists if checklist["id"] in existing]
 
     if len(posted_relevant_ids) < len(relevant_checklists):

--- a/tools/review-checklists/scripts/check_acknowledgements_test.py
+++ b/tools/review-checklists/scripts/check_acknowledgements_test.py
@@ -251,7 +251,7 @@ class TestValidateChecklistEvidence:
 
 
 class TestCheckAcknowledgementsMain:
-    @patch("check_acknowledgements.is_pr_in_merge_queue", return_value=False)
+    @patch("check_acknowledgements.refresh_merge_queue_notice")
     @patch("check_acknowledgements.set_commit_status")
     @patch(
         "check_acknowledgements.load_checklists",
@@ -270,7 +270,7 @@ class TestCheckAcknowledgementsMain:
             main()
         mock_status.assert_called_once_with(repo, "abc", "success", "No checklists applicable")
 
-    @patch("check_acknowledgements.is_pr_in_merge_queue", return_value=False)
+    @patch("check_acknowledgements.refresh_merge_queue_notice")
     @patch("check_acknowledgements.set_commit_status")
     @patch(
         "check_acknowledgements.find_existing_checklist_comments",
@@ -297,7 +297,7 @@ class TestCheckAcknowledgementsMain:
 
         mock_status.assert_called_once_with(repo, "abc", "pending", "Checklist comments not yet posted")
 
-    @patch("check_acknowledgements.is_pr_in_merge_queue", return_value=False)
+    @patch("check_acknowledgements.refresh_merge_queue_notice")
     @patch("check_acknowledgements.set_commit_status")
     @patch(
         "check_acknowledgements.load_checklists",
@@ -341,7 +341,7 @@ class TestCheckAcknowledgementsMain:
 
         mock_status.assert_called_once_with(repo, "abc", "pending", "Checklist comments not yet posted")
 
-    @patch("check_acknowledgements.is_pr_in_merge_queue", return_value=False)
+    @patch("check_acknowledgements.refresh_merge_queue_notice")
     @patch("check_acknowledgements.set_commit_status")
     @patch("check_acknowledgements.get_approving_reviewers", return_value=[])
     @patch(
@@ -376,7 +376,7 @@ class TestCheckAcknowledgementsMain:
 
         mock_status.assert_called_with(repo, "abc", "pending", "Awaiting at least one approving review")
 
-    @patch("check_acknowledgements.is_pr_in_merge_queue", return_value=False)
+    @patch("check_acknowledgements.refresh_merge_queue_notice")
     @patch("check_acknowledgements.set_commit_status")
     @patch(
         "check_acknowledgements.get_approving_reviewers",
@@ -442,7 +442,7 @@ class TestCheckAcknowledgementsMain:
             data = json.load(f)
         assert data["api-review"] == ["alice"]
 
-    @patch("check_acknowledgements.is_pr_in_merge_queue", return_value=False)
+    @patch("check_acknowledgements.refresh_merge_queue_notice")
     @patch("check_acknowledgements.set_commit_status")
     @patch(
         "check_acknowledgements.get_approving_reviewers",
@@ -499,26 +499,28 @@ class TestCheckAcknowledgementsMain:
 
         mock_status.assert_called_with(repo, "abc", "pending", "api-review: awaiting bob")
 
-    @patch("check_acknowledgements.ensure_merge_queue_notice_description")
-    @patch("check_acknowledgements.ensure_merge_queue_notice_comment")
-    @patch("check_acknowledgements.is_pr_in_merge_queue", return_value=True)
+    @patch("check_acknowledgements.refresh_merge_queue_notice")
     @patch("check_acknowledgements.set_commit_status")
     @patch(
         "check_acknowledgements.load_checklists",
         return_value=SAMPLE_CHECKLISTS,
     )
+    @patch("check_acknowledgements.find_existing_checklist_comments", return_value={})
     @patch("check_acknowledgements.get_repo_and_pr")
     @patch("check_acknowledgements.get_github_client")
-    def test_merge_queue_notice_refreshed_when_pr_enqueued(
+    def test_merge_queue_notice_refresh_invoked(
         self,
         mock_gh,
         mock_repo_pr,
+        mock_existing,
         mock_load,
         mock_status,
-        mock_in_queue,
-        mock_notice_comment,
-        mock_notice_description,
+        mock_refresh_notice,
     ):
+        # The detailed status/wording logic (modified/unmodified/unknown)
+        # lives in and is unit-tested against helpers.refresh_merge_queue_notice
+        # directly; this just verifies check_acknowledgements.py wires it up
+        # with the right arguments for every non-merge_group event.
         repo = MagicMock()
         pr = MagicMock()
         pr.head.sha = "abc"
@@ -528,8 +530,7 @@ class TestCheckAcknowledgementsMain:
         with patch.object(sys, "argv", ["check_acknowledgements"]):
             main()
 
-        mock_notice_comment.assert_called_once_with(pr)
-        mock_notice_description.assert_called_once_with(pr)
+        mock_refresh_notice.assert_called_once_with(pr, {})
 
     @patch("check_acknowledgements.set_commit_status")
     @patch("check_acknowledgements.get_repo_and_pr")

--- a/tools/review-checklists/scripts/helpers.py
+++ b/tools/review-checklists/scripts/helpers.py
@@ -16,6 +16,7 @@
 from __future__ import annotations
 
 import os
+from datetime import datetime, timezone
 from typing import Any
 
 import pathspec
@@ -308,20 +309,61 @@ MERGE_QUEUE_NOTICE_END = "<!-- review-checklist-merge-queue-notice:end -->"
 # Marker for a bot-managed PR comment carrying the same notice.
 MERGE_QUEUE_COMMENT_MARKER = "<!-- review-checklist-merge-queue-comment -->"
 
-MERGE_QUEUE_NOTICE = [
-    MERGE_QUEUE_NOTICE_START,
+_MERGE_QUEUE_NOTICE_HEADER = [
     "## Review Checklist Evidence Notice - Merge Queue",
     "",
-    "This pull request was modified after the review checklist evidence was recorded.",
-    "The review checklist evidence visible here does no longer reflect the evidence that will be recorded at merge.",
-    "Please rely on the evidence in the git history once the pull request was merged.",
-    "",
-    "The git history shows the evidence state at the time of merge queue entry.",
+    "This pull request is (or recently was) in the merge queue.",
     "A pull request may only enter the merge queue when all necessary review checklist acknowledgements are in place.",
-    "Changes made after this pull request enters the merge queue may update the evidence here,",
-    "but they do not affect the evidence recorded in the git history.",
-    MERGE_QUEUE_NOTICE_END,
+    "",
 ]
+
+_MERGE_QUEUE_NOTICE_BODY_BY_STATUS = {
+    # A human-authored change to checklist evidence (the description,
+    # acknowledgement-thread replies, approving reviews, or commits) was
+    # detected after this PR entered the merge queue, per GitHub's own
+    # event/edit history — not merely inferred from the PR currently being
+    # in the queue.
+    "modified": [
+        "Checklist evidence (the description, an acknowledgement reply, an approving review, or a commit)",
+        "changed after this pull request entered the merge queue.",
+        "The evidence visible here may no longer reflect what was true at merge-queue entry.",
+    ],
+    # Could not resolve the merge-queue entry timestamp, so no verdict is
+    # made either way — fail-open on the claim itself (never assert
+    # "modified" without evidence for it).
+    "unknown": [
+        "Whether checklist evidence changed since this pull request entered the merge queue could not be determined.",
+    ],
+}
+
+_MERGE_QUEUE_NOTICE_FOOTER = [
+    "",
+    "Once this pull request is merged, prefer the evidence recorded in git history over this description",
+    "where the two differ — the description keeps updating live for as long as this PR exists, while the",
+    "merge commit (if your merge-queue configuration embeds the PR title and description into it) is a",
+    "fixed, tamper-evident record of what was true at that point.",
+]
+
+
+def _build_merge_queue_notice_lines(status: str) -> list[str]:
+    """Build the merge-queue notice body lines for the given evidence status.
+
+    ``status`` is one of ``"modified"`` or ``"unknown"`` (see
+    ``checklist_evidence_modified_since`` / ``get_merge_queue_state``) and
+    selects which factual claim the notice makes about whether checklist
+    evidence changed since merge-queue entry. Callers never invoke this for
+    an ``"unmodified"`` verdict — nothing noteworthy to report means no
+    notice is posted or refreshed at all (see ``resolve_merge_queue_evidence_status``
+    callers in check_acknowledgements.py/post_checklists.py).
+    """
+    body = _MERGE_QUEUE_NOTICE_BODY_BY_STATUS.get(status, _MERGE_QUEUE_NOTICE_BODY_BY_STATUS["unknown"])
+    return (
+        [MERGE_QUEUE_NOTICE_START]
+        + _MERGE_QUEUE_NOTICE_HEADER
+        + body
+        + _MERGE_QUEUE_NOTICE_FOOTER
+        + [MERGE_QUEUE_NOTICE_END]
+    )
 
 
 def extract_evidence_block(description: str) -> str | None:
@@ -355,8 +397,6 @@ def build_evidence_block(
     ack_details: dict[str, list[dict[str, str]]],
 ) -> str:
     """Build the evidence block for the PR description."""
-    from datetime import datetime, timezone
-
     lines = [
         EVIDENCE_BLOCK_START,
         "<details>",
@@ -407,42 +447,91 @@ def update_pr_description_with_evidence(
         print("PR description evidence is already up to date")
 
 
-def is_pr_in_merge_queue(pr: Any) -> bool:
-    """Return whether the PR is currently in GitHub merge queue via GraphQL.
+def _resolve_repo_owner_and_name(pr: Any) -> tuple[str, str] | None:
+    """Return (owner, name) for the PR's repository, or None if unresolvable.
 
-    This is intentionally fail-closed (returns False) on any lookup error
-    rather than raising: its only callers use the result to decide whether
-    to post an advisory merge-queue notice on the PR, and a false negative
-    here at worst delays that notice until the next checklist-relevant
-    event — it never affects merge gating. The actual merge-queue gating
-    decision is made independently in check_acknowledgements.py's
-    ``merge_group`` handling, which resolves and validates the underlying
-    PR itself and fails the commit status (does not default to success)
-    if that resolution or validation fails.
+    Prefers the PR object's own base-repo reference; falls back to the
+    ``GITHUB_REPOSITORY`` environment variable (as set by Actions) when the
+    PR object doesn't carry it (e.g. a mock in tests).
     """
     repo_name = getattr(getattr(getattr(pr, "base", None), "repo", None), "full_name", "")
     if not repo_name or "/" not in repo_name:
         repo_name = os.environ.get("GITHUB_REPOSITORY", "")
     if "/" not in repo_name:
-        print("Could not determine repository for merge-queue lookup")
-        return False
+        return None
+    owner, name = repo_name.split("/", 1)
+    return owner, name
 
+
+def _resolve_pr_number(pr: Any) -> int | None:
+    """Return the PR number, falling back to the ``PR_NUMBER`` env var."""
     number = getattr(pr, "number", None)
     if not number:
         try:
             number = int(os.environ.get("PR_NUMBER", "0"))
         except ValueError:
             number = 0
-    if not number:
-        print("Could not determine PR number for merge-queue lookup")
-        return False
+    return number or None
 
-    owner, name = repo_name.split("/", 1)
+
+def get_merge_queue_state(pr: Any) -> tuple[bool, datetime | None]:
+    """Return (is_currently_in_queue, latest_enqueued_at) for the PR, via one GraphQL call.
+
+    Reads the ``AddedToMergeQueueEvent``/``RemovedFromMergeQueueEvent``
+    timeline: whichever of the two event types is chronologically *last*
+    determines current membership (an ``Added`` event with no later
+    ``Removed`` event means the PR is still enqueued), while the
+    ``createdAt`` of the latest ``AddedToMergeQueueEvent`` gives the
+    baseline timestamp comparisons should use (a PR can be dequeued and
+    re-enqueued more than once, e.g. after being kicked out for a new push).
+
+    These are real, GitHub-recorded event timestamps — not a live poll of a
+    boolean flag — so comparisons against them are not subject to the race
+    that made polling ``isInMergeQueue`` alone unreliable for deciding
+    whether content changed *after* enqueue (see
+    ``checklist_evidence_modified_since``). This single query replaces what
+    used to be two separate lookups (a live ``isInMergeQueue`` poll plus a
+    separate ``timelineItems`` query for the enqueue timestamp).
+
+    This is intentionally fail-closed (returns ``(False, None)``) on any
+    lookup error rather than raising: its only callers use the result to
+    decide whether to post an advisory merge-queue notice on the PR, and a
+    false negative here at worst delays that notice until the next
+    checklist-relevant event — it never affects merge gating. The actual
+    merge-queue gating decision is made independently in
+    check_acknowledgements.py's ``merge_group`` handling, which resolves and
+    validates the underlying PR itself and fails the commit status (does not
+    default to success) if that resolution or validation fails.
+    """
+    owner_and_name = _resolve_repo_owner_and_name(pr)
+    if owner_and_name is None:
+        print("Could not determine repository for merge-queue timeline lookup")
+        return False, None
+    owner, name = owner_and_name
+
+    number = _resolve_pr_number(pr)
+    if number is None:
+        print("Could not determine PR number for merge-queue timeline lookup")
+        return False, None
+
     query = """
       query($owner: String!, $name: String!, $number: Int!) {
         repository(owner: $owner, name: $name) {
           pullRequest(number: $number) {
-            isInMergeQueue
+            timelineItems(
+              itemTypes: [ADDED_TO_MERGE_QUEUE_EVENT, REMOVED_FROM_MERGE_QUEUE_EVENT]
+              last: 10
+            ) {
+              nodes {
+                __typename
+                ... on AddedToMergeQueueEvent {
+                  createdAt
+                }
+                ... on RemovedFromMergeQueueEvent {
+                  createdAt
+                }
+              }
+            }
           }
         }
       }
@@ -454,20 +543,207 @@ def is_pr_in_merge_queue(pr: Any) -> bool:
             {"owner": owner, "name": name, "number": int(number)},
         )
     except Exception as exc:
-        print(f"GraphQL merge-queue lookup failed: {exc}")
+        print(f"GraphQL merge-queue timeline lookup failed: {exc}")
+        return False, None
+
+    nodes = (
+        result.get("data", {}).get("repository", {}).get("pullRequest", {}).get("timelineItems", {}).get("nodes", [])
+    )
+    events = [
+        (node["createdAt"], node.get("__typename"))
+        for node in nodes
+        if node.get("createdAt") and node.get("__typename")
+    ]
+    if not events:
+        return False, None
+
+    events.sort(key=lambda item: item[0])
+
+    added_timestamps = [created_at for created_at, typename in events if typename == "AddedToMergeQueueEvent"]
+    latest_added_at = (
+        datetime.strptime(max(added_timestamps), "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+        if added_timestamps
+        else None
+    )
+
+    is_in_queue = events[-1][1] == "AddedToMergeQueueEvent"
+    return is_in_queue, latest_added_at
+
+
+def _get_pr_body_human_edits_after(pr: Any, since: datetime) -> bool:
+    """Return whether a non-bot editor edited the PR description after ``since``.
+
+    Uses GraphQL ``userContentEdits`` — GitHub's own append-only edit-history
+    audit trail for the PR description — rather than any state we would have
+    to store/protect ourselves. Edits made by this action's own bot account
+    (identified by GraphQL ``__typename: Bot``, not by matching a login
+    string, so this doesn't need to know the configured bot's name) are
+    excluded, since the evidence-block refresh is expected to keep rewriting
+    the description on every run and must not itself count as "modified".
+    """
+    owner_and_name = _resolve_repo_owner_and_name(pr)
+    if owner_and_name is None:
+        print("Could not determine repository for PR body edit-history lookup")
+        return False
+    owner, name = owner_and_name
+
+    number = _resolve_pr_number(pr)
+    if number is None:
+        print("Could not determine PR number for PR body edit-history lookup")
         return False
 
-    is_in_queue = result.get("data", {}).get("repository", {}).get("pullRequest", {}).get("isInMergeQueue")
-    if isinstance(is_in_queue, bool):
-        return is_in_queue
+    query = """
+      query($owner: String!, $name: String!, $number: Int!) {
+        repository(owner: $owner, name: $name) {
+          pullRequest(number: $number) {
+            userContentEdits(first: 100) {
+              nodes {
+                createdAt
+                editor {
+                  login
+                  __typename
+                }
+              }
+            }
+          }
+        }
+      }
+    """
 
-    print("GraphQL merge-queue lookup returned no boolean state")
+    try:
+        result = _run_graphql_query(
+            query,
+            {"owner": owner, "name": name, "number": int(number)},
+        )
+    except Exception as exc:
+        print(f"GraphQL PR body edit-history lookup failed: {exc}")
+        return False
+
+    edits = (
+        result.get("data", {}).get("repository", {}).get("pullRequest", {}).get("userContentEdits", {}).get("nodes", [])
+    )
+    for edit in edits:
+        editor = edit.get("editor") or {}
+        if editor.get("__typename") == "Bot":
+            continue
+        created_at_raw = edit.get("createdAt")
+        if not created_at_raw:
+            continue
+        created_at = datetime.strptime(created_at_raw, "%Y-%m-%dT%H:%M:%SZ").replace(tzinfo=timezone.utc)
+        if created_at > since:
+            return True
     return False
 
 
-def _build_merge_queue_notice_block() -> str:
+def checklist_evidence_modified_since(
+    pr: Any,
+    existing_comments: dict[str, Any],
+    enqueued_at: datetime,
+) -> bool:
+    """Return whether checklist evidence changed after ``enqueued_at``.
+
+    Deliberately scoped to the same primitives ``check_acknowledgements.py``
+    already treats as "evidence" — the PR description (which carries the
+    evidence block), checklist-thread replies (OK acknowledgements),
+    approving reviews, and the commit set — rather than flagging *any*
+    human activity on the PR (an unrelated comment or an incidental
+    description typo fix elsewhere should not trigger this).
+
+    Every timestamp compared here comes from GitHub's own event/edit
+    history (GraphQL ``timelineItems``/``userContentEdits``, REST
+    ``updated_at``/``submitted_at``), not from polling a live boolean at an
+    arbitrary later time, so this is not subject to the enqueue-ordering
+    race that made unconditionally trusting a live ``isInMergeQueue`` poll
+    unreliable.
+    """
+    # 1. PR description (evidence block) edited by a human after enqueue.
+    if _get_pr_body_human_edits_after(pr, enqueued_at):
+        return True
+
+    # 2. New or edited replies in checklist finding threads (acknowledgements).
+    finding_comment_ids = {comment.id for comment in existing_comments.values()}
+    for comment in pr.get_review_comments():
+        reply_to = getattr(comment, "in_reply_to_id", None)
+        if reply_to not in finding_comment_ids:
+            continue
+        if comment.created_at > enqueued_at:
+            return True
+        updated_at = getattr(comment, "updated_at", None)
+        if updated_at and updated_at > enqueued_at and updated_at != comment.created_at:
+            return True
+
+    # 3. Approver set changed (new/changed review submitted after enqueue).
+    for review in pr.get_reviews():
+        submitted_at = getattr(review, "submitted_at", None)
+        if submitted_at and submitted_at > enqueued_at:
+            return True
+
+    # 4. New commits pushed after enqueue (defensive: a merge queue normally
+    # dequeues a PR on a new push, but this covers that possibility anyway).
+    for commit in pr.get_commits():
+        commit_date = getattr(getattr(commit.commit, "author", None), "date", None)
+        if commit_date and commit_date > enqueued_at:
+            return True
+
+    return False
+
+
+def resolve_merge_queue_evidence_status(
+    pr: Any,
+    existing_comments: dict[str, Any],
+    enqueued_at: datetime | None,
+) -> str:
+    """Return ``"modified"``, ``"unmodified"``, or ``"unknown"`` for the PR's
+    checklist evidence relative to its most recent merge-queue entry.
+
+    Combines ``enqueued_at`` (the real, GitHub-recorded enqueue timestamp,
+    from ``get_merge_queue_state``) with ``checklist_evidence_modified_since``
+    (which primitives changed after it). Returns ``"unknown"`` — never
+    guessing either way — when the enqueue timestamp itself cannot be
+    resolved, e.g. because the PR was never observed as enqueued via the
+    timeline, or the lookup failed.
+    """
+    if enqueued_at is None:
+        return "unknown"
+    return "modified" if checklist_evidence_modified_since(pr, existing_comments, enqueued_at) else "unmodified"
+
+
+def refresh_merge_queue_notice(pr: Any, existing_comments: dict[str, Any]) -> None:
+    """Post/refresh the advisory merge-queue notice (comment + description)
+    for the PR, if warranted.
+
+    This is intentionally separate from ``check_acknowledgements.py``'s
+    ``merge_group`` handling (which already implies the PR is in the queue
+    and instead re-validates evidence and fails/passes the commit status).
+    This function instead covers the case of any other event (e.g. a review
+    comment posted on a PR that happens to still be enqueued) firing while
+    the PR is enqueued, so the advisory notice can be (re-)posted for it.
+
+    No-ops entirely (posts/updates nothing) unless the PR is currently
+    enqueued (per ``get_merge_queue_state``) *and* checklist evidence
+    changed since enqueue, or we couldn't determine whether it did — an
+    "unmodified" verdict doesn't warrant a notice at all, so no comment or
+    description update happens for it.
+
+    Shared by ``check_acknowledgements.py`` and ``post_checklists.py``,
+    which both need to perform this exact check after handling their
+    respective events.
+    """
+    is_in_queue, enqueued_at = get_merge_queue_state(pr)
+    if not is_in_queue:
+        return
+
+    status = resolve_merge_queue_evidence_status(pr, existing_comments, enqueued_at)
+    if status == "unmodified":
+        return
+
+    ensure_merge_queue_notice_comment(pr, status)
+    ensure_merge_queue_notice_description(pr, status)
+
+
+def _build_merge_queue_notice_block(status: str) -> str:
     """Return the standalone merge-queue notice for PR description."""
-    return "\n".join(MERGE_QUEUE_NOTICE)
+    return "\n".join(_build_merge_queue_notice_lines(status))
 
 
 def _remove_merge_queue_notice_block(description: str) -> str:
@@ -483,10 +759,17 @@ def _remove_merge_queue_notice_block(description: str) -> str:
         return description
 
 
-def ensure_merge_queue_notice_description(pr: Any) -> None:
-    """Ensure a standalone merge-queue notice exists in the PR description."""
+def ensure_merge_queue_notice_description(pr: Any, status: str = "unknown") -> None:
+    """Ensure a standalone merge-queue notice exists in the PR description.
+
+    ``status`` (one of ``"modified"``, ``"unmodified"``, ``"unknown"``) is
+    computed by the caller via ``resolve_merge_queue_evidence_status``
+    (which itself relies on ``get_merge_queue_state``/
+    ``checklist_evidence_modified_since``) and selects which factual claim
+    the notice makes — this function itself performs no detection.
+    """
     current_description = pr.body or ""
-    notice_block = _build_merge_queue_notice_block()
+    notice_block = _build_merge_queue_notice_block(status)
     description_without_notice = _remove_merge_queue_notice_block(current_description)
     base = description_without_notice.rstrip()
     if base:
@@ -499,9 +782,12 @@ def ensure_merge_queue_notice_description(pr: Any) -> None:
         print("Updated PR description with merge-queue evidence notice")
 
 
-def ensure_merge_queue_notice_comment(pr: Any) -> None:
-    """Ensure the PR has a single bot-managed merge-queue evidence notice."""
-    body = "\n".join([MERGE_QUEUE_COMMENT_MARKER] + MERGE_QUEUE_NOTICE)
+def ensure_merge_queue_notice_comment(pr: Any, status: str = "unknown") -> None:
+    """Ensure the PR has a single bot-managed merge-queue evidence notice.
+
+    See ``ensure_merge_queue_notice_description`` for what ``status`` means.
+    """
+    body = "\n".join([MERGE_QUEUE_COMMENT_MARKER] + _build_merge_queue_notice_lines(status))
 
     existing_comment = None
     for comment in pr.get_issue_comments():

--- a/tools/review-checklists/scripts/helpers_test.py
+++ b/tools/review-checklists/scripts/helpers_test.py
@@ -25,11 +25,13 @@ import yaml
 from helpers import (
     CHECKLIST_MARKER,
     MERGE_QUEUE_COMMENT_MARKER,
-    MERGE_QUEUE_NOTICE,
     MERGE_QUEUE_NOTICE_END,
     MERGE_QUEUE_NOTICE_START,
     OK_KEYWORD,
+    _build_merge_queue_notice_lines,
     _find_checklists_config,
+    _get_pr_body_human_edits_after,
+    checklist_evidence_modified_since,
     collect_acknowledgement_details,
     ensure_merge_queue_notice_comment,
     ensure_merge_queue_notice_description,
@@ -38,11 +40,13 @@ from helpers import (
     get_approving_reviewers,
     get_changed_files,
     get_github_client,
+    get_merge_queue_state,
     get_repo_and_pr,
-    is_pr_in_merge_queue,
     load_checklists,
     make_checklist_comment_body,
     match_checklists,
+    refresh_merge_queue_notice,
+    resolve_merge_queue_evidence_status,
     set_commit_status,
 )
 
@@ -606,47 +610,111 @@ class TestFindChecklistsConfig:
 # ---------------------------------------------------------------------------
 
 
-class TestIsPrInMergeQueue:
+class TestGetMergeQueueState:
     @patch("helpers._run_graphql_query")
-    def test_true_when_graphql_returns_true(self, mock_query):
-        mock_query.return_value = {"data": {"repository": {"pullRequest": {"isInMergeQueue": True}}}}
+    def test_currently_in_queue_after_added_event(self, mock_query):
+        mock_query.return_value = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "timelineItems": {
+                            "nodes": [
+                                {"__typename": "AddedToMergeQueueEvent", "createdAt": "2024-01-01T00:00:00Z"},
+                            ]
+                        }
+                    }
+                }
+            }
+        }
 
         pr = MagicMock()
         pr.base.repo.full_name = "org/repo"
         pr.number = 42
 
-        assert is_pr_in_merge_queue(pr) is True
+        is_in_queue, enqueued_at = get_merge_queue_state(pr)
+
+        assert is_in_queue is True
+        assert enqueued_at is not None
+        assert enqueued_at.year == 2024 and enqueued_at.day == 1
+        assert enqueued_at.tzinfo is not None
         mock_query.assert_called_once()
 
     @patch("helpers._run_graphql_query")
-    def test_false_when_graphql_returns_false(self, mock_query):
-        mock_query.return_value = {"data": {"repository": {"pullRequest": {"isInMergeQueue": False}}}}
+    def test_not_in_queue_after_removed_event(self, mock_query):
+        mock_query.return_value = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "timelineItems": {
+                            "nodes": [
+                                {"__typename": "AddedToMergeQueueEvent", "createdAt": "2024-01-01T00:00:00Z"},
+                                {"__typename": "RemovedFromMergeQueueEvent", "createdAt": "2024-01-02T00:00:00Z"},
+                            ]
+                        }
+                    }
+                }
+            }
+        }
 
         pr = MagicMock()
         pr.base.repo.full_name = "org/repo"
-        pr.number = 7
+        pr.number = 42
 
-        assert is_pr_in_merge_queue(pr) is False
+        is_in_queue, enqueued_at = get_merge_queue_state(pr)
+
+        # Not currently enqueued, but the latest enqueue timestamp is still
+        # reported for callers that already know it's not in queue and want
+        # the last known baseline anyway.
+        assert is_in_queue is False
+        assert enqueued_at is not None
+        assert enqueued_at.day == 1
 
     @patch("helpers._run_graphql_query")
-    def test_false_when_graphql_payload_missing_field(self, mock_query):
-        mock_query.return_value = {"data": {"repository": {"pullRequest": {}}}}
+    def test_uses_latest_added_timestamp_across_reenqueue_cycles(self, mock_query):
+        mock_query.return_value = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "timelineItems": {
+                            "nodes": [
+                                {"__typename": "AddedToMergeQueueEvent", "createdAt": "2024-01-01T00:00:00Z"},
+                                {"__typename": "RemovedFromMergeQueueEvent", "createdAt": "2024-01-02T00:00:00Z"},
+                                {"__typename": "AddedToMergeQueueEvent", "createdAt": "2024-01-03T00:00:00Z"},
+                            ]
+                        }
+                    }
+                }
+            }
+        }
 
         pr = MagicMock()
         pr.base.repo.full_name = "org/repo"
-        pr.number = 99
+        pr.number = 42
 
-        assert is_pr_in_merge_queue(pr) is False
+        is_in_queue, enqueued_at = get_merge_queue_state(pr)
+
+        assert is_in_queue is True
+        assert enqueued_at.day == 3
 
     @patch("helpers._run_graphql_query")
-    def test_false_when_graphql_call_fails(self, mock_query):
+    def test_returns_false_none_when_never_enqueued(self, mock_query):
+        mock_query.return_value = {"data": {"repository": {"pullRequest": {"timelineItems": {"nodes": []}}}}}
+
+        pr = MagicMock()
+        pr.base.repo.full_name = "org/repo"
+        pr.number = 42
+
+        assert get_merge_queue_state(pr) == (False, None)
+
+    @patch("helpers._run_graphql_query")
+    def test_returns_false_none_on_graphql_failure(self, mock_query):
         mock_query.side_effect = RuntimeError("boom")
 
         pr = MagicMock()
         pr.base.repo.full_name = "org/repo"
-        pr.number = 101
+        pr.number = 42
 
-        assert is_pr_in_merge_queue(pr) is False
+        assert get_merge_queue_state(pr) == (False, None)
 
 
 class TestEnsureMergeQueueNoticeDescription:
@@ -712,7 +780,7 @@ class TestEnsureMergeQueueNoticeComment:
 
     def test_noop_when_existing_comment_matches(self):
         existing = MagicMock()
-        existing.body = "\n".join([MERGE_QUEUE_COMMENT_MARKER] + MERGE_QUEUE_NOTICE)
+        existing.body = "\n".join([MERGE_QUEUE_COMMENT_MARKER] + _build_merge_queue_notice_lines("unknown"))
 
         pr = MagicMock()
         pr.get_issue_comments.return_value = [existing]
@@ -721,6 +789,256 @@ class TestEnsureMergeQueueNoticeComment:
 
         existing.edit.assert_not_called()
         pr.create_issue_comment.assert_not_called()
+
+    def test_wording_reflects_status(self):
+        pr = MagicMock()
+        pr.get_issue_comments.return_value = []
+
+        ensure_merge_queue_notice_comment(pr, status="modified")
+
+        posted = pr.create_issue_comment.call_args.args[0]
+        assert "changed after this pull request entered the merge queue" in posted
+
+
+# ---------------------------------------------------------------------------
+# get_merge_queue_state / _get_pr_body_human_edits_after /
+# checklist_evidence_modified_since / resolve_merge_queue_evidence_status
+# ---------------------------------------------------------------------------
+
+
+class TestGetPrBodyHumanEditsAfter:
+    @patch("helpers._run_graphql_query")
+    def test_true_when_human_edit_after_since(
+        self,
+        mock_query,
+    ):
+        import datetime as dt
+
+        mock_query.return_value = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "userContentEdits": {
+                            "nodes": [
+                                {
+                                    "createdAt": "2024-01-05T00:00:00Z",
+                                    "editor": {"login": "alice", "__typename": "User"},
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        pr = MagicMock()
+        pr.base.repo.full_name = "org/repo"
+        pr.number = 42
+        since = dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
+
+        assert _get_pr_body_human_edits_after(pr, since) is True
+
+    @patch("helpers._run_graphql_query")
+    def test_false_when_only_bot_edits_after_since(self, mock_query):
+        import datetime as dt
+
+        mock_query.return_value = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "userContentEdits": {
+                            "nodes": [
+                                {
+                                    "createdAt": "2024-01-05T00:00:00Z",
+                                    "editor": {"login": "review-checklists-bot", "__typename": "Bot"},
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        pr = MagicMock()
+        pr.base.repo.full_name = "org/repo"
+        pr.number = 42
+        since = dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
+
+        assert _get_pr_body_human_edits_after(pr, since) is False
+
+    @patch("helpers._run_graphql_query")
+    def test_false_when_human_edit_before_since(self, mock_query):
+        import datetime as dt
+
+        mock_query.return_value = {
+            "data": {
+                "repository": {
+                    "pullRequest": {
+                        "userContentEdits": {
+                            "nodes": [
+                                {
+                                    "createdAt": "2023-01-01T00:00:00Z",
+                                    "editor": {"login": "alice", "__typename": "User"},
+                                }
+                            ]
+                        }
+                    }
+                }
+            }
+        }
+        pr = MagicMock()
+        pr.base.repo.full_name = "org/repo"
+        pr.number = 42
+        since = dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
+
+        assert _get_pr_body_human_edits_after(pr, since) is False
+
+
+class TestChecklistEvidenceModifiedSince:
+    def _base_pr(self):
+        import datetime as dt
+
+        pr = MagicMock()
+        pr.get_review_comments.return_value = []
+        pr.get_reviews.return_value = []
+        pr.get_commits.return_value = []
+        return pr, dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
+
+    @patch("helpers._get_pr_body_human_edits_after", return_value=True)
+    def test_true_when_body_edited(self, _mock_edits):
+        pr, enqueued_at = self._base_pr()
+        assert checklist_evidence_modified_since(pr, {}, enqueued_at) is True
+
+    @patch("helpers._get_pr_body_human_edits_after", return_value=False)
+    def test_true_when_finding_reply_after_enqueue(self, _mock_edits):
+        import datetime as dt
+
+        pr, enqueued_at = self._base_pr()
+        finding_comment = MagicMock()
+        finding_comment.id = 111
+        existing = {"finding-1": finding_comment}
+
+        reply = MagicMock()
+        reply.in_reply_to_id = 111
+        reply.created_at = enqueued_at + dt.timedelta(hours=1)
+        reply.updated_at = reply.created_at
+        pr.get_review_comments.return_value = [reply]
+
+        assert checklist_evidence_modified_since(pr, existing, enqueued_at) is True
+
+    @patch("helpers._get_pr_body_human_edits_after", return_value=False)
+    def test_false_when_reply_unrelated_to_finding(self, _mock_edits):
+        import datetime as dt
+
+        pr, enqueued_at = self._base_pr()
+        finding_comment = MagicMock()
+        finding_comment.id = 111
+        existing = {"finding-1": finding_comment}
+
+        unrelated_reply = MagicMock()
+        unrelated_reply.in_reply_to_id = 999
+        unrelated_reply.created_at = enqueued_at + dt.timedelta(hours=1)
+        unrelated_reply.updated_at = unrelated_reply.created_at
+        pr.get_review_comments.return_value = [unrelated_reply]
+
+        assert checklist_evidence_modified_since(pr, existing, enqueued_at) is False
+
+    @patch("helpers._get_pr_body_human_edits_after", return_value=False)
+    def test_true_when_approving_review_after_enqueue(self, _mock_edits):
+        import datetime as dt
+
+        pr, enqueued_at = self._base_pr()
+        review = MagicMock()
+        review.submitted_at = enqueued_at + dt.timedelta(hours=1)
+        pr.get_reviews.return_value = [review]
+
+        assert checklist_evidence_modified_since(pr, {}, enqueued_at) is True
+
+    @patch("helpers._get_pr_body_human_edits_after", return_value=False)
+    def test_true_when_commit_after_enqueue(self, _mock_edits):
+        import datetime as dt
+
+        pr, enqueued_at = self._base_pr()
+        commit = MagicMock()
+        commit.commit.author.date = enqueued_at + dt.timedelta(hours=1)
+        pr.get_commits.return_value = [commit]
+
+        assert checklist_evidence_modified_since(pr, {}, enqueued_at) is True
+
+    @patch("helpers._get_pr_body_human_edits_after", return_value=False)
+    def test_false_when_nothing_changed(self, _mock_edits):
+        pr, enqueued_at = self._base_pr()
+        assert checklist_evidence_modified_since(pr, {}, enqueued_at) is False
+
+
+class TestResolveMergeQueueEvidenceStatus:
+    def test_unknown_when_enqueued_at_is_none(self):
+        pr = MagicMock()
+        assert resolve_merge_queue_evidence_status(pr, {}, None) == "unknown"
+
+    @patch("helpers.checklist_evidence_modified_since", return_value=True)
+    def test_modified_when_evidence_changed(self, _mock_modified):
+        import datetime as dt
+
+        pr = MagicMock()
+        enqueued_at = dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
+        assert resolve_merge_queue_evidence_status(pr, {}, enqueued_at) == "modified"
+
+    @patch("helpers.checklist_evidence_modified_since", return_value=False)
+    def test_unmodified_when_evidence_unchanged(self, _mock_modified):
+        import datetime as dt
+
+        pr = MagicMock()
+        enqueued_at = dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc)
+        assert resolve_merge_queue_evidence_status(pr, {}, enqueued_at) == "unmodified"
+
+
+class TestRefreshMergeQueueNotice:
+    @patch("helpers.ensure_merge_queue_notice_description")
+    @patch("helpers.ensure_merge_queue_notice_comment")
+    @patch("helpers.get_merge_queue_state", return_value=(False, None))
+    def test_noop_when_not_in_queue(self, _mock_state, mock_comment, mock_description):
+        pr = MagicMock()
+        refresh_merge_queue_notice(pr, {})
+        mock_comment.assert_not_called()
+        mock_description.assert_not_called()
+
+    @patch("helpers.resolve_merge_queue_evidence_status", return_value="unmodified")
+    @patch("helpers.ensure_merge_queue_notice_description")
+    @patch("helpers.ensure_merge_queue_notice_comment")
+    @patch("helpers.get_merge_queue_state")
+    def test_noop_when_in_queue_but_unmodified(self, mock_state, mock_comment, mock_description, _mock_resolve):
+        import datetime as dt
+
+        mock_state.return_value = (True, dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc))
+        pr = MagicMock()
+        refresh_merge_queue_notice(pr, {})
+        mock_comment.assert_not_called()
+        mock_description.assert_not_called()
+
+    @patch("helpers.resolve_merge_queue_evidence_status", return_value="modified")
+    @patch("helpers.ensure_merge_queue_notice_description")
+    @patch("helpers.ensure_merge_queue_notice_comment")
+    @patch("helpers.get_merge_queue_state")
+    def test_posts_notice_when_in_queue_and_modified(self, mock_state, mock_comment, mock_description, _mock_resolve):
+        import datetime as dt
+
+        mock_state.return_value = (True, dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc))
+        pr = MagicMock()
+        refresh_merge_queue_notice(pr, {})
+        mock_comment.assert_called_once_with(pr, "modified")
+        mock_description.assert_called_once_with(pr, "modified")
+
+    @patch("helpers.resolve_merge_queue_evidence_status", return_value="unknown")
+    @patch("helpers.ensure_merge_queue_notice_description")
+    @patch("helpers.ensure_merge_queue_notice_comment")
+    @patch("helpers.get_merge_queue_state")
+    def test_posts_notice_when_in_queue_and_unknown(self, mock_state, mock_comment, mock_description, _mock_resolve):
+        import datetime as dt
+
+        mock_state.return_value = (True, dt.datetime(2024, 1, 1, tzinfo=dt.timezone.utc))
+        pr = MagicMock()
+        refresh_merge_queue_notice(pr, {})
+        mock_comment.assert_called_once_with(pr, "unknown")
+        mock_description.assert_called_once_with(pr, "unknown")
 
 
 if __name__ == "__main__":

--- a/tools/review-checklists/scripts/post_checklists.py
+++ b/tools/review-checklists/scripts/post_checklists.py
@@ -29,13 +29,10 @@ import argparse
 from helpers import (
     build_evidence_block,
     collect_acknowledgement_details,
-    ensure_merge_queue_notice_comment,
-    ensure_merge_queue_notice_description,
     find_existing_checklist_comments,
     get_changed_files,
     get_github_client,
     get_repo_and_pr,
-    is_pr_in_merge_queue,
     load_checklists,
     make_checklist_comment_body,
     match_checklists,
@@ -105,10 +102,6 @@ def main() -> None:
         ack_details = collect_acknowledgement_details(pr, existing, posted_relevant_ids)
         evidence_block = build_evidence_block(relevant_checklists, ack_details)
         update_pr_description_with_evidence(pr, evidence_block)
-
-    if is_pr_in_merge_queue(pr):
-        ensure_merge_queue_notice_comment(pr)
-        ensure_merge_queue_notice_description(pr)
 
     # Set a pending check — actual pass/fail is determined by check_acknowledgements.
     set_commit_status(

--- a/tools/review-checklists/scripts/post_checklists_test.py
+++ b/tools/review-checklists/scripts/post_checklists_test.py
@@ -133,66 +133,6 @@ class TestPostChecklistsMain:
 
         existing_review.edit.assert_not_called()
 
-    @patch("post_checklists.ensure_merge_queue_notice_description")
-    @patch("post_checklists.ensure_merge_queue_notice_comment")
-    @patch("post_checklists.is_pr_in_merge_queue", return_value=True)
-    @patch("post_checklists.set_commit_status")
-    @patch("post_checklists.find_existing_checklist_comments", return_value={})
-    @patch("post_checklists.load_checklists", return_value=SAMPLE_CHECKLISTS)
-    @patch("post_checklists.get_repo_and_pr")
-    @patch("post_checklists.get_github_client")
-    def test_merge_queue_posts_notice_comment_and_description(
-        self,
-        mock_gh,
-        mock_repo_pr,
-        mock_load,
-        mock_existing,
-        mock_status,
-        mock_in_queue,
-        mock_notice_comment,
-        mock_notice_description,
-    ):
-        repo = MagicMock()
-        pr = MagicMock()
-        pr.head.sha = "abc123"
-        pr.get_files.return_value = [_make_file("src/api/handler.py")]
-        mock_repo_pr.return_value = (repo, pr)
-
-        main()
-
-        mock_notice_comment.assert_called_once_with(pr)
-        mock_notice_description.assert_called_once_with(pr)
-
-    @patch("post_checklists.ensure_merge_queue_notice_description")
-    @patch("post_checklists.ensure_merge_queue_notice_comment")
-    @patch("post_checklists.is_pr_in_merge_queue", return_value=False)
-    @patch("post_checklists.set_commit_status")
-    @patch("post_checklists.find_existing_checklist_comments", return_value={})
-    @patch("post_checklists.load_checklists", return_value=SAMPLE_CHECKLISTS)
-    @patch("post_checklists.get_repo_and_pr")
-    @patch("post_checklists.get_github_client")
-    def test_non_merge_queue_does_not_post_notice(
-        self,
-        mock_gh,
-        mock_repo_pr,
-        mock_load,
-        mock_existing,
-        mock_status,
-        mock_in_queue,
-        mock_notice_comment,
-        mock_notice_description,
-    ):
-        repo = MagicMock()
-        pr = MagicMock()
-        pr.head.sha = "abc123"
-        pr.get_files.return_value = [_make_file("src/api/handler.py")]
-        mock_repo_pr.return_value = (repo, pr)
-
-        main()
-
-        mock_notice_comment.assert_not_called()
-        mock_notice_description.assert_not_called()
-
 
 if __name__ == "__main__":
     sys.exit(pytest.main(sys.argv[1:]))


### PR DESCRIPTION
## Problem

The review-checklists bot marked every merged PR as "modified" (i.e. its checklist evidence changed after entering the merge queue), regardless of whether the PR description/comments were actually touched after enqueue.

Root cause: the old check relied on a live `isInMergeQueue` GraphQL poll. This races with our two-stage Actions dispatch (unprivileged trigger → `workflow_run` → privileged apply): an event can be *processed* after the PR is already enqueued even though the underlying human action happened *before* enqueue, causing a false "modified" verdict every time.

## Fix

Replace the live poll with GitHub's own append-only, tamper-evident history, read via GraphQL:

- `get_merge_queue_state(pr)`: one GraphQL call reading `AddedToMergeQueueEvent`/`RemovedFromMergeQueueEvent` timeline items — gives current queue membership *and* the real enqueue timestamp (handles re-enqueue cycles).
- `checklist_evidence_modified_since(pr, existing, enqueued_at)`: compares four checklist-relevant primitives against that timestamp — PR body human edits (via `userContentEdits`, excluding bot edits), checklist-thread reply edits/creates, approving reviews, and commits.
- `resolve_merge_queue_evidence_status(...)` / `refresh_merge_queue_notice(...)`: only post the advisory notice (comment + PR description) when evidence is confirmed `"modified"` or `"unknown"` — nothing is written when unmodified.

Also consolidated the duplicate call site: `post_checklists.py` no longer touches merge-queue-notice logic at all, since `check_acknowledgements.py`'s `action=check` step always runs unconditionally right after it in the same job.

Finally, updated the README: adopters must also configure `merge_commit_title: "PR_TITLE"` / `merge_commit_message: "PR_BODY"` (e.g. via Otterdog) for the merge commit to actually carry the PR title/body, per [eclipse-score/.eclipsefdn@d0589aed](https://github.com/eclipse-score/.eclipsefdn/commit/d0589aed9d52a9f417899d2df9fd1db0c7def759).

## Testing

`bazel test //tools/review-checklists/scripts:all` — 4/4 targets pass.