### PR TITLE
mw/com : Add integration test for moving proxy field

### DIFF
--- a/score/mw/com/test/common_test_resources/proxy_container.h
+++ b/score/mw/com/test/common_test_resources/proxy_container.h
@@ -39,6 +39,13 @@ class ProxyContainer
         return *proxy_;
     }
 
+    Proxy&& Extract()
+    {
+        SCORE_LANGUAGE_FUTURECPP_ASSERT_PRD_MESSAGE(proxy_ != nullptr,
+                                                    "Proxy was not successfully created! Cannot extract it!");
+        return std::move(*proxy_);
+    }
+
   private:
     std::unique_ptr<typename Proxy::HandleType> handle_{nullptr};
     std::mutex proxy_creation_mutex_{};

--- a/score/mw/com/test/move_semantics/proxy_field/BUILD
+++ b/score/mw/com/test/move_semantics/proxy_field/BUILD
@@ -1,0 +1,172 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_cc//cc:defs.bzl", "cc_binary", "cc_library")
+load("@score_baselibs//score/language/safecpp:toolchain_features.bzl", "COMPILER_WARNING_FEATURES")
+load("//bazel/tools:json_schema_validator.bzl", "validate_json_schema_test")
+load("//score/mw/com/test:pkg_application.bzl", "pkg_application")
+
+validate_json_schema_test(
+    name = "validate_config_schema",
+    json = "config/mw_com_config.json",
+    schema = "//score/mw/com:config_schema",
+    tags = ["lint"],
+)
+
+cc_library(
+    name = "test_field_datatype",
+    srcs = ["test_field_datatype.cpp"],
+    hdrs = ["test_field_datatype.h"],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        "//score/mw/com",
+    ],
+)
+
+cc_library(
+    name = "test_parameters",
+    srcs = ["test_parameters.cpp"],
+    hdrs = ["test_parameters.h"],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:command_line_parser",
+        "//score/mw/com/test/common_test_resources:fail_test",
+    ],
+)
+
+cc_library(
+    name = "provider",
+    srcs = ["provider.cpp"],
+    hdrs = ["provider.h"],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        ":test_field_datatype",
+        ":test_parameters",
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:fail_test",
+        "//score/mw/com/test/common_test_resources:process_synchronizer",
+        "//score/mw/com/test/common_test_resources:skeleton_container",
+    ],
+)
+
+cc_library(
+    name = "consumer",
+    srcs = ["consumer.cpp"],
+    hdrs = ["consumer.h"],
+    features = COMPILER_WARNING_FEATURES,
+    deps = [
+        ":test_field_datatype",
+        ":test_parameters",
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:fail_test",
+        "//score/mw/com/test/common_test_resources:process_synchronizer",
+        "//score/mw/com/test/common_test_resources:proxy_container",
+        "//score/mw/com/test/common_test_resources:proxy_event_receiver",
+        "//score/mw/com/test/common_test_resources:proxy_event_state_change_notifier",
+    ],
+)
+
+cc_binary(
+    name = "main_provider",
+    srcs = ["main_provider.cpp"],
+    data = ["config/mw_com_config.json"],
+    features = COMPILER_WARNING_FEATURES + [
+        "aborts_upon_exception",
+    ],
+    deps = [
+        ":provider",
+        ":test_parameters",
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:assert_handler",
+        "//score/mw/com/test/common_test_resources:fail_test",
+        "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
+        "@score_baselibs//score/string_manipulation/arguments",
+    ],
+)
+
+cc_binary(
+    name = "main_consumer",
+    srcs = ["main_consumer.cpp"],
+    data = ["config/mw_com_config.json"],
+    features = COMPILER_WARNING_FEATURES + [
+        "aborts_upon_exception",
+    ],
+    deps = [
+        ":consumer",
+        ":test_parameters",
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:assert_handler",
+        "//score/mw/com/test/common_test_resources:fail_test",
+        "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
+        "@score_baselibs//score/string_manipulation/arguments",
+    ],
+)
+
+cc_binary(
+    name = "main_consumer_and_provider",
+    srcs = ["main_consumer_and_provider.cpp"],
+    data = ["config/mw_com_config.json"],
+    features = COMPILER_WARNING_FEATURES + [
+        "aborts_upon_exception",
+    ],
+    deps = [
+        ":consumer",
+        ":provider",
+        ":test_parameters",
+        "//score/mw/com",
+        "//score/mw/com/test/common_test_resources:assert_handler",
+        "//score/mw/com/test/common_test_resources:fail_test",
+        "//score/mw/com/test/common_test_resources:stop_token_sig_term_handler",
+        "@score_baselibs//score/string_manipulation/arguments",
+    ],
+)
+
+pkg_application(
+    name = "main_provider-pkg",
+    app_name = "MainProviderApp",
+    bin = [":main_provider"],
+    etc = [
+        "config/mw_com_config.json",
+        "config/logging.json",
+    ],
+    visibility = [
+        "//score/mw/com/test/move_semantics/proxy_field:__subpackages__",
+    ],
+)
+
+pkg_application(
+    name = "main_consumer-pkg",
+    app_name = "MainConsumerApp",
+    bin = [":main_consumer"],
+    etc = [
+        "config/mw_com_config.json",
+        "config/logging.json",
+    ],
+    visibility = [
+        "//score/mw/com/test/move_semantics/proxy_field:__subpackages__",
+    ],
+)
+
+pkg_application(
+    name = "main_consumer_and_provider-pkg",
+    app_name = "MainConsumerAndProviderApp",
+    bin = [":main_consumer_and_provider"],
+    etc = [
+        "config/mw_com_config.json",
+        "config/logging.json",
+    ],
+    visibility = [
+        "//score/mw/com/test/move_semantics/proxy_field:__subpackages__",
+    ],
+)

--- a/score/mw/com/test/move_semantics/proxy_field/config/logging.json
+++ b/score/mw/com/test/move_semantics/proxy_field/config/logging.json
@@ -1,0 +1,7 @@
+{
+  "appId": "PFMS",
+  "appDesc": "proxy_field_move_semantics",
+  "logLevel": "kDebug",
+  "logLevelThresholdConsole": "kDebug",
+  "logMode": "kRemote|kConsole"
+}

--- a/score/mw/com/test/move_semantics/proxy_field/config/mw_com_config.json
+++ b/score/mw/com/test/move_semantics/proxy_field/config/mw_com_config.json
@@ -1,0 +1,105 @@
+{
+  "serviceTypes": [
+    {
+      "serviceTypeName": "/test/proxy_field_move_semantics/MoveFieldInterface",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "bindings": [
+        {
+          "binding": "SHM",
+          "serviceId": 2300,
+          "fields": [
+            {
+              "fieldName": "moved_field",
+              "fieldId": 1
+            }
+          ]
+        }
+      ]
+    }
+  ],
+  "serviceInstances": [
+    {
+      "instanceSpecifier": "test/proxy_field_move_semantics/MoveFieldInterfaceMovedTo",
+      "serviceTypeName": "/test/proxy_field_move_semantics/MoveFieldInterface",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "instances": [
+        {
+          "instanceId": 1,
+          "asil-level": "B",
+          "binding": "SHM",
+          "fields": [
+            {
+              "fieldName": "moved_field",
+              "numberOfSampleSlots": 4,
+              "maxSubscribers": 1
+            }
+          ],
+          "allowedConsumer": {
+            "QM": [
+              0
+            ],
+            "B": [
+              0
+            ]
+          },
+          "allowedProvider": {
+            "QM": [
+              0
+            ],
+            "B": [
+              0
+            ]
+          }
+        }
+      ]
+    },
+    {
+      "instanceSpecifier": "test/proxy_field_move_semantics/MoveFieldInterfaceMovedFrom",
+      "serviceTypeName": "/test/proxy_field_move_semantics/MoveFieldInterface",
+      "version": {
+        "major": 1,
+        "minor": 0
+      },
+      "instances": [
+        {
+          "instanceId": 2,
+          "asil-level": "B",
+          "binding": "SHM",
+          "fields": [
+            {
+              "fieldName": "moved_field",
+              "numberOfSampleSlots": 4,
+              "maxSubscribers": 1
+            }
+          ],
+          "allowedConsumer": {
+            "QM": [
+              0
+            ],
+            "B": [
+              0
+            ]
+          },
+          "allowedProvider": {
+            "QM": [
+              0
+            ],
+            "B": [
+              0
+            ]
+          }
+        }
+      ]
+    }
+  ],
+  "global": {
+    "asil-level": "B",
+    "applicationID": 4003
+  }
+}

--- a/score/mw/com/test/move_semantics/proxy_field/consumer.cpp
+++ b/score/mw/com/test/move_semantics/proxy_field/consumer.cpp
@@ -1,0 +1,232 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/test/move_semantics/proxy_field/consumer.h"
+
+#include "score/mw/com/test/common_test_resources/fail_test.h"
+#include "score/mw/com/test/common_test_resources/process_synchronizer.h"
+#include "score/mw/com/test/common_test_resources/proxy_container.h"
+#include "score/mw/com/test/common_test_resources/proxy_event_receiver.h"
+#include "score/mw/com/test/common_test_resources/proxy_event_state_change_notifier.h"
+#include "score/mw/com/test/move_semantics/proxy_field/test_field_datatype.h"
+
+#include <cstdint>
+#include <iostream>
+#include <vector>
+
+namespace score::mw::com::test
+{
+namespace
+{
+
+const std::string kInterprocessNotificationShmPath{"/proxy_field_move_semantics_interprocess_notification"};
+
+/// \brief Waits for exactly one new sample and verifies it matches the expected value.
+template <typename ReceiverType>
+void CallGetNewSampleAndCheckValue(ReceiverType& receiver,
+                                   const score::cpp::stop_token& stop_token,
+                                   const std::int32_t expected_value)
+{
+    const std::vector<std::int32_t> expected_samples{expected_value};
+    if (!receiver.WaitForSamples(stop_token, expected_samples))
+    {
+        FailTest("Consumer: Did not receive expected sample with value ", expected_value);
+    }
+}
+
+template <typename ProxyFieldType>
+void CallSetAndCheckReturnValue(ProxyFieldType& proxy_field,
+                                const std::int32_t set_request_value,
+                                const std::int32_t expected_accepted_value)
+{
+    const auto set_result = proxy_field.Set(set_request_value);
+    if (!set_result.has_value())
+    {
+        FailTest("Consumer: Set() failed: ", set_result.error());
+    }
+    const std::int32_t accepted_value = *(set_result.value());
+    if (accepted_value != expected_accepted_value)
+    {
+        FailTest("Consumer: Set() returned accepted value ", accepted_value, " but expected ", expected_accepted_value);
+    }
+    std::cout << "\nConsumer: Set() returned expected accepted value " << accepted_value << std::endl;
+}
+
+template <typename ProxyFieldType>
+void CallGetAndCheckValue(ProxyFieldType& proxy_field, const std::int32_t expected_value)
+{
+    const auto get_result = proxy_field.Get();
+    if (!get_result.has_value())
+    {
+        FailTest("Consumer: Get() failed: ", get_result.error());
+    }
+    if (*(get_result.value()) != expected_value)
+    {
+        FailTest("Consumer: Get() returned ", *(get_result.value()), " but expected ", expected_value);
+    }
+    std::cout << "\nConsumer: Get() returned expected value " << expected_value << std::endl;
+}
+
+template <typename ProxyFieldType>
+void SubscribeField(ProxyFieldType& proxy_field, const score::cpp::stop_token& stop_token)
+{
+    ProxyEventStateChangeNotifier subscription_notifier{proxy_field};
+    const auto subscribe_result = proxy_field.Subscribe(2U);
+    if (!subscribe_result.has_value())
+    {
+        FailTest("Consumer: Subscribe failed: ", subscribe_result.error());
+    }
+    if (!subscription_notifier.WaitForStateChange(stop_token, SubscriptionState::kSubscribed))
+    {
+        FailTest("Consumer: Subscription failed");
+    }
+}
+
+void RunConsumerMoveConstructAfterCreate(const score::cpp::stop_token& stop_token,
+                                         const std::string& failure_message_prefix)
+{
+    // Step 1. Find service and create proxy A
+    std::cout << "\nConsumer: Step 1 - Find service and create proxy A" << std::endl;
+    ProxyContainer<ProxyFieldMoveSemanticsProxy> proxy_a_container{};
+    proxy_a_container.CreateProxy(kInstanceSpecifierMovedTo, failure_message_prefix);
+    auto proxy_a = proxy_a_container.Extract();
+
+    // Step 2. Move construct proxy B from proxy A
+    std::cout << "\nConsumer: Step 2 - Move construct proxy B from proxy A" << std::endl;
+    auto proxy_b = std::move(proxy_a);
+
+    // Step 3. Subscribe
+    std::cout << "\nConsumer: Step 3 - Subscribe" << std::endl;
+    SubscribeField(proxy_b.moved_field_, stop_token);
+
+    // Step 4. GetNewSample, Set, Get
+    std::cout << "\nConsumer: Step 4 - GetNewSample, Set, Get" << std::endl;
+    const auto expected_accepted_value = DoubleAndIncrement(kSetRequestValue);
+    {
+        ProxyEventReceiver field_receiver{proxy_b.moved_field_};
+        CallGetNewSampleAndCheckValue(field_receiver, stop_token, kInitialValueMovedTo);
+        CallSetAndCheckReturnValue(proxy_b.moved_field_, kSetRequestValue, expected_accepted_value);
+        CallGetAndCheckValue(proxy_b.moved_field_, expected_accepted_value);
+    }
+
+    // Step 5. Unsubscribe
+    std::cout << "\nConsumer: Step 5 - Unsubscribe" << std::endl;
+    proxy_b.moved_field_.Unsubscribe();
+
+    // Step 6. Subscribe again
+    std::cout << "\nConsumer: Step 6 - Subscribe again" << std::endl;
+    SubscribeField(proxy_b.moved_field_, stop_token);
+
+    // Step 7. GetNewSample
+    std::cout << "\nConsumer: Step 7 - GetNewSample" << std::endl;
+    {
+        ProxyEventReceiver field_receiver{proxy_b.moved_field_};
+        // Re-subscribing delivers the field's current (last accepted) value as the new initial sample, proving that
+        // the re-subscribed proxy still reaches the correct channel.
+        CallGetNewSampleAndCheckValue(field_receiver, stop_token, expected_accepted_value);
+    }
+
+    proxy_b.moved_field_.Unsubscribe();
+}
+
+void RunConsumerMoveAssignAfterCreate(const score::cpp::stop_token& stop_token,
+                                      const std::string& failure_message_prefix)
+{
+    // Step 1. Find service and create proxy A (connected to the MovedFrom instance)
+    std::cout << "\nConsumer: Step 1 - Find service and create proxy A" << std::endl;
+    ProxyContainer<ProxyFieldMoveSemanticsProxy> proxy_a_container{};
+    proxy_a_container.CreateProxy(kInstanceSpecifierMovedFrom, failure_message_prefix);
+    auto proxy_a = proxy_a_container.Extract();
+
+    // Step 2. Find service and create proxy B (connected to the MovedTo instance)
+    std::cout << "\nConsumer: Step 2 - Find service and create proxy B" << std::endl;
+    ProxyContainer<ProxyFieldMoveSemanticsProxy> proxy_b_container{};
+    proxy_b_container.CreateProxy(kInstanceSpecifierMovedTo, failure_message_prefix);
+    auto proxy_b = proxy_b_container.Extract();
+
+    // Step 3. Move assign proxy A into proxy B. Proxy B now holds proxy A's channel (MovedFrom).
+    std::cout << "\nConsumer: Step 3 - Move assign proxy A into proxy B" << std::endl;
+    proxy_b = std::move(proxy_a);
+
+    // Step 4. Subscribe
+    std::cout << "\nConsumer: Step 4 - Subscribe" << std::endl;
+    SubscribeField(proxy_b.moved_field_, stop_token);
+
+    // Step 5. GetNewSample, Set, Get
+    std::cout << "\nConsumer: Step 5 - GetNewSample, Set, Get" << std::endl;
+    const auto expected_accepted_value = AddOneHundred(kSetRequestValue);
+    {
+        ProxyEventReceiver field_receiver{proxy_b.moved_field_};
+        CallGetNewSampleAndCheckValue(field_receiver, stop_token, kInitialValueMovedFrom);
+        CallSetAndCheckReturnValue(proxy_b.moved_field_, kSetRequestValue, expected_accepted_value);
+        CallGetAndCheckValue(proxy_b.moved_field_, expected_accepted_value);
+    }
+
+    // Step 6. Unsubscribe
+    std::cout << "\nConsumer: Step 6 - Unsubscribe" << std::endl;
+    proxy_b.moved_field_.Unsubscribe();
+
+    // Step 7. Subscribe again
+    std::cout << "\nConsumer: Step 7 - Subscribe again" << std::endl;
+    SubscribeField(proxy_b.moved_field_, stop_token);
+
+    // Step 8. GetNewSample
+    std::cout << "\nConsumer: Step 8 - GetNewSample" << std::endl;
+    {
+        ProxyEventReceiver field_receiver{proxy_b.moved_field_};
+        // Re-subscribing delivers the field's current (last accepted) value as the new initial sample, proving that
+        // the re-subscribed proxy still reaches the MovedFrom channel.
+        CallGetNewSampleAndCheckValue(field_receiver, stop_token, expected_accepted_value);
+    }
+
+    proxy_b.moved_field_.Unsubscribe();
+}
+
+}  // namespace
+
+void RunConsumer(const ProxyMoveScenario& scenario, const score::cpp::stop_token& stop_token)
+{
+    const std::string failure_message_prefix{"proxy_field_move_semantics"};
+
+    auto consumer_done_synchronizer_result = ProcessSynchronizer::Create(kInterprocessNotificationShmPath);
+    if (!consumer_done_synchronizer_result.has_value())
+    {
+        FailTest("proxy_field_move_semantics consumer failed: could not create consumer done synchronizer");
+    }
+
+    // Notify the provider when the consumer is done (or fails) so that it does not wait indefinitely.
+    ExitFunctionGuard done_guard{[&consumer_done_synchronizer_result]() {
+        consumer_done_synchronizer_result->Notify();
+    }};
+
+    switch (scenario)
+    {
+        case ProxyMoveScenario::kMoveConstructAfterCreate:
+        {
+            RunConsumerMoveConstructAfterCreate(stop_token, failure_message_prefix);
+            break;
+        }
+        case ProxyMoveScenario::kMoveAssignAfterCreate:
+        {
+            RunConsumerMoveAssignAfterCreate(stop_token, failure_message_prefix);
+            break;
+        }
+        case ProxyMoveScenario::kNumberOfScenarios:
+            [[fallthrough]];
+        default:
+            FailTest("proxy_field_move_semantics consumer failed: unknown scenario");
+    }
+
+    std::cout << "Consumer: Done with all field operations, exiting" << std::endl;
+}
+
+}  // namespace score::mw::com::test

--- a/score/mw/com/test/move_semantics/proxy_field/consumer.h
+++ b/score/mw/com/test/move_semantics/proxy_field/consumer.h
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_TEST_PROXY_FIELD_MOVE_SEMANTICS_CONSUMER_H
+#define SCORE_MW_COM_TEST_PROXY_FIELD_MOVE_SEMANTICS_CONSUMER_H
+
+#include "score/mw/com/test/move_semantics/proxy_field/test_parameters.h"
+
+#include <score/stop_token.hpp>
+
+namespace score::mw::com::test
+{
+
+void RunConsumer(const ProxyMoveScenario& scenario, const score::cpp::stop_token& stop_token);
+
+}  // namespace score::mw::com::test
+
+#endif  // SCORE_MW_COM_TEST_PROXY_FIELD_MOVE_SEMANTICS_CONSUMER_H

--- a/score/mw/com/test/move_semantics/proxy_field/integration_test/BUILD
+++ b/score/mw/com/test/move_semantics/proxy_field/integration_test/BUILD
@@ -1,0 +1,59 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+
+load("@rules_pkg//pkg:mappings.bzl", "pkg_filegroup")
+load("//quality/integration_testing:integration_testing.bzl", "integration_test")
+
+integration_test(
+    name = "move_construct_after_create_same_process_test",
+    srcs = [
+        "move_construct_after_create_same_process_test.py",
+        "test_fixture.py",
+    ],
+    filesystem = "//score/mw/com/test/move_semantics/proxy_field:main_consumer_and_provider-pkg",
+)
+
+integration_test(
+    name = "move_assign_after_create_same_process_test",
+    srcs = [
+        "move_assign_after_create_same_process_test.py",
+        "test_fixture.py",
+    ],
+    filesystem = "//score/mw/com/test/move_semantics/proxy_field:main_consumer_and_provider-pkg",
+)
+
+pkg_filegroup(
+    name = "different_processes_filesystem",
+    srcs = [
+        "//score/mw/com/test/move_semantics/proxy_field:main_consumer-pkg",
+        "//score/mw/com/test/move_semantics/proxy_field:main_provider-pkg",
+    ],
+)
+
+integration_test(
+    name = "move_construct_after_create_different_process_test",
+    srcs = [
+        "move_construct_after_create_different_process_test.py",
+        "test_fixture.py",
+    ],
+    filesystem = ":different_processes_filesystem",
+)
+
+integration_test(
+    name = "move_assign_after_create_different_process_test",
+    srcs = [
+        "move_assign_after_create_different_process_test.py",
+        "test_fixture.py",
+    ],
+    filesystem = ":different_processes_filesystem",
+)

--- a/score/mw/com/test/move_semantics/proxy_field/integration_test/move_assign_after_create_different_process_test.py
+++ b/score/mw/com/test/move_semantics/proxy_field/integration_test/move_assign_after_create_different_process_test.py
@@ -1,0 +1,19 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from test_fixture import consumer, provider, ProxyMoveScenario
+
+
+def test_move_assign_after_create_different_process(target):
+    with provider(target, ProxyMoveScenario.MOVE_ASSIGN_AFTER_CREATE):
+        with consumer(target, ProxyMoveScenario.MOVE_ASSIGN_AFTER_CREATE):
+            pass

--- a/score/mw/com/test/move_semantics/proxy_field/integration_test/move_assign_after_create_same_process_test.py
+++ b/score/mw/com/test/move_semantics/proxy_field/integration_test/move_assign_after_create_same_process_test.py
@@ -1,0 +1,18 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from test_fixture import consumer_and_provider, ProxyMoveScenario
+
+
+def test_move_assign_after_create_same_process(target):
+    with consumer_and_provider(target, ProxyMoveScenario.MOVE_ASSIGN_AFTER_CREATE):
+        pass

--- a/score/mw/com/test/move_semantics/proxy_field/integration_test/move_construct_after_create_different_process_test.py
+++ b/score/mw/com/test/move_semantics/proxy_field/integration_test/move_construct_after_create_different_process_test.py
@@ -1,0 +1,19 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from test_fixture import consumer, provider, ProxyMoveScenario
+
+
+def test_move_construct_after_create_different_process(target):
+    with provider(target, ProxyMoveScenario.MOVE_CONSTRUCT_AFTER_CREATE):
+        with consumer(target, ProxyMoveScenario.MOVE_CONSTRUCT_AFTER_CREATE):
+            pass

--- a/score/mw/com/test/move_semantics/proxy_field/integration_test/move_construct_after_create_same_process_test.py
+++ b/score/mw/com/test/move_semantics/proxy_field/integration_test/move_construct_after_create_same_process_test.py
@@ -1,0 +1,18 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from test_fixture import consumer_and_provider, ProxyMoveScenario
+
+
+def test_move_construct_after_create_same_process(target):
+    with consumer_and_provider(target, ProxyMoveScenario.MOVE_CONSTRUCT_AFTER_CREATE):
+        pass

--- a/score/mw/com/test/move_semantics/proxy_field/integration_test/test_fixture.py
+++ b/score/mw/com/test/move_semantics/proxy_field/integration_test/test_fixture.py
@@ -1,0 +1,35 @@
+# *******************************************************************************
+# Copyright (c) 2026 Contributors to the Eclipse Foundation
+#
+# See the NOTICE file(s) distributed with this work for additional
+# information regarding copyright ownership.
+#
+# This program and the accompanying materials are made available under the
+# terms of the Apache License Version 2.0 which is available at
+# https://www.apache.org/licenses/LICENSE-2.0
+#
+# SPDX-License-Identifier: Apache-2.0
+# *******************************************************************************
+from enum import IntEnum
+
+
+class ProxyMoveScenario(IntEnum):
+    MOVE_CONSTRUCT_AFTER_CREATE = 0
+    MOVE_ASSIGN_AFTER_CREATE = 1
+
+
+def consumer_and_provider(target, scenario, **kwargs):
+    args = ["--scenario", str(int(scenario)), "--service-instance-manifest", f"./etc/mw_com_config.json"]
+    return target.wrap_exec(
+        "bin/main_consumer_and_provider", args, cwd="/opt/MainConsumerAndProviderApp", wait_on_exit=True, **kwargs
+    )
+
+
+def consumer(target, scenario, **kwargs):
+    args = ["--scenario", str(int(scenario)), "--service-instance-manifest", f"./etc/mw_com_config.json"]
+    return target.wrap_exec("bin/main_consumer", args, cwd="/opt/MainConsumerApp", wait_on_exit=True, **kwargs)
+
+
+def provider(target, scenario, **kwargs):
+    args = ["--scenario", str(int(scenario)), "--service-instance-manifest", f"./etc/mw_com_config.json"]
+    return target.wrap_exec("bin/main_provider", args, cwd="/opt/MainProviderApp", wait_on_exit=True, **kwargs)

--- a/score/mw/com/test/move_semantics/proxy_field/main_consumer.cpp
+++ b/score/mw/com/test/move_semantics/proxy_field/main_consumer.cpp
@@ -1,0 +1,41 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/runtime.h"
+
+#include "score/mw/com/test/common_test_resources/assert_handler.h"
+#include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
+#include "score/mw/com/test/move_semantics/proxy_field/consumer.h"
+#include "score/mw/com/test/move_semantics/proxy_field/test_parameters.h"
+#include "score/string_manipulation/arguments/arguments.h"
+
+int main(int argc, const char** argv)
+{
+    auto test_configuration{score::mw::com::test::ReadCommandLineArguments(argc, argv)};
+
+    score::mw::com::test::SetupAssertHandler();
+    score::mw::com::runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
+
+    score::cpp::stop_source stop_source{};
+    const bool sig_term_handler_setup_success = score::mw::com::SetupStopTokenSigTermHandler(stop_source);
+    if (!sig_term_handler_setup_success)
+    {
+        std::cerr << "Unable to set signal handler for SIGINT and/or SIGTERM, cautiously continuing" << std::endl;
+    }
+
+    std::cout << "Starting consumer with scenario " << static_cast<std::size_t>(test_configuration.scenario)
+              << std::endl;
+
+    score::mw::com::test::RunConsumer(test_configuration.scenario, stop_source.get_token());
+
+    return EXIT_SUCCESS;
+}

--- a/score/mw/com/test/move_semantics/proxy_field/main_consumer_and_provider.cpp
+++ b/score/mw/com/test/move_semantics/proxy_field/main_consumer_and_provider.cpp
@@ -1,0 +1,50 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/runtime.h"
+
+#include "score/mw/com/test/common_test_resources/assert_handler.h"
+#include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
+#include "score/mw/com/test/move_semantics/proxy_field/consumer.h"
+#include "score/mw/com/test/move_semantics/proxy_field/provider.h"
+#include "score/mw/com/test/move_semantics/proxy_field/test_parameters.h"
+#include "score/string_manipulation/arguments/arguments.h"
+
+#include <future>
+
+int main(int argc, const char** argv)
+{
+    auto test_configuration{score::mw::com::test::ReadCommandLineArguments(argc, argv)};
+
+    score::mw::com::test::SetupAssertHandler();
+    score::mw::com::runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
+
+    score::cpp::stop_source stop_source{};
+    const bool sig_term_handler_setup_success = score::mw::com::SetupStopTokenSigTermHandler(stop_source);
+    if (!sig_term_handler_setup_success)
+    {
+        std::cerr << "Unable to set signal handler for SIGINT and/or SIGTERM, cautiously continuing" << std::endl;
+    }
+
+    std::cout << "Starting provider and consumer with scenario "
+              << static_cast<std::size_t>(test_configuration.scenario) << std::endl;
+
+    auto provider_future =
+        std::async(score::mw::com::test::RunProvider, test_configuration.scenario, stop_source.get_token());
+    auto consumer_future =
+        std::async(score::mw::com::test::RunConsumer, test_configuration.scenario, stop_source.get_token());
+
+    provider_future.get();
+    consumer_future.get();
+
+    return EXIT_SUCCESS;
+}

--- a/score/mw/com/test/move_semantics/proxy_field/main_provider.cpp
+++ b/score/mw/com/test/move_semantics/proxy_field/main_provider.cpp
@@ -1,0 +1,41 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/runtime.h"
+
+#include "score/mw/com/test/common_test_resources/assert_handler.h"
+#include "score/mw/com/test/common_test_resources/stop_token_sig_term_handler.h"
+#include "score/mw/com/test/move_semantics/proxy_field/provider.h"
+#include "score/mw/com/test/move_semantics/proxy_field/test_parameters.h"
+#include "score/string_manipulation/arguments/arguments.h"
+
+int main(int argc, const char** argv)
+{
+    auto test_configuration{score::mw::com::test::ReadCommandLineArguments(argc, argv)};
+
+    score::mw::com::test::SetupAssertHandler();
+    score::mw::com::runtime::InitializeRuntime(score::string_manipulation::GetArguments(argc, argv));
+
+    score::cpp::stop_source stop_source{};
+    const bool sig_term_handler_setup_success = score::mw::com::SetupStopTokenSigTermHandler(stop_source);
+    if (!sig_term_handler_setup_success)
+    {
+        std::cerr << "Unable to set signal handler for SIGINT and/or SIGTERM, cautiously continuing" << std::endl;
+    }
+
+    std::cout << "Starting provider with scenario " << static_cast<std::size_t>(test_configuration.scenario)
+              << std::endl;
+
+    score::mw::com::test::RunProvider(test_configuration.scenario, stop_source.get_token());
+
+    return EXIT_SUCCESS;
+}

--- a/score/mw/com/test/move_semantics/proxy_field/provider.cpp
+++ b/score/mw/com/test/move_semantics/proxy_field/provider.cpp
@@ -1,0 +1,116 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/test/move_semantics/proxy_field/provider.h"
+
+#include "score/mw/com/test/common_test_resources/fail_test.h"
+#include "score/mw/com/test/common_test_resources/process_synchronizer.h"
+#include "score/mw/com/test/common_test_resources/skeleton_container.h"
+#include "score/mw/com/test/move_semantics/proxy_field/test_field_datatype.h"
+
+#include <iostream>
+
+namespace score::mw::com::test
+{
+namespace
+{
+
+const std::string kInterprocessNotificationShmPath{"/proxy_field_move_semantics_interprocess_notification"};
+
+/// \brief Registers the "MovedTo" instance's Set-handler transform (DoubleAndIncrement) on the given skeleton.
+void RegisterMovedToSetHandler(ProxyFieldMoveSemanticsSkeleton& skeleton)
+{
+    const auto register_handler_result = skeleton.moved_field_.RegisterSetHandler([](std::int32_t& value) noexcept {
+        value = DoubleAndIncrement(value);
+    });
+    if (!register_handler_result.has_value())
+    {
+        FailTest("Provider: Unable to register MovedTo set handler: ", register_handler_result.error());
+    }
+}
+
+/// \brief Registers the "MovedFrom" instance's Set-handler transform (AddOneHundred) on the given skeleton.
+void RegisterMovedFromSetHandler(ProxyFieldMoveSemanticsSkeleton& skeleton)
+{
+    const auto register_handler_result = skeleton.moved_field_.RegisterSetHandler([](std::int32_t& value) noexcept {
+        value = AddOneHundred(value);
+    });
+    if (!register_handler_result.has_value())
+    {
+        FailTest("Provider: Unable to register MovedFrom set handler: ", register_handler_result.error());
+    }
+}
+
+void UpdateInitialValue(ProxyFieldMoveSemanticsSkeleton& skeleton, const std::int32_t initial_value)
+{
+    const auto update_result = skeleton.moved_field_.Update(initial_value);
+    if (!update_result.has_value())
+    {
+        FailTest("Provider: Unable to update field with initial value: ", update_result.error());
+    }
+}
+
+}  // namespace
+
+void RunProvider(const ProxyMoveScenario& scenario, const score::cpp::stop_token& stop_token)
+{
+    auto consumer_done_synchronizer_result = ProcessSynchronizer::Create(kInterprocessNotificationShmPath);
+    if (!consumer_done_synchronizer_result.has_value())
+    {
+        FailTest("proxy_field_move_semantics provider failed: could not create consumer done synchronizer");
+    }
+    auto& consumer_done_synchronizer = consumer_done_synchronizer_result.value();
+
+    if (scenario == ProxyMoveScenario::kNumberOfScenarios)
+    {
+        FailTest("proxy_field_move_semantics provider failed: unknown scenario");
+    }
+
+    // Step 1. Create skeleton(s). MoveConstruct only needs "MovedTo"; MoveAssign also needs "MovedFrom"
+    std::cout << "\nProvider: Step 1 - Create skeleton(s)" << std::endl;
+    SkeletonContainer<ProxyFieldMoveSemanticsSkeleton> moved_to_skeleton_container{};
+    moved_to_skeleton_container.CreateSkeleton(kInstanceSpecifierMovedTo, "proxy_field_move_semantics");
+
+    // Step 1a. Register set-handler and update initial value for the "MovedTo" instance
+    RegisterMovedToSetHandler(moved_to_skeleton_container.GetSkeleton());
+    UpdateInitialValue(moved_to_skeleton_container.GetSkeleton(), kInitialValueMovedTo);
+
+    SkeletonContainer<ProxyFieldMoveSemanticsSkeleton> moved_from_skeleton_container{};
+    if (scenario == ProxyMoveScenario::kMoveAssignAfterCreate)
+    {
+        // Create the "MovedFrom" skeleton only for the MoveAssign scenario and register its set-handler and
+        //  update its initial value
+        moved_from_skeleton_container.CreateSkeleton(kInstanceSpecifierMovedFrom, "proxy_field_move_semantics");
+        RegisterMovedFromSetHandler(moved_from_skeleton_container.GetSkeleton());
+        UpdateInitialValue(moved_from_skeleton_container.GetSkeleton(), kInitialValueMovedFrom);
+    }
+
+    // Step 2. Offer service(s)
+    std::cout << "\nProvider: Step 2 - Offer service(s)" << std::endl;
+    moved_to_skeleton_container.OfferService("proxy_field_move_semantics");
+    if (scenario == ProxyMoveScenario::kMoveAssignAfterCreate)
+    {
+        moved_from_skeleton_container.OfferService("proxy_field_move_semantics");
+    }
+
+    // Step 3. Wait for the consumer to finish its full move -> Subscribe -> GetNewSample/Set/Get -> Unsubscribe ->
+    // Subscribe -> GetNewSample sequence.
+    std::cout << "\nProvider: Step 3 - Ready, waiting for consumer to finish" << std::endl;
+    if (!consumer_done_synchronizer.WaitWithAbort(stop_token))
+    {
+        FailTest("proxy_field_move_semantics provider failed: waiting for consumer done was aborted");
+    }
+
+    std::cout << "Provider: Shutting down" << std::endl;
+}
+
+}  // namespace score::mw::com::test

--- a/score/mw/com/test/move_semantics/proxy_field/provider.h
+++ b/score/mw/com/test/move_semantics/proxy_field/provider.h
@@ -1,0 +1,27 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_TEST_PROXY_FIELD_MOVE_SEMANTICS_PROVIDER_H
+#define SCORE_MW_COM_TEST_PROXY_FIELD_MOVE_SEMANTICS_PROVIDER_H
+
+#include "score/mw/com/test/move_semantics/proxy_field/test_parameters.h"
+
+#include <score/stop_token.hpp>
+
+namespace score::mw::com::test
+{
+
+void RunProvider(const ProxyMoveScenario& scenario, const score::cpp::stop_token& stop_token);
+
+}  // namespace score::mw::com::test
+
+#endif  // SCORE_MW_COM_TEST_PROXY_FIELD_MOVE_SEMANTICS_PROVIDER_H

--- a/score/mw/com/test/move_semantics/proxy_field/test_field_datatype.cpp
+++ b/score/mw/com/test/move_semantics/proxy_field/test_field_datatype.cpp
@@ -1,0 +1,13 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/test/move_semantics/proxy_field/test_field_datatype.h"

--- a/score/mw/com/test/move_semantics/proxy_field/test_field_datatype.h
+++ b/score/mw/com/test/move_semantics/proxy_field/test_field_datatype.h
@@ -1,0 +1,37 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_TEST_PROXY_FIELD_MOVE_SEMANTICS_TEST_FIELD_DATATYPE_H
+#define SCORE_MW_COM_TEST_PROXY_FIELD_MOVE_SEMANTICS_TEST_FIELD_DATATYPE_H
+
+#include "score/mw/com/types.h"
+
+#include <cstdint>
+
+namespace score::mw::com::test
+{
+
+template <typename T>
+class ProxyFieldMoveSemanticsInterface : public T::Base
+{
+  public:
+    using T::Base::Base;
+
+    typename T::template Field<std::int32_t, WithSetter, WithGetter, WithNotifier> moved_field_{*this, "moved_field"};
+};
+
+using ProxyFieldMoveSemanticsProxy = score::mw::com::AsProxy<ProxyFieldMoveSemanticsInterface>;
+using ProxyFieldMoveSemanticsSkeleton = score::mw::com::AsSkeleton<ProxyFieldMoveSemanticsInterface>;
+
+}  // namespace score::mw::com::test
+
+#endif  // SCORE_MW_COM_TEST_PROXY_FIELD_MOVE_SEMANTICS_TEST_FIELD_DATATYPE_H

--- a/score/mw/com/test/move_semantics/proxy_field/test_parameters.cpp
+++ b/score/mw/com/test/move_semantics/proxy_field/test_parameters.cpp
@@ -1,0 +1,43 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#include "score/mw/com/test/move_semantics/proxy_field/test_parameters.h"
+
+#include "score/mw/com/test/common_test_resources/command_line_parser.h"
+#include "score/mw/com/test/common_test_resources/fail_test.h"
+
+namespace score::mw::com::test
+{
+
+CombinedTestConfiguration ReadCommandLineArguments(int argc, const char** argv)
+{
+    auto args = ParseCommandLineArguments(argc, argv, {{kScenario, ""}, {kServiceInstanceManifest, ""}});
+
+    const auto scenario_index = GetValue<std::size_t>(args, kScenario);
+    if (scenario_index >= static_cast<std::size_t>(ProxyMoveScenario::kNumberOfScenarios))
+    {
+        FailTest("Consumer: ",
+                 kScenario,
+                 " value ",
+                 scenario_index,
+                 " is out of range. Valid values are between 0 and ",
+                 static_cast<std::uint8_t>(ProxyMoveScenario::kNumberOfScenarios) - 1,
+                 ".");
+    }
+    const auto scenario = static_cast<ProxyMoveScenario>(scenario_index);
+
+    auto service_instance_manifest = GetValue<std::string>(args, kServiceInstanceManifest);
+
+    return {scenario, service_instance_manifest};
+}
+
+}  // namespace score::mw::com::test

--- a/score/mw/com/test/move_semantics/proxy_field/test_parameters.h
+++ b/score/mw/com/test/move_semantics/proxy_field/test_parameters.h
@@ -1,0 +1,77 @@
+/********************************************************************************
+ * Copyright (c) 2026 Contributors to the Eclipse Foundation
+ *
+ * See the NOTICE file(s) distributed with this work for additional
+ * information regarding copyright ownership.
+ *
+ * This program and the accompanying materials are made available under the
+ * terms of the Apache License Version 2.0 which is available at
+ * https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * SPDX-License-Identifier: Apache-2.0
+ ********************************************************************************/
+#ifndef SCORE_MW_COM_TEST_PROXY_FIELD_MOVE_SEMANTICS_TEST_PARAMETERS_H
+#define SCORE_MW_COM_TEST_PROXY_FIELD_MOVE_SEMANTICS_TEST_PARAMETERS_H
+
+#include "score/mw/com/types.h"
+
+#include <cstdint>
+#include <string>
+
+namespace score::mw::com::test
+{
+
+const std::string kScenario{"scenario"};
+const std::string kServiceInstanceManifest{"service-instance-manifest"};
+
+// Instance used by the MoveConstruct scenario (single instance: only the proxy handle moves, the channel stays the
+// same), and, in the MoveAssign scenario, the target instance whose proxy is overwritten (destroyed) by the move
+// assignment.
+const InstanceSpecifier kInstanceSpecifierMovedTo =
+    InstanceSpecifier::Create(std::string{"test/proxy_field_move_semantics/MoveFieldInterfaceMovedTo"}).value();
+
+// Only used in the MoveAssign scenario: the source instance whose proxy is move-assigned into the moved-to proxy.
+// After the move, the moved-to proxy must reach this instance's channel (and therefore its Set-handler transform and
+// values).
+const InstanceSpecifier kInstanceSpecifierMovedFrom =
+    InstanceSpecifier::Create(std::string{"test/proxy_field_move_semantics/MoveFieldInterfaceMovedFrom"}).value();
+
+// Initial field value for the "MovedTo" instance.
+constexpr std::int32_t kInitialValueMovedTo{18};
+
+// Initial field value for the "MovedFrom" instance (only used in the MoveAssign scenario).
+constexpr std::int32_t kInitialValueMovedFrom{7};
+
+// The consumer calls Set() once, after moving the proxy and subscribing, using kSetRequestValue.
+constexpr std::int32_t kSetRequestValue{1234};
+
+enum class ProxyMoveScenario : std::uint8_t
+{
+    kMoveConstructAfterCreate,
+    kMoveAssignAfterCreate,
+    kNumberOfScenarios
+};
+
+struct CombinedTestConfiguration
+{
+    ProxyMoveScenario scenario;
+    std::string service_instance_manifest;
+};
+
+CombinedTestConfiguration ReadCommandLineArguments(int argc, const char** argv);
+
+/// \brief Set-handler transform used by the "MovedTo" instance: value = (value * 2) + 1.
+constexpr std::int32_t DoubleAndIncrement(const std::int32_t value) noexcept
+{
+    return (value * 2) + 1;
+}
+
+/// \brief Set-handler transform used by the "MovedFrom" instance: value = value + 100.
+constexpr std::int32_t AddOneHundred(const std::int32_t value) noexcept
+{
+    return value + 100;
+}
+
+}  // namespace score::mw::com::test
+
+#endif  // SCORE_MW_COM_TEST_PROXY_FIELD_MOVE_SEMANTICS_TEST_PARAMETERS_H


### PR DESCRIPTION
Adding integration tests that verify a Proxy (and its ProxyField) can be move-constructed or move-assigned without disrupting method call.

Issues: https://github.com/eclipse-score/communication/issues/483