### PR TITLE
feat: add public config schema collection alias

### DIFF
--- a/config/BUILD
+++ b/config/BUILD
@@ -1,0 +1,16 @@
+filegroup(
+    name = "config_schemas_files",
+    srcs = [
+        "//score/mw/com/gateway/gateway_application/configuration:mw_com_gateway_config_schema",
+        "//score/mw/com/gateway/transport_layer/sample/configuration:mw_com_gateway_sample_transport_config_schema",
+        "//score/mw/com/impl/configuration:mw_com_config_schema",
+        "//score/mw/com/impl/tracing/configuration:comtrace_filter_config_schema",
+    ],
+    visibility = ["//visibility:private"],
+)
+
+alias(
+    name = "config_schemas",
+    actual = ":config_schemas_files",
+    visibility = ["//visibility:public"],
+)

--- a/score/mw/com/gateway/gateway_application/configuration/BUILD
+++ b/score/mw/com/gateway/gateway_application/configuration/BUILD
@@ -30,6 +30,7 @@ validate_json_schema_test(
 filegroup(
     name = "mw_com_gateway_config_schema",
     srcs = ["mw_com_gateway_config_schema.json"],
+    visibility = ["//config:__pkg__"],
 )
 
 cc_library(

--- a/score/mw/com/gateway/transport_layer/sample/configuration/BUILD
+++ b/score/mw/com/gateway/transport_layer/sample/configuration/BUILD
@@ -30,6 +30,7 @@ validate_json_schema_test(
 filegroup(
     name = "mw_com_gateway_sample_transport_config_schema",
     srcs = ["mw_com_gateway_sample_transport_config_schema.json"],
+    visibility = ["//config:__pkg__"],
 )
 
 cc_library(

--- a/score/mw/com/impl/configuration/BUILD
+++ b/score/mw/com/impl/configuration/BUILD
@@ -28,6 +28,7 @@ filegroup(
     name = "mw_com_config_schema",
     srcs = ["mw_com_config_schema.json"],
     visibility = [
+        "//config:__pkg__",
         "//score/mw/com:__subpackages__",
         "//score/mw/com/impl/configuration/test:__subpackages__",
     ],

--- a/score/mw/com/impl/tracing/configuration/BUILD
+++ b/score/mw/com/impl/tracing/configuration/BUILD
@@ -29,6 +29,7 @@ filegroup(
     name = "comtrace_filter_config_schema",
     srcs = ["comtrace_config_schema.json"],
     visibility = [
+        "//config:__pkg__",
         "//score/mw/com:__pkg__",
         "//score/mw/com/impl/tracing/configuration:__pkg__",
     ],


### PR DESCRIPTION
Expose the _config.schema.json files for convenient access to the SOME/IP config schema file.