### PR TITLE
fix(clang-tidy): resolve cppcoreguidelines-init-variables findings

### DIFF
--- a/score/message_passing/unix_domain/unix_domain_engine.cpp
+++ b/score/message_passing/unix_domain/unix_domain_engine.cpp
@@ -280,7 +280,7 @@ void UnixDomainEngine::SendPipeEvent(PipeEvent pipe_event) noexcept
 
 void UnixDomainEngine::ProcessPipeEvent() noexcept
 {
-    PipeEvent pipe_event;
+    PipeEvent pipe_event{PipeEvent::QUIT};
     std::ignore = os_resources_.unistd->read(pipe_fds_[0], &pipe_event, sizeof(pipe_event));
     if (pipe_event == PipeEvent::TIMER)
     {

--- a/score/message_passing/unix_domain/unix_domain_server.cpp
+++ b/score/message_passing/unix_domain/unix_domain_server.cpp
@@ -100,7 +100,7 @@ void UnixDomainServer::ServerConnection::RequestDisconnect() noexcept
 
 bool UnixDomainServer::ServerConnection::ProcessInput()
 {
-    std::uint8_t code;
+    std::uint8_t code{0U};
     auto& user_data = *user_data_;
     using HandlerPointerT = score::cpp::pmr::unique_ptr<IConnectionHandler>;
     auto message_expected = server_.engine_->ReceiveProtocolMessage(endpoint_.fd, code);

--- a/score/mw/com/test/flock/flock_test.cpp
+++ b/score/mw/com/test/flock/flock_test.cpp
@@ -50,8 +50,7 @@ void DoChildActions(int fd_to_write_to)
 {
     using namespace score::memory::shared;
 
-    FILE* stream;
-    stream = fdopen(fd_to_write_to, "w");
+    FILE* stream = fdopen(fd_to_write_to, "w");
     if (stream == nullptr)
     {
         std::cerr << "Child: Can't open pipe fd!" << std::endl;
@@ -240,9 +239,8 @@ bool WaitForChildFinished(int fd_to_read_from)
         return false;
     }
     bool child_is_done{false};
-    FILE* stream;
-    int c;
-    stream = fdopen(fd_to_read_from, "r");
+    FILE* stream = fdopen(fd_to_read_from, "r");
+    int c = 0;
     if (stream == nullptr)
     {
         std::cerr << "Controller: Can't open pipe fd!" << std::endl;

--- a/score/mw/com/test/smokeyeyes/smokeyeyes.cpp
+++ b/score/mw/com/test/smokeyeyes/smokeyeyes.cpp
@@ -387,11 +387,11 @@ int main(int argc, const char** argv)
     namespace ipc = boost::interprocess;
     using namespace score;
 
-    std::size_t num_clients;
-    std::size_t turns;
-    std::size_t batch_size;
-    bool no_wait;
-    std::size_t num_slots;
+    std::size_t num_clients{0U};
+    std::size_t turns{0U};
+    std::size_t batch_size{0U};
+    bool no_wait{false};
+    std::size_t num_slots{0U};
 
     po::options_description options;
     // clang-format off
@@ -487,7 +487,7 @@ int main(int argc, const char** argv)
         bool children_successful = true;
         for (auto pid : children)
         {
-            int wstatus;
+            int wstatus{0};
             waitpid(pid, &wstatus, 0);
             if (WIFEXITED(wstatus))
             {


### PR DESCRIPTION
## Summary

Fixes all `cppcoreguidelines-init-variables` clang-tidy findings (11 findings across 4 files).

## Approach

Initializes each flagged variable at its point of declaration instead of leaving it default-constructed/uninitialized, per the C++ Core Guidelines' recommendation that every variable be given a well-defined value as soon as it is declared. All changes are pure initialization additions — no behavioral change, since every affected variable is fully overwritten before its first read in the original code, and the chosen initial values (enum default, `0`, `false`) match the variables' subsequent overwritten semantics.

## Fixes

- **`unix_domain_engine.cpp`**: `PipeEvent pipe_event` is an out-parameter for a raw `read()` syscall that always overwrites it before use; initialized to `PipeEvent::QUIT` (a valid enumerator) as a safe default.
- **`unix_domain_server.cpp`**: `std::uint8_t code` is an out-parameter for `ReceiveProtocolMessage()`; zero-initialized.
- **`flock_test.cpp`**: `FILE* stream` was declared then immediately assigned from `fdopen()` on the next line; merged declaration and initialization (×2 occurrences). `int c` (loop-local `fgetc()` result) is zero-initialized.
- **`smokeyeyes.cpp`**: the `boost::program_options`-bound variables (`num_clients`, `turns`, `batch_size`, `no_wait`, `num_slots`) are populated by `po::store`/`po::notify` from their `default_value()`s; initialized to matching defaults so the variable is never observably uninitialized between declaration and parsing. `int wstatus`, an out-parameter for `waitpid()`, is zero-initialized.

## Verification

- Scoped clang-tidy build isolated to `cppcoreguidelines-init-variables` shows **0 findings** (down from 11 across 4 files).
- Full `bazel build //score/message_passing/... //score/mw/com/test/flock/... //score/mw/com/test/smokeyeyes/...` passes.
- `bazel test //score/message_passing:unix_domain_test //score/message_passing:unix_domain_test_linux` passes (2/2).
- `bazel test //:format_test_C++_with_clang-format` passes — no formatting issues introduced.

## Scope

This PR intentionally contains **only** `cppcoreguidelines-init-variables` fixes, per the project convention of one clang-tidy check per PR (see #995, #999, #1000, #1001, #1003, #1012, #1013).
