### PR TITLE
Require full branch-protection approval before checklist status goes green

### DIFF
--- a/tools/review-checklists/scripts/check_acknowledgements.py
+++ b/tools/review-checklists/scripts/check_acknowledgements.py
@@ -24,9 +24,10 @@ review comment (finding) that contains the ``OK`` keyword.  This script:
 3. For each checklist, finds the bot-posted review comment and its OK replies.
 4. Builds a mapping: checklist-id → set of reviewers who said OK.
 5. Compares against the set of approving reviewers.
-6. Sets commit status to *success* only when every approving reviewer has
-   acknowledged every relevant checklist.  Otherwise sets *pending* or
-   *failure*.
+6. Sets commit status to *success* only when the PR is fully approved per
+   branch protection (GitHub's ``reviewDecision``) **and** every approving
+   reviewer has acknowledged every relevant checklist. Otherwise sets
+   *pending* or *failure*.
 
 This script is invoked on every checklist-relevant event (it is always the
 last step run), so it doubles as the single, fully stateless source of
@@ -59,6 +60,7 @@ from helpers import (
     get_changed_files,
     get_github_client,
     get_repo_and_pr,
+    get_review_decision,
     load_checklists,
     match_checklists,
     refresh_merge_queue_notice,
@@ -86,13 +88,28 @@ def _acknowledgement_status(
     approvers: list[str],
     posted_relevant_ids: list[str],
     acks: dict[str, set[str]],
+    review_decision: str | None,
 ) -> tuple[str, str]:
     """Compute the (state, description) commit-status pair from ack data.
 
     Pure decision logic with no side effects, so it can be reused both for
     the live PR flow (which also refreshes evidence/comments) and for
     merge_group evidence validation (which must not write anything).
+
+    ``review_decision`` must be GitHub's own ``"APPROVED"`` verdict (the PR
+    currently satisfies its required-review branch-protection rules) before
+    this can go green. Without this gate, status could turn "success" from
+    only the *current* approver set (e.g. 1 of 2 required approvals), and a
+    still-outstanding required reviewer's later approval would instantly
+    satisfy GitHub's native review-count check against that stale, already
+    green status — before this (slower, two-stage) workflow re-runs to
+    verify the new reviewer also acknowledged every checklist. Requiring
+    "APPROVED" first means the status can only go green once no further
+    required review can arrive to race against it.
     """
+    if review_decision != "APPROVED":
+        return "pending", "Awaiting full branch-protection approval"
+
     if not approvers:
         return "pending", "Awaiting at least one approving review"
 
@@ -138,7 +155,8 @@ def _validate_checklist_evidence(pr: Any, checklists: list[dict]) -> tuple[str, 
 
     acks = _collect_ok_acknowledgements(pr, existing, posted_relevant_ids)
     approvers = get_approving_reviewers(pr)
-    return _acknowledgement_status(approvers, posted_relevant_ids, acks)
+    review_decision = get_review_decision(pr)
+    return _acknowledgement_status(approvers, posted_relevant_ids, acks, review_decision)
 
 
 def main() -> None:
@@ -225,7 +243,8 @@ def main() -> None:
     update_pr_description_with_evidence(pr, evidence_block)
 
     approvers = get_approving_reviewers(pr)
-    state, description = _acknowledgement_status(approvers, posted_relevant_ids, acks)
+    review_decision = get_review_decision(pr)
+    state, description = _acknowledgement_status(approvers, posted_relevant_ids, acks, review_decision)
     set_commit_status(repo, pr.head.sha, state, description)
     print(f"Acknowledgement status: {state} — {description}")
 

--- a/tools/review-checklists/scripts/check_acknowledgements_test.py
+++ b/tools/review-checklists/scripts/check_acknowledgements_test.py
@@ -238,11 +238,55 @@ class TestValidateChecklistEvidence:
                 "check_acknowledgements.get_approving_reviewers",
                 return_value=["alice"],
             ),
+            patch(
+                "check_acknowledgements.get_review_decision",
+                return_value="APPROVED",
+            ),
         ):
             state, description = _validate_checklist_evidence(pr, SAMPLE_CHECKLISTS)
 
         assert state == "success"
         assert description == "All checklists acknowledged by all approving reviewers"
+
+    def test_pending_when_not_fully_approved_despite_all_acked(self):
+        """A single approver having acked everything must not be enough if
+        branch protection still requires further approvals — otherwise a
+        still-outstanding required reviewer's later approval could satisfy
+        GitHub's native review-count check against an already-green, stale
+        status before this reviewer's own acknowledgement is verified."""
+        pr = MagicMock()
+        pr.get_files.return_value = [_make_file("src/api/foo.py")]
+
+        api_review_comment = MagicMock(id=100)
+        api_review_comment.body = "<!-- review-checklist:api-review -->"
+
+        ok_reply = _make_comment(
+            101,
+            "OK",
+            "alice",
+            datetime(2026, 1, 1, 0, 1, tzinfo=timezone.utc),
+        )
+        ok_reply.in_reply_to_id = 100
+        pr.get_review_comments.return_value = [ok_reply]
+
+        with (
+            patch(
+                "check_acknowledgements.find_existing_checklist_comments",
+                return_value={"api-review": api_review_comment},
+            ),
+            patch(
+                "check_acknowledgements.get_approving_reviewers",
+                return_value=["alice"],
+            ),
+            patch(
+                "check_acknowledgements.get_review_decision",
+                return_value="REVIEW_REQUIRED",
+            ),
+        ):
+            state, description = _validate_checklist_evidence(pr, SAMPLE_CHECKLISTS)
+
+        assert state == "pending"
+        assert description == "Awaiting full branch-protection approval"
 
 
 # ---------------------------------------------------------------------------
@@ -344,6 +388,7 @@ class TestCheckAcknowledgementsMain:
     @patch("check_acknowledgements.refresh_merge_queue_notice")
     @patch("check_acknowledgements.set_commit_status")
     @patch("check_acknowledgements.get_approving_reviewers", return_value=[])
+    @patch("check_acknowledgements.get_review_decision", return_value="APPROVED")
     @patch(
         "check_acknowledgements.load_checklists",
         return_value=SAMPLE_CHECKLISTS,
@@ -351,7 +396,7 @@ class TestCheckAcknowledgementsMain:
     @patch("check_acknowledgements.get_repo_and_pr")
     @patch("check_acknowledgements.get_github_client")
     def test_no_approvers_sets_pending(
-        self, mock_gh, mock_repo_pr, mock_load, mock_approvers, mock_status, mock_in_queue
+        self, mock_gh, mock_repo_pr, mock_load, mock_review_decision, mock_approvers, mock_status, mock_in_queue
     ):
         repo = MagicMock()
         pr = MagicMock()
@@ -382,6 +427,7 @@ class TestCheckAcknowledgementsMain:
         "check_acknowledgements.get_approving_reviewers",
         return_value=["alice"],
     )
+    @patch("check_acknowledgements.get_review_decision", return_value="APPROVED")
     @patch(
         "check_acknowledgements.load_checklists",
         return_value=SAMPLE_CHECKLISTS,
@@ -393,6 +439,7 @@ class TestCheckAcknowledgementsMain:
         mock_gh,
         mock_repo_pr,
         mock_load,
+        mock_review_decision,
         mock_approvers,
         mock_status,
         mock_in_queue,
@@ -448,6 +495,7 @@ class TestCheckAcknowledgementsMain:
         "check_acknowledgements.get_approving_reviewers",
         return_value=["alice", "bob"],
     )
+    @patch("check_acknowledgements.get_review_decision", return_value="APPROVED")
     @patch(
         "check_acknowledgements.load_checklists",
         return_value=SAMPLE_CHECKLISTS,
@@ -459,6 +507,7 @@ class TestCheckAcknowledgementsMain:
         mock_gh,
         mock_repo_pr,
         mock_load,
+        mock_review_decision,
         mock_approvers,
         mock_status,
         mock_in_queue,
@@ -569,6 +618,7 @@ class TestCheckAcknowledgementsMain:
         "check_acknowledgements.get_approving_reviewers",
         return_value=["alice"],
     )
+    @patch("check_acknowledgements.get_review_decision", return_value="APPROVED")
     @patch(
         "check_acknowledgements.load_checklists",
         return_value=SAMPLE_CHECKLISTS,
@@ -576,7 +626,7 @@ class TestCheckAcknowledgementsMain:
     @patch("check_acknowledgements.get_repo_and_pr")
     @patch("check_acknowledgements.get_github_client")
     def test_merge_group_validates_evidence_and_sets_success(
-        self, mock_gh, mock_repo_pr, mock_load, mock_approvers, mock_status
+        self, mock_gh, mock_repo_pr, mock_load, mock_review_decision, mock_approvers, mock_status
     ):
         repo = MagicMock()
         pr = MagicMock()
@@ -632,6 +682,7 @@ class TestCheckAcknowledgementsMain:
         "check_acknowledgements.get_approving_reviewers",
         return_value=["alice", "bob"],
     )
+    @patch("check_acknowledgements.get_review_decision", return_value="APPROVED")
     @patch(
         "check_acknowledgements.load_checklists",
         return_value=SAMPLE_CHECKLISTS,
@@ -639,7 +690,7 @@ class TestCheckAcknowledgementsMain:
     @patch("check_acknowledgements.get_repo_and_pr")
     @patch("check_acknowledgements.get_github_client")
     def test_merge_group_validates_evidence_and_sets_pending_on_missing_ack(
-        self, mock_gh, mock_repo_pr, mock_load, mock_approvers, mock_status
+        self, mock_gh, mock_repo_pr, mock_load, mock_review_decision, mock_approvers, mock_status
     ):
         repo = MagicMock()
         pr = MagicMock()

--- a/tools/review-checklists/scripts/helpers.py
+++ b/tools/review-checklists/scripts/helpers.py
@@ -275,6 +275,60 @@ def get_approving_reviewers(pr: PullRequest) -> list[str]:
     return sorted(approvers)
 
 
+def get_review_decision(pr: Any) -> str | None:
+    """Return the PR's branch-protection review decision via GraphQL.
+
+    ``reviewDecision`` is GitHub's own computed verdict on whether the PR
+    currently satisfies its required-review branch-protection rules (required
+    approving review count, CODEOWNERS, etc.) — one of ``"APPROVED"``,
+    ``"REVIEW_REQUIRED"``, or ``"CHANGES_REQUESTED"``. It is not exposed via
+    the REST API, hence the GraphQL round-trip.
+
+    Used to gate the "review-checklists" commit status: it must not go
+    green from a partial/current approver set alone (see
+    ``_acknowledgement_status``) if the PR is not yet fully approved per
+    branch protection — otherwise a still-outstanding required reviewer
+    could approve later, instantly satisfying GitHub's native review-count
+    check against our *already-green*, stale status, before our (slower,
+    two-stage) workflow has re-validated that this new reviewer has also
+    acknowledged every checklist.
+
+    Returns ``None`` on any lookup failure so callers can fail closed
+    (treat as not yet fully approved) rather than silently proceeding.
+    """
+    owner_and_name = _resolve_repo_owner_and_name(pr)
+    if owner_and_name is None:
+        print("Could not determine repository for review-decision lookup")
+        return None
+    owner, name = owner_and_name
+
+    number = _resolve_pr_number(pr)
+    if number is None:
+        print("Could not determine PR number for review-decision lookup")
+        return None
+
+    query = """
+      query($owner: String!, $name: String!, $number: Int!) {
+        repository(owner: $owner, name: $name) {
+          pullRequest(number: $number) {
+            reviewDecision
+          }
+        }
+      }
+    """
+
+    try:
+        result = _run_graphql_query(
+            query,
+            {"owner": owner, "name": name, "number": int(number)},
+        )
+    except Exception as exc:
+        print(f"GraphQL review-decision lookup failed: {exc}")
+        return None
+
+    return result.get("data", {}).get("repository", {}).get("pullRequest", {}).get("reviewDecision")
+
+
 # GitHub's commit-status API silently truncates/rejects descriptions longer
 # than this; keep our own text within the limit explicitly.
 COMMIT_STATUS_DESCRIPTION_MAX_LENGTH = 140

--- a/tools/review-checklists/scripts/helpers_test.py
+++ b/tools/review-checklists/scripts/helpers_test.py
@@ -42,6 +42,7 @@ from helpers import (
     get_github_client,
     get_merge_queue_state,
     get_repo_and_pr,
+    get_review_decision,
     load_checklists,
     make_checklist_comment_body,
     match_checklists,
@@ -513,6 +514,50 @@ class TestGetApprovingReviewers:
         pr = MagicMock()
         pr.get_reviews.return_value = []
         assert get_approving_reviewers(pr) == []
+
+
+# ---------------------------------------------------------------------------
+# get_review_decision
+# ---------------------------------------------------------------------------
+
+
+class TestGetReviewDecision:
+    @patch("helpers._run_graphql_query")
+    def test_returns_approved(self, mock_query):
+        mock_query.return_value = {"data": {"repository": {"pullRequest": {"reviewDecision": "APPROVED"}}}}
+
+        pr = MagicMock()
+        pr.base.repo.full_name = "org/repo"
+        pr.number = 42
+
+        assert get_review_decision(pr) == "APPROVED"
+
+    @patch("helpers._run_graphql_query")
+    def test_returns_review_required(self, mock_query):
+        mock_query.return_value = {"data": {"repository": {"pullRequest": {"reviewDecision": "REVIEW_REQUIRED"}}}}
+
+        pr = MagicMock()
+        pr.base.repo.full_name = "org/repo"
+        pr.number = 42
+
+        assert get_review_decision(pr) == "REVIEW_REQUIRED"
+
+    @patch("helpers._run_graphql_query")
+    def test_returns_none_on_graphql_failure(self, mock_query):
+        mock_query.side_effect = RuntimeError("boom")
+
+        pr = MagicMock()
+        pr.base.repo.full_name = "org/repo"
+        pr.number = 42
+
+        assert get_review_decision(pr) is None
+
+    def test_returns_none_when_repo_unresolvable(self):
+        pr = MagicMock()
+        pr.base = None
+        pr.number = 42
+
+        assert get_review_decision(pr) is None
 
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
Stacked on #978 — please merge that one first.

## Problem

`_acknowledgement_status` only required the *currently approving* set of reviewers to have acknowledged every checklist, not that the PR has reached branch protection's full required-approval count. This lets the "review-checklists" status go green from a single approver (e.g. of 2 required), and a later, still-outstanding required reviewer's approval then instantly satisfies GitHub's native review-count check against that stale, already-green status — before our (slower, two-stage) workflow re-runs to verify the new reviewer also acknowledged every checklist. A required reviewer's approval could effectively be "missed".

## Fix

Add `get_review_decision(pr)`: a GraphQL lookup of GitHub's own `reviewDecision` (`APPROVED`/`REVIEW_REQUIRED`/`CHANGES_REQUESTED`) — the authoritative verdict on whether the PR currently satisfies its required-review branch-protection rules.

Gate `_acknowledgement_status` on `review_decision == "APPROVED"` before considering approver acks at all, so the status can only go green once no further required review can arrive to race against it.

Wired into both call sites: the live PR flow in `main()` and the `merge_group` revalidation path (`_validate_checklist_evidence`), which already exists specifically to close the window between a PR's own check last going green and it actually entering the queue.

## Testing

`bazel test //tools/review-checklists/scripts:all` — 4/4 targets pass.

<!-- review-checklist-merge-queue-notice:start -->
## Review Checklist Evidence Notice - Merge Queue

This pull request was modified after the review checklist evidence was recorded.
The review checklist evidence visible here does no longer reflect the evidence that will be recorded at merge.
Please rely on the evidence in the git history once the pull request was merged.

The git history shows the evidence state at the time of merge queue entry.
A pull request may only enter the merge queue when all necessary review checklist acknowledgements are in place.
Changes made after this pull request enters the merge queue may update the evidence here,
but they do not affect the evidence recorded in the git history.
<!-- review-checklist-merge-queue-notice:end -->