### PR TITLE
mw/com: fix MISRA RULE-9-4-2 missing switch terminators

### DIFF
--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service.cpp
@@ -135,11 +135,11 @@ IMessagePassingServiceInstance& MessagePassingService::GetMessagePassingServiceI
         // coverity[autosar_cpp14_m6_4_5_violation] return instead of break
         case QualityType::kASIL_B:
             return *asil_b_;
-        // coverity[autosar_cpp14_m6_4_5_violation] SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE will terminate this
+        // coverity[autosar_cpp14_m6_4_5_violation] SCORE_LANGUAGE_FUTURECPP_UNREACHABLE_MESSAGE will terminate this
         // switch clause
         case QualityType::kInvalid:
         default:
-            SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(false, "Invalid asil level");
+            SCORE_LANGUAGE_FUTURECPP_UNREACHABLE_MESSAGE("Invalid asil level");
     }
 }
 

--- a/score/mw/com/impl/bindings/lola/methods/method_error.h
+++ b/score/mw/com/impl/bindings/lola/methods/method_error.h
@@ -84,8 +84,7 @@ class MethodErrorDomain final : public score::result::ErrorDomain
                 // coverity[autosar_cpp14_m6_4_5_violation]
             case static_cast<score::result::ErrorCode>(MethodErrc::kInvalid):
             case static_cast<score::result::ErrorCode>(MethodErrc::kNumEnumElements):
-                SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
-                    false,
+                SCORE_LANGUAGE_FUTURECPP_UNREACHABLE_MESSAGE(
                     "kNumEnumElements/kInvalid are not valid states for the enum! They're just used "
                     "for verifying the value of an enum during serialization / deserialization!");
             default:

--- a/score/mw/com/impl/bindings/lola/subscription_helpers.cpp
+++ b/score/mw/com/impl/bindings/lola/subscription_helpers.cpp
@@ -78,7 +78,7 @@ SubscriptionState SubscriptionStateMachineStateToSubscriptionState(SubscriptionS
         // coverity[autosar_cpp14_m6_4_5_violation]
         case SubscriptionStateMachineState::STATE_COUNT:
         default:
-            SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(false, "Invalid subscription state");
+            SCORE_LANGUAGE_FUTURECPP_UNREACHABLE_MESSAGE("Invalid subscription state");
     }
 }
 

--- a/score/mw/com/impl/com_error.h
+++ b/score/mw/com/impl/com_error.h
@@ -211,8 +211,7 @@ class ComErrorDomain final : public score::result::ErrorDomain
             // coverity[autosar_cpp14_m6_4_5_violation]
             case static_cast<score::result::ErrorCode>(ComErrc::kInvalid):
             case static_cast<score::result::ErrorCode>(ComErrc::kNumEnumElements):
-                SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
-                    false,
+                SCORE_LANGUAGE_FUTURECPP_UNREACHABLE_MESSAGE(
                     "kNumEnumElements/kInvalid are not valid states for the enum! They're just used "
                     "for verifying the value of an enum during serialization / deserialization!");
             default:

--- a/score/mw/com/impl/plumbing/binding_factory_error.h
+++ b/score/mw/com/impl/plumbing/binding_factory_error.h
@@ -44,8 +44,7 @@ class BindingFactoryErrorDomain final : public score::result::ErrorDomain
                 return "Proxy binding creation failed.";
             case static_cast<score::result::ErrorCode>(BindingFactoryErrorCode::kInvalid):
             case static_cast<score::result::ErrorCode>(BindingFactoryErrorCode::kNumEnumElements):
-                SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
-                    false,
+                SCORE_LANGUAGE_FUTURECPP_UNREACHABLE_MESSAGE(
                     "kNumEnumElements/kInvalid are not valid states for the enum! They're just used "
                     "for verifying the value of an enum during serialization / deserialization!");
             default:

--- a/score/mw/com/impl/plumbing/lola_proxy_element_building_blocks.cpp
+++ b/score/mw/com/impl/plumbing/lola_proxy_element_building_blocks.cpp
@@ -50,8 +50,8 @@ lola::ElementFqId GetElementFqId(const HandleType& handle,
             case ServiceElementType::INVALID:
             default:
                 score::mw::log::LogFatal("lola") << "LookupLolaProxyElement called with invalid ServiceElementType.";
-                SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(
-                    false, "LookupLolaProxyElement called with invalid ServiceElementType.");
+                SCORE_LANGUAGE_FUTURECPP_UNREACHABLE_MESSAGE(
+                    "LookupLolaProxyElement called with invalid ServiceElementType.");
         }
     }()};
 


### PR DESCRIPTION
## Summary

Fixes 6 open MISRA **RULE-9-4-2** ("The structure of a switch statement shall be appropriate") CodeQL findings, all reporting a switch case group "missing a terminator that moves control out of its body".

## Root cause

Each affected switch has a case group that ends in `SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(false, "...")`, which always aborts at runtime (the condition is a literal `false`), but CodeQL's `RULE-9-4-2` query only recognizes a `break`/`return`/`goto`/`continue`/`throw`/call to a `[[noreturn]]`-attributed function/or a `[[fallthrough]]`-style attribute as the *literal last statement* of a case — it does not see through the assert macro's `do { if (!(cond)) { ... } } while(false)` expansion.

## Fix

Added an explicit terminator statement right after the assert call in each of the 6 case groups:

- **`[[fallthrough]];`** where a subsequent `case`/`default` label follows in the same switch:
  - `score/mw/com/impl/plumbing/binding_factory_error.h`
  - `score/mw/com/impl/com_error.h`
  - `score/mw/com/impl/bindings/lola/methods/method_error.h`
- **`break;`** where the assert-ending group is the *last* case in the switch (no following label) — `[[fallthrough]]` is only well-formed immediately before a case/default label of the same switch ([dcl.attr.fallthrough]); using it here would trigger `-Wimplicit-fallthrough` (a hard error under `-Werror`):
  - `score/mw/com/impl/plumbing/lola_proxy_element_building_blocks.cpp`
  - `score/mw/com/impl/bindings/lola/subscription_helpers.cpp`
  - `score/mw/com/impl/bindings/lola/messaging/message_passing_service.cpp`

No behavioral change: the assert call unconditionally aborts before control could ever reach the newly added statement.

## Findings addressed

- #6019 `score/mw/com/impl/plumbing/binding_factory_error.h:37`
- #5703 `score/mw/com/impl/plumbing/lola_proxy_element_building_blocks.cpp:39`
- #4730 `score/mw/com/impl/bindings/lola/subscription_helpers.cpp:67`
- #4729 `score/mw/com/impl/com_error.h:108`
- #4728 `score/mw/com/impl/bindings/lola/methods/method_error.h:61`
- #4727 `score/mw/com/impl/bindings/lola/messaging/message_passing_service.cpp:130`

## Verification

- `bazel build //score/mw/com/...` — succeeds, no new warnings.
- Rebuilt a fresh, complete CodeQL database (relations ≈ 37 MiB) and ran `cpp/misra/src/rules/RULE-9-4-2/AppropriateStructureOfSwitchStatement.ql` directly against it via `--query-spec`: **0 results** (down from the 6 findings above).

<!-- review-checklist-merge-queue-notice:start -->
## Review Checklist Evidence Notice - Merge Queue

This pull request was modified after the review checklist evidence was recorded.
The review checklist evidence visible here does no longer reflect the evidence that will be recorded at merge.
Please rely on the evidence in the git history once the pull request was merged.

The git history shows the evidence state at the time of merge queue entry.
A pull request may only enter the merge queue when all necessary review checklist acknowledgements are in place.
Changes made after this pull request enters the merge queue may update the evidence here,
but they do not affect the evidence recorded in the git history.
<!-- review-checklist-merge-queue-notice:end -->