### PR TITLE
fix(clang-tidy): move deleted special member functions to public access (modernize-use-equals-delete)

### DIFF
--- a/score/message_passing/i_client_connection.h
+++ b/score/message_passing/i_client_connection.h
@@ -33,6 +33,12 @@ class IClientConnection
     ///          any of the connection's callbacks except for the StateCallback with the Stopped state as an argument.
     virtual ~IClientConnection() = default;
 
+    /// \brief An IClientConnection shall not be copyable or movable
+    IClientConnection(const IClientConnection&) = delete;
+    IClientConnection(IClientConnection&&) = delete;
+    IClientConnection& operator=(const IClientConnection&) = delete;
+    IClientConnection& operator=(IClientConnection&&) = delete;
+
     /// \brief Send a binary message to the respective server, don't expect a reply
     /// \details The call is non-blocking and will fail if it would otherwise block due to implementation details.
     ///          The call will likely fail with score::os::Error in State::Init and definitely fail in State::Stopped.
@@ -155,10 +161,6 @@ class IClientConnection
 
   protected:
     IClientConnection() noexcept = default;
-    IClientConnection(const IClientConnection&) = delete;
-    IClientConnection(IClientConnection&&) = delete;
-    IClientConnection& operator=(const IClientConnection&) = delete;
-    IClientConnection& operator=(IClientConnection&&) = delete;
 };
 
 }  // namespace score::message_passing

--- a/score/message_passing/i_client_factory.h
+++ b/score/message_passing/i_client_factory.h
@@ -34,6 +34,12 @@ namespace score::message_passing
 class IClientFactory
 {
   public:
+    /// \brief An IClientFactory shall not be copyable or movable
+    IClientFactory(const IClientFactory&) = delete;
+    IClientFactory(IClientFactory&&) = delete;
+    IClientFactory& operator=(const IClientFactory&) = delete;
+    IClientFactory& operator=(IClientFactory&&) = delete;
+
     // Suppress "AUTOSAR C++14 A9-6-1" rule findings. This rule declares: "Data types used for interfacing with hardware
     // or conforming to communication protocols shall be trivial, standard-layout and only contain members of types with
     // defined sizes."
@@ -72,10 +78,6 @@ class IClientFactory
     ~IClientFactory() = default;
 
     IClientFactory() noexcept = default;
-    IClientFactory(const IClientFactory&) = delete;
-    IClientFactory(IClientFactory&&) = delete;
-    IClientFactory& operator=(const IClientFactory&) = delete;
-    IClientFactory& operator=(IClientFactory&&) = delete;
 };
 
 }  // namespace score::message_passing

--- a/score/message_passing/i_server.h
+++ b/score/message_passing/i_server.h
@@ -31,6 +31,12 @@ class IServer
   public:
     virtual ~IServer() = default;
 
+    /// \brief An IServer shall not be copyable or movable
+    IServer(const IServer&) = delete;
+    IServer(IServer&&) = delete;
+    IServer& operator=(const IServer&) = delete;
+    IServer& operator=(IServer&&) = delete;
+
     /// \brief Sets up the callbacks for connection, disconnection and message reception notifications.
     /// \details The callbacks lifetime (or rather the lifetime of the system state captured in the callbacks by
     ///          reference) needs to end not earlier than after StopListening() (or the destructor) has returned.
@@ -52,10 +58,6 @@ class IServer
 
   protected:
     IServer() noexcept = default;
-    IServer(const IServer&) = delete;
-    IServer(IServer&&) = delete;
-    IServer& operator=(const IServer&) = delete;
-    IServer& operator=(IServer&&) = delete;
 };
 
 }  // namespace score::message_passing

--- a/score/message_passing/i_server_connection.h
+++ b/score/message_passing/i_server_connection.h
@@ -28,6 +28,12 @@ namespace score::message_passing
 class IServerConnection
 {
   public:
+    /// \brief An IServerConnection shall not be copyable or movable
+    IServerConnection(const IServerConnection&) = delete;
+    IServerConnection(IServerConnection&&) = delete;
+    IServerConnection& operator=(const IServerConnection&) = delete;
+    IServerConnection& operator=(IServerConnection&&) = delete;
+
     virtual const ClientIdentity& GetClientIdentity() const& noexcept = 0;
     virtual UserData& GetUserData() noexcept = 0;
 
@@ -41,10 +47,6 @@ class IServerConnection
     ~IServerConnection() noexcept = default;
 
     IServerConnection() noexcept = default;
-    IServerConnection(const IServerConnection&) = delete;
-    IServerConnection(IServerConnection&&) = delete;
-    IServerConnection& operator=(const IServerConnection&) = delete;
-    IServerConnection& operator=(IServerConnection&&) = delete;
 };
 
 }  // namespace score::message_passing

--- a/score/message_passing/i_server_factory.h
+++ b/score/message_passing/i_server_factory.h
@@ -26,6 +26,12 @@ namespace score::message_passing
 class IServerFactory
 {
   public:
+    /// \brief An IServerFactory shall not be copyable or movable
+    IServerFactory(const IServerFactory&) = delete;
+    IServerFactory(IServerFactory&&) = delete;
+    IServerFactory& operator=(const IServerFactory&) = delete;
+    IServerFactory& operator=(IServerFactory&&) = delete;
+
     struct ServerConfig
     {
         std::uint32_t max_queued_sends;       ///< Maximum number of Send messages by clients queued on server side.
@@ -44,10 +50,6 @@ class IServerFactory
     ~IServerFactory() = default;
 
     IServerFactory() noexcept = default;
-    IServerFactory(const IServerFactory&) = delete;
-    IServerFactory(IServerFactory&&) = delete;
-    IServerFactory& operator=(const IServerFactory&) = delete;
-    IServerFactory& operator=(IServerFactory&&) = delete;
 };
 
 }  // namespace score::message_passing

--- a/score/message_passing/i_shared_resource_engine.h
+++ b/score/message_passing/i_shared_resource_engine.h
@@ -31,6 +31,12 @@ class ISharedResourceEngine
   public:
     virtual ~ISharedResourceEngine() noexcept = default;
 
+    /// \brief An ISharedResourceEngine shall not be copyable or movable
+    ISharedResourceEngine(const ISharedResourceEngine&) = delete;
+    ISharedResourceEngine(ISharedResourceEngine&&) = delete;
+    ISharedResourceEngine& operator=(const ISharedResourceEngine&) = delete;
+    ISharedResourceEngine& operator=(ISharedResourceEngine&&) = delete;
+
     virtual score::cpp::pmr::memory_resource* GetMemoryResource() noexcept = 0;
 
     virtual const LoggingCallback& GetLogger() & noexcept = 0;
@@ -87,10 +93,6 @@ class ISharedResourceEngine
 
   protected:
     ISharedResourceEngine() noexcept = default;
-    ISharedResourceEngine(const ISharedResourceEngine&) = delete;
-    ISharedResourceEngine(ISharedResourceEngine&&) = delete;
-    ISharedResourceEngine& operator=(const ISharedResourceEngine&) = delete;
-    ISharedResourceEngine& operator=(ISharedResourceEngine&&) = delete;
 };
 
 }  // namespace score::message_passing

--- a/score/mw/com/impl/proxy_base.h
+++ b/score/mw/com/impl/proxy_base.h
@@ -53,6 +53,11 @@ class ProxyBase
 
     virtual ~ProxyBase() = default;
 
+    /// \brief A Proxy shall not be copyable
+    /// \requirement SWS_CM_00136
+    ProxyBase(const ProxyBase&) = delete;
+    ProxyBase& operator=(const ProxyBase&) = delete;
+
     /**
      * \api
      * \brief Tries to find a service that matches the given specifier synchronously.
@@ -124,11 +129,6 @@ class ProxyBase
         std::map<std::string_view, std::reference_wrapper<ReferenceToMoveable<ProxyFieldBase>::Reference>>;
     using ProxyMethods =
         std::map<std::string_view, std::reference_wrapper<ReferenceToMoveable<ProxyMethodBase>::Reference>>;
-
-    /// \brief A Proxy shall not be copyable
-    /// \requirement SWS_CM_00136
-    ProxyBase(const ProxyBase&) = delete;
-    ProxyBase& operator=(const ProxyBase&) = delete;
 
     /// \brief A Proxy shall be movable
     /// \requirement SWS_CM_00137

--- a/score/mw/com/impl/skeleton_event_base.h
+++ b/score/mw/com/impl/skeleton_event_base.h
@@ -50,6 +50,10 @@ class SkeletonEventBase : public EnableReferenceToMoveableFromThis<SkeletonEvent
 
     virtual ~SkeletonEventBase() = default;
 
+    /// \brief A SkeletonEventBase shall not be copyable
+    SkeletonEventBase(const SkeletonEventBase&) = delete;
+    SkeletonEventBase& operator=(const SkeletonEventBase&) & = delete;
+
     /// \brief Used to indicate that the event shall be available to consumer
     /// Performs binding independent functionality and then dispatches to the binding
     score::Result<void> PrepareOffer() noexcept
@@ -74,9 +78,6 @@ class SkeletonEventBase : public EnableReferenceToMoveableFromThis<SkeletonEvent
     }
 
   protected:
-    SkeletonEventBase(const SkeletonEventBase&) = delete;
-    SkeletonEventBase& operator=(const SkeletonEventBase&) & = delete;
-
     SkeletonEventBase(SkeletonEventBase&&) noexcept = default;
     SkeletonEventBase& operator=(SkeletonEventBase&&) & noexcept = default;
 


### PR DESCRIPTION
## Summary

Fixes all 204 `modernize-use-equals-delete` clang-tidy findings, all of which report "deleted member function should be public".

## Root cause

This category of finding has **no available FixIt** in clang-tidy: the check's autofix only adds `= delete` to a non-deleted function — it never relocates a declaration across access specifiers. Every flagged function here was already `= delete`, just placed under `protected`/`private` instead of `public`, so a manual fix was required (same category of limitation previously found for `misc-use-anonymous-namespace` in #1000).

## Scope

204 raw findings across 41 `.cpp` translation units collapse to **8 header files** where the flagged declarations actually live:

- `score/message_passing/i_client_connection.h`
- `score/message_passing/i_client_factory.h`
- `score/message_passing/i_server.h`
- `score/message_passing/i_server_connection.h`
- `score/message_passing/i_server_factory.h`
- `score/message_passing/i_shared_resource_engine.h`
- `score/mw/com/impl/proxy_base.h`
- `score/mw/com/impl/skeleton_event_base.h`

## Fix

Moved the deleted copy/move constructor and assignment operator declarations (with their doc comments) into each class's `public:` section, right after the destructor. Non-deleted (defaulted) constructors/destructors stay in their original `protected:` section. For `proxy_base.h` and `skeleton_event_base.h`, only the deleted **copy** members were relocated — the defaulted **move** members correctly remain protected (unflagged, unchanged).

## Verification

- `bazel build --config=clang-tidy` across `score/mw/com/...`, `score/message_passing/...`, `score/memory/...`, `quality/integration_testing/...` → **0 remaining `modernize-use-equals-delete` findings**, no new findings introduced.
- Plain `bazel build` over the same scope → compiles cleanly, no regressions.

This is a standalone PR per the maintainers' preference to keep each distinct clang-tidy concern isolated (see #995, #999, #1000 for prior examples in this series).
