### PR TITLE
fix(clang-tidy): resolve cppcoreguidelines-special-member-functions findings

### DIFF
--- a/score/mw/com/test/common_test_resources/sample_sender_receiver.cpp
+++ b/score/mw/com/test/common_test_resources/sample_sender_receiver.cpp
@@ -246,6 +246,10 @@ class TestDestructor
 {
   public:
     TestDestructor(score::cpp::stop_source& stop_source) : stop_source_{stop_source} {}
+    TestDestructor(const TestDestructor&) = delete;
+    TestDestructor& operator=(const TestDestructor&) = delete;
+    TestDestructor(TestDestructor&&) = delete;
+    TestDestructor& operator=(TestDestructor&&) = delete;
     ~TestDestructor()
     {
         stop_source_.request_stop();

--- a/score/mw/com/test/partial_restart/provider_restart/provider.cpp
+++ b/score/mw/com/test/partial_restart/provider_restart/provider.cpp
@@ -48,6 +48,11 @@ class CyclicEventSender
     CyclicEventSender(const CyclicEventSender& other) = delete;
     CyclicEventSender& operator=(const CyclicEventSender& rhs) = delete;
 
+    // Not movable either: the send-thread captures `this`, so moving this object would leave the running
+    // thread referencing a stale/moved-from instance.
+    CyclicEventSender(CyclicEventSender&& other) = delete;
+    CyclicEventSender& operator=(CyclicEventSender&& rhs) = delete;
+
     void Start()
     {
         SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(cyclic_send_thread_.joinable() == false,

--- a/score/mw/com/test/smokeyeyes/smokeyeyes.cpp
+++ b/score/mw/com/test/smokeyeyes/smokeyeyes.cpp
@@ -137,6 +137,13 @@ struct SharedState
         pthread_barrierattr_destroy(&barrier_attr);
     }
 
+    // Not copyable/movable: `barrier_` is an OS resource tied to this object's address (it is placed directly
+    // into shared memory via placement-new), so copying or moving it would not be meaningful.
+    SharedState(const SharedState&) = delete;
+    SharedState& operator=(const SharedState&) = delete;
+    SharedState(SharedState&&) = delete;
+    SharedState& operator=(SharedState&&) = delete;
+
     ~SharedState()
     {
         pthread_barrier_destroy(&barrier_);


### PR DESCRIPTION
## Summary

Fixes all `cppcoreguidelines-special-member-functions` clang-tidy findings (3 findings across 3 files).

## Approach

Explicitly declares the missing copy/move special member functions (deleted, since none of these classes support meaningful copy/move semantics) so each class fully follows the Rule of Five instead of relying on implicit generation, per the C++ Core Guidelines' recommendation that if any of destructor/copy/move is user-declared, all five should be declared.

## Fixes

- **`sample_sender_receiver.cpp`**: `TestDestructor` is a scope-guard type that calls `stop_source_.request_stop()` in its destructor; it is only ever used as a named local variable and was never intended to be copied or moved. Deleted copy/move constructor and assignment.
- **`provider.cpp` (partial_restart/provider_restart)**: `CyclicEventSender` already explicitly deleted its copy constructor/assignment (its `std::thread` member isn't copyable) but didn't declare move operations. Since its background thread captures `this`, moving the object would leave the thread referencing a stale instance, so move is deleted too, for the same reason copy already was.
- **`smokeyeyes.cpp`**: `SharedState` owns a `pthread_barrier_t` that is placed directly into shared memory via placement-new and destroyed in its destructor; the barrier is tied to this object's address, so copying or moving it is not meaningful. Deleted copy/move constructor and assignment.

All changes are pure declarations (`= delete`) with no behavioral change, since none of these types were ever copied or moved elsewhere in the codebase.

## Verification

- Scoped clang-tidy build isolated to `cppcoreguidelines-special-member-functions` shows **0 findings** (down from 3 across 3 files).
- Full `bazel build //score/mw/com/test/common_test_resources/... //score/mw/com/test/partial_restart/... //score/mw/com/test/smokeyeyes/...` passes.
- `bazel test //score/mw/com/test/partial_restart/provider_restart/integration_test:provider_restart_graceful` passes.
- `bazel test //:format_test_C++_with_clang-format` passes.

## Scope

This PR intentionally contains **only** `cppcoreguidelines-special-member-functions` fixes, per the project convention of one clang-tidy check per PR (see #995, #999, #1000, #1001, #1003, #1012, #1013, #1014).
