### PR TITLE
quality/api_surface: Report undocumented symbols without location

### DIFF
--- a/quality/api_surface/diff_api.py
+++ b/quality/api_surface/diff_api.py
@@ -55,10 +55,11 @@ def _format_undocumented_symbols(data: dict) -> str:
     ]
     for symbol in undocumented:
         lines.append(f"  {symbol['qualified_name']} ({symbol['kind']})")
-        # Location is diagnostic only and not part of the lock entry format,
-        # so it may be absent.
-        if "file" in symbol:
-            lines.append(f"    at {symbol['file']}:{symbol.get('line', '?')}")
+        # Lock entries only carry the API shape (see to_lock_entry in
+        # extract_api.py), so location is normally absent. Print it only if a
+        # producer supplies both fields.
+        if "file" in symbol and "line" in symbol:
+            lines.append(f"    at {symbol['file']}:{symbol['line']}")
     lines.extend(
         [
             "",

--- a/quality/api_surface/diff_api.py
+++ b/quality/api_surface/diff_api.py
@@ -55,7 +55,10 @@ def _format_undocumented_symbols(data: dict) -> str:
     ]
     for symbol in undocumented:
         lines.append(f"  {symbol['qualified_name']} ({symbol['kind']})")
-        lines.append(f"    at {symbol['file']}:{symbol['line']}")
+        # Location is diagnostic only and not part of the lock entry format,
+        # so it may be absent.
+        if "file" in symbol:
+            lines.append(f"    at {symbol['file']}:{symbol.get('line', '?')}")
     lines.extend(
         [
             "",

--- a/quality/api_surface/tests/test_diff_api.py
+++ b/quality/api_surface/tests/test_diff_api.py
@@ -44,6 +44,58 @@ class DiffApiDocsFlagTest(unittest.TestCase):
             current_file.write_text(json.dumps(payload), encoding="utf-8")
             self.assertEqual(diff_api.compare(str(lock_file), str(current_file)), 0)
 
+    def test_compare_reports_undocumented_symbols_without_location(self):
+        payload = {
+            "symbols": [],
+            "undocumented_symbols": [
+                {
+                    "kind": "function",
+                    "name": "foo",
+                    "qualified_name": "ns::foo",
+                    "signature": "foo : void ()",
+                }
+            ],
+        }
+        with tempfile.TemporaryDirectory() as tmpdir:
+            lock_file = Path(tmpdir) / "lock.json"
+            current_file = Path(tmpdir) / "current.json"
+            lock_file.write_text(json.dumps(payload), encoding="utf-8")
+            current_file.write_text(json.dumps(payload), encoding="utf-8")
+            self.assertEqual(diff_api.compare(str(lock_file), str(current_file), check_docs=True), 1)
+
+    def test_format_undocumented_symbols_omits_missing_location(self):
+        report = diff_api._format_undocumented_symbols(
+            {
+                "undocumented_symbols": [
+                    {
+                        "kind": "function",
+                        "name": "foo",
+                        "qualified_name": "ns::foo",
+                        "signature": "foo : void ()",
+                    }
+                ]
+            }
+        )
+        self.assertIn("ns::foo (function)", report)
+        self.assertNotIn("    at ", report)
+
+    def test_format_undocumented_symbols_includes_location_when_present(self):
+        report = diff_api._format_undocumented_symbols(
+            {
+                "undocumented_symbols": [
+                    {
+                        "kind": "function",
+                        "name": "foo",
+                        "qualified_name": "ns::foo",
+                        "signature": "foo : void ()",
+                        "file": "ns/foo.h",
+                        "line": 42,
+                    }
+                ]
+            }
+        )
+        self.assertIn("    at ns/foo.h:42", report)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
## Summary

`api_surface_test(check_docs = True)` crashes with `KeyError: 'file'` whenever the target has at least one undocumented public symbol, so the docs report is never printed.

`_format_undocumented_symbols()` reads `symbol['file']` / `symbol['line']`, but since 31aadcc4a the extractor deliberately strips both from every lock entry, including `undocumented_symbols`. The shell version of the diff tool already had this read; 36e83cc11 carried it over, and the non-empty path was never covered by a test.

## Change

- `diff_api.py`: print `at <file>:<line>` only when both fields are present. Otherwise the report lists the qualified name, which is enough to find the declaration.
- `tests/test_diff_api.py`: regression tests for the non-empty `undocumented_symbols` path, with and without location.

I did not make the extractor emit `file`/`line` again: `.update` copies the generated JSON verbatim into the committed lock file, so line numbers would churn it on every unrelated edit (the reason they were removed in 31aadcc4a). Happy to add a separate diagnostics output instead if you prefer locations in the report.

## Verification

- `bazel test //quality/api_surface/tests:test_diff_api`: fails with the `KeyError` before the fix, passes after.
- `//score/mw/com:api_surface_docs_test` now fails properly, listing the 106 undocumented symbols, instead of crashing. It is tagged `manual`, so CI is unaffected.

Closes #1053