### PR TITLE
Rust::com Rust target edition removes and rustfmt fix

### DIFF
--- a/score/mw/com/example/com-api-example/BUILD
+++ b/score/mw/com/example/com-api-example/BUILD
@@ -17,7 +17,6 @@ rust_library(
     name = "com-api-example-lib",
     srcs = glob(["src/**/*.rs"]),
     crate_name = "com_api_example",
-    edition = "2024",
     features = ["link_std_cpp_lib"],
     deps = [
         "//score/mw/com/example/com-api-example/com-api-gen",
@@ -35,7 +34,6 @@ rust_binary(
         "etc/logging.json",
         "etc/mw_com_config.json",
     ],
-    edition = "2024",
     env = {
         "MW_LOG_CONFIG_FILE": "score/mw/com/example/com-api-example/etc/logging.json",
     },
@@ -55,7 +53,6 @@ rust_test(
     name = "com-api-example-tokio-integration-test",
     srcs = ["tests_using_tokio_runtime.rs"],
     data = ["etc/mw_com_config.json"],
-    edition = "2024",
     features = ["link_std_cpp_lib"],
     tags = ["manual"],
     deps = [

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/BUILD
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/BUILD
@@ -37,7 +37,6 @@ rust_library(
         "common.rs",
     ],
     crate_root = "bridge_ffi.rs",
-    edition = "2024",
     visibility = [
         "//score/mw/com:__subpackages__",
     ],
@@ -50,7 +49,6 @@ rust_library(
 rust_library(
     name = "bridge_ffi_mock",
     srcs = ["bridge_ffi_mock.rs"],
-    edition = "2024",
     visibility = [
         "//score/mw/com:__subpackages__",
     ],
@@ -64,7 +62,6 @@ rust_library(
 rust_library(
     name = "bridge_ffi_lola",
     srcs = ["bridge_ffi_lola.rs"],
-    edition = "2024",
     visibility = [
         "//score/mw/com:__subpackages__",
     ],

--- a/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
+++ b/score/mw/com/impl/rust/com-api/com-api-ffi-lola/bridge_ffi_mock.rs
@@ -498,10 +498,11 @@ impl<T: Default> MockPointerAllocator<T> {
     /// - `false` if the pointer was not found in tracked allocations
     pub fn free(&self, ptr: *mut T) -> bool {
         let mut allocs = self.locked();
-        allocs
+        let freed = allocs
             .extract_if(.., |b| std::ptr::eq(b.as_mut(), ptr))
             .next()
-            .is_some()
+            .is_some();
+        freed
     }
 
     /// Assert that all allocations have been freed (count is 0).

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-lola/BUILD
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-lola/BUILD
@@ -21,7 +21,6 @@ rust_library(
         "producer.rs",
         "runtime.rs",
     ],
-    edition = "2024",
     visibility = ["//score/mw/com:__subpackages__"],
     deps = [
         "//score/mw/com/impl/plumbing/rust:sample_allocatee_ptr_rs",
@@ -37,7 +36,6 @@ rust_library(
 rust_test(
     name = "com-api-runtime-lola-tests",
     crate = ":com-api-runtime-lola",
-    edition = "2024",
     #tag will be removed wwhen sanitizer issue resolved for this
     tags = ["manual"],
     deps = [

--- a/score/mw/com/impl/rust/com-api/com-api-runtime-mock/BUILD
+++ b/score/mw/com/impl/rust/com-api/com-api-runtime-mock/BUILD
@@ -16,7 +16,6 @@ load("@rules_rust//rust:defs.bzl", "rust_library")
 rust_library(
     name = "com-api-runtime-mock",
     srcs = ["runtime.rs"],
-    edition = "2024",
     visibility = ["//score/mw/com:__subpackages__"],
     deps = [
         "//score/mw/com/rust/score_com_concept",

--- a/score/mw/com/rust/BUILD
+++ b/score/mw/com/rust/BUILD
@@ -18,7 +18,6 @@ rust_library(
     name = "score_com",
     srcs = ["score_com.rs"],
     crate_name = "score_com",
-    edition = "2024",
     visibility = [
         "//visibility:public",  # platform_only
     ],
@@ -36,7 +35,6 @@ rust_library(
     testonly = True,
     srcs = ["score_com_mock.rs"],
     crate_name = "score_com",
-    edition = "2024",
     visibility = [
         "//visibility:public",
     ],

--- a/score/mw/com/rust/score_com_concept/BUILD
+++ b/score/mw/com/rust/score_com_concept/BUILD
@@ -36,7 +36,10 @@ rust_test(
     name = "score_com_concept-test",
     crate = ":score_com_concept",
     tags = ["manual"],
-    deps = [":score_com_concept"],
+    deps = [
+        ":score_com_concept",
+        "//score/mw/com/rust:score_com",
+    ],
 )
 
 rust_doc_test(

--- a/score/mw/com/rust/score_com_concept/BUILD
+++ b/score/mw/com/rust/score_com_concept/BUILD
@@ -17,7 +17,6 @@ load("//quality/unit_testing:unit_testing.bzl", "rust_unit_test")
 rust_library(
     name = "score_com_concept",
     srcs = glob(["**/*.rs"]),
-    edition = "2024",
     proc_macro_deps = [
         "//score/mw/com/rust/score_com_macros:score-com-macros",
         "@score_communication_crate_index//:paste",
@@ -36,7 +35,6 @@ rust_library(
 rust_test(
     name = "score_com_concept-test",
     crate = ":score_com_concept",
-    edition = "2024",
     tags = ["manual"],
     deps = [":score_com_concept"],
 )

--- a/score/mw/com/test/basic_rust_api/producer_app/producer_app.rs
+++ b/score/mw/com/test/basic_rust_api/producer_app/producer_app.rs
@@ -89,8 +89,10 @@ fn run_bigdata_test<R: Runtime>(runtime: &R, num_cycles: u32) {
             .map_api_lanes_stamped_
             .allocate()
             .expect("Failed to allocate sample");
-        let mut sample = MapApiLanesStamped::default();
-        sample.x = x;
+        let sample = MapApiLanesStamped {
+            x,
+            ..Default::default()
+        };
         let ready = uninit.write(sample);
         ready.send().expect("Failed to send sample");
         println!("[bigdata-producer] Sent sample x={}", x);


### PR DESCRIPTION
* Use the Score Rust toolchain's default edition instead of specifying
the edition on each Rust Bazel target.