### PR TITLE
fix(clang-tidy): resolve misc-use-anonymous-namespace findings

### DIFF
--- a/score/mw/com/doc/tutorial/chapter_1/consumer.cpp
+++ b/score/mw/com/doc/tutorial/chapter_1/consumer.cpp
@@ -18,13 +18,16 @@
 #include <cstdio>
 #include <cstring>
 
-static std::atomic<bool> g_running{true};
+namespace
+{
+std::atomic<bool> g_running{true};
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     std::cout << "HelloWorld service consumer caught signal." << std::endl;
     g_running.store(false, std::memory_order_relaxed);
 }
+}  // namespace
 
 using HelloWorldProxy = score::mw::com::AsProxy<score::mw::com::tutorial::HelloWorldInterface>;
 

--- a/score/mw/com/doc/tutorial/chapter_1/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_1/provider.cpp
@@ -19,13 +19,16 @@
 #include <cstring>
 
 constexpr std::string_view kHelloWorld{"Hello World"};
-static std::atomic<bool> g_running{true};
+namespace
+{
+std::atomic<bool> g_running{true};
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     std::cout << "HelloWorld service provider caught signal." << std::endl;
     g_running.store(false, std::memory_order_relaxed);
 }
+}  // namespace
 
 using HelloWorldSkeleton = score::mw::com::AsSkeleton<score::mw::com::tutorial::HelloWorldInterface>;
 

--- a/score/mw/com/doc/tutorial/chapter_10/consumer/consumer.cpp
+++ b/score/mw/com/doc/tutorial/chapter_10/consumer/consumer.cpp
@@ -19,13 +19,16 @@
 #include <cstdio>
 #include <cstring>
 
-static std::atomic<bool> g_running{true};
+namespace
+{
+std::atomic<bool> g_running{true};
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     std::cout << "HelloWorld service consumer caught signal." << std::endl;
     g_running.store(false, std::memory_order_relaxed);
 }
+}  // namespace
 
 using HelloWorldProxy = score::mw::com::AsProxy<score::mw::com::tutorial::HelloWorldInterface>;
 

--- a/score/mw/com/doc/tutorial/chapter_10/provider/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_10/provider/provider.cpp
@@ -19,13 +19,16 @@
 #include <cstring>
 
 constexpr std::string_view kHelloWorld{"Hello World"};
-static std::atomic<bool> g_running{true};
+namespace
+{
+std::atomic<bool> g_running{true};
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     std::cout << "HelloWorld service provider caught signal." << std::endl;
     g_running.store(false, std::memory_order_relaxed);
 }
+}  // namespace
 
 using HelloWorldSkeleton = score::mw::com::AsSkeleton<score::mw::com::tutorial::HelloWorldInterface>;
 

--- a/score/mw/com/doc/tutorial/chapter_12/consumer/consumer.cpp
+++ b/score/mw/com/doc/tutorial/chapter_12/consumer/consumer.cpp
@@ -21,13 +21,16 @@
 #include <cstdio>
 #include <cstring>
 
-static std::atomic<bool> g_running{true};
+namespace
+{
+std::atomic<bool> g_running{true};
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     std::cout << "HelloWorld service consumer caught signal." << std::endl;
     g_running.store(false, std::memory_order_relaxed);
 }
+}  // namespace
 
 int main()
 {

--- a/score/mw/com/doc/tutorial/chapter_12/provider/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_12/provider/provider.cpp
@@ -17,13 +17,16 @@
 #include <csignal>
 #include <cstdlib>
 
-static std::atomic<bool> g_running{true};
+namespace
+{
+std::atomic<bool> g_running{true};
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     std::cout << "HelloWorld service provider caught signal." << std::endl;
     g_running.store(false, std::memory_order_relaxed);
 }
+}  // namespace
 
 int main()
 {

--- a/score/mw/com/doc/tutorial/chapter_2/consumer/consumer.cpp
+++ b/score/mw/com/doc/tutorial/chapter_2/consumer/consumer.cpp
@@ -19,13 +19,16 @@
 #include <cstdio>
 #include <cstring>
 
-static std::atomic<bool> g_running{true};
+namespace
+{
+std::atomic<bool> g_running{true};
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     std::cout << "HelloWorld service consumer caught signal." << std::endl;
     g_running.store(false, std::memory_order_relaxed);
 }
+}  // namespace
 
 using HelloWorldProxy = score::mw::com::AsProxy<score::mw::com::tutorial::HelloWorldInterface>;
 

--- a/score/mw/com/doc/tutorial/chapter_2/provider/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_2/provider/provider.cpp
@@ -19,13 +19,16 @@
 #include <cstring>
 
 constexpr std::string_view kHelloWorld{"Hello World"};
-static std::atomic<bool> g_running{true};
+namespace
+{
+std::atomic<bool> g_running{true};
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     std::cout << "HelloWorld service provider caught signal." << std::endl;
     g_running.store(false, std::memory_order_relaxed);
 }
+}  // namespace
 
 using HelloWorldSkeleton = score::mw::com::AsSkeleton<score::mw::com::tutorial::HelloWorldInterface>;
 

--- a/score/mw/com/doc/tutorial/chapter_3/consumer/consumer.cpp
+++ b/score/mw/com/doc/tutorial/chapter_3/consumer/consumer.cpp
@@ -25,18 +25,17 @@
 #include <utility>
 #include <vector>
 
-static std::atomic<bool> g_running{true};
+namespace
+{
+std::atomic<bool> g_running{true};
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     std::cout << "HelloWorld service consumer caught signal." << std::endl;
     g_running.store(false, std::memory_order_relaxed);
 }
 
 using HelloWorldProxy = score::mw::com::AsProxy<score::mw::com::tutorial::HelloWorldInterface>;
-
-namespace
-{
 
 // Bundles a proxy for a discovered service instance together with a human-readable description of its instance id
 // (used for logging).

--- a/score/mw/com/doc/tutorial/chapter_3/provider/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_3/provider/provider.cpp
@@ -32,9 +32,11 @@ constexpr std::array<std::string_view, 3U> kInstanceSpecifierStrings{"MyHelloWor
 // The provider waits this amount of time after bringing up a service instance before it brings up the next one.
 constexpr std::chrono::seconds kInstanceStaggerDelay{5};
 
-static std::atomic<bool> g_running{true};
+namespace
+{
+std::atomic<bool> g_running{true};
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     std::cout << "HelloWorld service provider caught signal." << std::endl;
     g_running.store(false, std::memory_order_relaxed);
@@ -43,7 +45,7 @@ static void SignalHandler(int /*signum*/)
 using HelloWorldSkeleton = score::mw::com::AsSkeleton<score::mw::com::tutorial::HelloWorldInterface>;
 
 // Creates a HelloWorldService skeleton for the given InstanceSpecifier and offers it.
-static HelloWorldSkeleton CreateAndOfferInstance(const std::string_view instance_specifier_string)
+HelloWorldSkeleton CreateAndOfferInstance(const std::string_view instance_specifier_string)
 {
     auto instance_specifier = score::mw::com::InstanceSpecifier::Create(std::string{instance_specifier_string});
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(instance_specifier.has_value(), "Failed to create InstanceSpecifier!");
@@ -61,9 +63,9 @@ static HelloWorldSkeleton CreateAndOfferInstance(const std::string_view instance
 }
 
 // Publishes one "message" event sample on the given service instance.
-static void SendSample(HelloWorldSkeleton& service_instance,
-                       const std::string_view instance_specifier_string,
-                       const std::size_t send_counter)
+void SendSample(HelloWorldSkeleton& service_instance,
+                const std::string_view instance_specifier_string,
+                const std::size_t send_counter)
 {
     // Allocate a slot, where to publish the next event
     auto sample_allocatee_ptr = service_instance.message.Allocate();
@@ -94,6 +96,7 @@ static void SendSample(HelloWorldSkeleton& service_instance,
         std::cout << "Sample send completed. Event \"message\" update sent: " << buf << std::endl;
     }
 }
+}  // namespace
 
 int main()
 {

--- a/score/mw/com/doc/tutorial/chapter_4/consumer/consumer.cpp
+++ b/score/mw/com/doc/tutorial/chapter_4/consumer/consumer.cpp
@@ -24,18 +24,17 @@
 #include <thread>
 #include <utility>
 
-static std::atomic<bool> g_running{true};
+namespace
+{
+std::atomic<bool> g_running{true};
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     std::cout << "HelloWorld service consumer caught signal." << std::endl;
     g_running.store(false, std::memory_order_relaxed);
 }
 
 using HelloWorldProxy = score::mw::com::AsProxy<score::mw::com::tutorial::HelloWorldInterface>;
-
-namespace
-{
 
 // Returns a human-readable name for a subscription state (for logging).
 const char* ToString(const score::mw::com::SubscriptionState state) noexcept

--- a/score/mw/com/doc/tutorial/chapter_4/provider/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_4/provider/provider.cpp
@@ -32,9 +32,11 @@ constexpr std::string_view kInstanceSpecifierString{"MyHelloWorldServiceInstance
 constexpr std::chrono::seconds kOfferDuration{8};
 constexpr std::chrono::seconds kStopOfferDuration{5};
 
-static std::atomic<bool> g_running{true};
+namespace
+{
+std::atomic<bool> g_running{true};
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     std::cout << "HelloWorld service provider caught signal." << std::endl;
     g_running.store(false, std::memory_order_relaxed);
@@ -43,7 +45,7 @@ static void SignalHandler(int /*signum*/)
 using HelloWorldSkeleton = score::mw::com::AsSkeleton<score::mw::com::tutorial::HelloWorldInterface>;
 
 // Publishes one "message" event sample on the given service instance.
-static void SendSample(HelloWorldSkeleton& service_instance, const std::size_t send_counter)
+void SendSample(HelloWorldSkeleton& service_instance, const std::size_t send_counter)
 {
     // Allocate a slot, where to publish the next event
     auto sample_allocatee_ptr = service_instance.message.Allocate();
@@ -72,6 +74,7 @@ static void SendSample(HelloWorldSkeleton& service_instance, const std::size_t s
         std::cout << "Sample send completed. Event \"message\" update sent: " << buf << std::endl;
     }
 }
+}  // namespace
 
 int main()
 {

--- a/score/mw/com/doc/tutorial/chapter_5/consumer/consumer.cpp
+++ b/score/mw/com/doc/tutorial/chapter_5/consumer/consumer.cpp
@@ -32,20 +32,19 @@ constexpr std::size_t kMaxSampleCount{5U};
 // The consumer is purely event-driven: it does no polling at all. The main thread just blocks on this condition
 // variable until a termination signal (SIGINT/SIGTERM) requests the shut down. The signal handler sets the flag and
 // notifies the condition variable.
-static std::mutex g_shutdown_mutex{};
-static std::condition_variable g_shutdown_cv{};
-static std::atomic<bool> g_shutdown_requested{false};
+namespace
+{
+std::mutex g_shutdown_mutex{};
+std::condition_variable g_shutdown_cv{};
+std::atomic<bool> g_shutdown_requested{false};
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     g_shutdown_requested.store(true, std::memory_order_relaxed);
     g_shutdown_cv.notify_one();
 }
 
 using HelloWorldProxy = score::mw::com::AsProxy<score::mw::com::tutorial::HelloWorldInterface>;
-
-namespace
-{
 
 // Returns a binding-independent, human-readable description of the service instance a handle refers to.
 //

--- a/score/mw/com/doc/tutorial/chapter_5/provider/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_5/provider/provider.cpp
@@ -33,9 +33,11 @@ constexpr std::string_view kInstanceSpecifierString{"MyHelloWorldServiceInstance
 constexpr std::chrono::milliseconds kMinSendDelay{100};
 constexpr std::chrono::milliseconds kMaxSendDelay{3000};
 
-static std::atomic<bool> g_running{true};
+namespace
+{
+std::atomic<bool> g_running{true};
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     std::cout << "HelloWorld service provider caught signal." << std::endl;
     g_running.store(false, std::memory_order_relaxed);
@@ -44,7 +46,7 @@ static void SignalHandler(int /*signum*/)
 using HelloWorldSkeleton = score::mw::com::AsSkeleton<score::mw::com::tutorial::HelloWorldInterface>;
 
 // Publishes one "message" event sample on the given service instance.
-static void SendSample(HelloWorldSkeleton& service_instance, const std::size_t send_counter)
+void SendSample(HelloWorldSkeleton& service_instance, const std::size_t send_counter)
 {
     // Allocate a slot, where to publish the next event
     auto sample_allocatee_ptr = service_instance.message.Allocate();
@@ -73,6 +75,7 @@ static void SendSample(HelloWorldSkeleton& service_instance, const std::size_t s
         std::cout << "Sample send completed. Event \"message\" update sent: " << buf << std::endl;
     }
 }
+}  // namespace
 
 int main()
 {

--- a/score/mw/com/doc/tutorial/chapter_6/consumer/consumer.cpp
+++ b/score/mw/com/doc/tutorial/chapter_6/consumer/consumer.cpp
@@ -35,13 +35,16 @@ using HelloWorldProxy = score::mw::com::AsProxy<score::mw::com::tutorial::HelloW
 using MessageSampleType = decltype(HelloWorldProxy::message)::SampleType;
 using MessageSamplePtr = score::mw::com::SamplePtr<MessageSampleType>;
 
-static std::atomic<bool> g_running{true};
+namespace
+{
+std::atomic<bool> g_running{true};
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     std::cout << "HelloWorld service consumer caught signal." << std::endl;
     g_running.store(false, std::memory_order_relaxed);
 }
+}  // namespace
 
 int main(int argc, const char** argv)
 {

--- a/score/mw/com/doc/tutorial/chapter_6/provider/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_6/provider/provider.cpp
@@ -19,13 +19,16 @@
 #include <cstring>
 
 constexpr std::string_view kHelloWorld{"Hello World"};
-static std::atomic<bool> g_running{true};
+namespace
+{
+std::atomic<bool> g_running{true};
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     std::cout << "HelloWorld service provider caught signal." << std::endl;
     g_running.store(false, std::memory_order_relaxed);
 }
+}  // namespace
 
 using HelloWorldSkeleton = score::mw::com::AsSkeleton<score::mw::com::tutorial::HelloWorldInterface>;
 

--- a/score/mw/com/doc/tutorial/chapter_7/consumer/consumer.cpp
+++ b/score/mw/com/doc/tutorial/chapter_7/consumer/consumer.cpp
@@ -32,11 +32,13 @@ constexpr std::size_t kMaxSampleCount{5U};
 // The consumer is purely event-driven: it does no polling at all. The main thread just blocks on this condition
 // variable until a termination signal (SIGINT/SIGTERM) requests the shut down. The signal handler sets the flag and
 // notifies the condition variable.
-static std::mutex g_shutdown_mutex{};
-static std::condition_variable g_shutdown_cv{};
-static std::atomic<bool> g_shutdown_requested{false};
+namespace
+{
+std::mutex g_shutdown_mutex{};
+std::condition_variable g_shutdown_cv{};
+std::atomic<bool> g_shutdown_requested{false};
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     g_shutdown_requested.store(true, std::memory_order_relaxed);
     g_shutdown_cv.notify_one();
@@ -47,9 +49,6 @@ using TirePressureProxy = score::mw::com::AsProxy<score::mw::com::tutorial::Tire
 // (impl-namespace) type directly - user applications must not reference score::mw::com::impl types. All four fields
 // have the same type, so any of them can be used here.
 using TirePressureField = decltype(TirePressureProxy::tire_pressure_front_left);
-
-namespace
-{
 
 // Returns a binding-independent, human-readable description of the service instance a handle refers to.
 //

--- a/score/mw/com/doc/tutorial/chapter_7/provider/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_7/provider/provider.cpp
@@ -40,9 +40,11 @@ constexpr std::chrono::milliseconds kMaxUpdateDelay{3000};
 constexpr float kMinTirePressure{2.0F};
 constexpr float kMaxTirePressure{2.5F};
 
-static std::atomic<bool> g_running{true};
+namespace
+{
+std::atomic<bool> g_running{true};
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     std::cout << "TirePressure service provider caught signal." << std::endl;
     g_running.store(false, std::memory_order_relaxed);
@@ -57,7 +59,7 @@ using TirePressureField = decltype(TirePressureSkeleton::tire_pressure_front_lef
 // Updates a single field with the given value. In contrast to an event, a field is updated via Field::Update(). We use
 // the Update(const FieldType&) overload here: it takes the value by const-reference and lets the middleware copy it.
 // This is the overload that must also be used to set the *initial* value of a field before OfferService().
-static void UpdateField(TirePressureField& field, const std::string_view field_name, const float value)
+void UpdateField(TirePressureField& field, const std::string_view field_name, const float value)
 {
     const auto update_result = field.Update(value);
     if (!update_result)
@@ -69,6 +71,7 @@ static void UpdateField(TirePressureField& field, const std::string_view field_n
         std::cout << "  " << field_name << " = " << value << " bar" << std::endl;
     }
 }
+}  // namespace
 
 int main()
 {

--- a/score/mw/com/doc/tutorial/chapter_8/consumer/consumer.cpp
+++ b/score/mw/com/doc/tutorial/chapter_8/consumer/consumer.cpp
@@ -32,25 +32,24 @@ constexpr std::size_t kNumberOfMeanElements{500U};
 
 // The main thread blocks on this condition variable until either the method calls have completed or a termination
 // signal (SIGINT/SIGTERM) requests the shut down.
-static std::mutex g_shutdown_mutex{};
-static std::condition_variable g_shutdown_cv{};
-static std::atomic<bool> g_shutdown_requested{false};
+namespace
+{
+std::mutex g_shutdown_mutex{};
+std::condition_variable g_shutdown_cv{};
+std::atomic<bool> g_shutdown_requested{false};
 
-static void RequestShutdown()
+void RequestShutdown()
 {
     g_shutdown_requested.store(true, std::memory_order_relaxed);
     g_shutdown_cv.notify_one();
 }
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     RequestShutdown();
 }
 
 using CalculatorProxy = score::mw::com::tutorial::CalculatorProxy;
-
-namespace
-{
 
 // Returns a binding-independent, human-readable description of the service instance a handle refers to. The only
 // portable (public API) way to obtain a representation of the instance id from a handle is:

--- a/score/mw/com/doc/tutorial/chapter_8/provider/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_8/provider/provider.cpp
@@ -29,15 +29,18 @@ constexpr std::string_view kInstanceSpecifierString{"MyCalculatorServiceInstance
 // a method. There is nothing to poll in main(), so - just like the event-driven consumer of chapter 5 - the main thread
 // simply blocks on this condition variable until a termination signal (SIGINT/SIGTERM) requests the shut down. The
 // signal handler sets the flag and notifies the condition variable.
-static std::mutex g_shutdown_mutex{};
-static std::condition_variable g_shutdown_cv{};
-static std::atomic<bool> g_shutdown_requested{false};
+namespace
+{
+std::mutex g_shutdown_mutex{};
+std::condition_variable g_shutdown_cv{};
+std::atomic<bool> g_shutdown_requested{false};
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     g_shutdown_requested.store(true, std::memory_order_relaxed);
     g_shutdown_cv.notify_one();
 }
+}  // namespace
 
 int main()
 {

--- a/score/mw/com/doc/tutorial/chapter_9/consumer/consumer.cpp
+++ b/score/mw/com/doc/tutorial/chapter_9/consumer/consumer.cpp
@@ -40,11 +40,13 @@ constexpr float kThresholdAdjustStep{0.1F};
 
 // The consumer is purely event-driven: the main thread just blocks on this condition variable until a termination
 // signal (SIGINT/SIGTERM) requests the shut down. The signal handler sets the flag and notifies the condition variable.
-static std::mutex g_shutdown_mutex{};
-static std::condition_variable g_shutdown_cv{};
-static std::atomic<bool> g_shutdown_requested{false};
+namespace
+{
+std::mutex g_shutdown_mutex{};
+std::condition_variable g_shutdown_cv{};
+std::atomic<bool> g_shutdown_requested{false};
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     g_shutdown_requested.store(true, std::memory_order_relaxed);
     g_shutdown_cv.notify_one();
@@ -54,9 +56,6 @@ static void SignalHandler(int /*signum*/)
 // instead of naming the internal (impl-namespace) type directly - user applications must not reference
 // score::mw::com::impl types.
 using TirePressureField = decltype(TirePressureExtendedProxy::tire_pressure_front_left);
-
-namespace
-{
 
 // Returns a binding-independent, human-readable description of the service instance a handle refers to. The only
 // portable (public API) way to obtain a representation of the instance id from a handle is:

--- a/score/mw/com/doc/tutorial/chapter_9/provider/provider.cpp
+++ b/score/mw/com/doc/tutorial/chapter_9/provider/provider.cpp
@@ -57,15 +57,17 @@ constexpr std::chrono::milliseconds kMaxUpdateDelay{3000};
 constexpr float kMinTirePressure{1.2F};
 constexpr float kMaxTirePressure{4.0F};
 
-static std::atomic<bool> g_running{true};
+namespace
+{
+std::atomic<bool> g_running{true};
 
 // The current threshold band. It is the provider's local mirror of the "tire_pressure_thresholds" field value: it is
 // initialized before the service is offered and updated by the set-handler whenever a consumer calls Set() on the
 // field. The main loop reads it to decide whether a tire pressure has left the band.
-static std::mutex g_thresholds_mutex{};
-static TirePressureThreshold g_current_thresholds{kInitialLowerThreshold, kInitialUpperThreshold};
+std::mutex g_thresholds_mutex{};
+TirePressureThreshold g_current_thresholds{kInitialLowerThreshold, kInitialUpperThreshold};
 
-static void SignalHandler(int /*signum*/)
+void SignalHandler(int /*signum*/)
 {
     std::cout << "TirePressureExtended service provider caught signal." << std::endl;
     g_running.store(false, std::memory_order_relaxed);
@@ -77,7 +79,7 @@ static void SignalHandler(int /*signum*/)
 using TirePressureField = decltype(TirePressureExtendedSkeleton::tire_pressure_front_left);
 
 // Updates a single tire pressure field with the given value and returns the value it was set to.
-static float UpdateField(TirePressureField& field, const std::string_view field_name, const float value)
+float UpdateField(TirePressureField& field, const std::string_view field_name, const float value)
 {
     const auto update_result = field.Update(value);
     if (!update_result)
@@ -92,10 +94,10 @@ static float UpdateField(TirePressureField& field, const std::string_view field_
 }
 
 // Clamps a single threshold value into [min, max] and logs an error message when an adjustment was necessary.
-static float ClampThreshold(const std::string_view threshold_name,
-                            const float value,
-                            const float min_value,
-                            const float max_value)
+float ClampThreshold(const std::string_view threshold_name,
+                     const float value,
+                     const float min_value,
+                     const float max_value)
 {
     if (value < min_value)
     {
@@ -111,6 +113,7 @@ static float ClampThreshold(const std::string_view threshold_name,
     }
     return value;
 }
+}  // namespace
 
 int main()
 {

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.h
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.h
@@ -753,8 +753,12 @@ inline ::score::mw::com::impl::rust::TypeOperationImpl<T>& get_type_operations()
             }                                                                                                          \
         };                                                                                                             \
                                                                                                                        \
-        /* Force instantiation at startup */                                                                           \
-        static id##_InterfaceRegistrationHelper id##_interface_reg_instance;
+        /* Force instantiation at startup (in an anonymous namespace so the instance has internal linkage without      \
+           relying on the deprecated 'static' meaning; see misc-use-anonymous-namespace) */                            \
+        namespace                                                                                                      \
+        {                                                                                                              \
+        id##_InterfaceRegistrationHelper id##_interface_reg_instance;                                                  \
+        } /* namespace */
 
 /// \brief Macro to register event member operations
 /// \details Creates registry for event member operations for a specific interface and event name.
@@ -785,7 +789,10 @@ inline ::score::mw::com::impl::rust::TypeOperationImpl<T>& get_type_operations()
         }                                                                                                         \
     };                                                                                                            \
                                                                                                                   \
-    static event_member##_EventRegistrationHelper event_member##_event_reg_instance;
+    namespace                                                                                                     \
+    {                                                                                                             \
+    event_member##_EventRegistrationHelper event_member##_event_reg_instance;                                     \
+    } /* namespace */
 
 #define END_EXPORT_MW_COM_INTERFACE() }  // namespace id##_detail
 


### PR DESCRIPTION
## Summary

Fixes all `misc-use-anonymous-namespace` clang-tidy findings (74 findings across 24 files) by manually applying the transformation the check recommends, since **clang-tidy does not implement an automatic FixIt for this check**.

## Why this couldn't be auto-fixed by the pipeline

I initially assumed the empty `--fix` patches produced by `aspect_rules_lint` were a pipeline bug and spent time debugging it (verbose clang-tidy invocation, manual sandbox reproduction, etc.). Root cause: this is **not a pipeline issue** — `misc-use-anonymous-namespace` only emits a plain warning/note; it never attaches a `FixItHint`, confirmed by:
- Manually re-running the exact recorded clang-tidy `--fix` command (extracted from the actual Bazel sandboxed action) outside Bazel: exit 0, findings printed, but the file is byte-for-byte identical before/after.
- clang-tidy's own docs / source for this check.

So the fixes below were applied by hand, following exactly what the check's message recommends ("move to anonymous namespace instead").

## Changes

- **22 tutorial/doc files** (`score/mw/com/doc/tutorial/chapter_{1,2,3,4,5,6,7,8,9,10,12}/{consumer,provider}`): wrapped file-scope `static` globals/functions (e.g. `g_running`, `g_shutdown_mutex`, `SignalHandler`, `SendSample`, `UpdateField`, ...) in an unnamed namespace and dropped the now-redundant `static` keyword.
- **`score/mw/com/impl/rust/com-api/com-api-ffi-lola/registry_bridge_macro.h`**: the `BEGIN_EXPORT_MW_COM_INTERFACE` / `EXPORT_MW_COM_EVENT` macros generate `static ..._reg_instance;` declarations, which were the source of the remaining findings in `vehicle_gen.cpp` and `bigdata_com_api_gen.cpp` (the only two call sites of these macros in the repo). Fixed at the single root cause (the macro definitions) by wrapping the generated declarations in a nested anonymous namespace instead of touching the two generated call-site files.

## Verification

```
bazel build --config=clang-tidy //score/mw/com/doc/tutorial/... //score/mw/com/example/com-api-example/... //score/mw/com/test/basic_rust_api/...
```
→ 0 remaining `misc-use-anonymous-namespace` findings in the affected scope.

```
bazel build //score/mw/com/doc/tutorial/... //score/mw/com/example/com-api-example/... //score/mw/com/test/basic_rust_api/...
```
→ builds cleanly, including the Rust FFI bridge consumers of the modified macro.

## Scope note

Per the earlier discussion, this PR is scoped **only** to `misc-use-anonymous-namespace` and does not touch the `readability-magic-numbers` (#993), external-repo header-filter (#995), or magic-numbers-check-disable (#999) changes from the other PRs.
