### PR TITLE
Fix clang-tidy readability-simplify-boolean-expr findings

### DIFF
--- a/score/memory/shared/memory_region_bounds.cpp
+++ b/score/memory/shared/memory_region_bounds.cpp
@@ -53,7 +53,7 @@ void MemoryRegionBounds::Reset() noexcept
 
 bool MemoryRegionBounds::has_value() const noexcept
 {
-    return !((start_address_ == kInvalidAddress) || (end_address_ == kInvalidAddress));
+    return (start_address_ != kInvalidAddress) && (end_address_ != kInvalidAddress);
 }
 
 std::uintptr_t MemoryRegionBounds::GetStartAddress() const noexcept

--- a/score/memory/shared/shared_memory_test_resources.cpp
+++ b/score/memory/shared/shared_memory_test_resources.cpp
@@ -305,7 +305,7 @@ void SharedMemoryResourceTest::expectShmOpenWithCreateFlagReturns(
     const score::cpp::expected_blank<score::os::Error> typed_memory_allocation_ret_value)
 {
     auto oflag = Fcntl::Open::kReadWrite | Fcntl::Open::kCreate | Fcntl::Open::kExclusive;
-    if (prefer_typed_memory == true)
+    if (prefer_typed_memory)
     {
         if (typed_memory_allocation_ret_value.has_value())
         {
@@ -448,7 +448,7 @@ void SharedMemoryResourceTest::expectSharedMemorySuccessfullyCreated(
     expectCreateLockFileReturns(TestValues::sharedMemorySegmentLockPath, lock_file_descriptor);
 
     // Then we can create the shared memory and initialize it
-    if (prefer_typed_memory == false)
+    if (!prefer_typed_memory)
     {
         expectShmOpenWithCreateFlagReturns(TestValues::sharedMemorySegmentPath, file_descriptor);
         expectFstatReturns(file_descriptor);

--- a/score/mw/com/impl/bindings/lola/event_slot_status.cpp
+++ b/score/mw/com/impl/bindings/lola/event_slot_status.cpp
@@ -79,8 +79,7 @@ auto EventSlotStatus::IsTimeStampBetween(const EventTimeStamp min_timestamp,
     // This a false-positive, all operands are parenthesized.
     // A bug ticket has been created to track this: [Ticket-165315](broken_link_j/Ticket-165315)
     // coverity[autosar_cpp14_a5_2_6_violation : FALSE]
-    return ((IsInWriting() == false) && (IsInvalid() == false) && (GetTimeStamp() > min_timestamp) &&
-            (GetTimeStamp() < max_timestamp));
+    return ((!IsInWriting()) && (!IsInvalid()) && (GetTimeStamp() > min_timestamp) && (GetTimeStamp() < max_timestamp));
 }
 
 // Suppress "AUTOSAR C++14 A9-3-1" rule finding: "Member functions shall not return non-const “raw” pointers or

--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance.cpp
@@ -486,7 +486,7 @@ void MessagePassingServiceInstance::HandleRegisterNotificationMsg(const score::c
     if (search != event_update_interested_nodes_.end())
     {
         auto inserted = search->second.insert(sender_node_id);
-        already_registered = (inserted.second == false);
+        already_registered = (!inserted.second);
         notify_status_change = !already_registered && (search->second.size() == 1U);
     }
     else
@@ -918,7 +918,7 @@ void MessagePassingServiceInstance::NotifyEventRemote(const ElementFqId event_id
                     << " failed with error: " << result.error();
             }
         }
-        if (num_ids_copied.second == true)
+        if (num_ids_copied.second)
         {
             // Suppress "AUTOSAR C++14 A4-7-1" rule finding. This rule states: "An integer expression shall not lead to
             // data loss". std::set is a sorted set of unique objects so the biggest element is the last one, and the
@@ -937,7 +937,7 @@ void MessagePassingServiceInstance::NotifyEventRemote(const ElementFqId event_id
                 break;
             }
         }
-    } while (num_ids_copied.second == true);
+    } while (num_ids_copied.second);
 
     if (loop_count > 1U)
     {
@@ -1018,7 +1018,7 @@ void MessagePassingServiceInstance::NotifyEvent(const ElementFqId event_id) noex
     // handlers may have an unknown/non-deterministic long runtime.
     std::shared_lock<std::shared_mutex> read_lock(event_update_handlers_mutex_);
     auto search = event_update_handlers_.find(event_id);
-    if ((search != event_update_handlers_.end()) && (search->second.empty() == false))
+    if ((search != event_update_handlers_.end()) && (!search->second.empty()))
     {
         read_lock.unlock();
         // Suppress "AUTOSAR C++14 A15-4-2" rule finding. This rule states: "If a function is declared to be noexcept,
@@ -1335,7 +1335,7 @@ void MessagePassingServiceInstance::RegisterEventNotificationRemote(const Elemen
         event_update_remote_registrations_.emplace(std::piecewise_construct,
                                                    std::forward_as_tuple(event_id),
                                                    std::forward_as_tuple(NodeCounter{target_node_id, 1U}));
-    if (registration_count_inserted.second == false)
+    if (!registration_count_inserted.second)
     {
         if (registration_count_inserted.first->second.node_id != target_node_id)
         {

--- a/score/mw/com/impl/bindings/lola/provider_event_data_control_local_view.cpp
+++ b/score/mw/com/impl/bindings/lola/provider_event_data_control_local_view.cpp
@@ -197,8 +197,7 @@ auto ProviderEventDataControlLocalView<AtomicIndirectorType>::RemoveAllocationsF
             auto status_value_type = static_cast<EventSlotStatus::value_type&>(status);
             auto status_new_value_type = static_cast<EventSlotStatus::value_type&>(status_new);
             // coverity[autosar_cpp14_a5_3_2_violation]
-            if (slot.compare_exchange_strong(status_value_type, status_new_value_type, std::memory_order_acq_rel) ==
-                false)
+            if (!slot.compare_exchange_strong(status_value_type, status_new_value_type, std::memory_order_acq_rel))
             {
                 // atomic could not be changed, contract violation (other skeleton must be dead, nobody other should
                 // change the slot)

--- a/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
@@ -704,7 +704,7 @@ bool SkeletonMemoryManager::CreateSharedMemoryForData(
     const auto path = shm_path_builder_.GetDataChannelShmName(lola_instance_id_);
     const bool use_typed_memory = register_shm_object_trace_callback.has_value();
     const memory::shared::SharedMemoryFactory::UserPermissions user_permissions =
-        ((permissions.empty()) && (lola_service_instance_deployment.strict_permissions_ == false))
+        ((permissions.empty()) && (!lola_service_instance_deployment.strict_permissions_))
             ? memory::shared::SharedMemoryFactory::WorldReadable{}
             : memory::shared::SharedMemoryFactory::UserPermissions{permissions};
     const auto memory_resource = score::memory::shared::SharedMemoryFactory::Create(
@@ -771,7 +771,7 @@ bool SkeletonMemoryManager::CreateSharedMemoryForControl(
     }
 
     const memory::shared::SharedMemoryFactory::UserPermissions user_permissions =
-        ((permissions.empty()) && (lola_service_instance_deployment.strict_permissions_ == false))
+        ((permissions.empty()) && (!lola_service_instance_deployment.strict_permissions_))
             ? memory::shared::SharedMemoryFactory::WorldWritable{}
             : memory::shared::SharedMemoryFactory::UserPermissions{permissions};
     control_resource = score::memory::shared::SharedMemoryFactory::Create(

--- a/score/mw/com/impl/configuration/configuration_json_parsing_strategy.cpp
+++ b/score/mw/com/impl/configuration/configuration_json_parsing_strategy.cpp
@@ -1055,7 +1055,7 @@ auto ParseGlobalProperties(const score::json::Object& top_level_object) -> Globa
                                                           "Configuration corrupted, check with json schema");
         const auto& process_properties_map = process_properties_obj.value().get();
         const auto asil_level = ParseAsilLevel(process_properties_map);
-        if (asil_level.has_value() == false)
+        if (!asil_level.has_value())
         {
             // set default (ASIL-QM)
             global_configuration.SetProcessAsilLevel(QualityType::kASIL_QM);

--- a/score/mw/com/impl/configuration/lola_service_instance_deployment.cpp
+++ b/score/mw/com/impl/configuration/lola_service_instance_deployment.cpp
@@ -101,7 +101,7 @@ json::Object ConvertUidMapToJson(const std::unordered_map<QualityType, std::vect
 
 auto areCompatible(const LolaServiceInstanceDeployment& lhs, const LolaServiceInstanceDeployment& rhs) noexcept -> bool
 {
-    if (((lhs.instance_id_.has_value()) == false) || (rhs.instance_id_.has_value() == false))
+    if ((!lhs.instance_id_.has_value()) || (!rhs.instance_id_.has_value()))
     {
         return true;
     }

--- a/score/mw/com/impl/instance_specifier.cpp
+++ b/score/mw/com/impl/instance_specifier.cpp
@@ -69,11 +69,7 @@ bool IsShortNameValid(const std::string_view shortname) noexcept
     }
 
     constexpr auto invalid_char_seq = "//";
-    if (shortname.find(invalid_char_seq, 0U) != std::string_view::npos)
-    {
-        return false;
-    }
-    return true;
+    return shortname.find(invalid_char_seq, 0U) == std::string_view::npos;
 }
 
 }  // namespace

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.cpp
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.cpp
@@ -125,12 +125,7 @@ bool mw_com_proxy_event_subscribe(ProxyEventBase* event_ptr, uint32_t max_sample
 
     auto result = event_ptr->Subscribe(max_sample_count);
 
-    if (!result.has_value())
-    {
-        return false;
-    }
-
-    return true;
+    return result.has_value();
 }
 
 /// \brief Unsubscribe from a proxy event to release sample buffers
@@ -261,7 +256,7 @@ std::uint32_t mw_com_type_registry_get_samples_from_event(ProxyEventBase* event_
 
     auto result = type_ops->GetSamplesFromEvent(event_ptr, max_samples, *callback);
 
-    if (result.has_value() == false)
+    if (!result.has_value())
     {
         return std::numeric_limits<std::uint32_t>::max();
     }
@@ -368,11 +363,7 @@ bool mw_com_proxy_set_event_receive_handler(ProxyEventBase* event_ptr, const Fat
     }
 
     auto result = event_ptr->SetReceiveHandler(RustFnMutCallable<RustBoxedCallable>{*boxed_handler});
-    if (result.has_value() == false)
-    {
-        return false;
-    }
-    return true;
+    return result.has_value();
 }
 
 /// \brief Clear event receive handler for proxy event

--- a/score/mw/com/test/partial_restart/consumer_handle_notification_data.cpp
+++ b/score/mw/com/test/partial_restart/consumer_handle_notification_data.cpp
@@ -26,7 +26,7 @@ void WaitTillServiceDisappears(HandleNotificationData& handle_notification_data)
 {
     std::unique_lock lock{handle_notification_data.mutex};
     handle_notification_data.condition_variable.wait(lock, [&handle_notification_data] {
-        return handle_notification_data.service_disappeared == true;
+        return handle_notification_data.service_disappeared;
     });
     handle_notification_data.service_disappeared = false;
 }

--- a/score/mw/com/test/partial_restart/provider_restart/provider_restart_application.cpp
+++ b/score/mw/com/test/partial_restart/provider_restart/provider_restart_application.cpp
@@ -120,7 +120,7 @@ int main(int argc, const char** argv)
         std::cerr << "Test Main: Running iteration " << test_iteration << " of "
                   << test_parameters.number_test_iterations << " of Provider-Restart-Test" << std::endl;
 
-        if (test_parameters.kill_provider == false)
+        if (!test_parameters.kill_provider)
         {
             if (test_parameters.create_proxy)
             {


### PR DESCRIPTION
## Summary

Simplifies boolean expressions flagged by clang-tidy's `readability-simplify-boolean-expr` check across 12 files, e.g. `x == true` → `x`, `x == false` → `!x`, and `if (cond) { return false; } return true;` → `return !cond;` (or the inverse):

- `score/memory/shared/memory_region_bounds.cpp`
- `score/memory/shared/shared_memory_test_resources.cpp`
- `score/mw/com/impl/bindings/lola/event_slot_status.cpp`
- `score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance.cpp`
- `score/mw/com/impl/bindings/lola/provider_event_data_control_local_view.cpp`
- `score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp`
- `score/mw/com/impl/configuration/configuration_json_parsing_strategy.cpp`
- `score/mw/com/impl/configuration/lola_service_instance_deployment.cpp`
- `score/mw/com/impl/instance_specifier.cpp`
- `score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.cpp`
- `score/mw/com/test/partial_restart/consumer_handle_notification_data.cpp`
- `score/mw/com/test/partial_restart/provider_restart/provider_restart_application.cpp`

## How this was produced

1. Temporarily isolated `readability-simplify-boolean-expr` in `.clang-tidy` (`Checks: -*, readability-simplify-boolean-expr,`).
2. Ran `bazel run //:clang-tidy.fix -- //...`, which applied 12 patches via clang-tidy's built-in auto-fix.
3. Restored `.clang-tidy` to its original, unmodified state (verified via `git diff` showing no residual changes) — this PR only contains the source changes.
4. **Manually reviewed every applied patch** and found/corrected two issues introduced by the auto-fix:
   - `lola_service_instance_deployment.cpp`: the fix-it dropped a closing parenthesis (`if (((!lhs...) || (!rhs...))`  — unbalanced, would not compile). Restored correct grouping: `if ((!lhs.instance_id_.has_value()) || (!rhs.instance_id_.has_value()))`.
   - `registry_bridge_macro.cpp`: one site was left as `return result.has_value() != false;` (valid but stylistically inconsistent with the identical pattern fixed elsewhere in the same file). Simplified further to `return result.has_value();`.

## Verification

- Built the affected target directories (`//score/memory/shared/...`, `//score/mw/com/impl/...`, `//score/mw/com/test/partial_restart/...`) — succeeds cleanly (only pre-existing, unrelated deprecation warnings).
- Ran the corresponding unit/integration tests for all three directories — all pass (253 pass + 27 pass, remainder skipped for unrelated environment reasons e.g. missing QNX/typed-memory support).