### PR TITLE
quality: justify CodeQL RULE-8-2-3 finding via in-code deviation marker

### DIFF
--- a/quality/static_analysis/coding-standards.yaml
+++ b/quality/static_analysis/coding-standards.yaml
@@ -9,6 +9,11 @@ deviations:
     code-identifier: "shared-memory-placement-new"
     scope: "Applies only to the specific placement-new expressions marked with this code identifier in score/memory/shared/managed_memory_resource.h and score/memory/shared/shared_memory_resource.cpp. This code-identifier must not be used anywhere else in the codebase."
     justification: "These marked placement-new expressions are part of the shared-memory allocator abstraction layer and must construct objects at a caller-supplied, already-allocated address (e.g. a page mapped via mmap or a slot from a custom memory resource). This requires placement new, i.e. the non-replaceable `operator new(std::size_t, void*)`. The raw new/delete usage is intentionally confined to these two call sites in the abstraction layer so that the rest of the codebase does not need to use advanced memory management directly."
+  - rule-id: "RULE-8-2-3"
+    query-id: "cpp/misra/cast-removes-const-or-volatile-from-pointer-or-reference"
+    code-identifier: "shared-memory-align-const-cast"
+    scope: "Applies only to the specific const_cast marked with this code identifier in score/memory/shared/shared_memory_resource.cpp. This code-identifier must not be used anywhere else in the codebase."
+    justification: "`do_allocation_algorithm` uses `std::align`, whose `void*&` out-parameter cannot bind to the `const void*` input pointer. `std::align` only reads and arithmetically adjusts the pointer value to compute an aligned address within the given buffer; it never writes through the pointer to modify the pointee (https://timsong-cpp.github.io/cppwp/n4659/ptr.align#lib:align). The const qualification of `alloc_start` is therefore not violated at runtime, and the `const_cast` is required purely to satisfy `std::align`'s non-const parameter type."
 guideline-recategorizations:
   - rule-id: "RULE-0-1-1"
     category: "disapplied"

--- a/score/memory/shared/shared_memory_resource.cpp
+++ b/score/memory/shared/shared_memory_resource.cpp
@@ -261,6 +261,7 @@ void* do_allocation_algorithm(const void* const alloc_start,
     // (https://timsong-cpp.github.io/cppwp/n4659/ptr.align#lib:align) so the const_cast will not result in undefined
     // behaviour.
     // coverity[autosar_cpp14_a5_2_3_violation]
+    // Deviation of MISRA RULE-8-2-3: codeql::misra_deviation_next_line(shared-memory-align-const-cast)
     void* aligned_address = const_cast<void*>(alloc_start);
     auto buffer_space = static_cast<std::size_t>(SubtractPointersBytes(alloc_end, alloc_start));
     return std::align(alignment, bytes, aligned_address, buffer_space);


### PR DESCRIPTION
## Summary

Justifies the single open MISRA **RULE-8-2-3** ("A cast shall not remove any const or volatile qualification from the type accessed via a pointer or by reference") CodeQL finding, using the same in-code, `code-identifier`-scoped deviation marker mechanism established in #977 (RULE-21-6-3) and #983 (RULE-6-8-3).

## Finding

`score/memory/shared/shared_memory_resource.cpp` — `do_allocation_algorithm()`:

```cpp
void* aligned_address = const_cast<void*>(alloc_start);
auto buffer_space = static_cast<std::size_t>(SubtractPointersBytes(alloc_end, alloc_start));
return std::align(alignment, bytes, aligned_address, buffer_space);
```

`do_allocation_algorithm` takes `const void* alloc_start` but must call `std::align`, whose out-parameter has type `void*&` and therefore cannot bind to a const-qualified pointer.

## Rationale (already documented in the file)

The existing comment right above the cast already explains why this is safe:

> `std::align` does not modify the underlying memory of `aligned_address` ([cppreference/cppwp ptr.align](https://timsong-cpp.github.io/cppwp/n4659/ptr.align#lib:align)), so the `const_cast` will not result in undefined behaviour.

`std::align` only reads and arithmetically adjusts the pointer value to compute an aligned address within the given buffer — it never writes through the pointer to modify the pointee. The `const_cast` exists purely to satisfy `std::align`'s non-const signature, not to actually mutate `const` data.

## Approach

- Added a new deviation record to `quality/static_analysis/coding-standards.yaml`, scoped via a dedicated `code-identifier` (`shared-memory-align-const-cast`) whose `scope` text restricts it to this single `const_cast` in `shared_memory_resource.cpp` — the marker cannot be silently reused elsewhere.
- Added a `// Deviation of MISRA RULE-8-2-3: codeql::misra_deviation_next_line(shared-memory-align-const-cast)` comment directly above the cast.

## Finding addressed

- #13870 `score/memory/shared/shared_memory_resource.cpp:264`

## Verification

- `bazel build //score/memory/...` — succeeds, all existing tests pass.
- `coding-standards.yaml` validated against the upstream coding-standards JSON schema.
- Rebuilt a fresh, complete CodeQL database and ran `cpp/misra/src/rules/RULE-8-2-3/CastRemovesConstOrVolatileFromPointerOrReference.ql` directly against it via `--query-spec`: **0 results** (down from 1). `analysis_reports/deviations_report.md` confirms the new code-identifier deviation record is recognized.

<!-- review-checklist-merge-queue-notice:start -->
## Review Checklist Evidence Notice - Merge Queue

This pull request was modified after the review checklist evidence was recorded.
The review checklist evidence visible here does no longer reflect the evidence that will be recorded at merge.
Please rely on the evidence in the git history once the pull request was merged.

The git history shows the evidence state at the time of merge queue entry.
A pull request may only enter the merge queue when all necessary review checklist acknowledgements are in place.
Changes made after this pull request enters the merge queue may update the evidence here,
but they do not affect the evidence recorded in the git history.
<!-- review-checklist-merge-queue-notice:end -->