### PR TITLE
Add integration test for mw::com add-on configurations

### DIFF
--- a/score/mw/com/test/common_test_resources/sample_sender_receiver.cpp
+++ b/score/mw/com/test/common_test_resources/sample_sender_receiver.cpp
@@ -608,6 +608,82 @@ int EventSenderReceiver::RunAsSkeleton(const score::mw::com::InstanceSpecifier& 
     return EXIT_SUCCESS;
 }
 
+int EventSenderReceiver::RunAsSkeletonWithNotificationExchange(
+    const score::mw::com::InstanceSpecifier& instance_specifier,
+    const std::chrono::milliseconds cycle_time,
+    const std::size_t num_cycles,
+    score::os::InterprocessNotification& interprocess_notification_from_proxy,
+    score::os::InterprocessNotification& interprocess_notification_to_proxy,
+    score::os::InterprocessNotification& interprocess_notification_subscribed_from_proxy,
+    const score::cpp::stop_token& stop_token)
+{
+    auto bigdata_result = BigDataSkeleton::Create(instance_specifier);
+    if (!bigdata_result.has_value())
+    {
+        std::cerr << "Unable to construct BigDataSkeleton: " << bigdata_result.error() << ", bailing!\n";
+        return EXIT_FAILURE;
+    }
+    auto& bigdata = bigdata_result.value();
+
+    const auto offer_result = bigdata.OfferService();
+    if (!offer_result.has_value())
+    {
+        std::cerr << "Unable to offer service for BigDataSkeleton: " << offer_result.error() << ", bailing!\n";
+        return EXIT_FAILURE;
+    }
+
+    // Let the proxy know the service is now offered and ready to be found/subscribed to.
+    interprocess_notification_to_proxy.notify();
+
+    // Only start sending once the proxy has explicitly confirmed that it has finished subscribing. Without this,
+    // samples sent before the proxy subscribes would be silently dropped/overwritten in the shared-memory ring
+    // buffer, and the proxy would then wait forever for samples that will never arrive.
+    if (!interprocess_notification_subscribed_from_proxy.waitWithAbort(stop_token))
+    {
+        std::cerr << "Request stop on stop token while waiting for proxy to subscribe. Exiting.\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "Starting to send data\n";
+
+    for (std::size_t cycle = 0U; cycle < num_cycles && !stop_token.stop_requested(); ++cycle)
+    {
+        auto sample_result = PrepareMapLaneSample(bigdata, cycle);
+        if (!sample_result.has_value())
+        {
+            std::cerr << "No sample received. Exiting.\n";
+            return EXIT_FAILURE;
+        }
+        auto sample = std::move(sample_result).value();
+
+        {
+            std::lock_guard<std::mutex> lock{event_sending_mutex_};
+            const auto send_result = bigdata.map_api_lanes_stamped_.Send(std::move(sample));
+            if (!send_result.has_value())
+            {
+                std::cerr << "Unable to send data. Exiting.\n";
+                return EXIT_FAILURE;
+            }
+            event_published_ = true;
+        }
+        std::this_thread::sleep_for(cycle_time);
+    }
+
+    // Stop offer once the proxy has confirmed that it received everything it needed.
+    // This should avoid racing StopOfferService() against the proxy's final GetNewSamples() call.
+    if (!interprocess_notification_from_proxy.waitWithAbort(stop_token))
+    {
+        std::cerr << "Request stop on stop token while waiting for proxy to finish. Exiting.\n";
+        return EXIT_FAILURE;
+    }
+
+    std::cout << "Stop offering service...";
+    bigdata.StopOfferService();
+    std::cout << "and terminating, bye bye\n";
+
+    return EXIT_SUCCESS;
+}
+
 int EventSenderReceiver::RunAsSkeletonWaitForProxy(const score::mw::com::InstanceSpecifier& instance_specifier,
                                                    score::os::InterprocessNotification& interprocess_notification,
                                                    const score::cpp::stop_token& stop_token)
@@ -875,6 +951,105 @@ int EventSenderReceiver::RunAsProxyCheckValuesCreatedFromConfig(
     std::cout << "and terminating, bye bye\n";
 
     // Tell the skeleton that the proxy has finished.
+    interprocess_notification_to_skeleton.notify();
+
+    return EXIT_SUCCESS;
+}
+
+int EventSenderReceiver::RunAsProxyWithNotificationExchange(
+    const score::mw::com::InstanceSpecifier& instance_specifier,
+    const std::chrono::milliseconds cycle_time,
+    const std::size_t num_cycles,
+    score::os::InterprocessNotification& interprocess_notification_from_skeleton,
+    score::os::InterprocessNotification& interprocess_notification_to_skeleton,
+    score::os::InterprocessNotification& interprocess_notification_subscribed_to_skeleton,
+    const score::cpp::stop_token& stop_token)
+{
+    constexpr const std::size_t SAMPLES_PER_CYCLE = 2U;
+
+    // Wait until the skeleton has offered the service before attempting to find it and subscribe
+    if (!interprocess_notification_from_skeleton.waitWithAbort(stop_token))
+    {
+        std::cerr << "Request stop on stop token while waiting for skeleton to offer service. Exiting.\n";
+        return EXIT_FAILURE;
+    }
+
+    auto handle_result = GetHandleFromSpecifier(instance_specifier, stop_token);
+    if (!handle_result.has_value())
+    {
+        std::cerr << "Unable to find service: " << instance_specifier
+                  << ". Failed with error: " << handle_result.error() << ", bailing!\n";
+        return EXIT_FAILURE;
+    }
+    auto handle = handle_result.value();
+
+    auto proxy_result = BigDataProxy::Create(std::move(handle));
+    if (!proxy_result.has_value())
+    {
+        std::cerr << "Unable to construct BigDataProxy: " << proxy_result.error() << ", bailing!\n";
+        return EXIT_FAILURE;
+    }
+    auto& bigdata = proxy_result.value();
+    auto& map_api_lanes_stamped_event = bigdata.map_api_lanes_stamped_;
+
+    std::cout << ToString(instance_specifier, ": Subscribing to service\n");
+    const auto subscribe_result = map_api_lanes_stamped_event.Subscribe(SAMPLES_PER_CYCLE);
+    if (!subscribe_result.has_value())
+    {
+        std::cerr << "Unable to subscribe to event: " << subscribe_result.error() << ", bailing!\n";
+        return EXIT_FAILURE;
+    }
+
+    // Inform the skeleton that proxy subscribed, so it can start sending. Used to avoid that sender sends
+    // before proxy subscribed and samples could get "lost" in buffer, which would not be detected on proxy side.
+    interprocess_notification_subscribed_to_skeleton.notify();
+
+    SampleReceiver receiver{instance_specifier};
+    for (std::size_t cycle = 0U; (cycle < num_cycles) && !stop_token.stop_requested();)
+    {
+        std::this_thread::sleep_for(cycle_time);
+
+        const auto received_before = receiver.GetReceivedSampleCount();
+        Result<std::size_t> num_samples_received = map_api_lanes_stamped_event.GetNewSamples(
+            [&receiver](SamplePtr<MapApiLanesStamped> sample) noexcept {
+                const MapApiLanesStamped& sample_value = GetSamplePtrValue(sample.get());
+                receiver.ReceiveSample(sample_value);
+            },
+            SAMPLES_PER_CYCLE);
+        const auto received = receiver.GetReceivedSampleCount() - received_before;
+
+        const bool get_new_samples_api_error = !num_samples_received.has_value();
+        const bool mismatch_api_returned_receive_count_vs_sample_callbacks =
+            !get_new_samples_api_error && (*num_samples_received != received);
+
+        if (get_new_samples_api_error || mismatch_api_returned_receive_count_vs_sample_callbacks)
+        {
+            std::stringstream ss;
+            ss << instance_specifier << ": Error in cycle " << cycle << " during sample reception: ";
+            if (mismatch_api_returned_receive_count_vs_sample_callbacks)
+            {
+                ss << "number of received samples doesn't match to what IPC claims: " << *num_samples_received << " vs "
+                   << received;
+            }
+            else
+            {
+                ss << std::move(num_samples_received).error();
+            }
+            ss << ", terminating.\n";
+            std::cerr << ss.str();
+
+            map_api_lanes_stamped_event.Unsubscribe();
+            return EXIT_FAILURE;
+        }
+
+        cycle += *num_samples_received;
+    }
+
+    std::cout << ToString(instance_specifier, ": Unsubscribing...\n");
+    map_api_lanes_stamped_event.Unsubscribe();
+    std::cout << ToString(instance_specifier, ": and terminating, bye bye\n");
+
+    // Tell the skeleton that we're done, so it's safe for it to stop offering the service.
     interprocess_notification_to_skeleton.notify();
 
     return EXIT_SUCCESS;

--- a/score/mw/com/test/common_test_resources/sample_sender_receiver.h
+++ b/score/mw/com/test/common_test_resources/sample_sender_receiver.h
@@ -56,6 +56,25 @@ class EventSenderReceiver
                                   score::os::InterprocessNotification& interprocess_notification,
                                   const score::cpp::stop_token& stop_token);
 
+    /**
+     * Basically the same as RunAsSkeleton(), but with 3 InterprocessNotification parameters that allow to inform
+     * the other process (RunAsProxyWithNotificationExchange()) about the current status of the communication.
+     * Those state notification objects are used to avoid races if services are offered/received multiple times.
+     *    @param interprocess_notification_to_proxy Notify proxy that service has been offered
+     *    @param interprocess_notification_from_proxy Proxy notifies skeleton that everything was received (so skeleton
+     * can stop offering service)
+     *    @param interprocess_notification_subscribed_from_proxy Proxy notifies skeleton that it has finished
+     * subscribing (so skeleton can start sending samples)
+     */
+    int RunAsSkeletonWithNotificationExchange(
+        const score::mw::com::InstanceSpecifier& instance_specifier,
+        const std::chrono::milliseconds cycle_time,
+        const std::size_t num_cycles,
+        score::os::InterprocessNotification& interprocess_notification_from_proxy,
+        score::os::InterprocessNotification& interprocess_notification_to_proxy,
+        score::os::InterprocessNotification& interprocess_notification_subscribed_from_proxy,
+        const score::cpp::stop_token& stop_token);
+
     template <typename ProxyType = score::mw::com::test::BigDataProxy,
               typename ProxyEventType = score::mw::com::impl::ProxyEvent<MapApiLanesStamped>>
     int RunAsProxy(const score::mw::com::InstanceSpecifier& instance_specifier,
@@ -70,6 +89,22 @@ class EventSenderReceiver
      */
     int RunAsProxyReceiveHandlerOnly(const score::mw::com::InstanceSpecifier& instance_specifier,
                                      const score::cpp::stop_token& stop_token);
+
+    /**
+     * Counterpart of RunAsSkeletonWithNotificationExchange(): Similar to RunAsProxy() but with 3
+     * InterProcessNotification parameters to exchange state information with the skeleton process.
+     * @param interprocess_notification_from_skeleton Skeleton notifies about service offered
+     * @param interprocess_notification_to_skeleton Inform skeleton that all data was received
+     * @param interprocess_notification_subscribed_to_skeleton Inform skeleton that proxy has subscribed
+     */
+    int RunAsProxyWithNotificationExchange(
+        const score::mw::com::InstanceSpecifier& instance_specifier,
+        const std::chrono::milliseconds cycle_time,
+        const std::size_t num_cycles,
+        score::os::InterprocessNotification& interprocess_notification_from_skeleton,
+        score::os::InterprocessNotification& interprocess_notification_to_skeleton,
+        score::os::InterprocessNotification& interprocess_notification_subscribed_to_skeleton,
+        const score::cpp::stop_token& stop_token);
 
     int RunAsProxyCheckEventSlots(const score::mw::com::InstanceSpecifier& instance_specifier,
                                   const std::uint16_t num_proxy_slots,

--- a/score/mw/com/test/loading_add_on_configuration/BUILD
+++ b/score/mw/com/test/loading_add_on_configuration/BUILD
@@ -1,0 +1,61 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:defs.bzl", "cc_binary")
+load("@score_baselibs//score/language/safecpp:toolchain_features.bzl", "COMPILER_WARNING_FEATURES")
+load("//score/mw/com/test:pkg_application.bzl", "pkg_application")
+
+exports_files(
+    ["logging.json"],
+    visibility = ["//score/mw/com/test:__subpackages__"],
+)
+
+cc_binary(
+    name = "add_on_loading_app",
+    srcs = [
+        "add_on_loading_application.cpp",
+        "add_on_loading_application.h",
+    ],
+    data = [
+        "mw_com_add_on_config.json",
+        "mw_com_config.json",
+    ],
+    features = COMPILER_WARNING_FEATURES + [
+        "aborts_upon_exception",
+    ],
+    deps = [
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:assert_handler",
+        "//score/mw/com/test/common_test_resources:command_line_parser",
+        "//score/mw/com/test/common_test_resources:sample_sender_receiver",
+        "//score/mw/com/test/common_test_resources:sctf_test_runner",
+        "//score/mw/com/test/common_test_resources:shared_memory_object_creator",
+        "//score/mw/com/test/common_test_resources:shared_memory_object_guard",
+    ],
+)
+
+pkg_application(
+    name = "add_on_loading-pkg",
+    app_name = "add_on_loading_app",
+    bin = [":add_on_loading_app"],
+    etc = [
+        "logging.json",
+        "mw_com_config.json",
+        "mw_com_add_on_config.json",
+    ],
+    visibility = [
+        "//platform/aas/test/mw/com:__pkg__",
+        "//pqr/abc/abc-lmn/config/project/cpu/os/hardware/hypervisor:__subpackages__",
+        "//score/mw/com/test/loading_add_on_configuration:__subpackages__",
+    ],
+)

--- a/score/mw/com/test/loading_add_on_configuration/add_on_loading_application.cpp
+++ b/score/mw/com/test/loading_add_on_configuration/add_on_loading_application.cpp
@@ -1,0 +1,310 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+#include "score/mw/com/test/loading_add_on_configuration/add_on_loading_application.h"
+
+#include "score/mw/com/test/common_test_resources/command_line_parser.h"
+
+#include "score/mw/com/test/common_test_resources/assert_handler.h"
+#include "score/mw/com/test/common_test_resources/sample_sender_receiver.h"
+#include "score/mw/com/test/common_test_resources/sctf_test_runner.h"
+#include "score/mw/com/test/common_test_resources/shared_memory_object_creator.h"
+#include "score/mw/com/test/common_test_resources/shared_memory_object_guard.h"
+#include "score/os/utils/interprocess/interprocess_notification.h"
+
+#include <score/assert.hpp>
+
+#include <cstdlib>
+#include <iostream>
+#include <map>
+#include <utility>
+#include <vector>
+
+using namespace std::chrono_literals;
+
+namespace
+{
+
+std::string ParseServiceInstanceManifest(int argc, const char** argv)
+{
+    const std::string service_instance_manifest_name = "addon_manifest";
+
+    auto args = score::mw::com::test::ParseCommandLineArguments(argc, argv, {{service_instance_manifest_name, ""}});
+    return score::mw::com::test::GetValue<std::string>(args, service_instance_manifest_name);
+}
+
+// Named shared-memory paths for the InterprocessNotification triples used to explicitly exchange state information
+// between sender and receiver across the 3 communication phases of this test. Each phase gets its own triple so
+// that phases can ever interfere with one another:
+//  - "offered" is notified by the skeleton once it has offered the service (the proxy must wait for this before
+//    finding/subscribing);
+//  - "subscribed" is notified by the proxy once it has finished subscribing (the skeleton must wait for this
+//    before it starts sending, so no samples are published before there is a subscriber to receive them);
+//  - "done" is notified by the proxy once it has received everything it needs (the skeleton must wait for this
+//    before calling StopOfferService()).
+const std::string kPhase1OfferedShmPath{"/addon_test_phase1_offered"};
+const std::string kPhase1SubscribedShmPath{"/addon_test_phase1_subscribed"};
+const std::string kPhase1DoneShmPath{"/addon_test_phase1_done"};
+const std::string kPhase2OfferedShmPath{"/addon_test_phase2_offered"};
+const std::string kPhase2SubscribedShmPath{"/addon_test_phase2_subscribed"};
+const std::string kPhase2DoneShmPath{"/addon_test_phase2_done"};
+const std::string kPhase3OfferedShmPath{"/addon_test_phase3_offered"};
+const std::string kPhase3SubscribedShmPath{"/addon_test_phase3_subscribed"};
+const std::string kPhase3DoneShmPath{"/addon_test_phase3_done"};
+
+// All 9 shared-memory paths used by the notification exchange, shared between the sender and receiver branches.
+const std::vector<std::string> kAllShmPaths{
+    kPhase1OfferedShmPath,
+    kPhase1SubscribedShmPath,
+    kPhase1DoneShmPath,
+    kPhase2OfferedShmPath,
+    kPhase2SubscribedShmPath,
+    kPhase2DoneShmPath,
+    kPhase3OfferedShmPath,
+    kPhase3SubscribedShmPath,
+    kPhase3DoneShmPath,
+};
+
+// RAII helper that creates/opens a SharedMemoryObjectCreator<InterprocessNotification> for each given
+// shared-memory path and keeps a SharedMemoryObjectGuard alongside it so that all objects are
+// cleaned up automatically.
+class InterprocessNotificationSet final
+{
+  public:
+    explicit InterprocessNotificationSet(const std::vector<std::string>& shared_memory_paths)
+    {
+        for (const auto& path : shared_memory_paths)
+        {
+            auto creator_result = score::mw::com::test::SharedMemoryObjectCreator<
+                score::os::InterprocessNotification>::CreateOrOpenObject(path);
+            if (!creator_result.has_value())
+            {
+                valid_ = false;
+                return;
+            }
+            auto [iterator, inserted] = creators_.try_emplace(path, std::move(creator_result).value());
+            static_cast<void>(inserted);
+            guards_.try_emplace(path, iterator->second);
+        }
+    }
+
+    ~InterprocessNotificationSet() = default;
+
+    InterprocessNotificationSet(const InterprocessNotificationSet&) = delete;
+    InterprocessNotificationSet& operator=(const InterprocessNotificationSet&) = delete;
+    InterprocessNotificationSet(InterprocessNotificationSet&&) = delete;
+    InterprocessNotificationSet& operator=(InterprocessNotificationSet&&) = delete;
+
+    bool IsValid() const noexcept
+    {
+        return valid_;
+    }
+
+    score::os::InterprocessNotification& Get(const std::string& shared_memory_path)
+    {
+        return creators_.at(shared_memory_path).GetObject();
+    }
+
+  private:
+    bool valid_{true};
+    // Declaration order matters here: members are destroyed in reverse declaration order, so guards_ (which
+    // hold references into creators_) are destroyed first, and creators_ (the referents) are destroyed after.
+    std::map<std::string, score::mw::com::test::SharedMemoryObjectCreator<score::os::InterprocessNotification>>
+        creators_;
+    std::map<std::string, score::mw::com::test::SharedMemoryObjectGuard<score::os::InterprocessNotification>> guards_;
+};
+
+score::mw::com::InstanceSpecifier GetInstanceSpecifier(const std::string& specifier_string)
+{
+    const auto instance_specifier_result = score::mw::com::InstanceSpecifier::Create(specifier_string);
+    if (!instance_specifier_result.has_value())
+    {
+        std::cerr << "Invalid instance specifier, terminating." << std::endl;
+        std::terminate();
+    }
+    return instance_specifier_result.value();
+}
+
+}  // namespace
+
+int main(int argc, const char** argv)
+{
+    score::mw::com::test::SetupAssertHandler();
+    using Parameters = score::mw::com::test::SctfTestRunner::RunParameters::Parameters;
+
+    const std::vector<Parameters> allowed_parameters{
+        Parameters::MODE, Parameters::NUM_CYCLES, Parameters::CYCLE_TIME, Parameters::SERVICE_INSTANCE_MANIFEST};
+    score::mw::com::test::SctfTestRunner test_runner(argc, argv, allowed_parameters);
+    const auto& run_parameters = test_runner.GetRunParameters();
+    const auto mode = run_parameters.GetMode();
+    const auto num_cycles = run_parameters.GetNumCycles();
+    const auto stop_token = test_runner.GetStopToken();
+
+    score::mw::com::test::EventSenderReceiver event_sender_receiver{};
+
+    const auto& instance_specifier = GetInstanceSpecifier(std::string{"score/cp60/MapApiLanesStamped"});
+
+    if (mode == "send" || mode == "skeleton")
+    {
+        const auto cycle_time = run_parameters.GetCycleTime();
+
+        // Create inter process notifications used to share state between the 2 applications
+        InterprocessNotificationSet notifications{kAllShmPaths};
+        if (!notifications.IsValid())
+        {
+            std::cerr << "Sender: Failed to create/open interprocess notification objects, terminating." << std::endl;
+            return EXIT_FAILURE;
+        }
+
+        // 1st send phase: Send service from original configuration
+        const auto first_send_result =
+            event_sender_receiver.RunAsSkeletonWithNotificationExchange(instance_specifier,
+                                                                        cycle_time,
+                                                                        num_cycles,
+                                                                        notifications.Get(kPhase1DoneShmPath),
+                                                                        notifications.Get(kPhase1OfferedShmPath),
+                                                                        notifications.Get(kPhase1SubscribedShmPath),
+                                                                        stop_token);
+
+        if (first_send_result != EXIT_SUCCESS)
+        {
+            return first_send_result;
+        }
+
+        // Load add-on configuration
+        const auto service_instance_manifest_path = ParseServiceInstanceManifest(argc, argv);
+        const auto add_on_load_result = score::mw::com::runtime::InitializeRuntimeAddonConfiguration(
+            score::mw::com::runtime::RuntimeConfiguration{service_instance_manifest_path});
+
+        if (!add_on_load_result.has_value())
+        {
+            std::cout << "Sender: Failed to load add-on configuration: " << add_on_load_result.error() << std::endl;
+            return EXIT_FAILURE;
+        }
+
+        // After loading add-on config. 2nd send phase: Try to send initial service again
+        const auto second_send_result =
+            event_sender_receiver.RunAsSkeletonWithNotificationExchange(instance_specifier,
+                                                                        cycle_time,
+                                                                        num_cycles,
+                                                                        notifications.Get(kPhase2DoneShmPath),
+                                                                        notifications.Get(kPhase2OfferedShmPath),
+                                                                        notifications.Get(kPhase2SubscribedShmPath),
+                                                                        stop_token);
+
+        if (second_send_result != EXIT_SUCCESS)
+        {
+            std::cerr << "Sender: Failed to offer initial service again after add-on configuration was loaded"
+                      << std::endl;
+            return EXIT_FAILURE;
+        }
+
+        const auto& addon_instance_specifier = GetInstanceSpecifier("score/cp60/MapApiLanes");
+        // 3rd send phase: Try to send new service defined in add-on configuration
+        const auto addon_send_result =
+            event_sender_receiver.RunAsSkeletonWithNotificationExchange(addon_instance_specifier,
+                                                                        cycle_time,
+                                                                        num_cycles,
+                                                                        notifications.Get(kPhase3DoneShmPath),
+                                                                        notifications.Get(kPhase3OfferedShmPath),
+                                                                        notifications.Get(kPhase3SubscribedShmPath),
+                                                                        stop_token);
+
+        if (addon_send_result != EXIT_SUCCESS)
+        {
+            std::cerr << "Sender: Failed to offer new add-on service" << std::endl;
+            return EXIT_FAILURE;
+        }
+
+        return EXIT_SUCCESS;
+    }
+    else if (mode == "recv" || mode == "proxy")
+    {
+        const auto cycle_time = run_parameters.GetCycleTime();
+
+        // Create inter process notifications used to share state between the 2 applications
+        InterprocessNotificationSet notifications{kAllShmPaths};
+        if (!notifications.IsValid())
+        {
+            std::cerr << "Receiver: Failed to create/open interprocess notification objects, terminating." << std::endl;
+            return EXIT_FAILURE;
+        }
+
+        // 1st receive phase: Try to receive service from original configuration
+        const auto first_receiv_result =
+            event_sender_receiver.RunAsProxyWithNotificationExchange(instance_specifier,
+                                                                     cycle_time,
+                                                                     num_cycles,
+                                                                     notifications.Get(kPhase1OfferedShmPath),
+                                                                     notifications.Get(kPhase1DoneShmPath),
+                                                                     notifications.Get(kPhase1SubscribedShmPath),
+                                                                     stop_token);
+
+        if (first_receiv_result != EXIT_SUCCESS)
+        {
+            return first_receiv_result;
+        }
+
+        // Initial communication was successful, load add-on configuration
+        const auto service_instance_manifest_path = ParseServiceInstanceManifest(argc, argv);
+        const auto add_on_load_result = score::mw::com::runtime::InitializeRuntimeAddonConfiguration(
+            score::mw::com::runtime::RuntimeConfiguration{service_instance_manifest_path});
+
+        if (!add_on_load_result.has_value())
+        {
+            std::cout << "Receiver: Failed to load add-on configuration on receiver side: "
+                      << add_on_load_result.error() << std::endl;
+            return EXIT_FAILURE;
+        }
+
+        // Add-on configuration successfully loaded. 2nd receive phase: Try to receive first service again
+        const auto second_receiv_result =
+            event_sender_receiver.RunAsProxyWithNotificationExchange(instance_specifier,
+                                                                     cycle_time,
+                                                                     num_cycles,
+                                                                     notifications.Get(kPhase2OfferedShmPath),
+                                                                     notifications.Get(kPhase2DoneShmPath),
+                                                                     notifications.Get(kPhase2SubscribedShmPath),
+                                                                     stop_token);
+
+        if (second_receiv_result != EXIT_SUCCESS)
+        {
+            std::cerr << "Receiver: Failed to receive initial service again after add-on configuration was loaded"
+                      << std::endl;
+            return EXIT_FAILURE;
+        }
+
+        const auto& addon_instance_specifier = GetInstanceSpecifier("score/cp60/MapApiLanes");
+
+        // 3rd receive phase: Receive service defined in add-on configuration
+        const auto addon_receiv_result =
+            event_sender_receiver.RunAsProxyWithNotificationExchange(addon_instance_specifier,
+                                                                     cycle_time,
+                                                                     num_cycles,
+                                                                     notifications.Get(kPhase3OfferedShmPath),
+                                                                     notifications.Get(kPhase3DoneShmPath),
+                                                                     notifications.Get(kPhase3SubscribedShmPath),
+                                                                     stop_token);
+
+        if (addon_receiv_result != EXIT_SUCCESS)
+        {
+            std::cerr << "Receiver: Failed to receive new add-on service" << std::endl;
+            return EXIT_FAILURE;
+        }
+
+        return EXIT_SUCCESS;
+    }
+
+    std::cerr << "Unknown mode " << mode << ", terminating." << std::endl;
+    return EXIT_FAILURE;
+}

--- a/score/mw/com/test/loading_add_on_configuration/add_on_loading_application.h
+++ b/score/mw/com/test/loading_add_on_configuration/add_on_loading_application.h
@@ -1,0 +1,17 @@
+/*******************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ *******************************************************************************/
+
+#ifndef SCORE_MW_COM_TEST_ADD_ON_LOADING_APPLICATION_H
+#define SCORE_MW_COM_TEST_ADD_ON_LOADING_APPLICATION_H
+
+#endif  // SCORE_MW_COM_TEST_ADD_ON_LOADING_APPLICATION_H

--- a/score/mw/com/test/loading_add_on_configuration/integration_test/BUILD
+++ b/score/mw/com/test/loading_add_on_configuration/integration_test/BUILD
@@ -1,0 +1,22 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+load("//quality/integration_testing:integration_testing.bzl", "integration_test")
+
+integration_test(
+    name = "test_add_on_config_loading",
+    timeout = "moderate",
+    srcs = [
+        "test_loading_add_on_config.py",
+    ],
+    filesystem = "//score/mw/com/test/loading_add_on_configuration:add_on_loading-pkg",
+)

--- a/score/mw/com/test/loading_add_on_configuration/integration_test/test_loading_add_on_config.py
+++ b/score/mw/com/test/loading_add_on_configuration/integration_test/test_loading_add_on_config.py
@@ -1,0 +1,43 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+
+def add_on_config_loading(target, mode, cycle_time=None, num_cycles=None, **kwargs):
+    args = ["--mode", mode, "--addon_manifest", "./etc/mw_com_add_on_config.json"]
+    if num_cycles is not None:
+        args += ["--num-cycles", str(num_cycles)]
+    if cycle_time is not None:
+        args += ["--cycle-time", str(cycle_time)]
+
+    return target.wrap_exec("bin/add_on_loading_app", args, cwd="/opt/add_on_loading_app", wait_on_exit=True, **kwargs)
+
+
+def test_add_on_config_loading(target):
+    """Tests loading and merging of add-on configurations with two applications"""
+    # One application is providing services, the other one is receiving the services, both will load an
+    # add-on configuration.
+    # The applications perform three communication phases:
+    # - providing/receiving a service defined in the initial configuration
+    # - providing/receiving the same service after the add-on configuratin has been loaded and merged
+    # - providing/receiving a new service that has been loaded from the add-on configuration
+    # Each phase is explicitly hand-shaken via
+    # a pair of InterprocessNotification objects (see RunAsSkeletonWithHandshake/
+    # RunAsProxyWithHandshake in sample_sender_receiver.cpp): the skeleton only calls
+    # StopOfferService() after the proxy has confirmed it received everything it needs, and the
+    # proxy only starts looking for/subscribing to the service after the skeleton has confirmed it
+    # is offered.
+    with (
+        add_on_config_loading(target, "send", cycle_time=40, num_cycles=10, wait_timeout=120),
+        add_on_config_loading(target, "recv", cycle_time=40, num_cycles=10, wait_timeout=120),
+    ):
+        pass

--- a/score/mw/com/test/loading_add_on_configuration/logging.json
+++ b/score/mw/com/test/loading_add_on_configuration/logging.json
@@ -1,0 +1,8 @@
+{
+  "appId": "ADDONL",
+  "appDesc": "addonloader",
+  "logLevel": "kDebug",
+  "logLevelThresholdConsole": "kDebug",
+  "logMode": "kRemote|kConsole",
+  "dynamicDatarouterIdentifiers" : true
+}

--- a/score/mw/com/test/loading_add_on_configuration/mw_com_add_on_config.json
+++ b/score/mw/com/test/loading_add_on_configuration/mw_com_add_on_config.json
@@ -1,0 +1,68 @@
+{
+  "serviceTypes": [
+    {
+      "serviceTypeName": "/score/adp/MapApiLanes",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "bindings": [
+        {
+          "binding": "SHM",
+          "serviceId": 6433,
+          "events": [
+            {
+              "eventName": "map_api_lanes_stamped",
+              "eventId": 1
+            },
+            {
+              "eventName": "dummy_data_stamped",
+              "eventId": 2
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "serviceInstances": [
+    {
+      "instanceSpecifier": "score/cp60/MapApiLanes",
+      "serviceTypeName": "/score/adp/MapApiLanes",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "instances": [
+        {
+          "instanceId": 1,
+          "allowedConsumer": {
+            "QM": [
+              4002,
+              0
+            ]
+          },
+          "allowedProvider": {
+            "QM": [
+              4001,
+              0
+            ]
+          },
+          "asil-level": "QM",
+          "binding": "SHM",
+          "events": [
+            {
+              "eventName": "map_api_lanes_stamped",
+              "numberOfSampleSlots": 10,
+              "maxSubscribers": 3
+            },
+            {
+              "eventName": "dummy_data_stamped",
+              "maxSamples": 10,
+              "maxSubscribers": 3
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}

--- a/score/mw/com/test/loading_add_on_configuration/mw_com_config.json
+++ b/score/mw/com/test/loading_add_on_configuration/mw_com_config.json
@@ -1,0 +1,83 @@
+{
+  "serviceTypes": [
+    {
+      "serviceTypeName": "/score/adp/MapApiLanesStamped",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "bindings": [
+        {
+          "binding": "SHM",
+          "serviceId": 6432,
+          "events": [
+            {
+              "eventName": "map_api_lanes_stamped",
+              "eventId": 1
+            },
+            {
+              "eventName": "dummy_data_stamped",
+              "eventId": 2
+            }
+          ]
+        }
+      ]
+    },
+    {
+      "serviceTypeName": "/bmw/adp/DummyServiceType",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "bindings": [
+        {
+          "binding": "SHM",
+          "serviceId": 6433,
+          "events": [
+          ]
+        }
+      ]
+    }
+  ],
+  "serviceInstances": [
+    {
+      "instanceSpecifier": "score/cp60/MapApiLanesStamped",
+      "serviceTypeName": "/score/adp/MapApiLanesStamped",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "instances": [
+        {
+          "instanceId": 1,
+          "allowedConsumer": {
+            "QM": [
+              4002,
+              0
+            ]
+          },
+          "allowedProvider": {
+            "QM": [
+              4001,
+              0
+            ]
+          },
+          "asil-level": "QM",
+          "binding": "SHM",
+          "events": [
+            {
+              "eventName": "map_api_lanes_stamped",
+              "numberOfSampleSlots": 10,
+              "maxSubscribers": 3
+            },
+            {
+              "eventName": "dummy_data_stamped",
+              "maxSamples": 10,
+              "maxSubscribers": 3
+            }
+          ]
+        }
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
This integration tests ensures that after merging two configurations, an existing instance identifer is still valid and can be used for communication. Also new service instances as defined in the add-on configuration can be created.