### PR TITLE
Configure performance-unnecessary-value-param to allow score::cpp::stop_token

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -241,6 +241,8 @@ CheckOptions:
     value: true
   - key: performance-unnecessary-value-param.IncludeStyle
     value: "llvm"
+  - key: performance-unnecessary-value-param.AllowedTypes
+    value: "::score::cpp::stop_token"
   - key: readability-container-data-pointer.IgnoredContainers
     value: ""
   - key: readability-redundant-casting.IgnoreTypeAliases


### PR DESCRIPTION
## Summary

Configures the clang-tidy `performance-unnecessary-value-param` check to allow `score::cpp::stop_token` to be passed by value, via the check's `AllowedTypes` option:

```yaml
- key: performance-unnecessary-value-param.AllowedTypes
  value: "::score::cpp::stop_token"
```

## Rationale

`score::cpp::stop_token` (equivalent to `std::stop_token`) is a lightweight, cheap-to-copy handle type that is idiomatically passed by value throughout this codebase, typically as the last parameter of a worker function invoked via `score::cpp::jthread` (mirroring `std::jthread`'s callback signature convention, e.g. `void worker(score::cpp::stop_token stop_token)`). `performance-unnecessary-value-param` doesn't know this type is cheap to copy and flags it as if it were an expensive-to-copy value parameter, which is a false positive for this specific type.

## Verification

- Isolated `performance-unnecessary-value-param` as the only enabled check in `.clang-tidy` and ran the aspect-based lint on `score/mw/com/test/common_test_resources`.
- **Without** `AllowedTypes`: 3 findings for `score::cpp::stop_token` parameters in `check_point_control.h`/`check_point_control.cpp` alone (confirmed via the generated SARIF report).
- **With** `AllowedTypes` set to `::score::cpp::stop_token`: those 3 findings are gone (0 results in the SARIF report), while the check remains active for all other types.
- `.clang-tidy` was restored to its full checks list before committing — this PR only contains the single `AllowedTypes` config addition.
- `bazel test //score/mw/com/test/common_test_resources/...` passes.