### PR TITLE
fix(clang-tidy): resolve bugprone-suspicious-stringview-data-usage findings

### DIFF
--- a/score/mw/com/gateway/gateway_application/configuration/gateway_config_parser.cpp
+++ b/score/mw/com/gateway/gateway_application/configuration/gateway_config_parser.cpp
@@ -36,8 +36,7 @@ auto ParseForwardedServices(const score::json::Any& json) noexcept -> std::vecto
     std::vector<std::string> forwarded_services{};
     if (json.As<score::json::Object>().has_value())
     {
-        const auto& forwarded_services_entry =
-            json.As<score::json::Object>().value().get().find(kForwardedServicesKey.data());
+        const auto& forwarded_services_entry = json.As<score::json::Object>().value().get().find(kForwardedServicesKey);
 
         if (forwarded_services_entry != json.As<score::json::Object>().value().get().cend())
         {
@@ -56,8 +55,7 @@ auto ParseReceivedServices(const score::json::Any& json) noexcept -> std::vector
 
     if (json.As<score::json::Object>().has_value())
     {
-        const auto& received_services_entry =
-            json.As<score::json::Object>().value().get().find(kReceivedServicesKey.data());
+        const auto& received_services_entry = json.As<score::json::Object>().value().get().find(kReceivedServicesKey);
 
         if (received_services_entry != json.As<score::json::Object>().value().get().cend())
         {
@@ -77,21 +75,20 @@ auto ParseTransportLayerRef(const score::json::Any& json) noexcept -> std::pair<
 
     if (json.As<score::json::Object>().has_value())
     {
-        const auto& transport_layer_entry =
-            json.As<score::json::Object>().value().get().find(kTransportLayerKey.data());
+        const auto& transport_layer_entry = json.As<score::json::Object>().value().get().find(kTransportLayerKey);
 
         if (transport_layer_entry != json.As<score::json::Object>().value().get().cend())
         {
             const auto& tl_obj = transport_layer_entry->second.As<score::json::Object>();
             if (tl_obj.has_value())
             {
-                const auto& id_entry = tl_obj.value().get().find(kTransportLayerIdKey.data());
+                const auto& id_entry = tl_obj.value().get().find(kTransportLayerIdKey);
                 if (id_entry != tl_obj.value().get().cend())
                 {
                     transport_layer_id = id_entry->second.As<std::string>().value().get();
                 }
 
-                const auto& path_entry = tl_obj.value().get().find(kTransportConfigPathKey.data());
+                const auto& path_entry = tl_obj.value().get().find(kTransportConfigPathKey);
                 if (path_entry != tl_obj.value().get().cend())
                 {
                     transport_config_path = path_entry->second.As<std::string>().value().get();

--- a/score/mw/com/gateway/transport_layer/sample/configuration/sample_transport_config_parser.cpp
+++ b/score/mw/com/gateway/transport_layer/sample/configuration/sample_transport_config_parser.cpp
@@ -62,15 +62,15 @@ auto ParseSampleTransportConfig(score::json::Any json) noexcept -> HyperVisorSoc
 
     const auto& obj = top_level_object.value().get();
 
-    const auto socket_entry = obj.find(kHvSocketConfigurationKey.data());
+    const auto socket_entry = obj.find(kHvSocketConfigurationKey);
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(socket_entry != obj.cend(),
                                                 "hypervisor-socket is mandatory in sample transport configuration.");
 
     const auto& socket_obj = socket_entry->second.As<score::json::Object>().value().get();
 
-    const auto remote_ip = socket_obj.find(kRemoteIpKey.data());
-    const auto local_port = socket_obj.find(kLocalPortKey.data());
-    const auto remote_port = socket_obj.find(kRemotePortKey.data());
+    const auto remote_ip = socket_obj.find(kRemoteIpKey);
+    const auto local_port = socket_obj.find(kLocalPortKey);
+    const auto remote_port = socket_obj.find(kRemotePortKey);
 
     SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(remote_ip != socket_obj.cend(),
                                                 "remote-ip is mandatory in hypervisor-socket configuration.");
@@ -84,7 +84,7 @@ auto ParseSampleTransportConfig(score::json::Any json) noexcept -> HyperVisorSoc
     config.local_port_ = local_port->second.As<std::uint16_t>().value();
     config.remote_port_ = remote_port->second.As<std::uint16_t>().value();
 
-    const auto request_timeout = socket_obj.find(kRequestTimeoutMsKey.data());
+    const auto request_timeout = socket_obj.find(kRequestTimeoutMsKey);
     if (request_timeout != socket_obj.cend())
     {
         config.request_timeout_ms_ = request_timeout->second.As<std::uint32_t>().value();

--- a/score/mw/com/impl/configuration/configuration_json_parsing_strategy.cpp
+++ b/score/mw/com/impl/configuration/configuration_json_parsing_strategy.cpp
@@ -130,7 +130,7 @@ void AbortIfFound(const score::json::Object::const_iterator& iterator_to_element
 
 auto ParseInstanceSpecifier(const score::json::Object& json_map) -> InstanceSpecifier
 {
-    const auto& instanceSpecifierJson = json_map.find(kInstanceSpecifierKey.data());
+    const auto& instanceSpecifierJson = json_map.find(kInstanceSpecifierKey);
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(instanceSpecifierJson != json_map.cend(),
                                                       "Configuration corrupted, check with json schema");
 
@@ -143,7 +143,7 @@ auto ParseInstanceSpecifier(const score::json::Object& json_map) -> InstanceSpec
 
 auto ParseServiceTypeName(const score::json::Object& json_map) -> const std::string&
 {
-    const auto& serviceTypeName = json_map.find(kServiceTypeNameKey.data());
+    const auto& serviceTypeName = json_map.find(kServiceTypeNameKey);
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(serviceTypeName != json_map.cend(),
                                                       "Configuration corrupted, check with json schema");
 
@@ -155,7 +155,7 @@ auto ParseServiceTypeName(const score::json::Object& json_map) -> const std::str
 
 auto ParseVersion(const score::json::Object& json_map) -> std::pair<std::uint32_t, std::uint32_t>
 {
-    const auto& version = json_map.find(kVersionKey.data());
+    const auto& version = json_map.find(kVersionKey);
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(version != json_map.cend(),
                                                       "Configuration corrupted, check with json schema");
 
@@ -163,8 +163,8 @@ auto ParseVersion(const score::json::Object& json_map) -> std::pair<std::uint32_
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(version_obj.has_value(),
                                                       "Configuration corrupted, check with json schema");
     const auto& version_object = version_obj.value().get();
-    const auto major_version_number = version_object.find(kMajorVersionKey.data());
-    const auto minor_version_number = version_object.find(kMinorVersionKey.data());
+    const auto major_version_number = version_object.find(kMajorVersionKey);
+    const auto minor_version_number = version_object.find(kMinorVersionKey);
 
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(major_version_number != version_object.cend(),
                                                       "Configuration corrupted, check with json schema");
@@ -191,7 +191,7 @@ auto ParseServiceTypeIdentifier(const score::json::Object& json) -> ServiceIdent
 
 auto ParseAsilLevel(const score::json::Object& json_map) -> std::optional<QualityType>
 {
-    const auto& quality = json_map.find(kAsilKey.data());
+    const auto& quality = json_map.find(kAsilKey);
     if (quality != json_map.cend())
     {
         auto quality_result = quality->second.As<std::string>();
@@ -217,7 +217,7 @@ auto ParseAsilLevel(const score::json::Object& json_map) -> std::optional<Qualit
 
 auto ParseShmSizeCalcMode(const score::json::Object& json_map) -> std::optional<ShmSizeCalculationMode>
 {
-    const auto& shm_size_calc_mode = json_map.find(kShmSizeCalcModeKey.data());
+    const auto& shm_size_calc_mode = json_map.find(kShmSizeCalcModeKey);
     if (shm_size_calc_mode != json_map.cend())
     {
         auto mode_result = shm_size_calc_mode->second.As<std::string>();
@@ -258,7 +258,7 @@ auto ParseAllowedUser(const score::json::Object& json_map, std::string_view key)
     -> std::unordered_map<QualityType, std::vector<uid_t>>
 {
     std::unordered_map<QualityType, std::vector<uid_t>> user_map{};
-    auto allowed_user = json_map.find(key.data());
+    auto allowed_user = json_map.find(key);
 
     if (allowed_user != json_map.cend())
     {
@@ -351,10 +351,10 @@ class ServiceElementInstanceDeploymentParser
 
     std::optional<LolaEventInstanceDeployment::SampleSlotCountType> GetNumberOfSampleSlots()
     {
-        const auto& number_of_sample_slots_it = json_object_.find(kEventNumberOfSampleSlotsKey.data());
+        const auto& number_of_sample_slots_it = json_object_.find(kEventNumberOfSampleSlotsKey);
 
         // deprecation check "for max_samples"
-        const auto& max_samples_it = json_object_.find(kEventMaxSamplesKey.data());
+        const auto& max_samples_it = json_object_.find(kEventMaxSamplesKey);
         if (max_samples_it == json_object_.cend())
         {
             return RetrieveJsonElement<SampleSlotCountType>(number_of_sample_slots_it);
@@ -379,7 +379,7 @@ class ServiceElementInstanceDeploymentParser
 auto ParseLolaEventInstanceDeployment(const score::json::Object& json_map, LolaServiceInstanceDeployment& service)
     -> void
 {
-    const auto& events = json_map.find(kEventsKey.data());
+    const auto& events = json_map.find(kEventsKey);
     if (events == json_map.cend())
     {
         return;
@@ -400,7 +400,7 @@ auto ParseLolaEventInstanceDeployment(const score::json::Object& json_map, LolaS
 
         ServiceElementInstanceDeploymentParser deployment_parser{event_object};
 
-        const auto& event_name_it = event_object.find(kEventNameKey.data());
+        const auto& event_name_it = event_object.find(kEventNameKey);
         auto event_name_value = deployment_parser.GetName(event_name_it);
 
         const auto number_of_sample_slots = deployment_parser.GetNumberOfSampleSlots();
@@ -430,7 +430,7 @@ auto ParseLolaEventInstanceDeployment(const score::json::Object& json_map, LolaS
 auto ParseLolaFieldInstanceDeployment(const score::json::Object& json_map, LolaServiceInstanceDeployment& service)
     -> void
 {
-    const auto& fields = json_map.find(kFieldsKey.data());
+    const auto& fields = json_map.find(kFieldsKey);
     if (fields == json_map.cend())
     {
         return;
@@ -487,7 +487,7 @@ auto ParseLolaFieldInstanceDeployment(const score::json::Object& json_map, LolaS
 auto ParseLolaMethodInstanceDeployment(const score::json::Object& json_map, LolaServiceInstanceDeployment& service)
     -> void
 {
-    const auto& methods = json_map.find(kMethodsKey.data());
+    const auto& methods = json_map.find(kMethodsKey);
     if (methods == json_map.cend())
     {
         return;
@@ -577,7 +577,7 @@ auto ParseServiceElementTracingEnabled(const score::json::Object& json_map,
 
 auto ParsePermissionChecks(const score::json::Object& deployment_map) -> std::string_view
 {
-    const auto permission_checks = deployment_map.find(kPermissionChecksKey.data());
+    const auto permission_checks = deployment_map.find(kPermissionChecksKey);
     if (permission_checks != deployment_map.cend())
     {
         auto perm_result_obj = permission_checks->second.As<std::string>();
@@ -596,7 +596,7 @@ auto ParsePermissionChecks(const score::json::Object& deployment_map) -> std::st
 auto ParseLolaServiceInstanceDeployment(const score::json::Object& json_map) -> LolaServiceInstanceDeployment
 {
     LolaServiceInstanceDeployment service{};
-    const auto& found_shm_size = json_map.find(kLolaShmSizeKey.data());
+    const auto& found_shm_size = json_map.find(kLolaShmSizeKey);
     if (found_shm_size != json_map.cend())
     {
         const auto found_shm_size_casted = found_shm_size->second.As<std::uint64_t>();
@@ -606,7 +606,7 @@ auto ParseLolaServiceInstanceDeployment(const score::json::Object& json_map) -> 
         service.shared_memory_size_ = found_shm_size_value;
     }
 
-    const auto& found_control_asil_b_shm_size = json_map.find(kLolaControlAsilBShmSizeKey.data());
+    const auto& found_control_asil_b_shm_size = json_map.find(kLolaControlAsilBShmSizeKey);
     if (found_control_asil_b_shm_size != json_map.cend())
     {
         const auto found_control_asil_b_shm_size_casted = found_control_asil_b_shm_size->second.As<std::uint64_t>();
@@ -616,7 +616,7 @@ auto ParseLolaServiceInstanceDeployment(const score::json::Object& json_map) -> 
         service.control_asil_b_memory_size_ = found_control_asil_b_shm_size_value;
     }
 
-    const auto& found_control_qm_shm_size = json_map.find(kLolaControlQmShmSizeKey.data());
+    const auto& found_control_qm_shm_size = json_map.find(kLolaControlQmShmSizeKey);
     if (found_control_qm_shm_size != json_map.cend())
     {
         const auto found_control_qm_shm_size_casted = found_control_qm_shm_size->second.As<std::uint64_t>();
@@ -626,7 +626,7 @@ auto ParseLolaServiceInstanceDeployment(const score::json::Object& json_map) -> 
         service.control_qm_memory_size_ = found_control_qm_shm_size_value;
     }
 
-    const auto& instance_id = json_map.find(kInstanceIdKey.data());
+    const auto& instance_id = json_map.find(kInstanceIdKey);
     if (instance_id != json_map.cend())
     {
         const auto instance_id_casted = instance_id->second.As<LolaServiceInstanceId::InstanceId>();
@@ -636,7 +636,7 @@ auto ParseLolaServiceInstanceDeployment(const score::json::Object& json_map) -> 
         service.instance_id_ = LolaServiceInstanceId{instance_id_value};
     }
 
-    const auto& inter_vm_support = json_map.find(kInterVmSupport.data());
+    const auto& inter_vm_support = json_map.find(kInterVmSupport);
     if (inter_vm_support != json_map.cend())
     {
         service.inter_vm_support_ = inter_vm_support->second.As<bool>().value();
@@ -644,7 +644,7 @@ auto ParseLolaServiceInstanceDeployment(const score::json::Object& json_map) -> 
 
     // No need to check that binding is SHM for now, because this method is only called if binding is SHM.
 
-    const auto& inter_vm_forwarded = json_map.find(kInterVmForwarded.data());
+    const auto& inter_vm_forwarded = json_map.find(kInterVmForwarded);
     if (inter_vm_forwarded != json_map.cend())
     {
         service.inter_vm_forwarded_ = inter_vm_forwarded->second.As<bool>().value();
@@ -697,7 +697,7 @@ auto ParseServiceInstanceDeployments(const score::json::Object& json_map,
         SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(
             asil_level.has_value() && (asil_level.value() != QualityType::kInvalid),
             "Configuration corrupted, check with json schema");
-        const auto binding = deployment_map.find(kBindingKey.data());
+        const auto binding = deployment_map.find(kBindingKey);
         if (binding != deployment_map.cend())
         {
             auto bindingValue_result = binding->second.As<std::string>();
@@ -743,7 +743,7 @@ auto ParseServiceInstanceDeployments(const score::json::Object& json_map,
 auto ParseServiceInstances(const score::json::Object& object, TracingConfiguration& tracing_configuration)
     -> Configuration::ServiceInstanceDeployments
 {
-    const auto& servicesInstances = object.find(kServiceInstancesKey.data());
+    const auto& servicesInstances = object.find(kServiceInstancesKey);
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(servicesInstances != object.cend(),
                                                       "Configuration corrupted, check with json schema");
     Configuration::ServiceInstanceDeployments service_instance_deployments{};
@@ -777,7 +777,7 @@ auto ParseServiceInstances(const score::json::Object& object, TracingConfigurati
 // coverity[autosar_cpp14_a15_5_3_violation]
 void ParseLolaEventTypeDeployments(const score::json::Object& json_map, LolaServiceTypeDeployment& service)
 {
-    const auto& events = json_map.find(kEventsKey.data());
+    const auto& events = json_map.find(kEventsKey);
     if (events == json_map.cend())
     {
         return;
@@ -792,8 +792,8 @@ void ParseLolaEventTypeDeployments(const score::json::Object& json_map, LolaServ
         SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(event_obj.has_value(),
                                                           "Configuration corrupted, check with json schema");
         const auto& event_object = event_obj.value().get();
-        const auto& event_name = event_object.find(kEventNameKey.data());
-        const auto& event_id = event_object.find(kEventIdKey.data());
+        const auto& event_name = event_object.find(kEventNameKey);
+        const auto& event_id = event_object.find(kEventIdKey);
 
         SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(
             (event_name != event_object.cend()) && (event_id != event_object.cend()),
@@ -813,7 +813,7 @@ void ParseLolaEventTypeDeployments(const score::json::Object& json_map, LolaServ
 // coverity[autosar_cpp14_a15_5_3_violation]
 void ParseLolaFieldTypeDeployments(const score::json::Object& json_map, LolaServiceTypeDeployment& service)
 {
-    const auto& fields = json_map.find(kFieldsKey.data());
+    const auto& fields = json_map.find(kFieldsKey);
     if (fields == json_map.cend())
     {
         return;
@@ -829,8 +829,8 @@ void ParseLolaFieldTypeDeployments(const score::json::Object& json_map, LolaServ
         SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(field_obj.has_value(),
                                                           "Configuration corrupted, check with json schema");
         const auto& field_object = field_obj.value().get();
-        const auto& field_name = field_object.find(kFieldNameKey.data());
-        const auto& field_id = field_object.find(kFieldIdKey.data());
+        const auto& field_name = field_object.find(kFieldNameKey);
+        const auto& field_id = field_object.find(kFieldIdKey);
 
         SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(
             (field_name != field_object.cend()) && (field_id != field_object.cend()),
@@ -850,7 +850,7 @@ void ParseLolaFieldTypeDeployments(const score::json::Object& json_map, LolaServ
 // coverity[autosar_cpp14_a15_5_3_violation]
 void ParseLolaMethodTypeDeployments(const score::json::Object& json_map, LolaServiceTypeDeployment& service)
 {
-    const auto& methods = json_map.find(kMethodsKey.data());
+    const auto& methods = json_map.find(kMethodsKey);
     if (methods == json_map.cend())
     {
         return;
@@ -866,8 +866,8 @@ void ParseLolaMethodTypeDeployments(const score::json::Object& json_map, LolaSer
         SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(method_object_casted.has_value(),
                                                           "Configuration corrupted, check with json schema");
         const auto& method_object = method_object_casted.value().get();
-        const auto& method_name = method_object.find(kMethodNameKey.data());
-        const auto& method_id = method_object.find(kMethodIdKey.data());
+        const auto& method_name = method_object.find(kMethodNameKey);
+        const auto& method_id = method_object.find(kMethodIdKey);
 
         SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(
             (method_name != method_object.cend()) && (method_id != method_object.cend()),
@@ -887,7 +887,7 @@ void ParseLolaMethodTypeDeployments(const score::json::Object& json_map, LolaSer
 // coverity[autosar_cpp14_a15_5_3_violation]
 auto ParseLoLaServiceTypeDeployments(const score::json::Object& json_map) -> LolaServiceTypeDeployment
 {
-    const auto& service_id = json_map.find(kServiceIdKey.data());
+    const auto& service_id = json_map.find(kServiceIdKey);
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(service_id != json_map.cend(),
                                                       "Configuration corrupted, check with json schema");
 
@@ -906,7 +906,7 @@ auto ParseLoLaServiceTypeDeployments(const score::json::Object& json_map) -> Lol
 // coverity[autosar_cpp14_a15_5_3_violation]
 auto ParseServiceTypeDeployment(const score::json::Object& json_map) -> ServiceTypeDeployment
 {
-    const auto& bindings = json_map.find(kBindingsKey.data());
+    const auto& bindings = json_map.find(kBindingsKey);
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(bindings != json_map.cend(),
                                                       "Configuration corrupted, check with json schema");
 
@@ -920,7 +920,7 @@ auto ParseServiceTypeDeployment(const score::json::Object& json_map) -> ServiceT
         SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(binding_obj.has_value(),
                                                           "Configuration corrupted, check with json schema");
         const auto& binding_map = binding_obj.value().get();
-        auto binding_type = binding_map.find(kBindingKey.data());
+        auto binding_type = binding_map.find(kBindingKey);
         SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(binding_type != binding_map.cend(),
                                                           "Configuration corrupted, check with json schema");
 
@@ -946,7 +946,7 @@ auto ParseServiceTypeDeployment(const score::json::Object& json_map) -> ServiceT
 // coverity[autosar_cpp14_a15_5_3_violation]
 auto ParseServiceTypes(const score::json::Object& json_map) -> Configuration::ServiceTypeDeployments
 {
-    const auto& service_types = json_map.find(kServiceTypesKey.data());
+    const auto& service_types = json_map.find(kServiceTypesKey);
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(service_types != json_map.cend(),
                                                       "Configuration corrupted, check with json schema");
 
@@ -972,7 +972,7 @@ auto ParseServiceTypes(const score::json::Object& json_map) -> Configuration::Se
 auto ParseReceiverQueueSize(const score::json::Object& global_config_map, const QualityType quality_type)
     -> std::optional<std::int32_t>
 {
-    const auto& queue_size = global_config_map.find(kQueueSizeKey.data());
+    const auto& queue_size = global_config_map.find(kQueueSizeKey);
     if (queue_size != global_config_map.cend())
     {
         std::string_view queue_type_str{};
@@ -995,7 +995,7 @@ auto ParseReceiverQueueSize(const score::json::Object& global_config_map, const 
         SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(queue_size_obj.has_value(),
                                                           "Configuration corrupted, check with json schema");
         const auto& queue_size_map = queue_size_obj.value().get();
-        const auto& asil_queue_size = queue_size_map.find(queue_type_str.data());
+        const auto& asil_queue_size = queue_size_map.find(queue_type_str);
         if (asil_queue_size != queue_size_map.cend())
         {
             return score::ResultToOptionalOrElse(asil_queue_size->second.As<std::int32_t>(), [](const auto&) {
@@ -1016,7 +1016,7 @@ auto ParseReceiverQueueSize(const score::json::Object& global_config_map, const 
 
 auto ParseSenderQueueSize(const score::json::Object& global_config_map) -> std::optional<std::int32_t>
 {
-    const auto& queue_size = global_config_map.find(kQueueSizeKey.data());
+    const auto& queue_size = global_config_map.find(kQueueSizeKey);
     if (queue_size != global_config_map.cend())
     {
         auto queue_size_obj = queue_size->second.As<json::Object>();
@@ -1047,7 +1047,7 @@ auto ParseSenderQueueSize(const score::json::Object& global_config_map) -> std::
 auto ParseGlobalProperties(const score::json::Object& top_level_object) -> GlobalConfiguration
 {
     GlobalConfiguration global_configuration{};
-    const auto& process_properties = top_level_object.find(kGlobalPropertiesKey.data());
+    const auto& process_properties = top_level_object.find(kGlobalPropertiesKey);
     if (process_properties != top_level_object.cend())
     {
         const auto process_properties_obj = process_properties->second.As<score::json::Object>();
@@ -1109,7 +1109,7 @@ auto ParseGlobalProperties(const score::json::Object& top_level_object) -> Globa
             global_configuration.SetShmSizeCalcMode(shm_size_calc_mode.value());
         }
 
-        const auto& application_id_it = process_properties_map.find(kApplicationIdKey.data());
+        const auto& application_id_it = process_properties_map.find(kApplicationIdKey);
         if (application_id_it != process_properties_map.cend())
         {
             const auto application_id_casted = application_id_it->second.As<std::uint32_t>();
@@ -1141,7 +1141,7 @@ auto ParseTracingEnabled(const score::json::Object& tracing_config_map) -> bool
 
 auto ParseTracingApplicationInstanceId(const score::json::Object& tracing_config_map) -> const std::string&
 {
-    const auto& tracing_application_instance_id = tracing_config_map.find(kTracingApplicationInstanceIDKey.data());
+    const auto& tracing_application_instance_id = tracing_config_map.find(kTracingApplicationInstanceIDKey);
     SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD_MESSAGE(tracing_application_instance_id != tracing_config_map.cend(),
                                                       "Configuration corrupted, check with json schema");
 
@@ -1153,7 +1153,7 @@ auto ParseTracingApplicationInstanceId(const score::json::Object& tracing_config
 
 auto ParseTracingTraceFilterConfigPath(const score::json::Object& tracing_config_map) -> std::string_view
 {
-    const auto& tracing_filter_config_path = tracing_config_map.find(kTracingTraceFilterConfigPathKey.data());
+    const auto& tracing_filter_config_path = tracing_config_map.find(kTracingTraceFilterConfigPathKey);
     if (tracing_filter_config_path != tracing_config_map.cend())
     {
         const auto tracing_filter_config_path_casted = tracing_filter_config_path->second.As<std::string>();


### PR DESCRIPTION
## Summary

Fixes all `bugprone-suspicious-stringview-data-usage` clang-tidy findings in the codebase.

## Root cause

All findings occur at call sites of `score::json::Object::find()`. `score::json::Object` is a `std::map<StringComparisonAdaptor, Any>`, and `StringComparisonAdaptor` has an implicit constructor from `std::string_view`. Despite this, many call sites narrowed a `std::string_view` key down to a raw `const char*` via `.data()` before calling `find()`:

```cpp
constexpr auto kHvSocketConfigurationKey = "hypervisor-socket"sv;
...
const auto socket_entry = obj.find(kHvSocketConfigurationKey.data());
```

`bugprone-suspicious-stringview-data-usage` flags this pattern because `.data()` discards the view's length and the result is not guaranteed to be null-terminated in general — passing the raw `char*` on to an API that expects a null-terminated C-string is a latent bug, even though in these specific cases the views happen to originate from null-terminated string literals.

## Fix

Pass the `std::string_view` key directly to `find()` instead of calling `.data()` on it:

```cpp
const auto socket_entry = obj.find(kHvSocketConfigurationKey);
```

This relies on the existing implicit `StringComparisonAdaptor(const std::string_view&)` conversion, removes the unsafe pattern, and is a pure call-site simplification with no behavioral change (same key comparison semantics, just without the intermediate C-string narrowing).

## Files changed

- `score/mw/com/gateway/transport_layer/sample/configuration/sample_transport_config_parser.cpp`
- `score/mw/com/gateway/gateway_application/configuration/gateway_config_parser.cpp`
- `score/mw/com/impl/configuration/configuration_json_parsing_strategy.cpp`

53 call sites fixed across the three files (5 + 5 + 43 respectively).

## Verification

- Full `bazel build //score/mw/com/... //score/memory/... //score/message_passing/...` passes.
- Scoped clang-tidy build isolated to `bugprone-suspicious-stringview-data-usage` shows **0 findings** (down from 53).
- All 51 tests under `score/mw/com/impl/configuration/...` and `score/mw/com/gateway/...` pass.

## Scope

This PR intentionally contains **only** `bugprone-suspicious-stringview-data-usage` fixes, per the project convention of one clang-tidy check per PR (see #995, #999, #1000, #1001, #1003).
