### PR TITLE
Make gateway transport layer messages own their data

### DIFF
--- a/score/mw/com/gateway/transport_layer/sample/message_framer_test.cpp
+++ b/score/mw/com/gateway/transport_layer/sample/message_framer_test.cpp
@@ -486,4 +486,83 @@ TEST_F(MessageFramerFixture, ReceiveMessageReturnsNullptrWhenPayloadRecvReturnsP
     EXPECT_EQ(message, nullptr);
 }
 
+TEST_F(MessageFramerFixture, ReceivedEventInfoNameRemainsValidAfterNextReceiveMessageCall)
+{
+    // Given a first ProvideServiceRequest whose single event is named "SpeedEvent"
+    auto specifier_1 = score::mw::com::InstanceSpecifier::Create(std::string{"Svc/Inst"});
+    ASSERT_TRUE(specifier_1.has_value());
+    std::vector<score::mw::com::EventInfo> elements_1{
+        {"SpeedEvent", score::mw::com::DataTypeMetaInfo{64U, 8U}},
+    };
+    ProvideServiceRequest request_1{std::move(specifier_1).value(), elements_1};
+
+    std::array<std::uint8_t, MessageFramer::kMaxPayloadSize> payload_1{};
+    const auto payload_1_size = request_1.Serialize(payload_1);
+    ASSERT_GT(payload_1_size, 0U);
+    const MessageHeader header_1 =
+        CreateMessageHeader(MessageType::kProvideServiceRequest, 1U, static_cast<std::uint32_t>(payload_1_size));
+
+    // And a second ProvideServiceRequest, with the exact same wire layout (same specifier length, one
+    // event of the same name length), whose event is named "XXXXXXXXXX" instead -- so that its
+    // serialized bytes land at the exact same offsets in the framer's reused receive buffer.
+    auto specifier_2 = score::mw::com::InstanceSpecifier::Create(std::string{"Svc/Inst"});
+    ASSERT_TRUE(specifier_2.has_value());
+    std::vector<score::mw::com::EventInfo> elements_2{
+        {"XXXXXXXXXX", score::mw::com::DataTypeMetaInfo{64U, 8U}},
+    };
+    ProvideServiceRequest request_2{std::move(specifier_2).value(), elements_2};
+
+    std::array<std::uint8_t, MessageFramer::kMaxPayloadSize> payload_2{};
+    const auto payload_2_size = request_2.Serialize(payload_2);
+    ASSERT_GT(payload_2_size, 0U);
+    ASSERT_EQ(payload_1_size, payload_2_size) << "Both payloads must have identical wire layout";
+    const MessageHeader header_2 =
+        CreateMessageHeader(MessageType::kProvideServiceRequest, 2U, static_cast<std::uint32_t>(payload_2_size));
+
+    EXPECT_CALL(socket_mock_, recv(kSocketFd, _, _, _))
+        .WillOnce(Invoke(
+            [header_1](auto, void* buffer, const std::size_t, auto) -> score::cpp::expected<ssize_t, score::os::Error> {
+                header_1.SerializeToBuffer(static_cast<std::uint8_t*>(buffer));
+                return static_cast<ssize_t>(MessageHeader::kWireSize);
+            }))
+        .WillOnce(
+            Invoke([&payload_1, payload_1_size](
+                       auto, void* buffer, const std::size_t, auto) -> score::cpp::expected<ssize_t, score::os::Error> {
+                std::memcpy(buffer, payload_1.data(), payload_1_size);
+                return static_cast<ssize_t>(payload_1_size);
+            }))
+        .WillOnce(Invoke(
+            [header_2](auto, void* buffer, const std::size_t, auto) -> score::cpp::expected<ssize_t, score::os::Error> {
+                header_2.SerializeToBuffer(static_cast<std::uint8_t*>(buffer));
+                return static_cast<ssize_t>(MessageHeader::kWireSize);
+            }))
+        .WillOnce(
+            Invoke([&payload_2, payload_2_size](
+                       auto, void* buffer, const std::size_t, auto) -> score::cpp::expected<ssize_t, score::os::Error> {
+                std::memcpy(buffer, payload_2.data(), payload_2_size);
+                return static_cast<ssize_t>(payload_2_size);
+            }));
+
+    // When the first message is received, its EventInfo::name correctly reads "SpeedEvent"...
+    auto first_message = framer_.ReceiveMessage(kSocketFd);
+    ASSERT_NE(first_message, nullptr);
+    auto* first_provide_request = dynamic_cast<ProvideServiceRequest*>(first_message.get());
+    ASSERT_NE(first_provide_request, nullptr);
+    ASSERT_EQ(first_provide_request->GetServiceElements().size(), 1U);
+    ASSERT_EQ(first_provide_request->GetServiceElements()[0].name, "SpeedEvent");
+
+    // ...and receiving a second, unrelated message on the same framer must not affect it: a
+    // correctly-implemented ReceiveMessage() returns fully independent, owned messages.
+    auto second_message = framer_.ReceiveMessage(kSocketFd);
+    ASSERT_NE(second_message, nullptr);
+
+    // Then the *first* message's EventInfo::name must still read "SpeedEvent". If it no longer
+    // does, the name was deserialized as a view into the framer's reused receive buffer rather
+    // than into storage owned by the message -- i.e. the dangling-view bug is present.
+    EXPECT_EQ(first_provide_request->GetServiceElements()[0].name, "SpeedEvent")
+        << "EventInfo::name dangled: it was silently overwritten by the second ReceiveMessage() "
+           "call because it still views into MessageFramer::receive_buffer_ instead of "
+           "independently-owned storage.";
+}
+
 }  // namespace score::mw::com::gateway

--- a/score/mw/com/gateway/transport_layer/sample/messages/gateway_messages.cpp
+++ b/score/mw/com/gateway/transport_layer/sample/messages/gateway_messages.cpp
@@ -53,6 +53,22 @@ bool DeserializeWithTemplate(T& message, score::cpp::span<const std::uint8_t> da
 
 }  // namespace
 
+ProvideServiceRequest::ProvideServiceRequest(const score::mw::com::InstanceSpecifier& service_instance_specifier,
+                                             const std::vector<score::mw::com::EventInfo>& service_elements,
+                                             std::uint32_t shm_control_size,
+                                             std::uint32_t shm_data_size)
+    : TransportMessage(MessageType::kProvideServiceRequest),
+      instance_specifier_(std::string{service_instance_specifier.ToString()}),
+      shm_control_size_(shm_control_size),
+      shm_data_size_(shm_data_size)
+{
+    elements_.reserve(service_elements.size());
+    for (const auto& element : service_elements)
+    {
+        elements_.emplace_back(element);
+    }
+}
+
 std::size_t ProvideServiceRequest::Serialize(score::cpp::span<std::uint8_t> buffer) const
 {
     return SerializeWithTemplate(*this, buffer);

--- a/score/mw/com/gateway/transport_layer/sample/messages/gateway_messages.h
+++ b/score/mw/com/gateway/transport_layer/sample/messages/gateway_messages.h
@@ -17,7 +17,9 @@
 #include "score/mw/com/gateway/transport_layer/transport.h"
 #include "score/mw/com/types.h"
 
+#include <cstddef>
 #include <string>
+#include <string_view>
 #include <tuple>
 #include <type_traits>
 #include <vector>
@@ -30,14 +32,54 @@ namespace score::mw::com::gateway
 /// (generic) skeleton for the given service instance.
 class ProvideServiceRequest : public TransportMessage
 {
+    /// \brief Wire-format representation of a single service element (event/field) exposed by a
+    /// ProvideServiceRequest.
+    class GatewayEventInfo
+    {
+        template <typename Self>
+        auto GetSerializeMembersImpl(Self& self) const
+        {
+            using SelfNoRef = std::remove_reference_t<Self>;
+            using NameType = std::conditional_t<std::is_const_v<SelfNoRef>, const std::string, std::string>;
+            using MetaType = std::conditional_t<std::is_const_v<SelfNoRef>, const DataTypeMetaInfo, DataTypeMetaInfo>;
+            return std::tuple<NameType&, MetaType&>(self.name_, self.data_type_meta_info_);
+        }
+
+      public:
+        GatewayEventInfo() = default;
+
+        explicit GatewayEventInfo(const EventInfo& event_info)
+            : name_{event_info.name}, data_type_meta_info_{event_info.data_type_meta_info}
+        {
+        }
+
+        EventInfo ToEventInfo() const
+        {
+            return EventInfo{std::string_view{name_}, data_type_meta_info_};
+        }
+
+        auto GetSerializeMembers() const
+        {
+            return GetSerializeMembersImpl(*this);
+        }
+        auto GetSerializeMembers()
+        {
+            return GetSerializeMembersImpl(*this);
+        }
+
+      private:
+        std::string name_{};
+        DataTypeMetaInfo data_type_meta_info_{};
+    };
+
     template <typename Self>
     static auto GetSerializeMembersImpl(Self& self)
     {
         using SelfNoRef = std::remove_reference_t<Self>;
         using StringType = std::conditional_t<std::is_const_v<SelfNoRef>, const std::string, std::string>;
         using VectorType = std::conditional_t<std::is_const_v<SelfNoRef>,
-                                              const std::vector<score::mw::com::EventInfo>,
-                                              std::vector<score::mw::com::EventInfo>>;
+                                              const std::vector<GatewayEventInfo>,
+                                              std::vector<GatewayEventInfo>>;
         using Uint32Type = std::conditional_t<std::is_const_v<SelfNoRef>, const std::uint32_t, std::uint32_t>;
         return std::tuple<StringType&, VectorType&, Uint32Type&, Uint32Type&>(
             self.instance_specifier_, self.elements_, self.shm_control_size_, self.shm_data_size_);
@@ -47,16 +89,9 @@ class ProvideServiceRequest : public TransportMessage
     ProvideServiceRequest() : TransportMessage(MessageType::kProvideServiceRequest) {}
 
     ProvideServiceRequest(const score::mw::com::InstanceSpecifier& service_instance_specifier,
-                          std::vector<score::mw::com::EventInfo> service_elements,
+                          const std::vector<score::mw::com::EventInfo>& service_elements,
                           std::uint32_t shm_control_size = 0U,
-                          std::uint32_t shm_data_size = 0U)
-        : TransportMessage(MessageType::kProvideServiceRequest),
-          instance_specifier_(std::string{service_instance_specifier.ToString()}),
-          elements_(std::move(service_elements)),
-          shm_control_size_(shm_control_size),
-          shm_data_size_(shm_data_size)
-    {
-    }
+                          std::uint32_t shm_data_size = 0U);
 
     std::size_t Serialize(score::cpp::span<std::uint8_t> buffer) const override;
     bool Deserialize(score::cpp::span<const std::uint8_t> data) override;
@@ -66,9 +101,15 @@ class ProvideServiceRequest : public TransportMessage
         return instance_specifier_;
     }
 
-    const std::vector<score::mw::com::EventInfo>& GetServiceElements() const
+    std::vector<EventInfo> GetServiceElements() const
     {
-        return elements_;
+        std::vector<EventInfo> result;
+        result.reserve(elements_.size());
+        for (const auto& element : elements_)
+        {
+            result.push_back(element.ToEventInfo());
+        }
+        return result;
     }
 
     std::uint32_t GetShmControlSize() const
@@ -92,7 +133,7 @@ class ProvideServiceRequest : public TransportMessage
 
   private:
     std::string instance_specifier_;
-    std::vector<score::mw::com::EventInfo> elements_;
+    std::vector<GatewayEventInfo> elements_;
     std::uint32_t shm_control_size_{0U};
     std::uint32_t shm_data_size_{0U};
 };


### PR DESCRIPTION
Gateway messages must own their data. Only this way they will be able to reliably provide their contained information to upper layers until they finished the action.

ProvideServiceRequest used EventInfo to represent elements. This type is a view-style type.
The underlying buffer containing the actual data was the receive socket. But this buffer is not ensured to stay stable for the full lifetime of ProvideServiceRequest.
It may be overwritten whenever a new message is received.

Introduces a new type GatewayEventInfo which is a data-owning copy of EventInfo.