### PR TITLE
Disable clang-tidy readability-else-after-return check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -128,7 +128,6 @@ Checks: >
   performance-unnecessary-copy-initialization,
   performance-unnecessary-value-param,
   readability-container-data-pointer,
-  readability-else-after-return,
   readability-magic-numbers,
   readability-math-missing-parentheses,
   readability-redundant-casting,


### PR DESCRIPTION
## Summary

Removes `readability-else-after-return` from the enabled checks in `.clang-tidy`.

## Rationale

We consider multiple early returns (an `if` block that returns, followed by an `else` block containing the remaining logic) to be at least as readable as the style this check enforces (inverting the condition, dropping the `else`, and dedenting the remaining logic) — arguably more so, since each branch stays visually self-contained and paired with its own return, and editing one branch doesn't force re-indenting the other. We'd like to allow both styles without lint noise, so we're disabling the check rather than reformatting existing code to avoid it.

## Verification

- `.clang-tidy` still parses as valid YAML after the change.
- Ran a clang-tidy lint build (`bazel build //score/mw/com/test/common_test_resources:check_point_control --config=clang-tidy-fix`) to confirm the config is still accepted and linting runs cleanly with the check removed.