### PR TITLE
fix(clang-tidy): disable readability-magic-numbers check

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -128,7 +128,6 @@ Checks: >
   performance-unnecessary-copy-initialization,
   performance-unnecessary-value-param,
   readability-container-data-pointer,
-  readability-magic-numbers,
   readability-math-missing-parentheses,
   readability-redundant-casting,
   readability-redundant-inline-specifier,


### PR DESCRIPTION
## Summary

Disables the clang-tidy `readability-magic-numbers` check instead of
continuing to fix every finding it raises.

## Rationale

The check flags essentially every raw numeric literal used outside of a
small built-in allowlist (`0`, `1`, and a few others). Across this codebase
that produces a very large number of findings with limited actionability:
many of the flagged literals are already self-explanatory in context
(array sizes, test fixture values, protocol/wire-format constants, bit
shift amounts, etc.), and wrapping each one in a named `static constexpr`
constant adds a layer of indirection without meaningfully improving
readability, at a high maintenance cost for changes touching those files
going forward.

## Change

Removes `readability-magic-numbers` from the `Checks:` list in
`//:.clang-tidy`. No `CheckOptions` were specific to this check, so no
further cleanup was needed.

## Verification

Rebuilt `//score/mw/com:runtime` with `--config=clang-tidy` and confirmed
the generated SARIF report no longer contains any
`readability-magic-numbers` findings (other, unrelated clang-tidy findings
are still reported as before).
