### PR TITLE
Fix clang-tidy readability-qualified-auto findings

### DIFF
--- a/score/memory/shared/memory_region_map.cpp
+++ b/score/memory/shared/memory_region_map.cpp
@@ -245,7 +245,7 @@ auto MemoryRegionMapImpl<AtomicIndirectorType>::GetBoundsFromAddress(const std::
         std::terminate();
     }
 
-    auto& latest_known_regions =
+    const auto& latest_known_regions =
         known_regions_versions_.at(static_cast<std::size_t>(latest_regions_version_index.value().GetIndex()));
 
     if (latest_known_regions.empty())
@@ -289,7 +289,7 @@ size_t MemoryRegionMapImpl<AtomicIndirectorType>::GetSize() const noexcept
         std::terminate();
     }
 
-    auto& latest_known_regions =
+    const auto& latest_known_regions =
         known_regions_versions_.at(static_cast<std::size_t>(latest_regions_version_index.value().GetIndex()));
     return latest_known_regions.size();
 }

--- a/score/memory/shared/memory_resource_proxy.cpp
+++ b/score/memory/shared/memory_resource_proxy.cpp
@@ -55,7 +55,7 @@ auto MemoryResourceProxy::allocate(const std::size_t bytes, const std::size_t al
     {
         PerformBoundsCheck(memory_identifier_);
     }
-    auto memoryResource = MemoryResourceRegistry::getInstance().at(this->memory_identifier_);
+    auto* memoryResource = MemoryResourceRegistry::getInstance().at(this->memory_identifier_);
     // it is already ensured via bounds check, that the memory resource exists
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(memoryResource != nullptr);
     return memoryResource->allocate(bytes, alignment);
@@ -63,7 +63,7 @@ auto MemoryResourceProxy::allocate(const std::size_t bytes, const std::size_t al
 
 auto MemoryResourceProxy::deallocate(void* const memory, const std::size_t byte) const -> void
 {
-    auto memoryResource = MemoryResourceRegistry::getInstance().at(this->memory_identifier_);
+    auto* memoryResource = MemoryResourceRegistry::getInstance().at(this->memory_identifier_);
     if (memoryResource != nullptr)
     {
         return memoryResource->deallocate(memory, byte);

--- a/score/memory/shared/memory_resource_registry.cpp
+++ b/score/memory/shared/memory_resource_registry.cpp
@@ -91,7 +91,7 @@ void score::memory::shared::MemoryResourceRegistry::remove_resource(const Memory
     {
         if (!resource_it->second->IsOffsetPtrBoundsCheckBypassingEnabled())
         {
-            const auto start_address = resource_it->second->getBaseAddress();
+            auto* const start_address = resource_it->second->getBaseAddress();
             const auto start_address_as_integer = CastPointerToInteger(start_address);
             region_map_.RemoveKnownRegion(start_address_as_integer);
         }

--- a/score/memory/shared/shared_memory_resource.cpp
+++ b/score/memory/shared/shared_memory_resource.cpp
@@ -531,7 +531,7 @@ score::cpp::expected_blank<Error> SharedMemoryResource::CreateImpl(const std::si
 
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(file_descriptor_ >= 0, "No valid file descriptor");
 
-    const auto typed_memory_ptr = (is_shm_in_typed_memory_ ? typed_memory_ptr_.get() : nullptr);
+    auto* const typed_memory_ptr = (is_shm_in_typed_memory_ ? typed_memory_ptr_.get() : nullptr);
     const auto stat_values = GetShmObjectStatInfo(file_descriptor_, (path != nullptr), path, typed_memory_ptr);
     file_owner_uid_ = stat_values.owner_uid;
 

--- a/score/message_passing/client_connection.cpp
+++ b/score/message_passing/client_connection.cpp
@@ -351,7 +351,7 @@ void ClientConnection::TryConnect() noexcept
     SCORE_LANGUAGE_FUTURECPP_ASSERT_DBG(((stop_reason_ == StopReason::kNone) && (state_ == State::kStarting)) ||
                                         ((state_ == State::kStopping) && (stop_reason_ == StopReason::kUserRequested)));
 
-    auto& logger = engine_->GetLogger();
+    const auto& logger = engine_->GetLogger();
 
     LogInfo(logger, "TryOpenClientConnection ", identifier_);
     LogWarnOnTimeout delay_guard(

--- a/score/message_passing/qnx_dispatch/qnx_resource_path.cpp
+++ b/score/message_passing/qnx_dispatch/qnx_resource_path.cpp
@@ -25,7 +25,7 @@ QnxResourcePath::QnxResourcePath(const std::string_view identifier) noexcept
 {
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION((identifier.size() > 0U) && (identifier.size() <= kMaxIdentifierLen));
 
-    auto identifier_begin = identifier.cbegin();
+    const auto* identifier_begin = identifier.cbegin();
     if (*identifier_begin == '/')
     {
         identifier_begin = std::next(identifier_begin);

--- a/score/mw/com/doc/tutorial/chapter_9/provider/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_9/provider/provider.cpp
@@ -203,7 +203,7 @@ int main()
         std::array<float, 4U> new_pressures{};
         for (std::size_t index = 0U; index < tires.size(); ++index)
         {
-            auto& [field, field_name, tire] = tires[index];
+            const auto& [field, field_name, tire] = tires[index];
             new_pressures[index] = UpdateField(field, field_name, pressure_distribution(random_engine));
         }
 

--- a/score/mw/com/gateway/transport_layer/sample/message_framer.cpp
+++ b/score/mw/com/gateway/transport_layer/sample/message_framer.cpp
@@ -28,7 +28,7 @@ using score::os::Socket;
 /// \brief Helper function to send the buffer's data over a socket.
 int SendAll(std::int32_t socket_fd, const void* data, std::size_t length)
 {
-    auto* ptr = static_cast<const char*>(data);
+    const auto* ptr = static_cast<const char*>(data);
     while (length > 0)
     {
         auto result = Socket::instance().sendto(socket_fd, ptr, length, Socket::MessageFlag::kNone, nullptr, 0);

--- a/score/mw/com/impl/bindings/lola/application_id_pid_mapping.cpp
+++ b/score/mw/com/impl/bindings/lola/application_id_pid_mapping.cpp
@@ -46,7 +46,7 @@ std::optional<pid_t> TryUpdatePidForExistingId(
     // Rationale: Tolerated due to containers providing pointer-like iterators.
     // The Coverity tool considers these iterators as raw pointers.
     // coverity[autosar_cpp14_m5_0_15_violation]
-    for (auto it = entries_begin; it != entries_end; it++)
+    for (auto* it = entries_begin; it != entries_end; it++)
     {
         // extract out into a separate function
         const auto status_applicationid = it->GetStatusAndApplicationIdAtomic();
@@ -114,7 +114,7 @@ std::optional<pid_t> RegisterPid(score::containers::DynamicArray<ApplicationIdPi
         // Rationale: Tolerated due to containers providing pointer-like iterators.
         // The Coverity tool considers these iterators as raw pointers.
         // coverity[autosar_cpp14_m5_0_15_violation]
-        for (auto it = entries_begin; it != entries_end; it++)
+        for (auto* it = entries_begin; it != entries_end; it++)
         {
             const auto status_applicationid = it->GetStatusAndApplicationIdAtomic();
             const auto entry_status = status_applicationid.first;

--- a/score/mw/com/impl/bindings/lola/messaging/mw_log_logger.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/mw_log_logger.cpp
@@ -37,7 +37,7 @@ score::message_passing::LoggingCallback GetMwLogLogger()
             return;
         }
         score::mw::log::LogStream stream = (*StreamFactories.at(severity_num))("mp_2");
-        for (auto& item : items)
+        for (const auto& item : items)
         {
             std::visit(
                 [&stream](auto&& arg) {

--- a/score/mw/com/impl/bindings/lola/proxy.cpp
+++ b/score/mw/com/impl/bindings/lola/proxy.cpp
@@ -564,7 +564,7 @@ ConsumerEventDataControlLocalView<> Proxy::GetConsumerEventDataControlLocalView(
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(control_ != nullptr,
                                                       "Proxy::GetEventControl: Managed memory control pointer is Null");
     auto& service_data_control = GetServiceDataControl(*control_);
-    const auto event_entry = service_data_control.event_controls_.find(element_fq_id);
+    auto* const event_entry = service_data_control.event_controls_.find(element_fq_id);
     if (event_entry == service_data_control.event_controls_.end())
     {
         score::mw::log::LogFatal("lola") << __func__ << __LINE__
@@ -594,7 +594,7 @@ EventSubscriptionControl<>& Proxy::GetEventSubscriptionControl(const ElementFqId
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(control_ != nullptr,
                                                       "Proxy::GetEventControl: Managed memory control pointer is Null");
     auto& service_data_control = GetServiceDataControl(*control_);
-    const auto event_entry = service_data_control.event_controls_.find(element_fq_id);
+    auto* const event_entry = service_data_control.event_controls_.find(element_fq_id);
     if (event_entry == service_data_control.event_controls_.end())
     {
         score::mw::log::LogFatal("lola") << __func__ << __LINE__
@@ -614,7 +614,7 @@ TransactionLogSet& Proxy::GetTransactionLogSet(const ElementFqId element_fq_id)
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(control_ != nullptr,
                                                       "Proxy::GetEventControl: Managed memory control pointer is Null");
     auto& service_data_control = GetServiceDataControl(*control_);
-    const auto event_entry = service_data_control.event_controls_.find(element_fq_id);
+    auto* const event_entry = service_data_control.event_controls_.find(element_fq_id);
     if (event_entry == service_data_control.event_controls_.end())
     {
         score::mw::log::LogFatal("lola") << __func__ << __LINE__
@@ -634,7 +634,7 @@ const EventMetaInfo& Proxy::GetEventMetaInfo(const ElementFqId element_fq_id) co
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(data_ != nullptr,
                                                       "Proxy::GetEventMetaInfo: Managed memory data pointer is Null");
     auto& service_data_storage = detail_proxy::GetServiceDataStorage(*data_);
-    const auto event_meta_info_entry = service_data_storage.events_metainfo_.find(element_fq_id);
+    auto* const event_meta_info_entry = service_data_storage.events_metainfo_.find(element_fq_id);
     if (event_meta_info_entry == service_data_storage.events_metainfo_.end())
     {
         score::mw::log::LogFatal("lola") << __func__ << __LINE__
@@ -663,7 +663,7 @@ bool Proxy::IsEventProvided(const std::string_view event_name) const
                                                       "IsEventProvided: Managed memory control pointer is Null");
     auto& service_data_control = GetServiceDataControl(*control_);
     const auto element_fq_id = event_name_to_element_fq_id_converter_.Convert(event_name);
-    const auto event_entry = service_data_control.event_controls_.find(element_fq_id);
+    auto* const event_entry = service_data_control.event_controls_.find(element_fq_id);
     const bool event_exists = (event_entry != service_data_control.event_controls_.end());
     return event_exists;
 }

--- a/score/mw/com/impl/bindings/lola/shm_path_builder.cpp
+++ b/score/mw/com/impl/bindings/lola/shm_path_builder.cpp
@@ -111,7 +111,7 @@ void EmitMethodFileName(std::ostream& out,
 
 std::string ShmPathBuilder::GetDataChannelShmName(const LolaServiceInstanceId::InstanceId instance_id) const noexcept
 {
-    const auto prefix = inter_vm_support_ ? kInterVmSharedShmPrefix : "/";
+    const auto* const prefix = inter_vm_support_ ? kInterVmSharedShmPrefix : "/";
     return EmitWithPrefix(prefix, [this, instance_id](auto& out) {
         EmitDataFileName(out, service_id_, instance_id);
     });
@@ -120,7 +120,7 @@ std::string ShmPathBuilder::GetDataChannelShmName(const LolaServiceInstanceId::I
 std::string ShmPathBuilder::GetControlChannelShmName(const LolaServiceInstanceId::InstanceId instance_id,
                                                      const QualityType channel_type) const noexcept
 {
-    const auto prefix = inter_vm_support_ ? kInterVmSharedShmPrefix : "/";
+    const auto* const prefix = inter_vm_support_ ? kInterVmSharedShmPrefix : "/";
     return EmitWithPrefix(prefix, [this, channel_type, instance_id](auto& out) noexcept {
         EmitControlFileName(out, channel_type, service_id_, instance_id);
     });
@@ -130,7 +130,7 @@ std::string ShmPathBuilder::GetMethodChannelShmName(
     const LolaServiceInstanceId::InstanceId instance_id,
     const ProxyInstanceIdentifier& proxy_instance_identifier) const noexcept
 {
-    const auto prefix = inter_vm_support_ ? kInterVmSharedShmPrefix : "/";
+    const auto* const prefix = inter_vm_support_ ? kInterVmSharedShmPrefix : "/";
     return EmitWithPrefix(prefix, [this, instance_id, proxy_instance_identifier](auto& out) noexcept {
         EmitMethodFileName(out, service_id_, instance_id, proxy_instance_identifier);
     });

--- a/score/mw/com/impl/bindings/lola/skeleton.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton.cpp
@@ -734,7 +734,7 @@ auto Skeleton::SubscribeMethods(const MethodData& method_data,
     const auto& method_call_queues = method_data.method_call_queues_;
     for (std::size_t method_idx = 0U; method_idx != method_call_queues.size(); method_idx++)
     {
-        auto& [unique_method_identifier, type_erased_call_queue] = method_call_queues[method_idx];
+        const auto& [unique_method_identifier, type_erased_call_queue] = method_call_queues[method_idx];
 
         // Defensive check for skeleton method population.
         // The skeleton_methods_ map is populated at skeleton construction time

--- a/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
@@ -278,7 +278,7 @@ void* SkeletonMemoryManager::RetrieveGenericEventDataFromOpenedSharedMemory(
 {
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(storage_ != nullptr, "Service data storage is not available.");
 
-    const auto event_meta_info_it = storage_->events_metainfo_.find(element_fq_id);
+    auto* const event_meta_info_it = storage_->events_metainfo_.find(element_fq_id);
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(event_meta_info_it != storage_->events_metainfo_.cend(),
                                                 "Could not find element fq id in meta info map");
 
@@ -298,7 +298,7 @@ void* SkeletonMemoryManager::RetrieveGenericEventDataFromOpenedSharedMemory(
 auto SkeletonMemoryManager::RetrieveEventControlsFromOpenedSharedMemory(const ElementFqId element_fq_id)
     -> std::pair<std::reference_wrapper<EventControl>, EventControl*>
 {
-    const auto event_control_qm_it = control_qm_->event_controls_.find(element_fq_id);
+    auto* const event_control_qm_it = control_qm_->event_controls_.find(element_fq_id);
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(event_control_qm_it != control_qm_->event_controls_.cend(),
                                                 "Could not find element fq id in map");
     EventControl& event_control_qm = event_control_qm_it->second;
@@ -307,7 +307,7 @@ auto SkeletonMemoryManager::RetrieveEventControlsFromOpenedSharedMemory(const El
         return {event_control_qm, nullptr};
     }
 
-    const auto event_control_asil_b_it = control_asil_b_->event_controls_.find(element_fq_id);
+    auto* const event_control_asil_b_it = control_asil_b_->event_controls_.find(element_fq_id);
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(event_control_asil_b_it != control_asil_b_->event_controls_.cend(),
                                                 "Could not find asil b element fq id in map");
     EventControl& event_control_asil_b = event_control_asil_b_it->second;

--- a/score/mw/com/impl/bindings/lola/test/skeleton_event_test_resources.cpp
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_event_test_resources.cpp
@@ -73,7 +73,7 @@ EventControl* SkeletonEventFixture::GetEventControl(const ElementFqId element_fq
     {
         return nullptr;
     }
-    const auto event_entry = service_data_control->event_controls_.find(element_fq_id);
+    auto* const event_entry = service_data_control->event_controls_.find(element_fq_id);
     if (event_entry != service_data_control->event_controls_.end())
     {
         return &event_entry->second;

--- a/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.cpp
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.cpp
@@ -92,19 +92,19 @@ ServiceTypeDeployment CreateTypeDeployment(const uint16_t lola_service_id,
                                            const std::vector<std::pair<std::string, std::uint8_t>>& method_ids)
 {
     LolaServiceTypeDeployment::EventIdMapping event_id_mapping{};
-    for (auto& event_with_id : event_ids)
+    for (const auto& event_with_id : event_ids)
     {
         event_id_mapping.insert(event_with_id);
     }
 
     LolaServiceTypeDeployment::FieldIdMapping field_id_mapping{};
-    for (auto& field_with_id : field_ids)
+    for (const auto& field_with_id : field_ids)
     {
         field_id_mapping.insert(field_with_id);
     }
 
     LolaServiceTypeDeployment::MethodIdMapping method_id_mapping{};
-    for (auto& method_with_id : method_ids)
+    for (const auto& method_with_id : method_ids)
     {
         method_id_mapping.insert(method_with_id);
     }
@@ -360,7 +360,7 @@ EventControl& SkeletonMockedMemoryFixture::GetEventControlFromServiceDataControl
     ElementFqId element_fq_id,
     ServiceDataControl& service_data_control) noexcept
 {
-    auto event_control_it = service_data_control.event_controls_.find(element_fq_id);
+    auto* event_control_it = service_data_control.event_controls_.find(element_fq_id);
     EXPECT_NE(event_control_it, service_data_control.event_controls_.cend());
     auto& event_control = event_control_it->second;
     return event_control;
@@ -370,7 +370,7 @@ ProviderEventDataControlLocalView<> SkeletonMockedMemoryFixture::GetProviderEven
     ElementFqId element_fq_id,
     ServiceDataControl& service_data_control) noexcept
 {
-    auto event_control_it = service_data_control.event_controls_.find(element_fq_id);
+    auto* event_control_it = service_data_control.event_controls_.find(element_fq_id);
     EXPECT_NE(event_control_it, service_data_control.event_controls_.cend());
 
     auto& event_control = event_control_it->second;
@@ -381,7 +381,7 @@ ConsumerEventDataControlLocalView<> SkeletonMockedMemoryFixture::GetConsumerEven
     ElementFqId element_fq_id,
     ServiceDataControl& service_data_control) noexcept
 {
-    auto event_control_it = service_data_control.event_controls_.find(element_fq_id);
+    auto* event_control_it = service_data_control.event_controls_.find(element_fq_id);
     EXPECT_NE(event_control_it, service_data_control.event_controls_.cend());
 
     auto& event_control = event_control_it->second;
@@ -392,7 +392,7 @@ TransactionLogSet& SkeletonMockedMemoryFixture::GetTransactionLogSetFromServiceD
     ElementFqId element_fq_id,
     ServiceDataControl& service_data_control) noexcept
 {
-    auto event_control_it = service_data_control.event_controls_.find(element_fq_id);
+    auto* event_control_it = service_data_control.event_controls_.find(element_fq_id);
     EXPECT_NE(event_control_it, service_data_control.event_controls_.cend());
 
     auto& event_control = event_control_it->second;

--- a/score/mw/com/impl/bindings/lola/test/transaction_log_test_resources.cpp
+++ b/score/mw/com/impl/bindings/lola/test/transaction_log_test_resources.cpp
@@ -147,7 +147,7 @@ bool IsProxyTransactionLogIdRegistered(TransactionLogSet& transaction_log_set,
                                        const TransactionLogId& transaction_log_id) noexcept
 {
     auto& transaction_logs = TransactionLogSetAttorney{transaction_log_set}.GetProxyTransactionLogs();
-    const auto result =
+    auto* const result =
         std::find_if(transaction_logs.begin(), transaction_logs.end(), [&transaction_log_id](const auto& element) {
             return (element.IsActive() && (element.GetTransactionLogId() == transaction_log_id));
         });
@@ -156,7 +156,7 @@ bool IsProxyTransactionLogIdRegistered(TransactionLogSet& transaction_log_set,
 
 bool IsSkeletonTransactionLogRegistered(TransactionLogSet& transaction_log_set) noexcept
 {
-    auto& transaction_log = TransactionLogSetAttorney{transaction_log_set}.GetSkeletonTransactionLog();
+    const auto& transaction_log = TransactionLogSetAttorney{transaction_log_set}.GetSkeletonTransactionLog();
     return transaction_log.has_value();
 }
 

--- a/score/mw/com/impl/bindings/lola/tracing/tracing_runtime.cpp
+++ b/score/mw/com/impl/bindings/lola/tracing/tracing_runtime.cpp
@@ -268,7 +268,7 @@ analysis::tracing::ServiceInstanceElement TracingRuntime::ConvertToTracingServic
     // coverity[autosar_cpp14_a15_4_2_violation]
     const auto& service_instance_deployment =
         configuration_.GetServiceInstanceDeployment(instance_specifier).value().get();
-    auto* lola_service_instance_deployment =
+    const auto* lola_service_instance_deployment =
         std::get_if<LolaServiceInstanceDeployment>(&service_instance_deployment.bindingInfo_);
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(lola_service_instance_deployment != nullptr);
 

--- a/score/mw/com/impl/bindings/lola/transaction_log_set.cpp
+++ b/score/mw/com/impl/bindings/lola/transaction_log_set.cpp
@@ -91,7 +91,7 @@ Result<void> TransactionLogSet::RollbackProxyTransactions(
     // the next TransactionLog. If there are only TransactionLogs remaining which cannot be rolled back, return an
     // error.
     Result<void> rollback_result{};
-    for (const auto transaction_log_node_it : transaction_log_node_iterators_to_be_rolled_back)
+    for (auto* const transaction_log_node_it : transaction_log_node_iterators_to_be_rolled_back)
     {
         rollback_result = transaction_log_node_it->GetTransactionLogLocalView().RollbackProxyElementLog(
             dereference_slot_callback, unsubscribe_callback);
@@ -205,7 +205,7 @@ TransactionLogSet::FindTransactionLogNodesToBeRolledBack(const TransactionLogId&
     //
     // coverity[autosar_cpp14_m5_0_15_violation]
     // coverity[autosar_cpp14_a5_3_2_violation : FALSE]
-    for (auto it = proxy_transaction_logs_.begin(); it != proxy_transaction_logs_.end(); it++)
+    for (auto* it = proxy_transaction_logs_.begin(); it != proxy_transaction_logs_.end(); it++)
     {
         // LCOV_EXCL_BR_STOP
         // coverity[autosar_cpp14_a5_3_2_violation : FALSE]
@@ -247,7 +247,7 @@ TransactionLogSet::AcquireNextAvailableSlot(TransactionLogId transaction_log_id)
         //
         // coverity[autosar_cpp14_m5_0_15_violation]
         // coverity[autosar_cpp14_a5_3_2_violation : FALSE]
-        for (auto it = proxy_transaction_logs_.begin(); it != proxy_transaction_logs_.end(); it++)
+        for (auto* it = proxy_transaction_logs_.begin(); it != proxy_transaction_logs_.end(); it++)
         {
             // LCOV_EXCL_BR_STOP
             auto& transaction_log_node = *it;

--- a/score/mw/com/impl/configuration/configuration_json_parsing_strategy.cpp
+++ b/score/mw/com/impl/configuration/configuration_json_parsing_strategy.cpp
@@ -685,7 +685,7 @@ auto ParseServiceInstanceDeployments(const score::json::Object& json_map,
     auto deplymentObjs_result = deploymentInstances->second.As<score::json::List>();
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(deplymentObjs_result.has_value(),
                                                       "Configuration corrupted, check with json schema");
-    auto& deplymentObjs = deplymentObjs_result.value().get();
+    const auto& deplymentObjs = deplymentObjs_result.value().get();
     for (const auto& deploymentInstance : deplymentObjs)
     {
         auto deployment_obj = deploymentInstance.As<score::json::Object>();

--- a/score/mw/com/impl/configuration/lola_service_instance_deployment.cpp
+++ b/score/mw/com/impl/configuration/lola_service_instance_deployment.cpp
@@ -53,7 +53,7 @@ std::unordered_map<QualityType, std::vector<uid_t>> ConvertJsonToUidMap(const js
     const auto& uid_map_json = GetValueFromJson<json::Object>(json_object, key);
 
     std::unordered_map<QualityType, std::vector<uid_t>> uid_map{};
-    for (auto& it : uid_map_json)
+    for (const auto& it : uid_map_json)
     {
         std::string quality_string{it.first.GetAsStringView().data(), it.first.GetAsStringView().size()};
         const QualityType quality_type{FromString(std::move(quality_string))};
@@ -65,7 +65,7 @@ std::unordered_map<QualityType, std::vector<uid_t>> ConvertJsonToUidMap(const js
         const auto& uids_json = uids_json_result.value().get();
 
         std::vector<uid_t> uids{};
-        for (auto& uid_json : uids_json)
+        for (const auto& uid_json : uids_json)
         {
             // Check if each individual UID element can be parsed to uid_t type
             const auto uid_result = uid_json.As<uid_t>();

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.cpp
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.cpp
@@ -59,7 +59,7 @@ ProxyEventBase* mw_com_get_event_from_proxy(ProxyBase* proxy_ptr, StringView int
     auto event = static_cast<std::string_view>(event_id);
     auto id = static_cast<std::string_view>(interface_id);
 
-    auto registry = GlobalRegistryMapping::FindMemberOperation(id, event);
+    auto* registry = GlobalRegistryMapping::FindMemberOperation(id, event);
 
     if (registry == nullptr)
     {
@@ -86,7 +86,7 @@ SkeletonEventBase* mw_com_get_event_from_skeleton(SkeletonBase* skeleton_ptr,
     auto event = static_cast<std::string_view>(event_id);
     auto id = static_cast<std::string_view>(interface_id);
 
-    auto registry = GlobalRegistryMapping::FindMemberOperation(id, event);
+    auto* registry = GlobalRegistryMapping::FindMemberOperation(id, event);
 
     if (registry == nullptr)
     {
@@ -157,7 +157,7 @@ ProxyBase* mw_com_create_proxy(StringView interface_id, const HandleType& handle
         return nullptr;
     }
     auto id = static_cast<std::string_view>(interface_id);
-    auto registry = GlobalRegistryMapping::FindInterfaceRegistry(id);
+    auto* registry = GlobalRegistryMapping::FindInterfaceRegistry(id);
 
     if (registry == nullptr)
     {
@@ -179,7 +179,7 @@ SkeletonBase* mw_com_create_skeleton(StringView interface_id, ::score::mw::com::
     }
 
     auto id = static_cast<std::string_view>(interface_id);
-    auto registry = GlobalRegistryMapping::FindInterfaceRegistry(id);
+    auto* registry = GlobalRegistryMapping::FindInterfaceRegistry(id);
 
     if (registry == nullptr)
     {
@@ -466,7 +466,7 @@ const void* mw_com_get_type_ops_instance(StringView interface_id, StringView mem
     auto id = static_cast<std::string_view>(interface_id);
     auto member = static_cast<std::string_view>(member_name);
 
-    auto registry = GlobalRegistryMapping::FindMemberOperation(id, member);
+    auto* registry = GlobalRegistryMapping::FindMemberOperation(id, member);
 
     if (registry == nullptr)
     {

--- a/score/mw/com/impl/service_discovery.cpp
+++ b/score/mw/com/impl/service_discovery.cpp
@@ -291,7 +291,7 @@ auto ServiceDiscovery::GetServiceDiscoveryClient(const InstanceIdentifier& insta
 {
     InstanceIdentifierView instance_identifier_view{instance_identifier};
     auto binding_type = instance_identifier_view.GetServiceInstanceDeployment().GetBindingType();
-    auto binding_runtime = runtime_.GetBindingRuntime(binding_type);
+    auto* binding_runtime = runtime_.GetBindingRuntime(binding_type);
 
     if (binding_runtime == nullptr)
     {

--- a/score/mw/com/impl/tracing/configuration/tracing_filter_config_parser.cpp
+++ b/score/mw/com/impl/tracing/configuration/tracing_filter_config_parser.cpp
@@ -223,13 +223,13 @@ void ParseEvent(const score::json::Any& json,
                                                                                    instance))
         {
             // trace points for the proxy side
-            for (auto& [bool_prop_name, trace_point_type] : filter_property_proxy_event_mappings)
+            for (const auto& [bool_prop_name, trace_point_type] : filter_property_proxy_event_mappings)
             {
                 AddTracePoint(
                     object, bool_prop_name, service_type, event_name, instance, trace_point_type, filter_config);
             }
             // trace points for the skeleton side
-            for (auto& [bool_prop_name, trace_point_type] : filter_property_skeleton_event_mappings)
+            for (const auto& [bool_prop_name, trace_point_type] : filter_property_skeleton_event_mappings)
             {
                 AddTracePoint(
                     object, bool_prop_name, service_type, event_name, instance, trace_point_type, filter_config);
@@ -318,7 +318,7 @@ void AddTracePointsFromSubObject(const score::json::Object& json_object,
         auto block_result = block->second.As<score::json::Object>();
         SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(block_result.has_value(),
                                                           "Configuration corrupted, check with json schema");
-        auto& block_object = block_result.value().get();
+        const auto& block_object = block_result.value().get();
         // trace points for the proxy side
         for (auto& prop_mapping : property_name_trace_point_mappings)
         {
@@ -343,8 +343,9 @@ void WarnNotImplementedTracePointsFromSubObject(const score::json::Object& json_
         auto block_result = block->second.As<score::json::Object>();
         SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(block_result.has_value(),
                                                           "Configuration corrupted, check with json schema");
-        auto& block_object = block_result.value().get();
-        for (auto& not_implemented_property_name : service_element_notifier_filter_properties_not_implemented_array)
+        const auto& block_object = block_result.value().get();
+        for (const auto& not_implemented_property_name :
+             service_element_notifier_filter_properties_not_implemented_array)
         {
             if (IsOptionalBoolPropertyEnabled(block_object, not_implemented_property_name))
             {

--- a/score/mw/com/test/check_values_created_from_config/check_values_created_from_config_application.cpp
+++ b/score/mw/com/test/check_values_created_from_config/check_values_created_from_config_application.cpp
@@ -100,7 +100,7 @@ class ConfigParser
 
     std::optional<std::string> GetShmName() const noexcept
     {
-        const auto lola_service_type_deployment =
+        const auto* const lola_service_type_deployment =
             std::get_if<score::mw::com::impl::LolaServiceTypeDeployment>(&type_deployment_.binding_info_);
         if (lola_service_type_deployment == nullptr)
         {

--- a/score/mw/com/test/common_test_resources/sample_sender_receiver.cpp
+++ b/score/mw/com/test/common_test_resources/sample_sender_receiver.cpp
@@ -310,7 +310,7 @@ const MapApiLanesStamped& GetSamplePtrValue(const MapApiLanesStamped* const samp
 /// Assumes that the object in memory being pointed to is of type MapApiLanesStamped.
 const MapApiLanesStamped& GetSamplePtrValue(const void* const void_ptr)
 {
-    auto* const typed_ptr = static_cast<const MapApiLanesStamped*>(void_ptr);
+    const auto* const typed_ptr = static_cast<const MapApiLanesStamped*>(void_ptr);
     return *typed_ptr;
 }
 

--- a/score/mw/com/test/concurrent_skeleton_creation/concurrent_skeleton_creation_application.cpp
+++ b/score/mw/com/test/concurrent_skeleton_creation/concurrent_skeleton_creation_application.cpp
@@ -79,9 +79,9 @@ int main(int argc, const char** argv)
         std::cerr << "Invalid instance specifier, terminating." << std::endl;
         return EXIT_FAILURE;
     }
-    auto& instance_specifier_1 = instance_specifier_result_1.value();
-    auto& instance_specifier_2 = instance_specifier_result_2.value();
-    auto& instance_specifier_3 = instance_specifier_result_3.value();
+    const auto& instance_specifier_1 = instance_specifier_result_1.value();
+    const auto& instance_specifier_2 = instance_specifier_result_2.value();
+    const auto& instance_specifier_3 = instance_specifier_result_3.value();
 
     std::atomic_bool success_flag{true};
     score::cpp::jthread skeletion_creation_and_offer_instance_1{[&success_flag, &instance_specifier_1]() {

--- a/score/mw/com/test/generic_skeleton/generic_generic_interaction_app.cpp
+++ b/score/mw/com/test/generic_skeleton/generic_generic_interaction_app.cpp
@@ -180,7 +180,7 @@ int run_consumer()
         // The receiver callback operates on type-erased memory (SamplePtr<const void>)
         const auto get_new_samples_result = generic_event.GetNewSamples(
             [&](auto sample) {
-                auto* typed_sample = static_cast<const MyEventData*>(sample.get());
+                const auto* typed_sample = static_cast<const MyEventData*>(sample.get());
 
                 if (is_first_sample)
                 {


### PR DESCRIPTION
## Summary

Adds missing pointer/reference qualifiers to `auto` declarations flagged by clang-tidy's `readability-qualified-auto` check across 28 files, e.g.:
- `auto x = ptr_returning_call();` → `auto* x = ptr_returning_call();`
- `auto& x = ...;` → `const auto& x = ...;` (when never mutated)
- `const auto x = ptr_returning_call();` → `auto* const x = ptr_returning_call();`

so the pointer-ness / constness of the declared variable is visible at the declaration site instead of being hidden behind `auto`.

Files touched:
- `score/memory/shared/memory_region_map.cpp`
- `score/memory/shared/memory_resource_proxy.cpp`
- `score/memory/shared/memory_resource_registry.cpp`
- `score/memory/shared/shared_memory_resource.cpp`
- `score/message_passing/client_connection.cpp`
- `score/message_passing/qnx_dispatch/qnx_resource_path.cpp`
- `score/mw/com/doc/tutorial/chapter_9/provider/provider.cpp`
- `score/mw/com/gateway/transport_layer/sample/message_framer.cpp`
- `score/mw/com/impl/bindings/lola/application_id_pid_mapping.cpp`
- `score/mw/com/impl/bindings/lola/messaging/mw_log_logger.cpp`
- `score/mw/com/impl/bindings/lola/proxy.cpp`
- `score/mw/com/impl/bindings/lola/shm_path_builder.cpp`
- `score/mw/com/impl/bindings/lola/skeleton.cpp`
- `score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp`
- `score/mw/com/impl/bindings/lola/test/skeleton_event_test_resources.cpp`
- `score/mw/com/impl/bindings/lola/test/skeleton_test_resources.cpp`
- `score/mw/com/impl/bindings/lola/test/transaction_log_test_resources.cpp`
- `score/mw/com/impl/bindings/lola/tracing/tracing_runtime.cpp`
- `score/mw/com/impl/bindings/lola/transaction_log_set.cpp`
- `score/mw/com/impl/configuration/configuration_json_parsing_strategy.cpp`
- `score/mw/com/impl/configuration/lola_service_instance_deployment.cpp`
- `score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.cpp`
- `score/mw/com/impl/service_discovery.cpp`
- `score/mw/com/impl/tracing/configuration/tracing_filter_config_parser.cpp`
- `score/mw/com/test/check_values_created_from_config/check_values_created_from_config_application.cpp`
- `score/mw/com/test/common_test_resources/sample_sender_receiver.cpp`
- `score/mw/com/test/concurrent_skeleton_creation/concurrent_skeleton_creation_application.cpp`
- `score/mw/com/test/generic_skeleton/generic_generic_interaction_app.cpp`

## How this was produced

1. Temporarily isolated `readability-qualified-auto` in `.clang-tidy` (`Checks: -*, readability-qualified-auto,`).
2. Ran `bazel run //:clang-tidy.fix -- //...`, which applied 28 patches via clang-tidy's built-in auto-fix (3 more were skipped as duplicates for a file compiled under multiple target configurations).
3. Restored `.clang-tidy` to its original, unmodified state (verified via `git diff` showing no residual changes) — this PR only contains the auto-fixed source changes.
4. Manually reviewed every applied patch — all are straightforward, semantically equivalent qualifier additions with no behavior changes.

## Verification

- `bazel build` succeeds (1809 targets) across all affected directories (`score/memory/shared`, `score/message_passing`, `score/mw/com/doc/tutorial/chapter_9`, `score/mw/com/gateway`, `score/mw/com/impl`, `score/mw/com/test`).
- `bazel test` for the same directories: 368 tests pass, 4 skipped for unrelated environment reasons (e.g. missing QNX/typed-memory support). An initial run showed 20 unrelated failures caused by Docker network/address-pool exhaustion in the sandbox (`docker.errors.APIError: all predefined address pools have been fully subnetted`); after pruning unused Docker networks, a full re-run passed cleanly, confirming these were pre-existing environment issues unrelated to this change.