### PR TITLE
fix(clang-tidy): resolve readability-magic-numbers findings

### DIFF
--- a/quality/integration_testing/test/main2.cpp
+++ b/quality/integration_testing/test/main2.cpp
@@ -13,13 +13,15 @@
 #include <fstream>
 #include <thread>
 
+constexpr auto kFileOpenRetryInterval{std::chrono::milliseconds{50}};
+
 int main()
 {
     std::ifstream file("/tmp/Hello.txt");
     while (not file.is_open())
     {
         file = std::ifstream("/tmp/Hello.txt");
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        std::this_thread::sleep_for(kFileOpenRetryInterval);
     }
     return 0;
 }

--- a/score/memory/shared/memory_region_map.cpp
+++ b/score/memory/shared/memory_region_map.cpp
@@ -33,6 +33,8 @@ namespace score::memory::shared::detail
 namespace
 {
 
+constexpr auto kAcquireRegionVersionRetrySleep = std::chrono::milliseconds{10};
+
 bool DoesRegionIteratorOverlapWithExistingRegionInMap(
     const std::map<std::uintptr_t, std::uintptr_t>::const_iterator region_it,
     const std::map<std::uintptr_t, std::uintptr_t>& map) noexcept
@@ -372,7 +374,7 @@ std::optional<std::uint8_t> MemoryRegionMapImpl<AtomicIndirectorType>::AcquireRe
                 // no action needed - a "continue" would be optimized out and lead to missing code coverage
             }
         }
-        std::this_thread::sleep_for(std::chrono::milliseconds{10});
+        std::this_thread::sleep_for(kAcquireRegionVersionRetrySleep);
     }
     return std::nullopt;
 }

--- a/score/memory/shared/memory_region_map.h
+++ b/score/memory/shared/memory_region_map.h
@@ -139,8 +139,9 @@ class MemoryRegionMapImpl final
     // Rationale: False positive - variable is used below.
     // coverity[autosar_cpp14_a0_1_1_violation : FALSE]
     static constexpr const std::uint8_t VERSION_COUNT{10U};
+    static constexpr const std::uint8_t MAX_LATEST_KNOWN_REGION_VERSION{255U};
     static_assert(
-        VERSION_COUNT <= 255U,
+        VERSION_COUNT <= MAX_LATEST_KNOWN_REGION_VERSION,
         "VERSION_COUNT needs to be smaller than 255 as our latest_known_region_version_ tracker is an uint8 ");
 
     /// \brief Increases the usage refcount of the latest regions version.

--- a/score/memory/shared/shared_memory_test_resources.h
+++ b/score/memory/shared/shared_memory_test_resources.h
@@ -56,6 +56,7 @@ struct TestValues
     static constexpr std::size_t some_share_memory_size{65535U};
     static constexpr uid_t our_uid{99};
     static constexpr uid_t typedmemd_uid{3020U};
+    static constexpr auto defaultLockFileDescriptor = 10;
 };
 
 class ManagedMemoryResourceTestAttorney
@@ -217,11 +218,12 @@ class SharedMemoryResourceTest : public ::testing::TestWithParam<bool>
                            bool is_read_write = true,
                            bool is_death_test = false);
 
-    void expectSharedMemorySuccessfullyOpened(std::int32_t file_descriptor,
-                                              bool is_read_write,
-                                              void* const data_region_start = reinterpret_cast<void*>(1),
-                                              uid_t st_uid = TestValues::our_uid,
-                                              std::int32_t lock_file_descriptor = 10);
+    void expectSharedMemorySuccessfullyOpened(
+        std::int32_t file_descriptor,
+        bool is_read_write,
+        void* const data_region_start = reinterpret_cast<void*>(1),
+        uid_t st_uid = TestValues::our_uid,
+        std::int32_t lock_file_descriptor = TestValues::defaultLockFileDescriptor);
 
     void expectSharedMemorySuccessfullyCreated(
         const std::int32_t file_descriptor,

--- a/score/memory/shared/test_offset_ptr/bounds_check_memory_pool.h
+++ b/score/memory/shared/test_offset_ptr/bounds_check_memory_pool.h
@@ -30,13 +30,18 @@ template <typename PointedType>
 class BoundsCheckMemoryPool
 {
   public:
+    static constexpr std::size_t kMemoryPoolSize{400U};
+    static constexpr std::size_t kPointedToAddressAfterValidRangeOffset{64U};
+    static constexpr std::size_t kValidRegionStartOffset{112U};
+    static constexpr std::size_t kValidRegionEndOffset{200U};
+
     // Memory pool of 400 bytes. The bytes 112 -> 200 are registered with the MemoryResourceRegistry (The specific
     // numbers are chosen to respect alignment of PointedType / OffsetPtr<PointedType>). This range will be used for
     // bounds checking. We use a larger memory pool than that registered with the MemoryResourceRegistry to allow fine
     // grained control of where OffsetPtrs and the pointed-to objects are created for testing e.g. we can create an
     // OffsetPtr within the region and point to an address such that the created object overlaps the memory region
     // boundary which should then fail during bounds checking.
-    using MemoryPool = std::array<std::uint8_t, 400>;
+    using MemoryPool = std::array<std::uint8_t, kMemoryPoolSize>;
 
     void Reset()
     {
@@ -64,7 +69,7 @@ class BoundsCheckMemoryPool
 
     MemoryPool::iterator GetPointedToAddressAfterValidRange() noexcept
     {
-        return end_of_valid_region_ + 64U;
+        return end_of_valid_region_ + kPointedToAddressAfterValidRangeOffset;
     }
 
     MemoryPool::iterator GetPointedToAddressOverlappingWithStartRange() noexcept
@@ -147,8 +152,8 @@ class BoundsCheckMemoryPool
     static constexpr std::size_t kThirdOffsetPtrFromSecondOffsetPtrBuffer{kOffsetPtrFromPointedToAddressBuffer};
 
     alignas(std::max_align_t) MemoryPool data_region_{};
-    MemoryPool::iterator start_of_valid_region_{data_region_.begin() + 112};
-    MemoryPool::iterator end_of_valid_region_{data_region_.begin() + 200};
+    MemoryPool::iterator start_of_valid_region_{data_region_.begin() + kValidRegionStartOffset};
+    MemoryPool::iterator end_of_valid_region_{data_region_.begin() + kValidRegionEndOffset};
 };
 
 template <typename T>

--- a/score/memory/shared/test_offset_ptr/offset_ptr_test_resources.h
+++ b/score/memory/shared/test_offset_ptr/offset_ptr_test_resources.h
@@ -32,6 +32,11 @@ namespace score::memory::shared::test
 {
 
 constexpr std::size_t kDefaultMemoryRegionSize{1000U};
+inline constexpr std::size_t kComplexTypeArraySize{10U};
+inline constexpr int kDummyIntValue{10};
+inline constexpr std::uint8_t kDummyUInt8Value{11U};
+inline constexpr std::size_t kVeryLargeTypeArraySize{100U};
+inline constexpr int kComplexTypeDummyMemberValue{10};
 
 using UseRegisteredMemoryResource = std::bool_constant<true>;
 using UseUnregisteredMemoryResource = std::bool_constant<false>;
@@ -42,7 +47,7 @@ struct ComplexTypeStruct
     std::uint8_t b;
     std::vector<int> c;
     std::string d;
-    std::array<std::uint8_t, 10> e;
+    std::array<std::uint8_t, kComplexTypeArraySize> e;
 };
 inline bool operator==(const ComplexTypeStruct& lhs, const ComplexTypeStruct& rhs) noexcept
 {
@@ -60,7 +65,7 @@ struct IntType
 
     static Type CreateDummyValue()
     {
-        return 10;
+        return kDummyIntValue;
     }
 };
 struct UInt8Type
@@ -69,12 +74,12 @@ struct UInt8Type
 
     static Type CreateDummyValue()
     {
-        return 11U;
+        return kDummyUInt8Value;
     }
 };
 struct VeryLargeType
 {
-    using Type = std::array<std::uint8_t, 100>;
+    using Type = std::array<std::uint8_t, kVeryLargeTypeArraySize>;
 
     static Type CreateDummyValue()
     {
@@ -93,7 +98,7 @@ struct ComplexType
     static Type CreateDummyValue()
     {
         Type dummy_type{};
-        dummy_type.a = 10;
+        dummy_type.a = kComplexTypeDummyMemberValue;
         return dummy_type;
     }
 };

--- a/score/message_passing/client_connection.cpp
+++ b/score/message_passing/client_connection.cpp
@@ -33,6 +33,7 @@ constexpr std::int32_t kConnectRetryT = 3;  // new_delay = prev_delay * (1 + 1/T
 constexpr std::int32_t kConnectRetryMsMax = 5000;
 
 constexpr std::chrono::milliseconds kConnectIpcWarningDelay{20};
+constexpr std::chrono::milliseconds kStopWaitPollInterval{10};
 }  // namespace
 
 ClientConnection::ClientConnection(std::shared_ptr<ISharedResourceEngine> engine,
@@ -83,7 +84,7 @@ ClientConnection::~ClientConnection() noexcept
         ClientConnection::Stop();
         while (state_ != State::kStopped)
         {
-            std::this_thread::sleep_for(std::chrono::milliseconds(10));
+            std::this_thread::sleep_for(kStopWaitPollInterval);
         }
         std::lock_guard<std::recursive_mutex> guard{callback_context_->finalize_mutex};
     }

--- a/score/message_passing/log/logging_callback.cpp
+++ b/score/message_passing/log/logging_callback.cpp
@@ -28,6 +28,8 @@ namespace score::message_passing
 namespace
 {
 
+constexpr std::size_t kLogBufferSize{1024U};
+
 // A std::streambuf that writes into a fixed, caller-provided memory block. When the block is full the default
 // overflow() returns EOF, which sets the stream's badbit and silently drops the remainder - so the logger neither
 // allocates nor overflows the buffer. Wrapping a stack buffer this way lets the console fallback logger reuse the
@@ -60,7 +62,7 @@ class FixedBufferStreamBuf final : public std::streambuf
 LoggingCallback GetCerrLogger()
 {
     return [](LogSeverity /*severity*/, LogItems items) -> void {
-        std::array<char, 1024U> buffer{};
+        std::array<char, kLogBufferSize> buffer{};
         FixedBufferStreamBuf stream_buffer{buffer.data(), buffer.size()};
         std::ostream stream{&stream_buffer};
         // Force the classic locale so integer formatting is deterministic (no digit grouping) and allocation-free.

--- a/score/mw/com/doc/tutorial/chapter_1/consumer.cpp
+++ b/score/mw/com/doc/tutorial/chapter_1/consumer.cpp
@@ -19,6 +19,8 @@
 #include <cstring>
 
 static std::atomic<bool> g_running{true};
+constexpr auto kFindServiceRetryDelay = std::chrono::milliseconds{100};
+constexpr auto kReceivePollInterval = std::chrono::milliseconds{200};
 
 static void SignalHandler(int /*signum*/)
 {
@@ -39,7 +41,7 @@ int main()
     std::optional<HelloWorldProxy::HandleType> service_handle{};
     while (g_running.load(std::memory_order_relaxed))
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(kFindServiceRetryDelay);
         auto service_handle_container_result = HelloWorldProxy::FindService(instance_specifier.value());
         SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(service_handle_container_result.has_value(),
                                                     "HelloWorldProxy::FindService failed!");
@@ -74,7 +76,7 @@ int main()
     size_t receive_counter{0};
     while (g_running.load(std::memory_order_relaxed))
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        std::this_thread::sleep_for(kReceivePollInterval);
         auto get_new_samples_result = hello_world_proxy.message.GetNewSamples(
             [&receive_counter](auto&& sample) {
                 const auto* buf = sample.Get()->data();

--- a/score/mw/com/doc/tutorial/chapter_1/hello_world_service.h
+++ b/score/mw/com/doc/tutorial/chapter_1/hello_world_service.h
@@ -23,7 +23,9 @@ class HelloWorldInterface : public Trait::Base
   public:
     using Trait::Base::Base;
 
-    using FixedSizeString = std::array<char, 255>;
+    static constexpr auto kMessageBufferSize = 255U;
+
+    using FixedSizeString = std::array<char, kMessageBufferSize>;
     typename Trait::template Event<FixedSizeString> message{*this, "message"};
 };
 }  // namespace score::mw::com::tutorial

--- a/score/mw/com/doc/tutorial/chapter_1/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_1/provider.cpp
@@ -19,6 +19,7 @@
 #include <cstring>
 
 constexpr std::string_view kHelloWorld{"Hello World"};
+constexpr auto kSampleSendDelay = std::chrono::milliseconds{100};
 static std::atomic<bool> g_running{true};
 
 static void SignalHandler(int /*signum*/)
@@ -49,7 +50,7 @@ int main()
     size_t send_counter{0};
     while (g_running.load(std::memory_order_relaxed))
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(kSampleSendDelay);
 
         // Allocate a slot, where to publish the next event
         auto sample_allocatee_ptr = hello_world_service_instance.message.Allocate();

--- a/score/mw/com/doc/tutorial/chapter_10/consumer/consumer.cpp
+++ b/score/mw/com/doc/tutorial/chapter_10/consumer/consumer.cpp
@@ -20,6 +20,8 @@
 #include <cstring>
 
 static std::atomic<bool> g_running{true};
+constexpr auto kServiceDiscoveryRetryDelay = std::chrono::milliseconds{100};
+constexpr auto kSamplePollingInterval = std::chrono::milliseconds{200};
 
 static void SignalHandler(int /*signum*/)
 {
@@ -42,7 +44,7 @@ int main(int argc, const char* argv[])
     std::optional<HelloWorldProxy::HandleType> service_handle{};
     while (g_running.load(std::memory_order_relaxed))
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(kServiceDiscoveryRetryDelay);
         auto service_handle_container_result = HelloWorldProxy::FindService(instance_specifier.value());
         SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(service_handle_container_result.has_value(),
                                                     "HelloWorldProxy::FindService failed!");
@@ -77,7 +79,7 @@ int main(int argc, const char* argv[])
     size_t receive_counter{0};
     while (g_running.load(std::memory_order_relaxed))
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        std::this_thread::sleep_for(kSamplePollingInterval);
         auto get_new_samples_result = hello_world_proxy.message.GetNewSamples(
             [&receive_counter](auto&& sample) {
                 const auto* buf = sample.Get()->data();

--- a/score/mw/com/doc/tutorial/chapter_10/hello_world_service.h
+++ b/score/mw/com/doc/tutorial/chapter_10/hello_world_service.h
@@ -23,7 +23,8 @@ class HelloWorldInterface : public Trait::Base
   public:
     using Trait::Base::Base;
 
-    using FixedSizeString = std::array<char, 255>;
+    static constexpr std::size_t kFixedSizeStringLength{255U};
+    using FixedSizeString = std::array<char, kFixedSizeStringLength>;
     typename Trait::template Event<FixedSizeString> message{*this, "message"};
 };
 }  // namespace score::mw::com::tutorial

--- a/score/mw/com/doc/tutorial/chapter_10/provider/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_10/provider/provider.cpp
@@ -19,6 +19,7 @@
 #include <cstring>
 
 constexpr std::string_view kHelloWorld{"Hello World"};
+constexpr auto kEventSendInterval{std::chrono::milliseconds{100}};
 static std::atomic<bool> g_running{true};
 
 static void SignalHandler(int /*signum*/)
@@ -49,7 +50,7 @@ int main()
     size_t send_counter{0};
     while (g_running.load(std::memory_order_relaxed))
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(kEventSendInterval);
 
         // Allocate a slot, where to publish the next event
         auto sample_allocatee_ptr = hello_world_service_instance.message.Allocate();

--- a/score/mw/com/doc/tutorial/chapter_11/long_running_service.h
+++ b/score/mw/com/doc/tutorial/chapter_11/long_running_service.h
@@ -22,13 +22,15 @@
 namespace score::mw::com::tutorial
 {
 
+inline constexpr auto kSerializedInstanceIdentifierCapacity{2048U};
+
 // A fixed-capacity character buffer used to transport the *serialized* form of an InstanceIdentifier
 // (InstanceIdentifier::ToString()) as a method argument. Method arguments are transported through shared memory and are
 // serialized via a plain memcpy, therefore every method argument type must be trivially copyable - which a
 // std::array<char, N> is. The capacity is chosen generously so that it can hold the serialized InstanceIdentifier of
 // the callback service instance used in this chapter (the consumer asserts at runtime that the serialized form actually
 // fits).
-using SerializedInstanceIdentifier = std::array<char, 2048>;
+using SerializedInstanceIdentifier = std::array<char, kSerializedInstanceIdentifierCapacity>;
 
 static_assert(std::is_trivially_copyable_v<SerializedInstanceIdentifier>,
               "SerializedInstanceIdentifier must be trivially copyable to be usable as a method argument.");

--- a/score/mw/com/doc/tutorial/chapter_12/consumer/consumer.cpp
+++ b/score/mw/com/doc/tutorial/chapter_12/consumer/consumer.cpp
@@ -22,6 +22,8 @@
 #include <cstring>
 
 static std::atomic<bool> g_running{true};
+constexpr std::chrono::milliseconds kFindServiceRetryInterval{100};
+constexpr std::chrono::milliseconds kSamplePollingInterval{200};
 
 static void SignalHandler(int /*signum*/)
 {
@@ -40,7 +42,7 @@ int main()
     std::optional<score::mw::com::tutorial::HelloWorldProxy::HandleType> service_handle{};
     while (g_running.load(std::memory_order_relaxed))
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(kFindServiceRetryInterval);
         auto service_handle_container_result =
             score::mw::com::tutorial::HelloWorldProxy::FindService(instance_specifier.value());
         SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(service_handle_container_result.has_value(),
@@ -75,7 +77,7 @@ int main()
 
     while (g_running.load(std::memory_order_relaxed))
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        std::this_thread::sleep_for(kSamplePollingInterval);
         proxy_component.GetNewSamples();
     }
     std::cout << "HelloWorld service consumer going down." << std::endl;

--- a/score/mw/com/doc/tutorial/chapter_12/hello_world_service.h
+++ b/score/mw/com/doc/tutorial/chapter_12/hello_world_service.h
@@ -19,13 +19,15 @@
 
 namespace score::mw::com::tutorial
 {
+inline constexpr std::size_t kFixedSizeStringLength{255};
+
 template <typename Trait>
 class HelloWorldInterface : public Trait::Base
 {
   public:
     using Trait::Base::Base;
 
-    using FixedSizeString = std::array<char, 255>;
+    using FixedSizeString = std::array<char, kFixedSizeStringLength>;
     typename Trait::template Event<FixedSizeString> message{*this, "message"};
 };
 

--- a/score/mw/com/doc/tutorial/chapter_12/provider/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_12/provider/provider.cpp
@@ -18,6 +18,7 @@
 #include <cstdlib>
 
 static std::atomic<bool> g_running{true};
+constexpr auto kSampleSendInterval = std::chrono::milliseconds{100};
 
 static void SignalHandler(int /*signum*/)
 {
@@ -48,7 +49,7 @@ int main()
     size_t send_counter{0};
     while (g_running.load(std::memory_order_relaxed))
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(kSampleSendInterval);
         const auto send_sample_result = skeleton_component.SendSample(send_counter);
         if (send_sample_result == score::mw::com::tutorial::SkeletonComponent::SendSampleResult::kNoSampleAllocated)
         {

--- a/score/mw/com/doc/tutorial/chapter_13/bidirectional_discovery/application_a.cpp
+++ b/score/mw/com/doc/tutorial/chapter_13/bidirectional_discovery/application_a.cpp
@@ -50,6 +50,7 @@ constexpr std::chrono::seconds kDiscoveryTimeout{5};
 constexpr std::uint32_t kNumIterations{20U};
 constexpr std::chrono::milliseconds kCycleTime{50};
 constexpr std::size_t kMaxSamples{16U};
+constexpr float kTirePressureIncrement{0.1F};
 
 }  // namespace
 
@@ -151,7 +152,7 @@ int main()
             return EXIT_FAILURE;
         }
 
-        *sample_result.value() = static_cast<float>(i) * 0.1F;
+        *sample_result.value() = static_cast<float>(i) * kTirePressureIncrement;
 
         score::Result<void> send_result = skeleton.tire_pressure_update.Send(std::move(sample_result.value()));
         if (!send_result.has_value())

--- a/score/mw/com/doc/tutorial/chapter_13/bidirectional_discovery/application_b.cpp
+++ b/score/mw/com/doc/tutorial/chapter_13/bidirectional_discovery/application_b.cpp
@@ -50,6 +50,7 @@ constexpr std::chrono::seconds kDiscoveryTimeout{5};
 constexpr std::uint32_t kNumIterations{20U};
 constexpr std::chrono::milliseconds kCycleTime{50};
 constexpr std::size_t kMaxSamples{16U};
+constexpr float kTirePressureStep{0.1F};
 
 }  // namespace
 
@@ -151,7 +152,7 @@ int main()
             return EXIT_FAILURE;
         }
 
-        *sample_result.value() = static_cast<float>(i) * 0.1F;
+        *sample_result.value() = static_cast<float>(i) * kTirePressureStep;
 
         score::Result<void> send_result = skeleton.tire_pressure_update.Send(std::move(sample_result.value()));
         if (!send_result.has_value())

--- a/score/mw/com/doc/tutorial/chapter_13/event_field_update/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_13/event_field_update/provider.cpp
@@ -29,6 +29,7 @@ namespace
 
 constexpr std::uint32_t kNumIterations{200U};
 constexpr std::chrono::milliseconds kCycleTime{10};
+constexpr float kTirePressureStep{0.1F};
 
 }  // namespace
 
@@ -78,7 +79,7 @@ int main()
             return EXIT_FAILURE;
         }
 
-        *sample_result.value() = static_cast<float>(i) * 0.1F;
+        *sample_result.value() = static_cast<float>(i) * kTirePressureStep;
 
         score::Result<void> send_result = skeleton.tire_pressure_update.Send(std::move(sample_result.value()));
         if (!send_result.has_value())
@@ -88,7 +89,8 @@ int main()
             return EXIT_FAILURE;
         }
 
-        score::Result<void> field_result = skeleton.tire_pressure_front_left.Update(static_cast<float>(i) * 0.1F);
+        score::Result<void> field_result =
+            skeleton.tire_pressure_front_left.Update(static_cast<float>(i) * kTirePressureStep);
         if (!field_result.has_value())
         {
             score::mw::log::LogError("SkEf") << "tire_pressure_front_left.Update failed";

--- a/score/mw/com/doc/tutorial/chapter_13/event_send_receive/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_13/event_send_receive/provider.cpp
@@ -29,6 +29,7 @@ namespace
 
 constexpr std::uint32_t kNumIterations{100U};
 constexpr std::chrono::milliseconds kCycleTime{10};
+constexpr float kTirePressureIncrement{0.1F};
 
 }  // namespace
 
@@ -78,7 +79,7 @@ int main()
             return EXIT_FAILURE;
         }
 
-        *sample_result.value() = static_cast<float>(i) * 0.1F;
+        *sample_result.value() = static_cast<float>(i) * kTirePressureIncrement;
 
         score::Result<void> send_result = skeleton.tire_pressure_update.Send(std::move(sample_result.value()));
         if (!send_result.has_value())

--- a/score/mw/com/doc/tutorial/chapter_13/start_find_service/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_13/start_find_service/provider.cpp
@@ -29,6 +29,7 @@ namespace
 
 constexpr std::uint32_t kNumIterations{100U};
 constexpr std::chrono::milliseconds kCycleTime{10};
+constexpr float kTirePressureStep{0.1F};
 
 }  // namespace
 
@@ -78,7 +79,7 @@ int main()
             return EXIT_FAILURE;
         }
 
-        *sample_result.value() = static_cast<float>(i) * 0.1F;
+        *sample_result.value() = static_cast<float>(i) * kTirePressureStep;
 
         score::Result<void> send_result = skeleton.tire_pressure_update.Send(std::move(sample_result.value()));
         if (!send_result.has_value())

--- a/score/mw/com/doc/tutorial/chapter_2/consumer/consumer.cpp
+++ b/score/mw/com/doc/tutorial/chapter_2/consumer/consumer.cpp
@@ -21,6 +21,12 @@
 
 static std::atomic<bool> g_running{true};
 
+namespace
+{
+constexpr auto kServiceDiscoveryRetryInterval{std::chrono::milliseconds{100}};
+constexpr auto kSamplePollInterval{std::chrono::milliseconds{200}};
+}  // namespace
+
 static void SignalHandler(int /*signum*/)
 {
     std::cout << "HelloWorld service consumer caught signal." << std::endl;
@@ -42,7 +48,7 @@ int main(int argc, const char* argv[])
     std::optional<HelloWorldProxy::HandleType> service_handle{};
     while (g_running.load(std::memory_order_relaxed))
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(kServiceDiscoveryRetryInterval);
         auto service_handle_container_result = HelloWorldProxy::FindService(instance_specifier.value());
         SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(service_handle_container_result.has_value(),
                                                     "HelloWorldProxy::FindService failed!");
@@ -77,7 +83,7 @@ int main(int argc, const char* argv[])
     size_t receive_counter{0};
     while (g_running.load(std::memory_order_relaxed))
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        std::this_thread::sleep_for(kSamplePollInterval);
         auto get_new_samples_result = hello_world_proxy.message.GetNewSamples(
             [&receive_counter](auto&& sample) {
                 const auto* buf = sample.Get()->data();

--- a/score/mw/com/doc/tutorial/chapter_2/hello_world_service.h
+++ b/score/mw/com/doc/tutorial/chapter_2/hello_world_service.h
@@ -23,7 +23,8 @@ class HelloWorldInterface : public Trait::Base
   public:
     using Trait::Base::Base;
 
-    using FixedSizeString = std::array<char, 255>;
+    static constexpr std::size_t kMessageBufferSize{255U};
+    using FixedSizeString = std::array<char, kMessageBufferSize>;
     typename Trait::template Event<FixedSizeString> message{*this, "message"};
 };
 }  // namespace score::mw::com::tutorial

--- a/score/mw/com/doc/tutorial/chapter_2/provider/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_2/provider/provider.cpp
@@ -19,6 +19,7 @@
 #include <cstring>
 
 constexpr std::string_view kHelloWorld{"Hello World"};
+constexpr auto kEventSendInterval = std::chrono::milliseconds{100};
 static std::atomic<bool> g_running{true};
 
 static void SignalHandler(int /*signum*/)
@@ -49,7 +50,7 @@ int main()
     size_t send_counter{0};
     while (g_running.load(std::memory_order_relaxed))
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(kEventSendInterval);
 
         // Allocate a slot, where to publish the next event
         auto sample_allocatee_ptr = hello_world_service_instance.message.Allocate();

--- a/score/mw/com/doc/tutorial/chapter_3/consumer/consumer.cpp
+++ b/score/mw/com/doc/tutorial/chapter_3/consumer/consumer.cpp
@@ -38,6 +38,8 @@ using HelloWorldProxy = score::mw::com::AsProxy<score::mw::com::tutorial::HelloW
 namespace
 {
 
+constexpr auto kSamplePollInterval{std::chrono::milliseconds{200}};
+
 // Bundles a proxy for a discovered service instance together with a human-readable description of its instance id
 // (used for logging).
 struct DiscoveredInstance
@@ -153,7 +155,7 @@ int main()
     // Main loop: poll the "message" event of every discovered service instance for new samples.
     while (g_running.load(std::memory_order_relaxed))
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        std::this_thread::sleep_for(kSamplePollInterval);
 
         std::lock_guard<std::mutex> lock{discovered_instances_mutex};
         for (auto& discovered_instance : discovered_instances)

--- a/score/mw/com/doc/tutorial/chapter_3/hello_world_service.h
+++ b/score/mw/com/doc/tutorial/chapter_3/hello_world_service.h
@@ -23,7 +23,9 @@ class HelloWorldInterface : public Trait::Base
   public:
     using Trait::Base::Base;
 
-    using FixedSizeString = std::array<char, 255>;
+    static constexpr auto kMessageBufferSize = 255U;
+
+    using FixedSizeString = std::array<char, kMessageBufferSize>;
     typename Trait::template Event<FixedSizeString> message{*this, "message"};
 };
 }  // namespace score::mw::com::tutorial

--- a/score/mw/com/doc/tutorial/chapter_3/provider/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_3/provider/provider.cpp
@@ -31,6 +31,7 @@ constexpr std::array<std::string_view, 3U> kInstanceSpecifierStrings{"MyHelloWor
 
 // The provider waits this amount of time after bringing up a service instance before it brings up the next one.
 constexpr std::chrono::seconds kInstanceStaggerDelay{5};
+constexpr auto kSampleSendInterval{std::chrono::milliseconds{100}};
 
 static std::atomic<bool> g_running{true};
 
@@ -121,7 +122,7 @@ int main()
             next_instance_time = std::chrono::steady_clock::now() + kInstanceStaggerDelay;
         }
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(kSampleSendInterval);
 
         // Send a new event sample on every service instance that is already up and running.
         for (std::size_t i = 0; i < service_instances.size(); ++i)

--- a/score/mw/com/doc/tutorial/chapter_4/consumer/consumer.cpp
+++ b/score/mw/com/doc/tutorial/chapter_4/consumer/consumer.cpp
@@ -36,6 +36,7 @@ using HelloWorldProxy = score::mw::com::AsProxy<score::mw::com::tutorial::HelloW
 
 namespace
 {
+constexpr auto kProxyMainLoopPollInterval{std::chrono::milliseconds{200}};
 
 // Returns a human-readable name for a subscription state (for logging).
 const char* ToString(const score::mw::com::SubscriptionState state) noexcept
@@ -278,7 +279,7 @@ int main()
             break;
         }
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(200));
+        std::this_thread::sleep_for(kProxyMainLoopPollInterval);
 
         std::lock_guard<std::mutex> lock{state.mutex};
         if (!state.proxies_created)

--- a/score/mw/com/doc/tutorial/chapter_4/hello_world_service.h
+++ b/score/mw/com/doc/tutorial/chapter_4/hello_world_service.h
@@ -23,7 +23,8 @@ class HelloWorldInterface : public Trait::Base
   public:
     using Trait::Base::Base;
 
-    using FixedSizeString = std::array<char, 255>;
+    static constexpr std::size_t kMessageBufferSize{255U};
+    using FixedSizeString = std::array<char, kMessageBufferSize>;
     typename Trait::template Event<FixedSizeString> message{*this, "message"};
 };
 }  // namespace score::mw::com::tutorial

--- a/score/mw/com/doc/tutorial/chapter_4/provider/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_4/provider/provider.cpp
@@ -31,6 +31,7 @@ constexpr std::string_view kInstanceSpecifierString{"MyHelloWorldServiceInstance
 // kSubscriptionPending.
 constexpr std::chrono::seconds kOfferDuration{8};
 constexpr std::chrono::seconds kStopOfferDuration{5};
+constexpr auto kSendCycleDelay = std::chrono::milliseconds{500};
 
 static std::atomic<bool> g_running{true};
 
@@ -126,7 +127,7 @@ int main()
             }
         }
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        std::this_thread::sleep_for(kSendCycleDelay);
 
         // Only send event updates while the service is currently offered.
         if (offered)

--- a/score/mw/com/doc/tutorial/chapter_5/hello_world_service.h
+++ b/score/mw/com/doc/tutorial/chapter_5/hello_world_service.h
@@ -23,7 +23,9 @@ class HelloWorldInterface : public Trait::Base
   public:
     using Trait::Base::Base;
 
-    using FixedSizeString = std::array<char, 255>;
+    static constexpr auto kMessageBufferSize = 255U;
+
+    using FixedSizeString = std::array<char, kMessageBufferSize>;
     typename Trait::template Event<FixedSizeString> message{*this, "message"};
 };
 }  // namespace score::mw::com::tutorial

--- a/score/mw/com/doc/tutorial/chapter_6/hello_world_service.h
+++ b/score/mw/com/doc/tutorial/chapter_6/hello_world_service.h
@@ -17,13 +17,15 @@
 
 namespace score::mw::com::tutorial
 {
+inline constexpr std::size_t kFixedSizeStringLength{255};
+
 template <typename Trait>
 class HelloWorldInterface : public Trait::Base
 {
   public:
     using Trait::Base::Base;
 
-    using FixedSizeString = std::array<char, 255>;
+    using FixedSizeString = std::array<char, kFixedSizeStringLength>;
     typename Trait::template Event<FixedSizeString> message{*this, "message"};
 };
 }  // namespace score::mw::com::tutorial

--- a/score/mw/com/doc/tutorial/chapter_6/provider/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_6/provider/provider.cpp
@@ -19,6 +19,7 @@
 #include <cstring>
 
 constexpr std::string_view kHelloWorld{"Hello World"};
+constexpr auto kSampleSendInterval = std::chrono::milliseconds{100};
 static std::atomic<bool> g_running{true};
 
 static void SignalHandler(int /*signum*/)
@@ -49,7 +50,7 @@ int main()
     size_t send_counter{0};
     while (g_running.load(std::memory_order_relaxed))
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(kSampleSendInterval);
 
         // Allocate a slot, where to publish the next event
         auto sample_allocatee_ptr = hello_world_service_instance.message.Allocate();

--- a/score/mw/com/doc/tutorial/chapter_8/consumer/consumer.cpp
+++ b/score/mw/com/doc/tutorial/chapter_8/consumer/consumer.cpp
@@ -29,6 +29,7 @@
 
 // The number of leading array elements the consumer fills and asks the provider to average.
 constexpr std::size_t kNumberOfMeanElements{500U};
+constexpr std::uint32_t kMaximumMeanElementValue{100U};
 
 // The main thread blocks on this condition variable until either the method calls have completed or a termination
 // signal (SIGINT/SIGTERM) requests the shut down.
@@ -126,7 +127,7 @@ void CallArithmeticMean(CalculatorProxy& proxy, std::mt19937& random_engine)
     auto& [array_ptr] = allocate_result.value();
 
     // Step 2: Fill the array *in place* (through the pointer into the shared-memory slot - no copy of the array).
-    std::uniform_int_distribution<std::uint32_t> value_distribution{0U, 100U};
+    std::uniform_int_distribution<std::uint32_t> value_distribution{0U, kMaximumMeanElementValue};
     for (std::size_t index = 0U; index < kNumberOfMeanElements; ++index)
     {
         array_ptr->internal_array_[index] = value_distribution(random_engine);

--- a/score/mw/com/gateway/transport_layer/sample/bidirectional_transport.cpp
+++ b/score/mw/com/gateway/transport_layer/sample/bidirectional_transport.cpp
@@ -35,6 +35,8 @@ namespace
 {
 
 using score::os::Socket;
+constexpr auto kInitialConnectionPollInterval = std::chrono::milliseconds{10};
+constexpr auto kAcceptRetryInterval = std::chrono::milliseconds{100};
 
 /// \brief Sets the TCP_NODELAY option on the given socket file descriptor to disable Nagle's algorithm in order to
 /// reduce latency.
@@ -94,7 +96,7 @@ score::Result<void> BidirectionalTransport::Setup()
     // the transport is actually ready to send and receive messages
     while (!is_connected_ && !threads_.ShutdownRequested())
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        std::this_thread::sleep_for(kInitialConnectionPollInterval);
     }
 
     if (!is_connected_)
@@ -253,7 +255,7 @@ bool BidirectionalTransport::WaitForConnection(score::cpp::stop_token stop_token
             if (accept_result.error() == score::os::Error::createFromErrno(EAGAIN) ||
                 accept_result.error() == score::os::Error::createFromErrno(EWOULDBLOCK))
             {
-                std::this_thread::sleep_for(std::chrono::milliseconds(100));
+                std::this_thread::sleep_for(kAcceptRetryInterval);
                 continue;
             }
             if (!stop_token.stop_requested())

--- a/score/mw/com/gateway/transport_layer/sample/configuration/hypervisor_socket_configuration.h
+++ b/score/mw/com/gateway/transport_layer/sample/configuration/hypervisor_socket_configuration.h
@@ -23,12 +23,14 @@ namespace score::mw::com::gateway
 class HyperVisorSocketConfiguration
 {
   public:
+    static constexpr std::uint32_t kDefaultRequestTimeoutMs{5000U};
+
     HyperVisorSocketConfiguration() = default;
 
     score::os::Ipv4Address remote_ip_{};
     std::uint16_t local_port_{0};
     std::uint16_t remote_port_{0};
-    std::uint32_t request_timeout_ms_{5000};
+    std::uint32_t request_timeout_ms_{kDefaultRequestTimeoutMs};
 };
 
 }  // namespace score::mw::com::gateway

--- a/score/mw/com/gateway/transport_layer/sample/i_bidirectional_transport.h
+++ b/score/mw/com/gateway/transport_layer/sample/i_bidirectional_transport.h
@@ -18,16 +18,20 @@
 
 #include <score/callback.hpp>
 
+#include <cstddef>
 #include <memory>
 
 namespace score::mw::com::gateway
 {
 
+inline constexpr std::size_t kMessageHandlerInlineStorageSize{64U};
+
 /// \brief Interface of BidirectionalTransport, introduced only for testing/mocking purposes
 class IBidirectionalTransport
 {
   public:
-    using MessageHandler = score::cpp::callback<void(std::unique_ptr<TransportMessage>), 64>;
+    using MessageHandler =
+        score::cpp::callback<void(std::unique_ptr<TransportMessage>), kMessageHandlerInlineStorageSize>;
 
     virtual ~IBidirectionalTransport() = default;
 

--- a/score/mw/com/gateway/transport_layer/sample/test/app1_main.cpp
+++ b/score/mw/com/gateway/transport_layer/sample/test/app1_main.cpp
@@ -14,6 +14,7 @@
 #include "score/mw/com/gateway/transport_layer/sample/configuration/hypervisor_socket_configuration.h"
 
 #include <atomic>
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <thread>
@@ -23,13 +24,17 @@ using score::mw::com::gateway::HyperVisorSocketConfiguration;
 
 namespace
 {
+constexpr std::uint16_t kApp1LocalPort{9001U};
+constexpr std::uint16_t kApp1RemotePort{9000U};
+constexpr int kMaxReceivePollCount{200};
+constexpr auto kReceivePollInterval = std::chrono::milliseconds{50};
 
 HyperVisorSocketConfiguration CreateConfiguration()
 {
     HyperVisorSocketConfiguration config{};
     config.remote_ip_ = score::os::Ipv4Address{"127.0.0.1"};
-    config.local_port_ = 9001;
-    config.remote_port_ = 9000;
+    config.local_port_ = kApp1LocalPort;
+    config.remote_port_ = kApp1RemotePort;
     return config;
 }
 
@@ -70,9 +75,9 @@ int ExecuteWithRegularConnection()
 
     int sleep_counter = 0;
     // Sleep until all expected messages are received or a timeout occurs (whichever comes first)
-    while (received_message_count < expected_amount_received_messages || sleep_counter < 200)
+    while (received_message_count < expected_amount_received_messages || sleep_counter < kMaxReceivePollCount)
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        std::this_thread::sleep_for(kReceivePollInterval);
         sleep_counter++;
     }
 

--- a/score/mw/com/gateway/transport_layer/sample/test/app2_main.cpp
+++ b/score/mw/com/gateway/transport_layer/sample/test/app2_main.cpp
@@ -14,6 +14,7 @@
 #include "score/mw/com/gateway/transport_layer/sample/configuration/hypervisor_socket_configuration.h"
 
 #include <atomic>
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <thread>
@@ -24,12 +25,22 @@ using score::mw::com::gateway::HyperVisorSocketConfiguration;
 namespace
 {
 
+constexpr std::uint16_t kApp2LocalPort{9000U};
+constexpr std::uint16_t kApp2RemotePort{9001U};
+constexpr std::uint32_t kTestEventPayloadSize{64U};
+constexpr std::uint32_t kTestEventPayloadAlignment{8U};
+constexpr std::uint32_t kTestFieldPayloadSize{32U};
+constexpr std::uint32_t kSharedMemoryControlSize{4U};
+constexpr std::uint32_t kSharedMemoryDataSize{8U};
+constexpr int kRegularConnectionTimeoutPollCount{100};
+constexpr std::chrono::milliseconds kRegularConnectionPollInterval{50};
+
 HyperVisorSocketConfiguration CreateConfiguration()
 {
     HyperVisorSocketConfiguration config{};
     config.remote_ip_ = score::os::Ipv4Address{"127.0.0.1"};
-    config.local_port_ = 9000;
-    config.remote_port_ = 9001;
+    config.local_port_ = kApp2LocalPort;
+    config.remote_port_ = kApp2RemotePort;
     return config;
 }
 
@@ -37,10 +48,12 @@ void SendMessages(BidirectionalTransport& transport)
 {
     auto service_request = score::mw::com::gateway::ProvideServiceRequest{
         score::mw::com::impl::InstanceSpecifier::Create(std::string{"TestService/Instance1"}).value(),
-        {{"TestEvent", {64U, 8U}}, {"TestField", {32U, 4U}}},
-        4U,
-        8U};
+        {{"TestEvent", {kTestEventPayloadSize, kTestEventPayloadAlignment}},
+         {"TestField", {kTestFieldPayloadSize, kSharedMemoryControlSize}}},
+        kSharedMemoryControlSize,
+        kSharedMemoryDataSize};
     const auto send_result = transport.SendRequest(service_request);
+    static_cast<void>(send_result);
 
     auto notification = score::mw::com::gateway::RegisterNotificationRequest{
         score::mw::com::impl::InstanceSpecifier::Create(std::string{"TestService/Instance1"}).value(),
@@ -79,9 +92,10 @@ int ExecuteWithRegularConnection()
     int expected_amount_received_messages = 1;
     int sleep_counter = 0;
     // Sleep until all expected messages are received or a timeout occurs (whichever comes first)
-    while (received_message_count < expected_amount_received_messages || sleep_counter < 100)
+    while (received_message_count < expected_amount_received_messages ||
+           sleep_counter < kRegularConnectionTimeoutPollCount)
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(50));
+        std::this_thread::sleep_for(kRegularConnectionPollInterval);
         sleep_counter++;
     }
 
@@ -114,9 +128,9 @@ int ExecuteWithReconnect()
 
         auto request = score::mw::com::gateway::ProvideServiceRequest{
             score::mw::com::impl::InstanceSpecifier::Create(std::string{"TestService/Instance1"}).value(),
-            {{"TestEvent", {64U, 8U}}},
-            4U,
-            8U};
+            {{"TestEvent", {kTestEventPayloadSize, kTestEventPayloadAlignment}}},
+            kSharedMemoryControlSize,
+            kSharedMemoryDataSize};
         const auto send_result = transport.SendRequest(request);
         if (!send_result)
         {
@@ -150,9 +164,9 @@ int ExecuteWithReconnect()
 
         auto request = score::mw::com::gateway::ProvideServiceRequest{
             score::mw::com::impl::InstanceSpecifier::Create(std::string{"TestService/Instance1"}).value(),
-            {{"TestField", {32U, 4U}}},
-            4U,
-            8U};
+            {{"TestField", {kTestFieldPayloadSize, kSharedMemoryControlSize}}},
+            kSharedMemoryControlSize,
+            kSharedMemoryDataSize};
         const auto send_result = transport.SendRequest(request);
         if (!send_result)
         {

--- a/score/mw/com/impl/bindings/lola/application_id_pid_mapping_entry.cpp
+++ b/score/mw/com/impl/bindings/lola/application_id_pid_mapping_entry.cpp
@@ -17,6 +17,13 @@
 namespace score::mw::com::impl::lola
 {
 
+namespace
+{
+
+constexpr std::uint32_t kStatusBitShift{32U};
+
+}  // namespace
+
 std::pair<ApplicationIdPidMappingEntry::MappingEntryStatus, std::uint32_t>
 ApplicationIdPidMappingEntry::GetStatusAndApplicationIdAtomic() noexcept
 {
@@ -30,7 +37,7 @@ ApplicationIdPidMappingEntry::GetStatusAndApplicationIdAtomic() noexcept
     static_assert(std::is_same<std::uint16_t,
                                std::underlying_type<ApplicationIdPidMappingEntry::MappingEntryStatus>::type>::value,
                   "MappingEntryStatus is not of expected underlying type");
-    const auto status_part = static_cast<std::uint16_t>((status_applictionid >> 32U) & kMaskStatus);
+    const auto status_part = static_cast<std::uint16_t>((status_applictionid >> kStatusBitShift) & kMaskStatus);
     const auto application_id_part = static_cast<std::uint32_t>(status_applictionid & kMaskApplicationId);
     // Suppress "AUTOSAR C++14 A7-2-1" rule: "An expression with enum underlying type shall only have values
     // corresponding to the enumerators of the enumeration.".
@@ -50,7 +57,7 @@ ApplicationIdPidMappingEntry::key_type ApplicationIdPidMappingEntry::CreateKey(M
                                                                                std::uint32_t application_id) noexcept
 {
     ApplicationIdPidMappingEntry::key_type result = static_cast<std::uint16_t>(status);
-    result = result << 32U;
+    result = result << kStatusBitShift;
     result |= static_cast<std::uint64_t>(application_id);
     return result;
 }

--- a/score/mw/com/impl/bindings/lola/element_fq_id.h
+++ b/score/mw/com/impl/bindings/lola/element_fq_id.h
@@ -127,9 +127,13 @@ struct hash<score::mw::com::impl::lola::ElementFqId>
 {
     std::size_t operator()(const score::mw::com::impl::lola::ElementFqId& element_fq_id) const noexcept
     {
-        return std::hash<std::uint64_t>{}((static_cast<std::uint64_t>(element_fq_id.service_id_) << 32U) |
-                                          (static_cast<std::uint64_t>(element_fq_id.element_id_) << 16U) |
-                                          static_cast<std::uint64_t>(element_fq_id.instance_id_));
+        static constexpr unsigned int kServiceIdShiftBits{32U};
+        static constexpr unsigned int kElementIdShiftBits{16U};
+
+        return std::hash<std::uint64_t>{}(
+            (static_cast<std::uint64_t>(element_fq_id.service_id_) << kServiceIdShiftBits) |
+            (static_cast<std::uint64_t>(element_fq_id.element_id_) << kElementIdShiftBits) |
+            static_cast<std::uint64_t>(element_fq_id.instance_id_));
     }
 };
 }  // namespace std

--- a/score/mw/com/impl/bindings/lola/event_slot_status.cpp
+++ b/score/mw/com/impl/bindings/lola/event_slot_status.cpp
@@ -21,6 +21,10 @@ constexpr EventSlotStatus::value_type INVALID_EVENT = 0U;
 
 /// \brief Indicates that the event data is altered and one should not increase the refcount.
 constexpr EventSlotStatus::value_type IN_WRITING = std::numeric_limits<EventSlotStatus::SubscriberCount>::max();
+
+constexpr EventSlotStatus::value_type kLowWordMask = 0x00000000FFFFFFFFU;
+constexpr EventSlotStatus::value_type kHighWordMask = 0xFFFFFFFF00000000U;
+constexpr std::uint32_t kWordBitWidth = 32U;
 }  // namespace
 
 EventSlotStatus::EventSlotStatus(const value_type init_val) noexcept : data_{init_val} {}
@@ -33,12 +37,12 @@ EventSlotStatus::EventSlotStatus(const EventTimeStamp timestamp, const Subscribe
 
 auto EventSlotStatus::GetReferenceCount() const noexcept -> SubscriberCount
 {
-    return static_cast<SubscriberCount>(data_ & 0x00000000FFFFFFFFU);  // ignore first 4 byte
+    return static_cast<SubscriberCount>(data_ & kLowWordMask);  // ignore first 4 byte
 }
 
 auto EventSlotStatus::GetTimeStamp() const noexcept -> EventTimeStamp
 {
-    return static_cast<EventTimeStamp>(data_ >> 32U);  // ignore last 4 byte
+    return static_cast<EventTimeStamp>(data_ >> kWordBitWidth);  // ignore last 4 byte
 }
 
 auto EventSlotStatus::IsInvalid() const noexcept -> bool
@@ -63,12 +67,12 @@ auto EventSlotStatus::MarkInvalid() noexcept -> void
 
 auto EventSlotStatus::SetTimeStamp(const EventTimeStamp time_stamp) noexcept -> void
 {
-    data_ = static_cast<value_type>(time_stamp) << 32U;
+    data_ = static_cast<value_type>(time_stamp) << kWordBitWidth;
 }
 
 auto EventSlotStatus::SetReferenceCount(const SubscriberCount ref_count) noexcept -> void
 {
-    data_ = (data_ & 0xFFFFFFFF00000000U) | static_cast<value_type>(ref_count);
+    data_ = (data_ & kHighWordMask) | static_cast<value_type>(ref_count);
 }
 
 auto EventSlotStatus::IsTimeStampBetween(const EventTimeStamp min_timestamp,

--- a/score/mw/com/impl/bindings/lola/event_subscription_control.cpp
+++ b/score/mw/com/impl/bindings/lola/event_subscription_control.cpp
@@ -19,6 +19,9 @@ namespace score::mw::com::impl::lola
 namespace
 {
 
+constexpr std::uint32_t kSubscriberCountBitShift{16U};
+constexpr std::uint32_t kSubscribedSamplesMask{0x0000FFFFU};
+
 inline EventSubscriptionControl<>::SubscriberCountType GetSubscribersFromState(
     std::uint32_t subscription_state) noexcept
 {
@@ -26,7 +29,7 @@ inline EventSubscriptionControl<>::SubscriberCountType GetSubscribersFromState(
     // not lead to data loss.".
     // This is an in purpose casting to get the subscribers from the subscription state.
     // coverity[autosar_cpp14_a4_7_1_violation]
-    return static_cast<EventSubscriptionControl<>::SubscriberCountType>(subscription_state >> 16U);
+    return static_cast<EventSubscriptionControl<>::SubscriberCountType>(subscription_state >> kSubscriberCountBitShift);
 }
 
 inline EventSubscriptionControl<>::SlotNumberType GetSubscribedSamplesFromState(
@@ -36,14 +39,14 @@ inline EventSubscriptionControl<>::SlotNumberType GetSubscribedSamplesFromState(
     // not lead to data loss.".
     // This is an in purpose casting to get the subscribed samples from the subscription state.
     // coverity[autosar_cpp14_a4_7_1_violation]
-    return static_cast<std::uint16_t>(subscription_state & 0x0000FFFFU);
+    return static_cast<std::uint16_t>(subscription_state & kSubscribedSamplesMask);
 }
 
 inline std::uint32_t CreateState(EventSubscriptionControl<>::SubscriberCountType subscriber_count,
                                  EventSubscriptionControl<>::SlotNumberType subscribed_slots)
 {
     std::uint32_t result{subscriber_count};
-    result = result << 16U;
+    result = result << kSubscriberCountBitShift;
     result += subscribed_slots;
     return result;
 }

--- a/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance.cpp
+++ b/score/mw/com/impl/bindings/lola/messaging/message_passing_service_instance.cpp
@@ -881,7 +881,7 @@ void MessagePassingServiceInstance::NotifyEventRemote(const ElementFqId event_id
     do
     {
         // LCOV_EXCL_START exceeds "short" limit for unit tests
-        if (loop_count == 255U)
+        if (loop_count == std::numeric_limits<decltype(loop_count)>::max())
         {
             score::mw::log::LogError("lola")
                 << "An overflow in counting the node identifiers to notifies event update.";

--- a/score/mw/com/impl/bindings/lola/messaging/node_identifier_copier.h
+++ b/score/mw/com/impl/bindings/lola/messaging/node_identifier_copier.h
@@ -23,7 +23,9 @@
 namespace score::mw::com::impl::lola
 {
 
-using NodeIdTmpBufferType = std::array<pid_t, 20>;
+inline constexpr auto kNodeIdTmpBufferCapacity{20U};
+
+using NodeIdTmpBufferType = std::array<pid_t, kNodeIdTmpBufferCapacity>;
 
 /// \brief Copies node identifiers (pid) contained within (container) values of a map into a given buffer under
 ///        read-lock

--- a/score/mw/com/impl/bindings/lola/path_builder.cpp
+++ b/score/mw/com/impl/bindings/lola/path_builder.cpp
@@ -22,6 +22,8 @@ namespace
 {
 
 using InstanceId = LolaServiceInstanceId::InstanceId;
+constexpr std::int32_t kServiceIdWidth{16};
+constexpr std::int32_t kInstanceIdWidth{5};
 
 }  // namespace
 
@@ -39,12 +41,12 @@ void AppendServiceAndInstance(std::ostream& out, const std::uint16_t service_id,
 
 void AppendService(std::ostream& out, const std::uint16_t service_id) noexcept
 {
-    out << std::setfill('0') << std::setw(16) << service_id << '-';
+    out << std::setfill('0') << std::setw(kServiceIdWidth) << service_id << '-';
 }
 
 void AppendInstanceId(std::ostream& out, const InstanceId instance_id) noexcept
 {
-    out << std::setw(5) << instance_id;
+    out << std::setw(kInstanceIdWidth) << instance_id;
 }
 
 }  // namespace score::mw::com::impl::lola

--- a/score/mw/com/impl/bindings/lola/provider_event_data_control_local_view.cpp
+++ b/score/mw/com/impl/bindings/lola/provider_event_data_control_local_view.cpp
@@ -228,7 +228,7 @@ void ProviderEventDataControlLocalView<AtomicIndirectorType>::LogPerformanceMetr
 {
     score::cpp::ignore = num_alloc_retries.fetch_add(retry_counter);
 
-    if ((retry_counter >= 100U))
+    if ((retry_counter >= MAX_ALLOCATE_RETRIES))
     {
         ++num_alloc_misses;
     }

--- a/score/mw/com/impl/bindings/lola/service_discovery/lola_service_instance_identifier.cpp
+++ b/score/mw/com/impl/bindings/lola/service_discovery/lola_service_instance_identifier.cpp
@@ -16,6 +16,9 @@
 namespace score::mw::com::impl::lola
 {
 
+constexpr auto kServiceIdShiftBits{32U};
+constexpr auto kInstanceIdShiftBits{16U};
+
 LolaServiceInstanceIdentifier::LolaServiceInstanceIdentifier(LolaServiceId service_id) noexcept
     : service_id_{service_id}, instance_id_{std::nullopt}
 {
@@ -65,10 +68,12 @@ std::size_t std::hash<score::mw::com::impl::lola::LolaServiceInstanceIdentifier>
 {
     static_assert(sizeof(score::mw::com::impl::LolaServiceId) <= 4U);
     static_assert(sizeof(score::mw::com::impl::LolaServiceInstanceId::InstanceId) <= 2U);
-    std::size_t result{static_cast<std::size_t>(identifier.GetServiceId()) << 32U};
+    std::size_t result{static_cast<std::size_t>(identifier.GetServiceId())
+                       << score::mw::com::impl::lola::kServiceIdShiftBits};
     if (identifier.GetInstanceId().has_value())
     {
-        result += static_cast<std::size_t>(identifier.GetInstanceId().value()) << 16U;
+        result += static_cast<std::size_t>(identifier.GetInstanceId().value())
+                  << score::mw::com::impl::lola::kInstanceIdShiftBits;
         result += 1U;
     }
     return result;

--- a/score/mw/com/impl/bindings/lola/shm_path_builder.cpp
+++ b/score/mw/com/impl/bindings/lola/shm_path_builder.cpp
@@ -31,6 +31,7 @@ constexpr auto kControlChannelPrefix = "lola-ctl-";
 constexpr auto kMethodChannelPrefix = "lola-methods-";
 constexpr auto kAsilBControlChannelSuffix = "-b";
 constexpr auto kInterVmSharedShmPrefix = "/intervm-shared-shmem/";
+constexpr int kProxyIdentifierFieldWidth{5};
 
 /// Emit file name of the control file to an ostream
 ///
@@ -103,8 +104,10 @@ void EmitMethodFileName(std::ostream& out,
     AppendServiceAndInstance(out, service_id, instance_id);
 
     out << '-';
-    out << std::setfill('0') << std::setw(5) << proxy_instance_identifier.application_id << '-';
-    out << std::setfill('0') << std::setw(5) << proxy_instance_identifier.proxy_instance_counter;
+    out << std::setfill('0') << std::setw(kProxyIdentifierFieldWidth) << proxy_instance_identifier.application_id
+        << '-';
+    out << std::setfill('0') << std::setw(kProxyIdentifierFieldWidth)
+        << proxy_instance_identifier.proxy_instance_counter;
 }
 
 }  // namespace

--- a/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_memory_manager.cpp
@@ -99,12 +99,16 @@ enum class ShmObjectType : std::uint8_t
     kData = 0x02,
 };
 
+constexpr std::uint32_t kServiceIdShiftBits{24U};
+constexpr std::uint32_t kInstanceIdShiftBits{8U};
+
 std::uint64_t CalculateMemoryResourceId(const LolaServiceTypeDeployment::ServiceId lola_service_id,
                                         const LolaServiceInstanceId::InstanceId lola_instance_id,
                                         const ShmObjectType object_type)
 {
-    return ((static_cast<std::uint64_t>(lola_service_id) << 24U) +
-            (static_cast<std::uint64_t>(lola_instance_id) << 8U) + static_cast<std::uint8_t>(object_type));
+    return ((static_cast<std::uint64_t>(lola_service_id) << kServiceIdShiftBits) +
+            (static_cast<std::uint64_t>(lola_instance_id) << kInstanceIdShiftBits) +
+            static_cast<std::uint8_t>(object_type));
 }
 
 /// \brief Determines whether the given event/field bindings are generic (type-erased) or typed bindings.

--- a/score/mw/com/impl/bindings/lola/test/proxy_event_test_resources.cpp
+++ b/score/mw/com/impl/bindings/lola/test/proxy_event_test_resources.cpp
@@ -30,6 +30,7 @@ namespace
 
 const auto kControlChannelPrefix{"/lola-ctl-"};
 const auto kDataChannelPrefix{"/lola-data-"};
+constexpr std::uint32_t kFindServiceHandleValue{10U};
 
 using namespace ::score::memory::shared;
 
@@ -133,7 +134,7 @@ void ProxyMockedMemoryFixture::InitialiseProxyWithConstructor(const InstanceIden
                 // In practice, if a service is available at the point in time when the Proxy is created then the find
                 // service handler will be called synchronously in the StartFindService call. We simulate this here by
                 // calling the handler with a handle.
-                auto find_service_handle = make_FindServiceHandle(10U);
+                auto find_service_handle = make_FindServiceHandle(kFindServiceHandleValue);
                 auto handle = make_HandleType(identifier_);
                 auto found_service_handle_container = ServiceHandleContainer<HandleType>{handle};
 
@@ -158,7 +159,7 @@ void ProxyMockedMemoryFixture::InitialiseProxyWithCreate(const InstanceIdentifie
 {
     EnrichedInstanceIdentifier enriched_instance_identifier{instance_identifier};
     ON_CALL(service_discovery_mock_, StartFindService(_, enriched_instance_identifier))
-        .WillByDefault(Return(make_FindServiceHandle(10U)));
+        .WillByDefault(Return(make_FindServiceHandle(kFindServiceHandleValue)));
 
     proxy_ = Proxy::Create(make_HandleType(instance_identifier));
 }

--- a/score/mw/com/impl/bindings/lola/test/proxy_event_test_resources.h
+++ b/score/mw/com/impl/bindings/lola/test/proxy_event_test_resources.h
@@ -170,6 +170,9 @@ class ProxyMockedMemoryFixture : public ::testing::Test
     static constexpr pid_t kDummyPid{123456};
     static constexpr uid_t kDummyUid{2543};
     static constexpr GlobalConfiguration::ApplicationId kDummyApplicationId{6543};
+    static constexpr LolaServiceInstanceId::InstanceId kLolaServiceInstanceIdValue{0x10U};
+    static constexpr LolaServiceId kLolaServiceIdValue{0xCDEFU};
+    static constexpr IMessagePassingService::HandlerRegistrationNoType kCurrentSubscriptionNo{37U};
 
     ProxyMockedMemoryFixture() noexcept;
 
@@ -189,8 +192,8 @@ class ProxyMockedMemoryFixture : public ::testing::Test
     void InitialiseDummySkeletonEvent(const ElementFqId element_fq_id,
                                       const SkeletonEventProperties& skeleton_event_properties);
 
-    LolaServiceInstanceId lola_service_instance_id_{0x10};
-    LolaServiceId lola_service_id_{0xcdef};
+    LolaServiceInstanceId lola_service_instance_id_{kLolaServiceInstanceIdValue};
+    LolaServiceId lola_service_id_{kLolaServiceIdValue};
     LolaServiceInstanceDeployment lola_service_instance_deployment_{lola_service_instance_id_};
     LolaServiceTypeDeployment lola_service_deployment_{lola_service_id_};
     ServiceIdentifierType service_identifier_ = make_ServiceIdentifierType("foo");
@@ -255,7 +258,7 @@ class LolaProxyEventResources : public ProxyMockedMemoryFixture
                                      lola_service_instance_id_.GetId(),
                                      ServiceElementType::EVENT};
 
-    IMessagePassingService::HandlerRegistrationNoType current_subscription_no_ = 37U;
+    IMessagePassingService::HandlerRegistrationNoType current_subscription_no_ = kCurrentSubscriptionNo;
 };
 
 }  // namespace score::mw::com::impl::lola

--- a/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.cpp
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.cpp
@@ -43,6 +43,9 @@ using ::testing::ReturnRef;
 using ::testing::StrEq;
 using ::testing::WithArg;
 
+constexpr std::uint16_t kEventControlNumberOfSlots{10U};
+constexpr std::uint16_t kEventControlMaxSubscribers{10U};
+
 }  // namespace
 
 LolaServiceInstanceDeployment CreateLolaServiceInstanceDeployment(
@@ -348,10 +351,10 @@ std::unique_ptr<ServiceDataControl> SkeletonMockedMemoryFixture::CreateServiceDa
                                                                           : control_asil_b_shared_memory_resource_mock_;
     auto service_data_control = std::make_unique<ServiceDataControl>(1U, *created_resource);
 
-    auto event_control =
-        service_data_control->event_controls_.emplace(std::piecewise_construct,
-                                                      std::forward_as_tuple(element_fq_id),
-                                                      std::forward_as_tuple(10U, 10U, true, *created_resource));
+    auto event_control = service_data_control->event_controls_.emplace(
+        std::piecewise_construct,
+        std::forward_as_tuple(element_fq_id),
+        std::forward_as_tuple(kEventControlNumberOfSlots, kEventControlMaxSubscribers, true, *created_resource));
     EXPECT_TRUE(event_control.second);
     return service_data_control;
 }

--- a/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h
+++ b/score/mw/com/impl/bindings/lola/test/skeleton_test_resources.h
@@ -470,10 +470,11 @@ class SkeletonMockedMemoryFixture : public ::testing::Test
     template <typename SampleType>
     ServiceDataStorage CreateServiceDataStorageWithEvent(ElementFqId element_fq_id) noexcept
     {
+        constexpr auto kEventDataStorageSlotCount = 10U;
         ServiceDataStorage service_data_storage{1U, *data_shared_memory_resource_mock_};
 
         auto* event_data_storage = data_shared_memory_resource_mock_->construct<EventDataStorage<SampleType>>(
-            10U, *data_shared_memory_resource_mock_);
+            kEventDataStorageSlotCount, *data_shared_memory_resource_mock_);
 
         auto inserted_data_slots = service_data_storage.events_.emplace(
             std::piecewise_construct, std::forward_as_tuple(element_fq_id), std::forward_as_tuple(event_data_storage));

--- a/score/mw/com/impl/bindings/lola/test/transaction_log_test_resources.cpp
+++ b/score/mw/com/impl/bindings/lola/test/transaction_log_test_resources.cpp
@@ -18,11 +18,18 @@
 namespace score::mw::com::impl::lola
 {
 
+namespace
+{
+
+constexpr std::uint32_t kSubscriberCountBitShift{16U};
+
+}  // namespace
+
 std::uint32_t CreateEventSubscriptionControlState(EventSubscriptionControl<>::SubscriberCountType subscriber_count,
                                                   EventSubscriptionControl<>::SlotNumberType subscribed_slots)
 {
     std::uint32_t result{subscriber_count};
-    result = result << 16U;
+    result = result << kSubscriberCountBitShift;
     result += subscribed_slots;
     return result;
 }

--- a/score/mw/com/impl/bindings/lola/test_doubles/fake_service_data.cpp
+++ b/score/mw/com/impl/bindings/lola/test_doubles/fake_service_data.cpp
@@ -25,6 +25,7 @@ namespace
 // Fixed capacity used for the fixed-capacity containers within the fake ServiceDataStorage. Test-doubles add their
 // events dynamically, so we simply reserve a generous upper bound.
 constexpr std::size_t kMaxNumberOfServiceElements{100U};
+constexpr auto kFakeServiceDataSharedMemorySize{65535U};
 }  // namespace
 
 std::unique_ptr<FakeServiceData> FakeServiceData::Create(const std::string& control_file_name,
@@ -84,7 +85,7 @@ FakeServiceData::FakeServiceData(const std::string& control_file_name,
                     memory_resource->construct<ServiceDataControl>(kMaxNumberOfServiceElements, *memory_resource);
             }
         },
-        65535U);
+        kFakeServiceDataSharedMemorySize);
 
     data_memory = score::memory::shared::SharedMemoryFactory::Create(
         data_file_name,
@@ -98,7 +99,7 @@ FakeServiceData::FakeServiceData(const std::string& control_file_name,
                 data_storage->skeleton_uid_ = skeleton_uid_in;
             }
         },
-        65535U);
+        kFakeServiceDataSharedMemorySize);
 }
 
 FakeServiceData::~FakeServiceData() noexcept

--- a/score/mw/com/impl/configuration/service_instance_id.cpp
+++ b/score/mw/com/impl/configuration/service_instance_id.cpp
@@ -31,6 +31,7 @@ namespace
 constexpr auto kBindingInfoKeySerInstID = "bindingInfo";
 constexpr auto kBindingInfoIndexKeySerInstID = "bindingInfoIndex";
 constexpr auto kSerializationVersionKeySerInstID = "serializationVersion";
+constexpr auto kMaxSingleHexDigitValue{0xFU};
 
 // This function with this signature is only defined here. And is in  anonymous namespace.
 // coverity[autosar_cpp14_a2_10_4_violation : FALSE]
@@ -65,7 +66,7 @@ std::string ToHashStringImpl(const ServiceInstanceId::BindingInformation& bindin
 
     // The conversion to hex string below does not work with a std::uint8_t, so we cast it to an int. However, we
     // ensure that the value is less than 16 to ensure it will fit with a single char in the string representation.
-    static_assert(std::variant_size<ServiceInstanceId::BindingInformation>::value <= 0xFU,
+    static_assert(std::variant_size<ServiceInstanceId::BindingInformation>::value <= kMaxSingleHexDigitValue,
                   "BindingInformation variant size should be less than 16");
 
     // The above assert checks that the variant type, of which binding_info_is a type of holds less variants than can

--- a/score/mw/com/impl/configuration/service_type_deployment.cpp
+++ b/score/mw/com/impl/configuration/service_type_deployment.cpp
@@ -25,6 +25,7 @@ namespace score::mw::com::impl
 
 namespace
 {
+constexpr auto kMaxSingleHexDigitValue{0xFU};
 
 // coverity[autosar_cpp14_a2_10_4_violation] False positive, function is in anonymous namespace
 ServiceTypeDeployment::BindingInformation GetBindingInfoFromJson(const score::json::Object& json_object)
@@ -54,7 +55,7 @@ std::string ToHashStringImpl(const ServiceTypeDeployment::BindingInformation& bi
 {
     // The conversion to hex string below does not work with a std::uint8_t, so we cast it to an int. However, we
     // ensure that the value is less than 16 to ensure it will fit with a single char in the string representation.
-    static_assert(std::variant_size<ServiceTypeDeployment::BindingInformation>::value <= 0xFU,
+    static_assert(std::variant_size<ServiceTypeDeployment::BindingInformation>::value <= kMaxSingleHexDigitValue,
                   "BindingInformation variant size should be less than 16");
     // coverity[autosar_cpp14_a4_7_1_violation] Static assert ensures that only uint8_t values are used
     auto binding_info_index = static_cast<int>(binding_info.index());

--- a/score/mw/com/impl/generic_proxy_event_binding.h
+++ b/score/mw/com/impl/generic_proxy_event_binding.h
@@ -33,11 +33,14 @@ namespace score::mw::com::impl
 class GenericProxyEventBinding : public ProxyEventBindingBase
 {
   public:
+    static constexpr auto kCallbackStorageSize{80U};
+
     /// Type-erased callback used for the GetNewSamples method.
     ///
-    /// The size of 80U is chosen to allow us to store another score::cpp::callback within this callback. This is needed
-    /// as we wrap the user provided callback in order to perform tracing functionality.
-    using Callback = score::cpp::callback<void(SamplePtr<void>, tracing::ITracingRuntime::TracePointDataId), 80U>;
+    /// The size of kCallbackStorageSize is chosen to allow us to store another score::cpp::callback within this
+    /// callback. This is needed as we wrap the user provided callback in order to perform tracing functionality.
+    using Callback =
+        score::cpp::callback<void(SamplePtr<void>, tracing::ITracingRuntime::TracePointDataId), kCallbackStorageSize>;
 
     /// \brief Get pending data from the event.
     ///

--- a/score/mw/com/impl/mocking/i_proxy_event.h
+++ b/score/mw/com/impl/mocking/i_proxy_event.h
@@ -57,7 +57,8 @@ class IProxyEvent : public IProxyEventBase
     IProxyEvent() = default;
     ~IProxyEvent() override = default;
 
-    using Callback = score::cpp::callback<void(SamplePtr<SampleType>), 80U>;
+    static constexpr std::size_t kCallbackCapacity{80U};
+    using Callback = score::cpp::callback<void(SamplePtr<SampleType>), kCallbackCapacity>;
 
     virtual Result<std::size_t> GetNewSamples(Callback&&, const std::size_t) = 0;
 

--- a/score/mw/com/impl/proxy_event_binding.h
+++ b/score/mw/com/impl/proxy_event_binding.h
@@ -39,11 +39,14 @@ template <typename SampleType>
 class ProxyEventBinding : public ProxyEventBindingBase
 {
   public:
+    static constexpr auto kCallbackStorageSize = 80U;
+
     /// Type-erased callback used for the GetNewSamples method.
     ///
     /// The size of 80U is chosen to allow us to store another score::cpp::callback within this callback. This is needed
     /// as we wrap the user provided callback in order to perform tracing functionality.
-    using Callback = score::cpp::callback<void(SamplePtr<SampleType>, tracing::ITracingRuntime::TracePointDataId), 80U>;
+    using Callback = score::cpp::callback<void(SamplePtr<SampleType>, tracing::ITracingRuntime::TracePointDataId),
+                                          kCallbackStorageSize>;
 
     /// \brief Get pending data from the event.
     ///

--- a/score/mw/com/impl/skeleton_binding.h
+++ b/score/mw/com/impl/skeleton_binding.h
@@ -37,6 +37,8 @@ class SkeletonEventBindingBase;
 class SkeletonBinding
 {
   public:
+    static constexpr auto kShmObjectTraceCallbackSize{64U};
+
     using SkeletonEventBindings = std::map<std::string_view, std::reference_wrapper<SkeletonEventBindingBase>>;
 
     /// \brief callback type for registering shared-memory objects with tracing
@@ -47,13 +49,14 @@ class SkeletonBinding
                                   ServiceElementType element_type,
                                   memory::shared::ISharedMemoryResource::FileDescriptor shm_object_fd,
                                   void* shm_memory_start_address),
-                             64U>;
+                             kShmObjectTraceCallbackSize>;
 
     /// \brief callback type for unregistering shared-memory objects with tracing
     /// \details Needs only get used/called by bindings, which use shared-memory as their underlying communication/
     ///          data-exchange mechanism.
     using UnregisterShmObjectTraceCallback =
-        score::cpp::callback<void(std::string_view element_name, ServiceElementType element_type), 64U>;
+        score::cpp::callback<void(std::string_view element_name, ServiceElementType element_type),
+                             kShmObjectTraceCallbackSize>;
 
     // For the moment, SkeletonFields use only SkeletonEventBindings. However, in the future when Get / Set are
     // supported in fields, then SkeletonFieldBindings will be a map in which the values are:

--- a/score/mw/com/impl/skeleton_event_binding.h
+++ b/score/mw/com/impl/skeleton_event_binding.h
@@ -31,6 +31,8 @@
 namespace score::mw::com::impl
 {
 
+inline constexpr std::size_t kSkeletonEventTraceCallbackStorageSize{64U};
+
 // Will come from plumbing
 template <typename SampleType>
 class SampleAllocateePtr;
@@ -38,8 +40,9 @@ class SampleAllocateePtr;
 class SkeletonEventBindingBase
 {
   public:
-    using SubscribeTraceCallback = score::cpp::callback<void(std::size_t, bool), 64U>;
-    using UnsubscribeTraceCallback = score::cpp::callback<void(), 64U>;
+    using SubscribeTraceCallback =
+        score::cpp::callback<void(std::size_t, bool), kSkeletonEventTraceCallbackStorageSize>;
+    using UnsubscribeTraceCallback = score::cpp::callback<void(), kSkeletonEventTraceCallbackStorageSize>;
 
     SkeletonEventBindingBase() = default;
 
@@ -80,7 +83,8 @@ template <typename SampleType>
 class SkeletonEventBinding : public SkeletonEventBindingBase
 {
   public:
-    using SendTraceCallback = score::cpp::callback<void(SampleAllocateePtr<SampleType>&), 64U>;
+    using SendTraceCallback =
+        score::cpp::callback<void(SampleAllocateePtr<SampleType>&), kSkeletonEventTraceCallbackStorageSize>;
 
     /// \brief SampleType is allocated by the user and provided to the middleware to send
     /// \return On failure, returns an error code.

--- a/score/mw/com/impl/test/dummy_instance_identifier_builder.cpp
+++ b/score/mw/com/impl/test/dummy_instance_identifier_builder.cpp
@@ -21,6 +21,14 @@
 namespace score::mw::com::impl
 {
 
+namespace
+{
+
+constexpr LolaServiceInstanceId::InstanceId kDummyLolaServiceInstanceIdValue{0x42U};
+constexpr uid_t kDummyAllowedConsumerUid{42};
+
+}  // namespace
+
 DummyInstanceIdentifierBuilder::DummyInstanceIdentifierBuilder()
     : service_instance_deployment_{},
       service_type_deployment_{0x0},
@@ -33,8 +41,8 @@ DummyInstanceIdentifierBuilder::DummyInstanceIdentifierBuilder()
 
 InstanceIdentifier DummyInstanceIdentifierBuilder::CreateValidLolaInstanceIdentifier()
 {
-    service_instance_deployment_.instance_id_ = LolaServiceInstanceId{0x42};
-    service_instance_deployment_.allowed_consumer_ = {{QualityType::kASIL_QM, {42}}};
+    service_instance_deployment_.instance_id_ = LolaServiceInstanceId{kDummyLolaServiceInstanceIdValue};
+    service_instance_deployment_.allowed_consumer_ = {{QualityType::kASIL_QM, {kDummyAllowedConsumerUid}}};
     type_deployment_.binding_info_ = service_type_deployment_;
     instance_deployment_ = std::make_unique<ServiceInstanceDeployment>(
         type_, service_instance_deployment_, QualityType::kASIL_QM, instance_specifier_);
@@ -55,8 +63,8 @@ InstanceIdentifier DummyInstanceIdentifierBuilder::CreateValidLolaInstanceIdenti
 InstanceIdentifier DummyInstanceIdentifierBuilder::CreateValidLolaInstanceIdentifierWithEvent(
     const LolaServiceInstanceDeployment::EventInstanceMapping& events)
 {
-    service_instance_deployment_.instance_id_ = LolaServiceInstanceId{0x42};
-    service_instance_deployment_.allowed_consumer_ = {{QualityType::kASIL_QM, {42}}};
+    service_instance_deployment_.instance_id_ = LolaServiceInstanceId{kDummyLolaServiceInstanceIdValue};
+    service_instance_deployment_.allowed_consumer_ = {{QualityType::kASIL_QM, {kDummyAllowedConsumerUid}}};
     service_instance_deployment_.events_ = events;
 
     // The GenericSkeleton needs the event names to be present in the Type Deployment
@@ -78,8 +86,8 @@ InstanceIdentifier DummyInstanceIdentifierBuilder::CreateValidLolaInstanceIdenti
 InstanceIdentifier DummyInstanceIdentifierBuilder::CreateValidLolaInstanceIdentifierWithField(
     const LolaServiceInstanceDeployment::FieldInstanceMapping& fields)
 {
-    service_instance_deployment_.instance_id_ = LolaServiceInstanceId{0x42};
-    service_instance_deployment_.allowed_consumer_ = {{QualityType::kASIL_QM, {42}}};
+    service_instance_deployment_.instance_id_ = LolaServiceInstanceId{kDummyLolaServiceInstanceIdValue};
+    service_instance_deployment_.allowed_consumer_ = {{QualityType::kASIL_QM, {kDummyAllowedConsumerUid}}};
     service_instance_deployment_.fields_ = fields;
     type_deployment_.binding_info_ = service_type_deployment_;
     instance_deployment_ = std::make_unique<ServiceInstanceDeployment>(

--- a/score/mw/com/impl/tracing/proxy_event_tracing.cpp
+++ b/score/mw/com/impl/tracing/proxy_event_tracing.cpp
@@ -32,6 +32,9 @@ namespace score::mw::com::impl::tracing
 namespace
 {
 
+constexpr auto kTracingReceiveHandlerStorageSize{128U};
+using TracingReceiveHandler = score::cpp::callback<void(void), kTracingReceiveHandlerStorageSize>;
+
 void UpdateTracingDataFromTraceResult(Result<void> trace_result,
                                       ProxyEventTracingData& proxy_event_tracing_data,
                                       bool& proxy_event_trace_point)
@@ -414,14 +417,13 @@ void TraceCallReceiveHandler(ProxyEventTracingData& proxy_event_tracing_data,
     }
 }
 
-score::cpp::callback<void(void), 128U> CreateTracingReceiveHandler(
-    ProxyEventTracingData& proxy_event_tracing_data,
-    const ProxyEventBindingBase& proxy_event_binding_base,
-    EventReceiveHandler handler)
+TracingReceiveHandler CreateTracingReceiveHandler(ProxyEventTracingData& proxy_event_tracing_data,
+                                                  const ProxyEventBindingBase& proxy_event_binding_base,
+                                                  EventReceiveHandler handler)
 {
     if (proxy_event_tracing_data.enable_call_receive_handler)
     {
-        score::cpp::callback<void(void), 128U> tracing_receive_handler =
+        TracingReceiveHandler tracing_receive_handler =
             [&proxy_event_tracing_data, &proxy_event_binding_base, handler = std::move(handler)]() {
                 TraceCallReceiveHandler(proxy_event_tracing_data, proxy_event_binding_base);
                 handler();

--- a/score/mw/com/impl/tracing/proxy_event_tracing.h
+++ b/score/mw/com/impl/tracing/proxy_event_tracing.h
@@ -33,6 +33,8 @@
 namespace score::mw::com::impl::tracing
 {
 
+inline constexpr auto kTracingReceiveHandlerInlineBufferSize{128U};
+
 ProxyEventTracingData GenerateProxyTracingStructFromEventConfig(const InstanceIdentifier& instance_identifier,
                                                                 const std::string_view event_name);
 ProxyEventTracingData GenerateProxyTracingStructFromFieldConfig(const InstanceIdentifier& instance_identifier,
@@ -55,7 +57,7 @@ void TraceCallGetNewSamplesCallback(ProxyEventTracingData& proxy_event_tracing_d
 void TraceCallReceiveHandler(ProxyEventTracingData& proxy_event_tracing_data,
                              const ProxyEventBindingBase& proxy_event_binding_base);
 
-score::cpp::callback<void(void), 128U> CreateTracingReceiveHandler(
+score::cpp::callback<void(void), kTracingReceiveHandlerInlineBufferSize> CreateTracingReceiveHandler(
     ProxyEventTracingData& proxy_event_tracing_data,
     const ProxyEventBindingBase& proxy_event_binding_base,
     EventReceiveHandler handler);

--- a/score/mw/com/impl/tracing/type_erased_sample_ptr.h
+++ b/score/mw/com/impl/tracing/type_erased_sample_ptr.h
@@ -30,7 +30,9 @@ class TypeErasedSamplePtr
     }
 
   private:
-    score::cpp::callback<void(), 128U> type_erased_sample_ptr_;
+    static constexpr auto kTypeErasedSamplePtrCallbackStorageSize{128U};
+
+    score::cpp::callback<void(), kTypeErasedSamplePtrCallbackStorageSize> type_erased_sample_ptr_;
 };
 
 }  // namespace score::mw::com::impl::tracing

--- a/score/mw/com/performance_benchmarks/api_microbenchmarks/lola_allocate_send_benchmarks.cpp
+++ b/score/mw/com/performance_benchmarks/api_microbenchmarks/lola_allocate_send_benchmarks.cpp
@@ -29,6 +29,7 @@ namespace
 
 std::size_t gGetNewSamplesBenchmarkIndex{0};
 constexpr std::string_view kBenchmarkInstanceSpecifier = "test/lolabenchmark";
+constexpr int kBenchmarkRepetitions{10};
 
 struct DataExchangeConfig
 {
@@ -52,7 +53,7 @@ class LolaAllocateSendBenchmarkFixture : public benchmark::Fixture
     LolaAllocateSendBenchmarkFixture()
     {
         // This code is run once per benchmark
-        this->Repetitions(10);
+        this->Repetitions(kBenchmarkRepetitions);
         this->ReportAggregatesOnly(true);
         this->ThreadRange(1, 1);
         this->MeasureProcessCPUTime();

--- a/score/mw/com/performance_benchmarks/api_microbenchmarks/lola_get_new_samples_benchmarks.cpp
+++ b/score/mw/com/performance_benchmarks/api_microbenchmarks/lola_get_new_samples_benchmarks.cpp
@@ -29,6 +29,7 @@ namespace
 
 std::size_t gGetNewSamplesBenchmarkIndex{0};
 constexpr std::string_view kBenchmarkInstanceSpecifier = "test/lolabenchmark";
+constexpr int kBenchmarkRepetitions{10};
 
 struct DataExchangeConfig
 {
@@ -52,7 +53,7 @@ class LolaGetNewSamplesBenchmarkFixture : public benchmark::Fixture
     LolaGetNewSamplesBenchmarkFixture()
     {
         // This code is run once per benchmark
-        this->Repetitions(10);
+        this->Repetitions(kBenchmarkRepetitions);
         this->ReportAggregatesOnly(true);
         this->ThreadRange(1, 1);
         this->MeasureProcessCPUTime();

--- a/score/mw/com/performance_benchmarks/api_microbenchmarks/lola_get_num_new_samples_benchmarks.cpp
+++ b/score/mw/com/performance_benchmarks/api_microbenchmarks/lola_get_num_new_samples_benchmarks.cpp
@@ -23,7 +23,11 @@ namespace score::mw::com::test
 namespace
 {
 constexpr std::string_view kBenchmarkInstanceSpecifier = "test/lolabenchmark";
-}
+constexpr int kBenchmarkRepetitions{10};
+constexpr std::size_t kSubscriptionCapacity{32U};
+constexpr int kSamplesToPublish{100};
+constexpr std::chrono::milliseconds kFixtureCleanupDelay{100};
+}  // namespace
 
 // This fixture will be used to benchmark the LoLa runtime
 class LolaGetNumNewSamplesAvailableBenchmarkFixture : public benchmark::Fixture
@@ -35,7 +39,7 @@ class LolaGetNumNewSamplesAvailableBenchmarkFixture : public benchmark::Fixture
 
     LolaGetNumNewSamplesAvailableBenchmarkFixture()
     {
-        this->Repetitions(10);
+        this->Repetitions(kBenchmarkRepetitions);
         this->ReportAggregatesOnly(true);
         this->ThreadRange(1, 1);
         this->UseRealTime();
@@ -75,11 +79,11 @@ class LolaGetNumNewSamplesAvailableBenchmarkFixture : public benchmark::Fixture
         proxy_ = std::move(proxy_result_.value());
 
         // Subscribe to the event with capacity for 32 samples
-        auto subscribe_result = proxy_->test_event.Subscribe(/*max_num_samples*/ 32);
+        auto subscribe_result = proxy_->test_event.Subscribe(kSubscriptionCapacity);
         SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD(subscribe_result.has_value());
 
         sender_thread_ = std::thread([this]() {
-            for (int i = 0; i < 100; ++i)
+            for (int i = 0; i < kSamplesToPublish; ++i)
             {
                 auto sample_alloc_result = skeleton_->test_event.Allocate();
                 if (!sample_alloc_result.has_value())
@@ -115,7 +119,7 @@ class LolaGetNumNewSamplesAvailableBenchmarkFixture : public benchmark::Fixture
         }
 
         // Allow some time for cleanup to complete
-        std::this_thread::sleep_for(std::chrono::milliseconds{100});
+        std::this_thread::sleep_for(kFixtureCleanupDelay);
     }
 
   protected:

--- a/score/mw/com/performance_benchmarks/api_microbenchmarks/lola_interface.h
+++ b/score/mw/com/performance_benchmarks/api_microbenchmarks/lola_interface.h
@@ -26,9 +26,10 @@ using byte = std::uint8_t;
 constexpr std::size_t B = 1;
 constexpr std::size_t KB = 1024 * B;
 constexpr std::size_t MB = KB * KB;
+constexpr std::size_t kPayloadSizeInMegabytes{5U};
 }  // namespace
 
-using DataType = std::array<byte, 5 * MB>;
+using DataType = std::array<byte, kPayloadSizeInMegabytes * MB>;
 
 template <typename T>
 struct TestInterface : public T::Base

--- a/score/mw/com/performance_benchmarks/api_microbenchmarks/lola_public_api_benchmarks.cpp
+++ b/score/mw/com/performance_benchmarks/api_microbenchmarks/lola_public_api_benchmarks.cpp
@@ -26,7 +26,8 @@ namespace score::mw::com::test
 namespace
 {
 constexpr std::string_view kBenchmarkInstanceSpecifier = "/score/mw/com/test/TestInterface";
-}
+constexpr int kBenchmarkRepetitions{10};
+}  // namespace
 
 // This fixture will be used to benchmark the LoLa runtime
 class LolaBenchmarkFixture : public benchmark::Fixture
@@ -34,7 +35,7 @@ class LolaBenchmarkFixture : public benchmark::Fixture
   public:
     LolaBenchmarkFixture()
     {
-        this->Repetitions(10);
+        this->Repetitions(kBenchmarkRepetitions);
         this->ReportAggregatesOnly(true);
         this->ThreadRange(1, 1);
         this->UseRealTime();

--- a/score/mw/com/performance_benchmarks/macro_benchmark/lola_benchmarking_client.cpp
+++ b/score/mw/com/performance_benchmarks/macro_benchmark/lola_benchmarking_client.cpp
@@ -31,6 +31,8 @@ constexpr std::string_view kLogContext{"BCli"};
 namespace score::mw::com::test
 {
 
+constexpr int kClientCreationJitterRangeMs{100};
+
 namespace
 {
 
@@ -399,7 +401,8 @@ int main(int argc, const char** argv)
     for (unsigned int i = 0; i < config.number_of_clients; i++)
     {
         // fuzz the creation time of the proxies
-        std::this_thread::sleep_for(std::chrono::milliseconds{std::rand() % 100});
+        std::this_thread::sleep_for(
+            std::chrono::milliseconds{std::rand() % score::mw::com::test::kClientCreationJitterRangeMs});
         workers.push_back(std::thread([&config, &exit_code, &test_stop_token]() noexcept {
             auto success = score::mw::com::test::RunClient(config, test_stop_token);
 

--- a/score/mw/com/performance_benchmarks/macro_benchmark/lola_interface.h
+++ b/score/mw/com/performance_benchmarks/macro_benchmark/lola_interface.h
@@ -26,9 +26,10 @@ using byte = std::uint8_t;
 constexpr std::size_t B = 1;
 constexpr std::size_t KB = 1024 * B;
 constexpr std::size_t MB = KB * KB;
+constexpr std::size_t kBenchmarkPayloadSizeInMegabytes = 5U;
 }  // namespace
 
-using DataType = std::array<byte, 5 * MB>;
+using DataType = std::array<byte, kBenchmarkPayloadSizeInMegabytes * MB>;
 
 template <typename T>
 struct TestInterface : public T::Base

--- a/score/mw/com/test/common_test_resources/assert_handler.cpp
+++ b/score/mw/com/test/common_test_resources/assert_handler.cpp
@@ -27,6 +27,8 @@ namespace score::mw::com::test
 namespace
 {
 
+constexpr auto kAssertionLogFlushDelay{std::chrono::milliseconds{500}};
+
 void assert_handler(const score::cpp::handler_parameters& params)
 {
     std::cerr << "Assertion \"" << params.condition << "\" failed";
@@ -38,7 +40,7 @@ void assert_handler(const score::cpp::handler_parameters& params)
     std::cerr.flush();
 
     score::mw::log::LogFatal("AsHa") << params.condition << params.message << params.file << params.line;
-    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    std::this_thread::sleep_for(kAssertionLogFlushDelay);
 
     const char* const no_abort = std::getenv("ASSERT_NO_CORE");
     if (no_abort != nullptr)
@@ -62,7 +64,7 @@ void SetupAssertHandler()
     score::cpp::set_assertion_handler(assert_handler);
     // in addition, delay the calls to std::terminate() till the datarouter is able to read the logs
     std::set_terminate([]() {
-        std::this_thread::sleep_for(std::chrono::milliseconds(500));
+        std::this_thread::sleep_for(kAssertionLogFlushDelay);
         std::abort();
     });
 }

--- a/score/mw/com/test/common_test_resources/big_datatype.h
+++ b/score/mw/com/test/common_test_resources/big_datatype.h
@@ -29,6 +29,19 @@ namespace score::mw::com::test
 
 constexpr std::size_t MAX_SUCCESSORS = 16U;
 constexpr std::size_t MAX_LANES = 32000U;
+inline constexpr std::size_t MAX_LANE_CONNECTION_INFOS = 10U;
+inline constexpr std::size_t MAX_LANE_RESTRICTION_INFOS = 10U;
+inline constexpr std::size_t MAX_SHOULDER_LANE_INFOS = 10U;
+inline constexpr std::size_t MAX_LINK_IDS_PER_LANE = 10U;
+inline constexpr std::size_t MAX_PREDECESSOR_LANES = 10U;
+inline constexpr std::size_t MAX_CENTER_LINE_POINTS = 10U;
+inline constexpr std::size_t MAX_SPEED_LIMITS_PER_LANE = 10U;
+inline constexpr std::size_t MAX_BOUNDARY_IDS_PER_SIDE = 10U;
+inline constexpr std::size_t MAX_LINK_ASSOCIATIONS_PER_LANE = 10U;
+inline constexpr std::size_t MAX_BIDIRECTIONAL_USAGE_RANGES = 10U;
+inline constexpr std::size_t FRAME_ID_LENGTH = 10U;
+inline constexpr std::size_t MAX_LANE_BOUNDARIES = 20000U;
+inline constexpr std::size_t MAX_LANE_GROUPS = 20000U;
 
 enum class StdTimestampSyncState : std::uint32_t
 {
@@ -126,7 +139,7 @@ struct LaneConnectionInfo
     }
 };
 
-using LaneConnectionInfoList = std::array<LaneConnectionInfo, 10U>;
+using LaneConnectionInfoList = std::array<LaneConnectionInfo, MAX_LANE_CONNECTION_INFOS>;
 
 struct LaneRestrictionInfo
 {
@@ -138,7 +151,7 @@ struct LaneRestrictionInfo
     }
 };
 
-using LaneRestrictionInfoList = std::array<LaneRestrictionInfo, 10U>;
+using LaneRestrictionInfoList = std::array<LaneRestrictionInfo, MAX_LANE_RESTRICTION_INFOS>;
 
 struct ShoulderLaneInfo
 {
@@ -150,7 +163,7 @@ struct ShoulderLaneInfo
     }
 };
 
-using ShoulderLaneInfoList = std::array<ShoulderLaneInfo, 10U>;
+using ShoulderLaneInfoList = std::array<ShoulderLaneInfo, MAX_SHOULDER_LANE_INFOS>;
 
 struct LaneToLinkAssociation
 {
@@ -225,16 +238,16 @@ struct MapApiLaneData
     LaneIdType lane_id{0U};
 
     /// @brief range: [1, n]. The IDs of all links that this lane belongs to
-    std::array<map_api::LinkId, 10U> link_ids;
+    std::array<map_api::LinkId, MAX_LINK_IDS_PER_LANE> link_ids;
 
     /// @brief The IDs of all lane from which this lane can be reached in longitudinal direction
-    std::array<LaneIdType, 10U> predecessor_lanes;
+    std::array<LaneIdType, MAX_PREDECESSOR_LANES> predecessor_lanes;
 
     /// @brief The IDs of all lane that can be reached from this lane in longitudinal direction
     std::array<LaneIdType, MAX_SUCCESSORS> successor_lanes;
 
     /// @brief The center line of this lane
-    std::array<adp::MapApiPointData, 10U> center_line;
+    std::array<adp::MapApiPointData, MAX_CENTER_LINE_POINTS> center_line;
 
     /// @brief The innermost left boundary at the beginning of this lane
     LaneBoundaryId left_boundary_id{0U};
@@ -278,7 +291,7 @@ struct MapApiLaneData
     map_api::LengthM length_in_m{0.0};
 
     /// @brief The speed limits on the current lane
-    std::array<adp::map_api::SpeedLimit, 10U> speed_limits;
+    std::array<adp::map_api::SpeedLimit, MAX_SPEED_LIMITS_PER_LANE> speed_limits;
 
     /// @brief struct describing whether the lane is part of calculated Most Probable Path, or if yes within a range
     adp::map_api::LaneFollowsMpp lane_follows_mpp;
@@ -287,16 +300,16 @@ struct MapApiLaneData
     bool is_fully_attributed{false};
 
     /// @brief array containing the IDs of all left lane boundaries ordered from curb to middle
-    std::array<LaneBoundaryId, 10U> left_lane_boundaries_ids;
+    std::array<LaneBoundaryId, MAX_BOUNDARY_IDS_PER_SIDE> left_lane_boundaries_ids;
 
     /// @brief array containing the IDs of all right lane boundaries ordered from curb to middle
-    std::array<LaneBoundaryId, 10U> right_lane_boundaries_ids;
+    std::array<LaneBoundaryId, MAX_BOUNDARY_IDS_PER_SIDE> right_lane_boundaries_ids;
 
     /// @brief links associated with current lane
-    std::array<map_api::LaneToLinkAssociation, 10U> link_associations;
+    std::array<map_api::LaneToLinkAssociation, MAX_LINK_ASSOCIATIONS_PER_LANE> link_associations;
 
     /// @brief array of lane ranges where lane can be used in both directions.
-    std::array<map_api::LaneUsedInBothDirections, 10U> used_in_both_directions;
+    std::array<map_api::LaneUsedInBothDirections, MAX_BIDIRECTIONAL_USAGE_RANGES> used_in_both_directions;
 
     using IsEnumerableTag = void;
 
@@ -359,7 +372,7 @@ struct MapApiLanesStamped
     /// Depending on the driving scenario, different coordinate frames can be used.
     /// Case "map_debug" : for Highway scenario it is an NTM planar coordinate system.
     /// Case: "local_map_frame": for Urban scenario it is a vehicle's local coordinate system.
-    std::array<char, 10U> frame_id;
+    std::array<char, FRAME_ID_LENGTH> frame_id;
 
     /// @brief Current projection id.
     ///
@@ -375,12 +388,12 @@ struct MapApiLanesStamped
 
     /// @brief An array, containing lane boundaries, which refer to lanes from the given parent data structure. Lane
     /// boundary indicates edge of the lane.
-    std::array<MapApiLaneBoundaryData, 20000U> lane_boundaries;
+    std::array<MapApiLaneBoundaryData, MAX_LANE_BOUNDARIES> lane_boundaries;
 
     /// @brief All lanes from HD map for a relevant piece of road.
     std::array<MapApiLaneData, MAX_LANES> lanes;
 
-    std::array<LaneGroupData, 20000U> lane_groups;
+    std::array<LaneGroupData, MAX_LANE_GROUPS> lane_groups;
 
     std::uint32_t x;
     std::size_t hash_value;

--- a/score/mw/com/test/common_test_resources/general_resources.cpp
+++ b/score/mw/com/test/common_test_resources/general_resources.cpp
@@ -27,6 +27,13 @@
 namespace score::mw::com::test
 {
 
+namespace
+{
+
+constexpr std::uint8_t kOpenSharedCheckpointRetries{20U};
+
+}  // namespace
+
 void ObjectCleanupGuard::AddConsumerCheckpointControlGuard(
     SharedMemoryObjectCreator<CheckPointControl>& consumer_checkpoint_control_guard) noexcept
 {
@@ -150,7 +157,7 @@ os::Result<SharedMemoryObjectCreator<CheckPointControl>> OpenSharedCheckPointCon
         SharedMemoryObjectCreator<CheckPointControl>::OpenObject(shared_memory_file_path_string);
     if (!(checkpoint_control_guard_result.has_value()))
     {
-        std::uint8_t retry_counter{20};
+        std::uint8_t retry_counter{kOpenSharedCheckpointRetries};
         while ((retry_counter-- > 0) && (!checkpoint_control_guard_result.has_value()))
         {
             const std::chrono::milliseconds poll_interval{50U};

--- a/score/mw/com/test/common_test_resources/sample_sender_receiver.cpp
+++ b/score/mw/com/test/common_test_resources/sample_sender_receiver.cpp
@@ -41,6 +41,8 @@ namespace
 {
 
 constexpr std::size_t START_HASH = 64738U;
+constexpr std::size_t kMaxShmOpenPathLength = 1024U;
+constexpr std::chrono::milliseconds kSubscriptionStatePollInterval{100};
 
 std::ostream& operator<<(std::ostream& stream, const InstanceSpecifier& instance_specifier)
 {
@@ -69,7 +71,7 @@ std::string ToString(Args... args)
     return oss.str();
 }
 
-void HashArray(const std::array<LaneIdType, 16U>& array, std::size_t& seed)
+void HashArray(const std::array<LaneIdType, MAX_SUCCESSORS>& array, std::size_t& seed)
 {
     const std::ptrdiff_t buffer_size =
         reinterpret_cast<const std::uint8_t*>(&*array.cend()) - reinterpret_cast<const std::uint8_t*>(&*array.cbegin());
@@ -145,7 +147,7 @@ class MmanMock : public os::Mman
     }
 
   private:
-    mutable char last_shm_open_path_[1024];
+    mutable char last_shm_open_path_[kMaxShmOpenPathLength];
     mutable std::uint32_t shm_open_callcount_;
 };
 
@@ -867,7 +869,7 @@ int EventSenderReceiver::RunAsProxyCheckValuesCreatedFromConfig(
     // Wait for the subscription to finish before unsubscribing.
     while (bigdata.map_api_lanes_stamped_.GetSubscriptionState() != SubscriptionState::kSubscribed)
     {
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(kSubscriptionStatePollInterval);
     }
 
     std::cout << "Unsubscribing...";

--- a/score/mw/com/test/common_test_resources/sync_utils.cpp
+++ b/score/mw/com/test/common_test_resources/sync_utils.cpp
@@ -17,6 +17,11 @@
 #include <fstream>
 #include <iostream>
 
+namespace
+{
+constexpr std::chrono::milliseconds kFileCreationPollInterval{500};
+}
+
 score::mw::com::test::SyncCoordinator::SyncCoordinator(std::string file_name) : file_name_{std::move(file_name)} {}
 
 void score::mw::com::test::SyncCoordinator::Signal() noexcept
@@ -57,7 +62,7 @@ void score::mw::com::test::SyncCoordinator::CheckFileCreation(
             return;
         }
         std::cout << "File doesn't exist yet, failed to synchronize" << std::endl;
-        std::this_thread::sleep_for(std::chrono::milliseconds{500});
+        std::this_thread::sleep_for(kFileCreationPollInterval);
     }
 }
 

--- a/score/mw/com/test/concurrent_skeleton_creation/concurrent_skeleton_creation_application.cpp
+++ b/score/mw/com/test/concurrent_skeleton_creation/concurrent_skeleton_creation_application.cpp
@@ -27,9 +27,14 @@
 #include <thread>
 #include <vector>
 
+namespace
+{
+constexpr auto kSkeletonCreateIterations = 10U;
+}  // namespace
+
 void CreateAndOfferSkeleton(const score::mw::com::InstanceSpecifier& instance_specifier, std::atomic_bool& success_flag)
 {
-    for (std::size_t j = 0; j < 10; ++j)
+    for (std::size_t j = 0; j < kSkeletonCreateIterations; ++j)
     {
         auto bigdata_result = score::mw::com::test::BigDataSkeleton::Create(instance_specifier);
         if (!bigdata_result.has_value())

--- a/score/mw/com/test/find_any_semantics/client.cpp
+++ b/score/mw/com/test/find_any_semantics/client.cpp
@@ -27,6 +27,9 @@ namespace
 {
 
 constexpr auto kMaxNumSamples{1U};
+constexpr int kFieldSubscribeError{-7};
+constexpr int kSampleNotReceivedError{-5};
+constexpr int kUnexpectedSampleValueError{-6};
 
 int run_client(const std::size_t num_retries, const std::chrono::milliseconds retry_backoff_time)
 {
@@ -86,7 +89,7 @@ int run_client(const std::size_t num_retries, const std::chrono::milliseconds re
         if (!subscribe_result.has_value())
         {
             std::cerr << "Unable to subscribe to field, terminating\n";
-            return -7;
+            return kFieldSubscribeError;
         }
         retries = num_retries;
         while (lola_proxy.test_field.GetSubscriptionState() != score::mw::com::SubscriptionState::kSubscribed)
@@ -110,13 +113,13 @@ int run_client(const std::size_t num_retries, const std::chrono::milliseconds re
         if (!received_value.has_value())
         {
             std::cerr << "Lola didn't receive a sample!\n";
-            return -5;
+            return kSampleNotReceivedError;
         }
 
         if (received_value.value() != kTestValue)
         {
             std::cerr << "Expecting:" << kTestValue << " Received:" << received_value.value() << "!\n ";
-            return -6;
+            return kUnexpectedSampleValueError;
         }
     }
     return 0;

--- a/score/mw/com/test/flock/flock_test.cpp
+++ b/score/mw/com/test/flock/flock_test.cpp
@@ -40,6 +40,9 @@ namespace score::mw::com::test
 namespace
 {
 const char kChildDone = 'Z';
+constexpr auto kChildSleepDuration{std::chrono::seconds{5U}};
+constexpr int kChildNotificationMaxRetries{10};
+constexpr auto kChildNotificationPollInterval{std::chrono::milliseconds{100U}};
 
 /// \brief Action the forked child process does.
 /// \details Child process creates TWO "lock-files" under /tmp_discovery/flockTest. One it flocks with a shared-lock,
@@ -107,7 +110,7 @@ void DoChildActions(int fd_to_write_to)
     while (true)
     {
         std::cout << "Child: Going to sleep" << std::endl;
-        std::this_thread::sleep_for(std::chrono::seconds{5U});
+        std::this_thread::sleep_for(kChildSleepDuration);
         std::cout << "Child: Wake up again." << std::endl;
     }
 }
@@ -249,7 +252,7 @@ bool WaitForChildFinished(int fd_to_read_from)
         return false;
     }
     // Wait until child has created flocked files ...
-    for (auto i = 0; i < 10; ++i)
+    for (auto i = 0; i < kChildNotificationMaxRetries; ++i)
     {
         c = fgetc(stream);
         if (c == EOF)
@@ -259,7 +262,7 @@ bool WaitForChildFinished(int fd_to_read_from)
                 // child hasn't sent notification, that it is done yet
                 std::cerr << "Controller: Child has not yet created flock-files. Go to sleep again and recheck later."
                           << std::endl;
-                std::this_thread::sleep_for(std::chrono::milliseconds{100U});
+                std::this_thread::sleep_for(kChildNotificationPollInterval);
             }
             else
             {

--- a/score/mw/com/test/generic_skeleton/generic_generic_interaction_app.cpp
+++ b/score/mw/com/test/generic_skeleton/generic_generic_interaction_app.cpp
@@ -21,11 +21,18 @@
 namespace
 {
 
+constexpr std::size_t kCounterPayloadBytes{sizeof(std::uint64_t)};
+constexpr auto kInitialSubscriptionWait = std::chrono::seconds{5};
+constexpr auto kEventSendInterval = std::chrono::milliseconds{10};
+constexpr int kMaxFindServiceRetries{50};
+constexpr auto kFindServiceRetryInterval = std::chrono::milliseconds{100};
+constexpr auto kConsumerPollInterval = std::chrono::milliseconds{5};
+
 struct MyEventData
 {
     std::uint64_t counter;
 #if PAYLOAD_SIZE > 8
-    char padding[PAYLOAD_SIZE - 8];
+    char padding[PAYLOAD_SIZE - kCounterPayloadBytes];
 #endif
 };
 
@@ -91,7 +98,7 @@ int run_provider(score::cpp::stop_token stop_token)
 
     std::cout << "[PROVIDER] Generic-Generic " << PAYLOAD_SIZE << "-byte - Waiting 5s for consumer to subscribe..."
               << std::endl;
-    std::this_thread::sleep_for(std::chrono::seconds(5));
+    std::this_thread::sleep_for(kInitialSubscriptionWait);
     std::cout << "[PROVIDER] Finished initial 5s sleep." << std::endl;
 
     std::uint64_t i{0};
@@ -116,7 +123,7 @@ int run_provider(score::cpp::stop_token stop_token)
             return 1;
         }
         std::cout << "[PROVIDER] " << PAYLOAD_SIZE << "-byte Event Sent sample: " << i << std::endl;
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        std::this_thread::sleep_for(kEventSendInterval);
         i++;
     }
 
@@ -132,12 +139,12 @@ int run_consumer()
 
     score::Result<score::mw::com::ServiceHandleContainer<score::mw::com::GenericProxy::HandleType>> handles_res;
     int retries{0};
-    while (retries < 50)
+    while (retries < kMaxFindServiceRetries)
     {
         handles_res = score::mw::com::GenericProxy::FindService(instance_specifier);
         if (handles_res.has_value() && !handles_res.value().empty())
             break;
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(kFindServiceRetryInterval);
         retries++;
     }
     if (!handles_res.has_value() || handles_res.value().empty())
@@ -208,7 +215,7 @@ int run_consumer()
             std::cerr << "[CONSUMER] Failed to get new samples." << std::endl;
             return 1;
         }
-        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        std::this_thread::sleep_for(kConsumerPollInterval);
     }
     if (data_mismatches > 0)
     {

--- a/score/mw/com/test/generic_skeleton/generic_typed_interaction_app.cpp
+++ b/score/mw/com/test/generic_skeleton/generic_typed_interaction_app.cpp
@@ -32,11 +32,19 @@
 namespace
 {
 
+constexpr std::size_t kCounterFieldSize = sizeof(std::uint64_t);
+constexpr std::chrono::seconds kConsumerSubscriptionWait{5};
+constexpr std::chrono::milliseconds kSendInterval{10};
+constexpr std::chrono::seconds kServiceDiscoveryTimeout{5};
+constexpr std::chrono::milliseconds kServiceDiscoveryPollInterval{100};
+constexpr auto kServiceDiscoveryRetryCount = kServiceDiscoveryTimeout / kServiceDiscoveryPollInterval;
+constexpr std::chrono::milliseconds kSamplePollInterval{5};
+
 struct MyEventData
 {
     std::uint64_t counter;
 #if PAYLOAD_SIZE > 8
-    char padding[PAYLOAD_SIZE - 8];
+    char padding[PAYLOAD_SIZE - kCounterFieldSize];
 #endif
 };
 
@@ -90,7 +98,7 @@ int run_provider(score::cpp::stop_token stop_token)
     // Wait for the consumer to start and subscribe BEFORE sending data
     score::mw::log::LogInfo("GenericSkeletonProvider")
         << PAYLOAD_SIZE << "-byte - Waiting 5s for consumer to subscribe...";
-    std::this_thread::sleep_for(std::chrono::seconds(5));
+    std::this_thread::sleep_for(kConsumerSubscriptionWait);
 
     std::uint64_t i{0};
     while (!stop_token.stop_requested())
@@ -111,7 +119,7 @@ int run_provider(score::cpp::stop_token stop_token)
         }
 
         score::mw::log::LogInfo("GenericSkeletonProvider") << PAYLOAD_SIZE << "-byte Event Sent sample: " << i;
-        std::this_thread::sleep_for(std::chrono::milliseconds(10));
+        std::this_thread::sleep_for(kSendInterval);
         i++;
     }
 
@@ -134,14 +142,14 @@ int run_consumer()
 
     score::Result<score::mw::com::ServiceHandleContainer<MyTestServiceProxy::HandleType>> handles_res;
     int retries{0};
-    while (retries < 50)  // Try for up to 5 seconds
+    while (retries < kServiceDiscoveryRetryCount)
     {
         handles_res = MyTestServiceProxy::FindService(instance_specifier);
         if (handles_res.has_value() && !handles_res.value().empty())
         {
             break;  // Service found!
         }
-        std::this_thread::sleep_for(std::chrono::milliseconds(100));
+        std::this_thread::sleep_for(kServiceDiscoveryPollInterval);
         retries++;
     }
 
@@ -201,7 +209,7 @@ int run_consumer()
             return 1;
         }
 
-        std::this_thread::sleep_for(std::chrono::milliseconds(5));
+        std::this_thread::sleep_for(kSamplePollInterval);
     }
 
     if (data_mismatches > 0)

--- a/score/mw/com/test/inotify/inotify_test.cpp
+++ b/score/mw/com/test/inotify/inotify_test.cpp
@@ -38,6 +38,8 @@ namespace score::mw::com::test
 namespace
 {
 
+constexpr auto kEventProcessingWaitTime = std::chrono::milliseconds{300};
+
 void do_cleanup(const std::string& folder)
 {
     score::filesystem::StandardFilesystem fs;
@@ -167,7 +169,7 @@ int run_inotify_test()
     std::cout << "Deleted file: " << test_file << std::endl;
 
     std::cout << "waiting for events_checker_thread to receive and process the events." << std::endl;
-    std::this_thread::sleep_for(std::chrono::milliseconds(300));  // On QNX it takes around 251ms to receive the event.
+    std::this_thread::sleep_for(kEventProcessingWaitTime);  // On QNX it takes around 251ms to receive the event.
 
     auto inotify_result = i_notify.RemoveWatch(watch_descriptor.value());
     if (!(inotify_result.has_value()))

--- a/score/mw/com/test/inotify_stress_test/inotify_stress_test.cpp
+++ b/score/mw/com/test/inotify_stress_test/inotify_stress_test.cpp
@@ -63,6 +63,9 @@ namespace
 {
 
 const std::string kShmNamePrefix{"inotify_stress_test_worker_"};
+constexpr mode_t kBaseDirectoryPermissions{0777};
+constexpr std::size_t kDefaultNumProcesses{5U};
+constexpr std::size_t kDefaultCycles{100U};
 
 int DoSetup()
 {
@@ -75,7 +78,7 @@ int DoSetup()
     }
     // Allow non-root worker processes (when --base-uid / --base-gid are used) to create
     // subdirectories and files inside the shared base folder.
-    if (::chmod(kBaseFolder.c_str(), 0777) != 0)
+    if (::chmod(kBaseFolder.c_str(), kBaseDirectoryPermissions) != 0)
     {
         std::cerr << getpid() << ": chmod on base directory failed: " << strerror(errno) << std::endl;
         return -1;
@@ -97,9 +100,9 @@ int ParseArguments(int argc,
     // clang-format off
     options.add_options()
         ("help",          "Display the help message")
-        ("num-processes", po::value<std::size_t>(&num_processes)->default_value(5U),
+        ("num-processes", po::value<std::size_t>(&num_processes)->default_value(kDefaultNumProcesses),
                           "Number of worker processes to spawn")
-        ("cycles",        po::value<std::size_t>(&cycles)->default_value(100U),
+        ("cycles",        po::value<std::size_t>(&cycles)->default_value(kDefaultCycles),
                           "Number of stress cycles before terminating")
         ("base-uid",      po::value<std::uint32_t>(&base_uid)->default_value(0U),
                           "Base UID: worker N calls setuid(base-uid + N). 0 = skip setuid.")

--- a/score/mw/com/test/inotify_stress_test/worker.cpp
+++ b/score/mw/com/test/inotify_stress_test/worker.cpp
@@ -38,6 +38,7 @@ namespace
 {
 
 constexpr mode_t kExpectedDirMode{0755U};
+constexpr mode_t kPermissionBitsMask{0777U};
 
 /// \brief Maximum number of add+remove attempts per cycle before a worker reports failure. Tolerates the
 ///        transient EINVAL the QNX io-notify manager can return under heavy concurrent watch churn.
@@ -52,10 +53,10 @@ bool HasCorrectPermissions(const pid_t pid, const std::string& path, const mode_
         std::cerr << pid << ": stat on " << path << " failed: " << strerror(errno) << std::endl;
         return false;
     }
-    if ((st.st_mode & 0777U) != expected_mode)
+    if ((st.st_mode & kPermissionBitsMask) != expected_mode)
     {
         std::cerr << pid << ": Directory " << path << " has wrong permissions: actual " << std::oct
-                  << (st.st_mode & 0777U) << ", expected " << expected_mode << std::dec << std::endl;
+                  << (st.st_mode & kPermissionBitsMask) << ", expected " << expected_mode << std::dec << std::endl;
         return false;
     }
     return true;

--- a/score/mw/com/test/methods/edge_cases_test/skeleton_recreation_test.cpp
+++ b/score/mw/com/test/methods/edge_cases_test/skeleton_recreation_test.cpp
@@ -19,6 +19,7 @@
 
 #include "score/mw/com/runtime.h"
 
+#include <chrono>
 #include <cstdint>
 #include <cstdlib>
 #include <iostream>
@@ -35,6 +36,7 @@ const std::string kFailureMessagePrefix{"skeleton_recreation_test"};
 constexpr std::int32_t kReturnOnlyMethodReturnValue{15};
 constexpr std::int32_t kInArgOnlyMethodTestValueA{17};
 constexpr std::int32_t kInArgOnlyMethodTestValueB{18};
+constexpr auto kProxyReconnectPollInterval = std::chrono::milliseconds{30};
 
 constexpr std::int32_t kTestValueA{10};
 constexpr std::int32_t kTestValueB{20};
@@ -146,7 +148,7 @@ void RunSkeletonRecreationWithSameProxyTest(const score::cpp::stop_token& stop_t
         // method in a loop until it succeeds. If it succeeded then it indicates that the proxy reconnected.
         while (!stop_token.stop_requested() && !consumer.GetProxy().without_args_or_return().has_value())
         {
-            std::this_thread::sleep_for(std::chrono::milliseconds(30));
+            std::this_thread::sleep_for(kProxyReconnectPollInterval);
         }
         if (stop_token.stop_requested())
         {

--- a/score/mw/com/test/move_semantics/skeleton_event/provider.cpp
+++ b/score/mw/com/test/move_semantics/skeleton_event/provider.cpp
@@ -17,6 +17,7 @@
 #include "score/mw/com/test/common_test_resources/skeleton_container.h"
 #include "score/mw/com/test/move_semantics/skeleton_event/test_event_datatype.h"
 
+#include <chrono>
 #include <cstdint>
 #include <utility>
 
@@ -26,6 +27,7 @@ namespace
 {
 
 const std::string kInterprocessNotificationShmPath{"/skeleton_event_move_semantics_interprocess_notification"};
+constexpr auto kSampleSendInterval = std::chrono::milliseconds{20};
 
 void SendSamples(SkeletonMoveSemanticsSkeleton& skeleton,
                  const std::size_t number_of_samples_to_send_per_offer,
@@ -39,7 +41,7 @@ void SendSamples(SkeletonMoveSemanticsSkeleton& skeleton,
         {
             FailTest("Provider: Send failed: ", send_result.error());
         }
-        std::this_thread::sleep_for(std::chrono::milliseconds(20));
+        std::this_thread::sleep_for(kSampleSendInterval);
     }
 }
 

--- a/score/mw/com/test/partial_restart/provider_restart/consumer.cpp
+++ b/score/mw/com/test/partial_restart/provider_restart/consumer.cpp
@@ -34,6 +34,7 @@ namespace score::mw::com::test
 namespace
 {
 const std::chrono::seconds kMaxHandleNotificationWaitTime{15U};
+constexpr auto kSubscriptionResubscribePollInterval{std::chrono::milliseconds{50U}};
 }  // namespace
 
 void DoConsumerActionsWithProxy(CheckPointControl& check_point_control,
@@ -171,7 +172,7 @@ void DoConsumerActionsWithProxy(CheckPointControl& check_point_control,
             std::cerr << "Consumer: Wait for event switch to kSubscribed aborted via stop-token!" << std::endl;
             return;
         }
-        std::this_thread::sleep_for(std::chrono::milliseconds{50U});
+        std::this_thread::sleep_for(kSubscriptionResubscribePollInterval);
         subscription_state = lola_proxy.simple_event_.GetSubscriptionState();
     }
     check_point_control.CheckPointReached(3);

--- a/score/mw/com/test/partial_restart/provider_restart/provider.cpp
+++ b/score/mw/com/test/partial_restart/provider_restart/provider.cpp
@@ -34,6 +34,7 @@ namespace
 {
 
 const std::chrono::milliseconds kSampleSendCycleTime{40};
+constexpr auto kInitialSimpleEventMember2Value{42U};
 
 /// \brief cyclic event-send-thread used by producer
 class CyclicEventSender
@@ -72,7 +73,7 @@ class CyclicEventSender
   private:
     void CyclicSendActivity(score::cpp::stop_token stop_token) noexcept
     {
-        SimpleEventDatatype event_data{1U, 42U};
+        SimpleEventDatatype event_data{1U, kInitialSimpleEventMember2Value};
         while (!stop_token.stop_requested())
         {
             // Provider sends an event update (which leads - since IPC-Tracing is enabled - to a transaction-log update)

--- a/score/mw/com/test/partial_restart/provider_restart/provider.h
+++ b/score/mw/com/test/partial_restart/provider_restart/provider.h
@@ -19,9 +19,11 @@
 namespace score::mw::com::test
 {
 
+inline constexpr std::size_t kDefaultNumSamplesSentToNotifyCheckPoint{5U};
+
 struct ProviderParameters
 {
-    size_t num_samples_sent_to_notify_check_point{5};
+    size_t num_samples_sent_to_notify_check_point{kDefaultNumSamplesSentToNotifyCheckPoint};
 };
 
 /// \brief

--- a/score/mw/com/test/partial_restart/provider_restart_max_subscribers/provider_restart_max_subscribers_application.cpp
+++ b/score/mw/com/test/partial_restart/provider_restart_max_subscribers/provider_restart_max_subscribers_application.cpp
@@ -41,6 +41,7 @@ const std::string_view kProviderCheckpointControlName = "Provider";
 const std::string_view kConsumerCheckpointControlName = "Consumer";
 
 const std::chrono::seconds kMaxWaitTimeToReachCheckpoint{60U};
+constexpr std::size_t kDefaultProviderRestartIterations{5U};
 
 using CheckPointControl = score::mw::com::test::CheckPointControl;
 
@@ -66,7 +67,7 @@ std::optional<TestParameters> ParseTestParameters(int argc, const char** argv) n
     options.add_options()
         ("help", "Display the help message")
         ("service_instance_manifest", po::value<std::string>(&service_instance_manifest)->default_value(""), "Path to the com configuration file")
-        ("iterations,t", po::value<std::size_t>(&test_parameters.number_test_iterations)->default_value(5), "Number of cycles (provider restarts) to be done")
+        ("iterations,t", po::value<std::size_t>(&test_parameters.number_test_iterations)->default_value(kDefaultProviderRestartIterations), "Number of cycles (provider restarts) to be done")
         ("is-proxy-connected-during-restart,c", po::value<bool>(&test_parameters.connected_proxy_during_restart), "Whether a proxy should be connected to the skeleton during skeleton restart.");
     // clang-format on
     po::variables_map args;

--- a/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/provider.cpp
+++ b/score/mw/com/test/partial_restart/proxy_restart_shall_not_affect_other_proxies/provider.cpp
@@ -28,6 +28,7 @@ constexpr auto kInstanceSpecifierString{"partial_restart/small_but_great"};
 const auto kInstanceSpecifier =
     score::mw::com::InstanceSpecifier::Create(std::string{kInstanceSpecifierString}).value();
 const std::chrono::milliseconds kDelayBetweenSendEvents{20U};
+constexpr std::uint32_t kSimpleEventSecondMemberValue{42U};
 }  // namespace
 
 void PerformProviderActions(CheckPointControl& check_point_control,
@@ -67,7 +68,7 @@ void PerformProviderActions(CheckPointControl& check_point_control,
     //*********************************************************
     while (!stop_token.stop_requested())
     {
-        auto result = service_instance.simple_event_.Send({1U, 42U});
+        auto result = service_instance.simple_event_.Send({1U, kSimpleEventSecondMemberValue});
         if (!result.has_value())
         {
             std::cout << "Provider Step(2): Sending of event failed: " << result.error() << "\n";

--- a/score/mw/com/test/service_discovery_during_consumer_crash/consumer.h
+++ b/score/mw/com/test/service_discovery_during_consumer_crash/consumer.h
@@ -24,10 +24,12 @@
 
 namespace score::mw::com::test
 {
+inline constexpr auto kMaxRandomDelayNanoseconds{501U};
+
 inline std::chrono::nanoseconds get_random_time()
 {
     auto rd = std::random_device();
-    std::uniform_int_distribution<std::uint32_t> dist(0, 501);
+    std::uniform_int_distribution<std::uint32_t> dist(0, kMaxRandomDelayNanoseconds);
     return std::chrono::nanoseconds{dist(rd)};
 }
 

--- a/score/mw/com/test/service_discovery_during_provider_crash/consumer.h
+++ b/score/mw/com/test/service_discovery_during_provider_crash/consumer.h
@@ -25,10 +25,12 @@
 namespace score::mw::com::test
 {
 
+constexpr std::uint32_t kMaxRandomNanoseconds{101U};
+
 inline std::chrono::nanoseconds get_random_time()
 {
     auto rd = std::random_device();
-    std::uniform_int_distribution<std::uint32_t> dist(0, 101);
+    std::uniform_int_distribution<std::uint32_t> dist(0, kMaxRandomNanoseconds);
     return std::chrono::nanoseconds{dist(rd)};
 }
 

--- a/score/mw/com/test/service_discovery_during_provider_crash/service_discovery_during_provider_crash_application.cpp
+++ b/score/mw/com/test/service_discovery_during_provider_crash/service_discovery_during_provider_crash_application.cpp
@@ -42,6 +42,7 @@ constexpr std::string_view kProviderCheckpointControlName = "Provider";
 constexpr std::string_view kConsumerCheckpointControlName = "Consumer";
 
 const std::chrono::seconds kMaxWaitTimeToReachCheckpoint{30U};
+constexpr auto kConsumerHealthCheckDelay{std::chrono::milliseconds{10}};
 
 /// \brief Test parameters for the ITF test.
 struct TestParameters
@@ -202,10 +203,9 @@ int DoConsumerCrash(const score::cpp::stop_token& test_stop_token, int argc, con
     // ********************************************************************************
     // Step (5) - Short Idle time to check if consumer is ok
     // ********************************************************************************
-    std::chrono::milliseconds short_wait{10};
     std::cout << "Controller Step (5): Idling for a few milliseconds,"
               << "before checking if the consumer is still in a valid state." << std::endl;
-    std::this_thread::sleep_for(short_wait);
+    std::this_thread::sleep_for(kConsumerHealthCheckDelay);
 
     if (consumer_checkpoint_control.HasErrorOccurred())
     {

--- a/score/mw/com/test/smokeyeyes/smokeyeyes.cpp
+++ b/score/mw/com/test/smokeyeyes/smokeyeyes.cpp
@@ -155,6 +155,10 @@ enum class DataState
 
 int run_sender(SharedState& shared_state, const std::size_t turns, const std::size_t batch_size, const bool no_wait)
 {
+    constexpr int kOfferServiceFailureExitCode{-5};
+    constexpr int kSentSamplesColumnWidth{16};
+    constexpr std::size_t kMillisecondsPerSecond{1000U};
+
     auto instance_specifier_result =
         score::mw::com::InstanceSpecifier::Create(std::string{"smokeyeyes/small_but_great"});
     if (!instance_specifier_result.has_value())
@@ -175,7 +179,7 @@ int run_sender(SharedState& shared_state, const std::size_t turns, const std::si
     if (!offer_service_result.has_value())
     {
         std::cerr << "Unable to offer service: " << offer_service_result.error() << "!\n";
-        return -5;
+        return kOfferServiceFailureExitCode;
     }
 
     const auto start_clock = std::chrono::steady_clock::now();
@@ -194,7 +198,8 @@ int run_sender(SharedState& shared_state, const std::size_t turns, const std::si
         const auto now = std::chrono::steady_clock::now();
         if (now - time_last_stats > 1s)
         {
-            std::cout << "\rSent samples: " << std::setfill(' ') << std::setw(16) << turn * batch_size << std::flush;
+            std::cout << "\rSent samples: " << std::setfill(' ') << std::setw(kSentSamplesColumnWidth)
+                      << turn * batch_size << std::flush;
             time_last_stats = now;
         }
 
@@ -210,7 +215,7 @@ int run_sender(SharedState& shared_state, const std::size_t turns, const std::si
     const auto duration = std::chrono::steady_clock::now() - start_clock;
     const auto elapsed_ms = std::chrono::duration_cast<std::chrono::milliseconds>(duration).count();
     std::cout << "Sending " << turns * batch_size << " messages took " << elapsed_ms << "ms ("
-              << turns * batch_size * 1000 / static_cast<std::size_t>(elapsed_ms) << " msg/s)\n";
+              << turns * batch_size * kMillisecondsPerSecond / static_cast<std::size_t>(elapsed_ms) << " msg/s)\n";
 
     return 0;
 }
@@ -223,6 +228,12 @@ int run_receiver(SharedState& shared_state,
 {
     constexpr auto FIND_SERVICE_POLL_INTERVAL{20ms};
     constexpr std::size_t FIND_SERVICE_MAX_NUM_RETRIES{250U};
+    constexpr int kProxyCreationFailureExitCode{-5};
+    constexpr std::size_t kSubscriptionStatePollRetries{100U};
+    constexpr auto kSubscriptionStatePollInterval{10ms};
+    constexpr int kSampleReceiveFailureExitCode{-6};
+    constexpr int kSubscriptionTimeoutExitCode{-7};
+    constexpr int kDataValidationFailureExitCode{-8};
 
     ServiceHandleContainer<DataProxy::HandleType> handles{};
     for (std::size_t retry = 0U; retry < FIND_SERVICE_MAX_NUM_RETRIES; ++retry)
@@ -277,19 +288,19 @@ int run_receiver(SharedState& shared_state,
     {
         std::cerr << "Unable to establish connection to sender: " << std::move(receiver_result).error()
                   << ", terminating\n";
-        return -5;
+        return kProxyCreationFailureExitCode;
     }
     auto& receiver = receiver_result.value();
     std::ignore = receiver.struct_event_.Subscribe(num_slots);
-    for (std::size_t retry = 0U; retry < 100U; ++retry)
+    for (std::size_t retry = 0U; retry < kSubscriptionStatePollRetries; ++retry)
     {
         if (receiver.struct_event_.GetSubscriptionState() != SubscriptionState::kSubscribed)
         {
-            std::this_thread::sleep_for(10ms);
+            std::this_thread::sleep_for(kSubscriptionStatePollInterval);
         }
         else
         {
-            out << "Subscribed after " << retry * 10 << "ms\n";
+            out << "Subscribed after " << retry * kSubscriptionStatePollInterval.count() << "ms\n";
             break;
         }
     }
@@ -297,7 +308,7 @@ int run_receiver(SharedState& shared_state,
     if (receiver.struct_event_.GetSubscriptionState() != SubscriptionState::kSubscribed)
     {
         std::cerr << "PID " << getpid() << " unable to subscribe to service, terminating!\n";
-        return -7;
+        return kSubscriptionTimeoutExitCode;
     }
 
     int result{0};
@@ -331,7 +342,7 @@ int run_receiver(SharedState& shared_state,
             if (!num_samples_received.has_value())
             {
                 out << "Error receiving sample: " << std::move(num_samples_received).error() << ", terminating!\n";
-                result = -6;
+                result = kSampleReceiveFailureExitCode;
                 break;
             }
             else
@@ -372,7 +383,7 @@ int run_receiver(SharedState& shared_state,
 
     if (result == 0 && data_state != DataState::kUnchanged)
     {
-        result = -8;
+        result = kDataValidationFailureExitCode;
     }
 
     return result;
@@ -387,6 +398,8 @@ int main(int argc, const char** argv)
     namespace ipc = boost::interprocess;
     using namespace score;
 
+    constexpr std::size_t kDefaultTurns{10U};
+
     std::size_t num_clients;
     std::size_t turns;
     std::size_t batch_size;
@@ -399,7 +412,7 @@ int main(int argc, const char** argv)
         ("help", "Display the help message")
         ("service_instance_manifest", po::value<std::string>(), "Path to the com configuration file")
         ("num-clients", po::value<std::size_t>(&num_clients)->default_value(1U), "Number of clients that will be spawned during a test run")
-        ("turns", po::value<std::size_t>(&turns)->default_value(10U), "Number of sample batches to send before terminating")
+        ("turns", po::value<std::size_t>(&turns)->default_value(kDefaultTurns), "Number of sample batches to send before terminating")
         ("batch-size", po::value<std::size_t>(&batch_size)->default_value(3U), "Number of samples per batch")
         ("no-wait", po::bool_switch(&no_wait), "If set, do not wait for receivers after having sent a batch")
         ("log-prefix", po::value<std::string>(), "Log output to a file with this prefix and a .log suffix")

--- a/score/mw/com/test/unsubscribe_deadlock/unsubscribe_deadlock_application.cpp
+++ b/score/mw/com/test/unsubscribe_deadlock/unsubscribe_deadlock_application.cpp
@@ -32,10 +32,11 @@
 #include <thread>
 
 const score::mw::com::test::MapApiLanesStamped kEvent_sample{};
+constexpr std::size_t kSkeletonCreateIterations{10U};
 
 void CreateAndOfferSkeleton(const score::mw::com::InstanceSpecifier& instance_specifier, std::atomic_bool& success_flag)
 {
-    for (std::size_t j = 0; j < 10; ++j)
+    for (std::size_t j = 0; j < kSkeletonCreateIterations; ++j)
     {
         auto bigdata_result = score::mw::com::test::BigDataSkeleton::Create(instance_specifier);
         if (!bigdata_result.has_value())


### PR DESCRIPTION
## Summary

Resolves clang-tidy `readability-magic-numbers` findings across the repository.

Raw numeric literals used in non-trivial expressions (bit shifts, size/offset
calculations, timeouts, buffer sizes, test fixture constants, etc.) are
replaced with named `static constexpr` constants whose names describe their
purpose (e.g. `kServiceIdShiftBits`, `kElementIdShiftBits`). This documents
intent at the point of use and satisfies the clang-tidy check without
changing any runtime behavior.

## Scope

101 files across `score/mw/com`, `score/memory/shared`, `score/message_passing`,
and `quality/integration_testing`, spanning production sources, tutorials,
benchmarks, and test resources.

## Verification

No functional changes intended. Verified by building the full affected scope
with Bazel:

```
bazel build //score/mw/com/... //score/memory/... //score/message_passing/... //quality/integration_testing/...
```

All 2183 targets built successfully with no new compiler errors.
