### PR TITLE
Gateway application binary

### DIFF
--- a/quality/visibility_guard/public_targets.golden
+++ b/quality/visibility_guard/public_targets.golden
@@ -54,6 +54,7 @@
 //score/mw/com/dependability:mw_com_doc_needs
 //score/mw/com/dependability:mw_com_index
 //score/mw/com/dependability:mw_com_rst
+//score/mw/com/gateway/gateway_application:gateway_application_runner
 //score/mw/com/performance_benchmarks/macro_benchmark/config_generator:config_generator_rule.bzl
 //score/mw/com/performance_benchmarks/macro_benchmark:logging.json
 //score/mw/com/performance_benchmarks/macro_benchmark:lola_benchmarking_client

--- a/score/mw/com/gateway/README.md
+++ b/score/mw/com/gateway/README.md
@@ -23,6 +23,8 @@ This README describes the implementation details specific to this codebase.
 | [gateway_application/gateway_error.h](gateway_application/gateway_error.h) | Error codes returned by `GatewayApplication`. |
 | [gateway_application/configuration/gateway_configuration.h](gateway_application/configuration/gateway_configuration.h) | Parsed gateway configuration (forwarded/received services, transport ID, config path). |
 | [gateway_application/configuration/gateway_config_parser.h](gateway_application/configuration/gateway_config_parser.h) | Parses `mw_com_gateway_config.json` into `GatewayConfiguration`. |
+| [gateway_application/gateway_application_runner.h](gateway_application/gateway_application_runner.h) / [.cpp](gateway_application/gateway_application_runner.cpp) | `RunGatewayApplication()` / `SignalHandler()` — reusable library entry point: parses the gateway config, sets up and starts a `GatewayApplication`, then blocks until shutdown is requested. Depended on by `gateway_application_bin`; can equally be linked into another process/library that wants to embed a gateway. |
+| [gateway_application/gateway_application_main.cpp](gateway_application/gateway_application_main.cpp) | `main()` of `gateway_application_bin`. Parses the two CLI args, initializes the `mw::com` runtime, installs `SIGINT`/`SIGTERM` handlers, and calls `RunGatewayApplication()`. |
 | [transport_layer/transport.h](transport_layer/transport.h) | `Transport` abstract base class — called by `GatewayApplication` to send cross-domain requests. |
 | [transport_layer/transport_factory.h](transport_layer/transport_factory.h) | Creates the correct `Transport` implementation from configuration. |
 | [transport_layer/transport_mock.h](transport_layer/transport_mock.h) | GMock of `Transport` used in unit tests. |
@@ -108,6 +110,24 @@ Key fields:
   (via `config-path`).
 
 See [gateway_application/configuration/](gateway_application/configuration/) for the JSON schema and examples.
+
+### Running the Gateway Application
+
+`gateway_application_bin` (built from [gateway_application_main.cpp](gateway_application/gateway_application_main.cpp))
+takes exactly two positional arguments:
+
+```sh
+gateway_application_bin <mw_com_config-path> <gateway-config-path>
+```
+
+`main()` only handles argument parsing, `mw::com` runtime initialization and `SIGINT`/`SIGTERM` handling; the actual
+setup/start/wait-for-shutdown sequence lives in `RunGatewayApplication()` in
+[gateway_application_runner.h](gateway_application/gateway_application_runner.h) /
+[.cpp](gateway_application/gateway_application_runner.cpp), so it can be reused from another binary or embedded
+directly into another process without going through `main()`/`argv`.
+
+See [gateway_application/etc/](gateway_application/etc/) for a complete runnable pair of sample configs (Source +
+Destination side) and the exact commands to launch them.
 
 ## Detailed Sequences
 

--- a/score/mw/com/gateway/gateway_application/BUILD
+++ b/score/mw/com/gateway/gateway_application/BUILD
@@ -120,9 +120,7 @@ cc_library(
     srcs = ["gateway_application_runner.cpp"],
     hdrs = ["gateway_application_runner.h"],
     features = COMPILER_WARNING_FEATURES,
-    visibility = [
-        "//score/mw/com/gateway:__subpackages__",
-    ],
+    visibility = ["//visibility:public"],
     deps = [
         ":gateway_application",
         "//score/mw/com/gateway/gateway_application/configuration:gateway_config_parser",
@@ -137,7 +135,9 @@ cc_binary(
         ":logging.json",
     ],
     env = {"MW_LOG_CONFIG_FILE": "$(location logging.json)"},
-    visibility = ["//visibility:public"],
+    visibility = [
+        "//score/mw/com/gateway:__subpackages__",
+    ],
     deps = [
         ":gateway_application_runner",
         "//score/mw/com:runtime",

--- a/score/mw/com/gateway/gateway_application/BUILD
+++ b/score/mw/com/gateway/gateway_application/BUILD
@@ -116,6 +116,38 @@ cc_unit_test(
 )
 
 cc_library(
+    name = "gateway_application_runner",
+    srcs = ["gateway_application_runner.cpp"],
+    hdrs = ["gateway_application_runner.h"],
+    features = COMPILER_WARNING_FEATURES,
+    visibility = [
+        "//score/mw/com/gateway:__subpackages__",
+    ],
+    deps = [
+        ":gateway_application",
+        "//score/mw/com/gateway/gateway_application/configuration:gateway_config_parser",
+        "@score_baselibs//score/mw/log",
+    ],
+)
+
+cc_binary(
+    name = "gateway_application_bin",
+    srcs = ["gateway_application_main.cpp"],
+    data = [
+        ":logging.json",
+    ],
+    env = {"MW_LOG_CONFIG_FILE": "$(location logging.json)"},
+    visibility = ["//visibility:public"],
+    deps = [
+        ":gateway_application_runner",
+        "//score/mw/com:runtime",
+        "//score/mw/com:runtime_configuration",
+        "@score_baselibs//score/language/futurecpp",
+        "@score_baselibs//score/mw/log",
+    ],
+)
+
+cc_library(
     name = "gateway_core_mock",
     srcs = ["gateway_core_mock.cpp"],
     hdrs = ["gateway_core_mock.h"],

--- a/score/mw/com/gateway/gateway_application/etc/README.md
+++ b/score/mw/com/gateway/gateway_application/etc/README.md
@@ -1,0 +1,74 @@
+<!----
+*******************************************************************************
+Copyright (c) 2026 Contributors to the Eclipse Foundation
+
+See the NOTICE file(s) distributed with this work for additional
+information regarding copyright ownership.
+
+This program and the accompanying materials are made available under the
+terms of the Apache License Version 2.0 which is available at
+https://www.apache.org/licenses/LICENSE-2.0
+
+SPDX-License-Identifier: Apache-2.0
+*******************************************************************************
+-->
+
+# Gateway Application — Sample Runtime Configuration
+
+This directory bundles a complete, runnable pair of configurations for `gateway_application_bin`: one set for a
+**Source Gateway** process and one for a **Destination Gateway** process (see [Source vs. Destination
+roles](../../README.md#architecture) in the gateway README). Together they demonstrate an inter-domain forwarding
+setup for the two sample services shipped with the `mw::com` tutorial (`HelloWorldService`) and a vehicle interface
+example (`VehicleInterface`).
+
+It also holds `logging.json`, the `mw::log` configuration applied to the gateway process itself.
+
+## Files
+
+| File | Role |
+|---|---|
+| `mw_com_config_source_gateway.json` / `mw_com_config_destination_gateway.json` | Standard `mw::com` deployment config for each side — `serviceTypes` and `serviceInstances` (binding, ASIL level, sample slots, allowed consumers). Passed as the **first** `gateway_application_bin` argument (`<mw_com_config-path>`). |
+| `mw_com_gateway_config_source_gateway.json` / `mw_com_gateway_config_destination_gateway.json` | Gateway-specific config — which services this side forwards (`forwarded-services`) or expects to receive (`expected-received-services`), and which transport layer to use. Passed as the **second** `gateway_application_bin` argument (`<gateway-config-path>`). |
+| `mw_com_gateway_sample_transport_config_source_gateway.json` / `..._destination_gateway.json` | Config for the bundled `sample_hypervisor` transport (see [transport_layer/sample](../../transport_layer/sample)) — remote IP, local/remote ports, request timeout. Not passed on the command line; referenced by the `transport-layer.config-path` field of the matching `mw_com_gateway_config_*.json` file above. |
+| `logging.json` | `mw::log` config for the gateway process (log level, console output). Auto-discovered by `mw::log` from `<binary-dir>/../etc/logging.json`, or overridden via the `MW_LOG_CONFIG_FILE` environment variable — see the `score/mw/log` module's own README for the full discovery order. |
+
+For the general schema of each config file, see [../configuration/](../configuration) (gateway config) and
+[../../transport_layer/sample/configuration/](../../transport_layer/sample/configuration) (transport config).
+
+## How the files link together
+
+Each `mw_com_gateway_config_*_gateway.json` references its transport config via an **absolute path**:
+
+```json
+"transport-layer": {
+    "id": "sample_hypervisor",
+    "config-path": "/etc/mw_com_gateway_sample_transport_config_destination_gateway.json"
+}
+```
+
+`GatewayConfigParser` passes this path through unmodified to `TransportFactory::Create()` — it is **not** resolved
+relative to the gateway config file's own location. To run a side locally, either:
+
+- deploy that side's `mw_com_gateway_sample_transport_config_*_gateway.json` to the literal path referenced
+  (`/etc/mw_com_gateway_sample_transport_config_*_gateway.json` on the target/container), or
+- copy this file and edit `config-path` to wherever you placed the transport config.
+
+## Running locally
+
+Each side is a separate `gateway_application_bin` process, given its own `mw_com_config` and `gateway_config`:
+
+```sh
+# Destination side
+gateway_application_bin \
+    etc/mw_com_config_destination_gateway.json \
+    etc/mw_com_gateway_config_destination_gateway.json
+
+# Source side
+gateway_application_bin \
+    etc/mw_com_config_source_gateway.json \
+    etc/mw_com_gateway_config_source_gateway.json
+```
+
+The sample transport connects the two sides over TCP (`hypervisor-socket` in the transport config); update
+`remote-ip` in the `_source_gateway` / `_destination_gateway` sample transport files if the two sides are not on
+`localhost`/the default addresses shown.

--- a/score/mw/com/gateway/gateway_application/etc/mw_com_config_destination_gateway.json
+++ b/score/mw/com/gateway/gateway_application/etc/mw_com_config_destination_gateway.json
@@ -1,0 +1,111 @@
+{
+  "serviceTypes": [
+    {
+      "serviceTypeName": "/score/mw/com/tutorial/HelloWorldService",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "bindings": [
+        {
+          "binding": "SHM",
+          "serviceId": 8711,
+          "events": [
+            {
+              "eventName": "message",
+              "eventId": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "serviceTypeName": "/bmw/adp/VehicleInterface",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "bindings": [
+        {
+          "binding": "SHM",
+          "serviceId": 6433,
+          "events": [
+            {
+              "eventName": "left_tire",
+              "eventId": 1
+            },
+            {
+              "eventName": "exhaust",
+              "eventId": 2
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "serviceInstances": [
+    {
+      "instanceSpecifier": "MyHelloWorldServiceInstance",
+      "serviceTypeName": "/score/mw/com/tutorial/HelloWorldService",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "instances": [
+        {
+          "instanceId": 1,
+          "asil-level": "QM",
+          "binding": "SHM",
+          "events": [
+            {
+              "eventName": "message",
+              "numberOfSampleSlots": 10,
+              "maxSubscribers": 3
+            }
+          ],
+          "interVmSupport": true,
+          "interVmForwarded": true
+        }
+      ]
+    },
+        {
+      "instanceSpecifier": "/Vehicle/Service1/Instance",
+      "serviceTypeName": "/bmw/adp/VehicleInterface",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "instances": [
+        {
+          "instanceId": 1,
+          "allowedConsumer": {
+            "QM": [
+              4002,
+              0
+            ]
+          },
+          "allowedProvider": {
+            "QM": [
+              4001,
+              0
+            ]
+          },
+          "asil-level": "QM",
+          "binding": "SHM",
+          "events": [
+            {
+              "eventName": "left_tire",
+              "numberOfSampleSlots": 30,
+              "maxSubscribers": 3
+            },
+            {
+              "eventName": "exhaust",
+              "numberOfSampleSlots": 30,
+              "maxSubscribers": 3
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/score/mw/com/gateway/gateway_application/etc/mw_com_config_source_gateway.json
+++ b/score/mw/com/gateway/gateway_application/etc/mw_com_config_source_gateway.json
@@ -1,0 +1,111 @@
+{
+  "serviceTypes": [
+    {
+      "serviceTypeName": "/score/mw/com/tutorial/HelloWorldService",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "bindings": [
+        {
+          "binding": "SHM",
+          "serviceId": 8711,
+          "events": [
+            {
+              "eventName": "message",
+              "eventId": 1
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "serviceTypeName": "/bmw/adp/VehicleInterface",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "bindings": [
+        {
+          "binding": "SHM",
+          "serviceId": 6433,
+          "events": [
+            {
+              "eventName": "left_tire",
+              "eventId": 1
+            },
+            {
+              "eventName": "exhaust",
+              "eventId": 2
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "serviceInstances": [
+    {
+      "instanceSpecifier": "MyHelloWorldServiceInstance",
+      "serviceTypeName": "/score/mw/com/tutorial/HelloWorldService",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "instances": [
+        {
+          "instanceId": 1,
+          "asil-level": "QM",
+          "binding": "SHM",
+          "events": [
+            {
+              "eventName": "message",
+              "numberOfSampleSlots": 10,
+              "maxSubscribers": 3
+            }
+          ],
+          "interVmSupport": true,
+          "interVmForwarded": true
+        }
+      ]
+    },
+        {
+      "instanceSpecifier": "/Vehicle/Service1/Instance",
+      "serviceTypeName": "/bmw/adp/VehicleInterface",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "instances": [
+        {
+          "instanceId": 1,
+          "allowedConsumer": {
+            "QM": [
+              4002,
+              0
+            ]
+          },
+          "allowedProvider": {
+            "QM": [
+              4001,
+              0
+            ]
+          },
+          "asil-level": "QM",
+          "binding": "SHM",
+          "events": [
+            {
+              "eventName": "left_tire",
+              "numberOfSampleSlots": 30,
+              "maxSubscribers": 3
+            },
+            {
+              "eventName": "exhaust",
+              "numberOfSampleSlots": 30,
+              "maxSubscribers": 3
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/score/mw/com/gateway/gateway_application/etc/mw_com_gateway_config_destination_gateway.json
+++ b/score/mw/com/gateway/gateway_application/etc/mw_com_gateway_config_destination_gateway.json
@@ -1,0 +1,12 @@
+{
+  "forwarded-services": [
+  ],
+  "expected-received-services": [
+    "MyHelloWorldServiceInstance",
+    "/Vehicle/Service1/Instance"
+  ],
+  "transport-layer": {
+    "id": "sample_hypervisor",
+    "config-path": "/etc/mw_com_gateway_sample_transport_config_destination_gateway.json"
+  }
+}

--- a/score/mw/com/gateway/gateway_application/etc/mw_com_gateway_config_source_gateway.json
+++ b/score/mw/com/gateway/gateway_application/etc/mw_com_gateway_config_source_gateway.json
@@ -1,0 +1,12 @@
+{
+  "forwarded-services": [
+    "MyHelloWorldServiceInstance",
+    "/Vehicle/Service1/Instance"
+  ],
+  "expected-received-services": [
+  ],
+  "transport-layer": {
+    "id": "sample_hypervisor",
+    "config-path": "/etc/mw_com_gateway_sample_transport_config_source_gateway.json"
+  }
+}

--- a/score/mw/com/gateway/gateway_application/etc/mw_com_gateway_sample_transport_config_destination_gateway.json
+++ b/score/mw/com/gateway/gateway_application/etc/mw_com_gateway_sample_transport_config_destination_gateway.json
@@ -1,0 +1,8 @@
+{
+  "hypervisor-socket": {
+    "remote-ip": "172.17.0.1",
+    "local-port": 45002,
+    "remote-port": 45001,
+    "request-timeout-ms": 5000
+  }
+}

--- a/score/mw/com/gateway/gateway_application/etc/mw_com_gateway_sample_transport_config_source_gateway.json
+++ b/score/mw/com/gateway/gateway_application/etc/mw_com_gateway_sample_transport_config_source_gateway.json
@@ -1,0 +1,8 @@
+{
+  "hypervisor-socket": {
+    "remote-ip": "172.17.0.6",
+    "local-port": 45001,
+    "remote-port": 45002,
+    "request-timeout-ms": 5000
+  }
+}

--- a/score/mw/com/gateway/gateway_application/gateway_application_main.cpp
+++ b/score/mw/com/gateway/gateway_application/gateway_application_main.cpp
@@ -1,0 +1,45 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "score/filesystem/path.h"
+#include "score/mw/com/gateway/gateway_application/gateway_application_runner.h"
+#include "score/mw/com/runtime.h"
+#include "score/mw/log/logging.h"
+
+#include <score/span.hpp>
+
+#include <csignal>
+#include <cstddef>
+#include <string>
+
+int main(int argc, char* argv[])
+{
+    if (argc != 3)
+    {
+        score::mw::log::LogError() << "Usage: gateway_application_bin <mw_com_config-path> <gateway-config-path>";
+        return 1;
+    }
+
+    std::signal(SIGINT, score::mw::com::gateway::SignalHandler);
+    std::signal(SIGTERM, score::mw::com::gateway::SignalHandler);
+
+    const score::cpp::span<char*> args{argv, static_cast<std::size_t>(argc)};
+    const std::string mw_com_config_path = args[1];
+    const std::string gateway_config_path = args[2];
+    score::mw::com::runtime::InitializeRuntime(
+        score::mw::com::runtime::RuntimeConfiguration{score::filesystem::Path{mw_com_config_path}});
+
+    score::mw::com::gateway::RunGatewayApplication(gateway_config_path);
+
+    return 0;
+}

--- a/score/mw/com/gateway/gateway_application/gateway_application_runner.cpp
+++ b/score/mw/com/gateway/gateway_application/gateway_application_runner.cpp
@@ -1,0 +1,70 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+
+#include "score/mw/com/gateway/gateway_application/gateway_application_runner.h"
+
+#include "score/mw/com/gateway/gateway_application/configuration/gateway_config_parser.h"
+#include "score/mw/com/gateway/gateway_application/gateway_application.h"
+#include "score/mw/log/logging.h"
+
+#include <atomic>
+#include <condition_variable>
+#include <mutex>
+
+namespace score::mw::com::gateway
+{
+
+namespace
+{
+std::atomic<bool> g_running{true};
+std::condition_variable g_shutdown_cv;
+std::mutex g_shutdown_mutex;
+}  // namespace
+
+void SignalHandler(int /*signal*/) noexcept
+{
+    g_running.store(false, std::memory_order_relaxed);
+    g_shutdown_cv.notify_one();
+}
+
+void RunGatewayApplication(const std::string& config_path)
+{
+    auto app_configuration = ParseGatewayConfig(config_path);
+    GatewayApplication gateway_app{std::move(app_configuration)};
+
+    const auto setup_result = gateway_app.Setup();
+    if (!setup_result.has_value())
+    {
+        score::mw::log::LogError() << "Gateway application setup failed: " << setup_result.error();
+        return;
+    }
+
+    const auto start_result = gateway_app.Start();
+    if (!start_result.has_value())
+    {
+        score::mw::log::LogError() << "Gateway application failed to start: " << start_result.error();
+        return;
+    }
+
+    score::mw::log::LogInfo() << "Gateway application started. Press Ctrl+C to stop.";
+
+    std::unique_lock<std::mutex> lock{g_shutdown_mutex};
+    while (g_running.load(std::memory_order_relaxed))
+    {
+        g_shutdown_cv.wait(lock);
+    }
+
+    score::mw::log::LogInfo() << "Gateway application shutting down.";
+}
+
+}  // namespace score::mw::com::gateway

--- a/score/mw/com/gateway/gateway_application/gateway_application_runner.h
+++ b/score/mw/com/gateway/gateway_application/gateway_application_runner.h
@@ -1,0 +1,32 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+#ifndef SCORE_MW_COM_GATEWAY_GATEWAY_APPLICATION_GATEWAY_APPLICATION_RUNNER_H
+#define SCORE_MW_COM_GATEWAY_GATEWAY_APPLICATION_GATEWAY_APPLICATION_RUNNER_H
+
+#include <string>
+
+namespace score::mw::com::gateway
+{
+
+/// \brief Signal handler that requests a graceful shutdown of a running gateway application.
+/// \details Registered by callers for signals such as SIGINT/SIGTERM before invoking RunGatewayApplication().
+void SignalHandler(int signal) noexcept;
+
+/// \brief Parses the gateway configuration, sets up and starts the gateway application, then blocks until a
+/// shutdown is requested via SignalHandler().
+/// \param config_path Path to the gateway configuration file.
+void RunGatewayApplication(const std::string& config_path);
+
+}  // namespace score::mw::com::gateway
+
+#endif  // SCORE_MW_COM_GATEWAY_GATEWAY_APPLICATION_GATEWAY_APPLICATION_RUNNER_H

--- a/score/mw/com/gateway/gateway_application/logging.json
+++ b/score/mw/com/gateway/gateway_application/logging.json
@@ -1,0 +1,8 @@
+{
+  "appId": "GWA",
+  "appDesc": "Gateway Application",
+  "logLevel": "kDebug",
+  "logLevelThresholdConsole": "kDebug",
+  "logMode": "kConsole",
+  "dynamicDatarouterIdentifiers" : true
+}

--- a/score/mw/com/gateway/transport_layer/sample/message_framer_test.cpp
+++ b/score/mw/com/gateway/transport_layer/sample/message_framer_test.cpp
@@ -486,4 +486,83 @@ TEST_F(MessageFramerFixture, ReceiveMessageReturnsNullptrWhenPayloadRecvReturnsP
     EXPECT_EQ(message, nullptr);
 }
 
+TEST_F(MessageFramerFixture, ReceivedEventInfoNameRemainsValidAfterNextReceiveMessageCall)
+{
+    // Given a first ProvideServiceRequest whose single event is named "SpeedEvent"
+    auto specifier_1 = score::mw::com::InstanceSpecifier::Create(std::string{"Svc/Inst"});
+    ASSERT_TRUE(specifier_1.has_value());
+    std::vector<score::mw::com::EventInfo> elements_1{
+        {"SpeedEvent", score::mw::com::DataTypeMetaInfo{64U, 8U}},
+    };
+    ProvideServiceRequest request_1{std::move(specifier_1).value(), elements_1};
+
+    std::array<std::uint8_t, MessageFramer::kMaxPayloadSize> payload_1{};
+    const auto payload_1_size = request_1.Serialize(payload_1);
+    ASSERT_GT(payload_1_size, 0U);
+    const MessageHeader header_1 =
+        CreateMessageHeader(MessageType::kProvideServiceRequest, 1U, static_cast<std::uint32_t>(payload_1_size));
+
+    // And a second ProvideServiceRequest, with the exact same wire layout (same specifier length, one
+    // event of the same name length), whose event is named "XXXXXXXXXX" instead -- so that its
+    // serialized bytes land at the exact same offsets in the framer's reused receive buffer.
+    auto specifier_2 = score::mw::com::InstanceSpecifier::Create(std::string{"Svc/Inst"});
+    ASSERT_TRUE(specifier_2.has_value());
+    std::vector<score::mw::com::EventInfo> elements_2{
+        {"XXXXXXXXXX", score::mw::com::DataTypeMetaInfo{64U, 8U}},
+    };
+    ProvideServiceRequest request_2{std::move(specifier_2).value(), elements_2};
+
+    std::array<std::uint8_t, MessageFramer::kMaxPayloadSize> payload_2{};
+    const auto payload_2_size = request_2.Serialize(payload_2);
+    ASSERT_GT(payload_2_size, 0U);
+    ASSERT_EQ(payload_1_size, payload_2_size) << "Both payloads must have identical wire layout";
+    const MessageHeader header_2 =
+        CreateMessageHeader(MessageType::kProvideServiceRequest, 2U, static_cast<std::uint32_t>(payload_2_size));
+
+    EXPECT_CALL(socket_mock_, recv(kSocketFd, _, _, _))
+        .WillOnce(Invoke(
+            [header_1](auto, void* buffer, const std::size_t, auto) -> score::cpp::expected<ssize_t, score::os::Error> {
+                header_1.SerializeToBuffer(static_cast<std::uint8_t*>(buffer));
+                return static_cast<ssize_t>(MessageHeader::kWireSize);
+            }))
+        .WillOnce(
+            Invoke([&payload_1, payload_1_size](
+                       auto, void* buffer, const std::size_t, auto) -> score::cpp::expected<ssize_t, score::os::Error> {
+                std::memcpy(buffer, payload_1.data(), payload_1_size);
+                return static_cast<ssize_t>(payload_1_size);
+            }))
+        .WillOnce(Invoke(
+            [header_2](auto, void* buffer, const std::size_t, auto) -> score::cpp::expected<ssize_t, score::os::Error> {
+                header_2.SerializeToBuffer(static_cast<std::uint8_t*>(buffer));
+                return static_cast<ssize_t>(MessageHeader::kWireSize);
+            }))
+        .WillOnce(
+            Invoke([&payload_2, payload_2_size](
+                       auto, void* buffer, const std::size_t, auto) -> score::cpp::expected<ssize_t, score::os::Error> {
+                std::memcpy(buffer, payload_2.data(), payload_2_size);
+                return static_cast<ssize_t>(payload_2_size);
+            }));
+
+    // When the first message is received, its EventInfo::name correctly reads "SpeedEvent"...
+    auto first_message = framer_.ReceiveMessage(kSocketFd);
+    ASSERT_NE(first_message, nullptr);
+    auto* first_provide_request = dynamic_cast<ProvideServiceRequest*>(first_message.get());
+    ASSERT_NE(first_provide_request, nullptr);
+    ASSERT_EQ(first_provide_request->GetServiceElements().size(), 1U);
+    ASSERT_EQ(first_provide_request->GetServiceElements()[0].name, "SpeedEvent");
+
+    // ...and receiving a second, unrelated message on the same framer must not affect it: a
+    // correctly-implemented ReceiveMessage() returns fully independent, owned messages.
+    auto second_message = framer_.ReceiveMessage(kSocketFd);
+    ASSERT_NE(second_message, nullptr);
+
+    // Then the *first* message's EventInfo::name must still read "SpeedEvent". If it no longer
+    // does, the name was deserialized as a view into the framer's reused receive buffer rather
+    // than into storage owned by the message -- i.e. the dangling-view bug is present.
+    EXPECT_EQ(first_provide_request->GetServiceElements()[0].name, "SpeedEvent")
+        << "EventInfo::name dangled: it was silently overwritten by the second ReceiveMessage() "
+           "call because it still views into MessageFramer::receive_buffer_ instead of "
+           "independently-owned storage.";
+}
+
 }  // namespace score::mw::com::gateway

--- a/score/mw/com/gateway/transport_layer/sample/messages/gateway_messages.cpp
+++ b/score/mw/com/gateway/transport_layer/sample/messages/gateway_messages.cpp
@@ -53,6 +53,22 @@ bool DeserializeWithTemplate(T& message, score::cpp::span<const std::uint8_t> da
 
 }  // namespace
 
+ProvideServiceRequest::ProvideServiceRequest(const score::mw::com::InstanceSpecifier& service_instance_specifier,
+                                             const std::vector<score::mw::com::EventInfo>& service_elements,
+                                             std::uint32_t shm_control_size,
+                                             std::uint32_t shm_data_size)
+    : TransportMessage(MessageType::kProvideServiceRequest),
+      instance_specifier_(std::string{service_instance_specifier.ToString()}),
+      shm_control_size_(shm_control_size),
+      shm_data_size_(shm_data_size)
+{
+    elements_.reserve(service_elements.size());
+    for (const auto& element : service_elements)
+    {
+        elements_.emplace_back(element);
+    }
+}
+
 std::size_t ProvideServiceRequest::Serialize(score::cpp::span<std::uint8_t> buffer) const
 {
     return SerializeWithTemplate(*this, buffer);

--- a/score/mw/com/gateway/transport_layer/sample/messages/gateway_messages.h
+++ b/score/mw/com/gateway/transport_layer/sample/messages/gateway_messages.h
@@ -17,7 +17,9 @@
 #include "score/mw/com/gateway/transport_layer/transport.h"
 #include "score/mw/com/types.h"
 
+#include <cstddef>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <type_traits>
 #include <vector>
@@ -30,14 +32,54 @@ namespace score::mw::com::gateway
 /// (generic) skeleton for the given service instance.
 class ProvideServiceRequest : public TransportMessage
 {
+    /// \brief Wire-format representation of a single service element (event/field) exposed by a
+    /// ProvideServiceRequest.
+    class GatewayEventInfo
+    {
+        template <typename Self>
+        auto GetSerializeMembersImpl(Self& self) const
+        {
+            using SelfNoRef = std::remove_reference_t<Self>;
+            using NameType = std::conditional_t<std::is_const_v<SelfNoRef>, const std::string, std::string>;
+            using MetaType = std::conditional_t<std::is_const_v<SelfNoRef>, const DataTypeMetaInfo, DataTypeMetaInfo>;
+            return std::tuple<NameType&, MetaType&>(self.name_, self.data_type_meta_info_);
+        }
+
+      public:
+        GatewayEventInfo() = default;
+
+        explicit GatewayEventInfo(const EventInfo& event_info)
+            : name_{event_info.name}, data_type_meta_info_{event_info.data_type_meta_info}
+        {
+        }
+
+        EventInfo ToEventInfo() const
+        {
+            return EventInfo{std::string_view{name_}, data_type_meta_info_};
+        }
+
+        auto GetSerializeMembers() const
+        {
+            return GetSerializeMembersImpl(*this);
+        }
+        auto GetSerializeMembers()
+        {
+            return GetSerializeMembersImpl(*this);
+        }
+
+      private:
+        std::string name_{};
+        DataTypeMetaInfo data_type_meta_info_{};
+    };
+
     template <typename Self>
     static auto GetSerializeMembersImpl(Self& self)
     {
         using SelfNoRef = std::remove_reference_t<Self>;
         using StringType = std::conditional_t<std::is_const_v<SelfNoRef>, const std::string, std::string>;
         using VectorType = std::conditional_t<std::is_const_v<SelfNoRef>,
-                                              const std::vector<score::mw::com::EventInfo>,
-                                              std::vector<score::mw::com::EventInfo>>;
+                                              const std::vector<GatewayEventInfo>,
+                                              std::vector<GatewayEventInfo>>;
         using Uint32Type = std::conditional_t<std::is_const_v<SelfNoRef>, const std::uint32_t, std::uint32_t>;
         return std::tuple<StringType&, VectorType&, Uint32Type&, Uint32Type&>(
             self.instance_specifier_, self.elements_, self.shm_control_size_, self.shm_data_size_);
@@ -47,16 +89,9 @@ class ProvideServiceRequest : public TransportMessage
     ProvideServiceRequest() : TransportMessage(MessageType::kProvideServiceRequest) {}
 
     ProvideServiceRequest(const score::mw::com::InstanceSpecifier& service_instance_specifier,
-                          std::vector<score::mw::com::EventInfo> service_elements,
+                          const std::vector<score::mw::com::EventInfo>& service_elements,
                           std::uint32_t shm_control_size = 0U,
-                          std::uint32_t shm_data_size = 0U)
-        : TransportMessage(MessageType::kProvideServiceRequest),
-          instance_specifier_(std::string{service_instance_specifier.ToString()}),
-          elements_(std::move(service_elements)),
-          shm_control_size_(shm_control_size),
-          shm_data_size_(shm_data_size)
-    {
-    }
+                          std::uint32_t shm_data_size = 0U);
 
     std::size_t Serialize(score::cpp::span<std::uint8_t> buffer) const override;
     bool Deserialize(score::cpp::span<const std::uint8_t> data) override;
@@ -66,9 +101,15 @@ class ProvideServiceRequest : public TransportMessage
         return instance_specifier_;
     }
 
-    const std::vector<score::mw::com::EventInfo>& GetServiceElements() const
+    std::vector<EventInfo> GetServiceElements() const
     {
-        return elements_;
+        std::vector<EventInfo> result;
+        result.reserve(elements_.size());
+        for (const auto& element : elements_)
+        {
+            result.push_back(element.ToEventInfo());
+        }
+        return result;
     }
 
     std::uint32_t GetShmControlSize() const
@@ -92,7 +133,7 @@ class ProvideServiceRequest : public TransportMessage
 
   private:
     std::string instance_specifier_;
-    std::vector<score::mw::com::EventInfo> elements_;
+    std::vector<GatewayEventInfo> elements_;
     std::uint32_t shm_control_size_{0U};
     std::uint32_t shm_data_size_{0U};
 };


### PR DESCRIPTION
Add gateway application binary, reusable runner library, and sample config

- Add the gateway_application_runner library (RunGatewayApplication() /
  SignalHandler()), which owns gateway config parsing plus the
  setup/start/wait-for-shutdown sequence. It has no dependency on
  main()/argv, so it can be linked into other applications or libraries
  outside this repo that want to embed a gateway process.

- Add gateway_application_bin, a thin main() that parses the two CLI
  args, initializes the mw::com runtime, installs SIGINT/SIGTERM
  handlers, and calls into the runner library — the entry point used
  within this repo to run a standalone gateway process.

- Add sample runtime configuration under gateway_application/etc/
  (mw_com config, gateway config, sample transport config, and
  logging.json) for both the source and destination gateway roles,
  with a README documenting how the files link together and how to
  run the pair locally. Interfaces in configuration linked to `score/mw/com/example/com-api-example` and `score/mw/com/doc/tutorial/chapter_1`

Issue #387 
