### PR TITLE
fix(clang-tidy): exclude external Bazel repositories from findings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -166,7 +166,7 @@ Checks: >
 WarningsAsErrors: >
   clang-analyzer-*,
 
-HeaderFilterRegex: '^(?!.*/third_party/).*'
+HeaderFilterRegex: '^(?!(third_party|external)/).*'
 
 FormatStyle: file
 

--- a/tools/lint/linters.bzl
+++ b/tools/lint/linters.bzl
@@ -21,12 +21,27 @@ load("@bazel_skylib//rules:write_file.bzl", "write_file")
 visibility(["//..."])
 
 # Define the clang-tidy linter aspect using LLVM toolchain
+# NOTE: lint_target_headers is deliberately left False (the aspect_rules_lint
+# default). When enabled it computes its own `-header-filter` regex from the
+# target's own header directories, which unconditionally overrides (rather
+# than merges with) //:.clang-tidy's HeaderFilterRegex, and falls back to
+# matching *every* header (".*") whenever a target has more than one header
+# directory (e.g. because of _virtual_includes) -- letting findings from
+# external Bazel repositories (bazel-out/.../external/<repo>/...), which we
+# cannot fix or influence, leak into the results.
+#
+# header_filter is set explicitly (rather than relying on clang-tidy
+# discovering //:.clang-tidy's HeaderFilterRegex on its own, which isn't
+# reliable from inside the sandbox) to the same pattern as
+# //:.clang-tidy's HeaderFilterRegex, so our own headers are still linted
+# while third_party/ and external/ (Bazel external repositories) are
+# excluded.
 clang_tidy = lint_clang_tidy_aspect(
     binary = Label("@llvm_toolchain//:clang-tidy"),
     configs = [
         Label("//:.clang-tidy"),
     ],
-    lint_target_headers = True,
+    header_filter = "^(?!(third_party|external)/).*$",
     angle_includes_are_system = True,
     verbose = False,
 )


### PR DESCRIPTION
## Summary

clang-tidy findings currently include diagnostics reported in headers from
external Bazel repositories (e.g. `bazel-out/.../external/score_baselibs+/...`),
which we cannot fix or influence upstream. This excludes them from results.

## Root cause

The clang-tidy aspect (`tools/lint/linters.bzl`) was configured with
`lint_target_headers = True`. This makes `aspect_rules_lint` compute its own
`-header-filter` regex from the target's own header directories instead of
honoring `//:.clang-tidy`'s `HeaderFilterRegex`. That computed filter falls
back to matching every header (`.*`) whenever a target has more than one
header directory (e.g. because of `_virtual_includes`), so findings from
`external/` and `third_party/` leaked through unfiltered.

## Fix

- `.clang-tidy`: `HeaderFilterRegex` now also excludes `external/` in
  addition to `third_party/`.
- `tools/lint/linters.bzl`: disabled `lint_target_headers` and instead pass
  an explicit `header_filter` matching `//:.clang-tidy`'s `HeaderFilterRegex`
  directly to the aspect (relying on clang-tidy's own config-file discovery
  from inside the Bazel sandbox proved unreliable).

## Verification

Built `//score/mw/com/...` with `--config=clang-tidy` and aggregated all
generated SARIF reports:

- Before: hundreds of findings pointed into
  `external/score_baselibs+/...` headers.
- After: 0 external findings, while findings in our own repo (645 in
  `.cpp` files, 11 in our own `.h` headers, e.g.
  `score/mw/com/impl/bindings/lola/*.h`) are still correctly reported.
