### PR TITLE
Fix clang-tidy modernize-deprecated-headers findings

### DIFF
--- a/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.cpp
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.cpp
@@ -25,7 +25,7 @@
 #include <gmock/gmock.h>
 
 #include <unistd.h>
-#include <stdint.h>
+#include <cstdint>
 #include <functional>
 #include <memory>
 #include <optional>

--- a/score/mw/com/test/common_test_resources/child_process_guard.cpp
+++ b/score/mw/com/test/common_test_resources/child_process_guard.cpp
@@ -13,7 +13,7 @@
 
 #include "score/mw/com/test/common_test_resources/child_process_guard.h"
 #include <sys/wait.h>
-#include <stdlib.h>
+#include <cstdlib>
 
 #include <cerrno>
 #include <csignal>

--- a/score/mw/com/test/flock/flock_test.cpp
+++ b/score/mw/com/test/flock/flock_test.cpp
@@ -18,7 +18,7 @@
 
 #include <fcntl.h>
 #include <unistd.h>
-#include <signal.h>
+#include <csignal>
 #include <cstring>
 #include <iostream>
 #include <string>

--- a/score/mw/com/test/shared_memory_storage/shared_memory_storage_application.cpp
+++ b/score/mw/com/test/shared_memory_storage/shared_memory_storage_application.cpp
@@ -21,9 +21,9 @@
 
 #include "score/os/utils/interprocess/interprocess_notification.h"
 
-#include <stdint.h>
 #include <array>
 #include <chrono>
+#include <cstdint>
 #include <cstdlib>
 #include <mutex>
 #include <optional>


### PR DESCRIPTION
## Summary

Fixes clang-tidy's `modernize-deprecated-headers` findings by replacing deprecated C-style headers with their C++ equivalents in 4 files:

- `score/mw/com/impl/bindings/lola/test/skeleton_test_resources.cpp`: `<stdint.h>` → `<cstdint>`
- `score/mw/com/test/common_test_resources/child_process_guard.cpp`: `<stdlib.h>` → `<cstdlib>`
- `score/mw/com/test/flock/flock_test.cpp`: `<signal.h>` → `<csignal>`
- `score/mw/com/test/shared_memory_storage/shared_memory_storage_application.cpp`: `<stdint.h>` → `<cstdint>`

## How this was produced

Per the request to use the repo's clang-tidy auto-fix tooling scoped to ONLY this check:
1. Temporarily isolated `modernize-deprecated-headers` in `.clang-tidy` (`Checks: -*, modernize-deprecated-headers,`).
2. Ran `bazel run //:clang-tidy.fix -- //...`, which applied the 4 header replacements above via clang-tidy's built-in auto-fix.
3. Restored `.clang-tidy` to its original, unmodified state (verified via `git diff` showing no residual changes) — this PR only contains the auto-fixed source changes.

## Verification

- `bazel build` on the containing target directories for all 4 files succeeds (only pre-existing, unrelated `-Wdeprecated-declarations` warnings remain).
- Ran the owning unit/integration tests for the affected targets — all pass:
  - `//score/mw/com/impl/bindings/lola/test:proxy_component_test`
  - `//score/mw/com/impl/bindings/lola/test:skeleton_component_test`
  - `//score/mw/com/impl/bindings/lola/test:skeleton_event_component_test`
  - `//score/mw/com/test/common_test_resources:command_line_parser_test`
  - `//score/mw/com/test/shared_memory_storage/integration_test:shared_memory_storage`