### PR TITLE
tutorial: Fix line numbers in literalincludes

### DIFF
--- a/score/mw/com/doc/tutorial/chapter_1/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_1/README.rst
@@ -185,7 +185,7 @@ The 1st important step happens in line 30:
 
 .. literalinclude:: provider.cpp
    :language: cpp
-   :lines: 30-30
+   :lines: 33-33
    :caption: provider.cpp
 
 
@@ -211,7 +211,7 @@ Then in line 40 we create an instance of the skeleton class with the `Create` (n
 
 .. literalinclude:: provider.cpp
    :language: cpp
-   :lines: 40-40
+   :lines: 43-43
    :caption: provider.cpp
 
 
@@ -225,7 +225,7 @@ its value in case of success), in line 43 we move the skeleton instance out of t
 
 .. literalinclude:: provider.cpp
    :language: cpp
-   :lines: 43-43
+   :lines: 46-46
    :caption: provider.cpp
 
 
@@ -239,7 +239,7 @@ After the call to `OfferService` in line 45 succeeds:
 
 .. literalinclude:: provider.cpp
    :language: cpp
-   :lines: 45-45
+   :lines: 48-48
    :caption: provider.cpp
 
 
@@ -251,7 +251,7 @@ Step 1 in line 55 allocates memory for a new event-sample for the "message" even
 
 .. literalinclude:: provider.cpp
    :language: cpp
-   :lines: 55-55
+   :lines: 58-58
    :caption: provider.cpp
 
 Step 2 in line 74 then signals to score::mw::com, that updating/writing to the memory is done and this new sample
@@ -259,7 +259,7 @@ can be made visible to consumers:
 
 .. literalinclude:: provider.cpp
    :language: cpp
-   :lines: 74-74
+   :lines: 77-77
    :caption: provider.cpp
 
 
@@ -282,7 +282,7 @@ the `HelloWorldInterface` via the `AsProxy` template, which we also introduce an
 
 .. literalinclude:: consumer.cpp
    :language: cpp
-   :lines: 29-29
+   :lines: 32-32
    :caption: consumer.cpp
 
 
@@ -291,7 +291,7 @@ In the while-loop starting in line 40, the consumer tries to find the service in
 
 .. literalinclude:: consumer.cpp
    :language: cpp
-   :lines: 43-43
+   :lines: 46-46
    :caption: consumer.cpp
 
 
@@ -314,7 +314,7 @@ instance for the service instance via the `Create` method of the `HelloWorldProx
 
 .. literalinclude:: consumer.cpp
    :language: cpp
-   :lines: 58-58
+   :lines: 61-61
    :caption: consumer.cpp
 
 
@@ -324,7 +324,7 @@ Symmetrically to the provider side, we move the proxy instance out of the result
 
 .. literalinclude:: consumer.cpp
    :language: cpp
-   :lines: 65-65
+   :lines: 68-68
    :caption: consumer.cpp
 
 
@@ -335,7 +335,7 @@ line 66:
 
 .. literalinclude:: consumer.cpp
    :language: cpp
-   :lines: 66-66
+   :lines: 69-69
    :caption: consumer.cpp
 
 
@@ -352,7 +352,7 @@ The API to do this, is the `ProxyEvent::GetNewSamples` API. You see the call in 
 
 .. literalinclude:: consumer.cpp
    :language: cpp
-   :lines: 78-84
+   :lines: 81-87
    :caption: consumer.cpp
 
 

--- a/score/mw/com/doc/tutorial/chapter_12/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_12/README.rst
@@ -52,7 +52,7 @@ You can see that cut in the consumer application:
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 44-67
+   :lines: 47-70
    :caption: consumer/consumer.cpp
 
 
@@ -60,7 +60,7 @@ You can see that cut in the consumer application:
 
 .. literalinclude:: provider/provider.cpp
    :language: cpp
-   :lines: 36-43
+   :lines: 39-46
    :caption: provider/provider.cpp
 
 

--- a/score/mw/com/doc/tutorial/chapter_13/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_13/README.rst
@@ -340,7 +340,7 @@ The ``start_find_service/consumer.cpp`` example shows this:
 
 .. literalinclude:: start_find_service/consumer.cpp
    :language: cpp
-   :lines: 51-98
+   :lines: 52-99
    :caption: start_find_service/consumer.cpp — StartFindService with bounded wait before forbid_heap()
 
 The key rule is: **wait for the discovery callback to complete before calling**
@@ -379,7 +379,7 @@ The ``bidirectional_discovery/application_a.cpp`` example shows this sequence:
 
 .. literalinclude:: bidirectional_discovery/application_a.cpp
    :language: cpp
-   :lines: 59-141
+   :lines: 60-142
    :caption: bidirectional_discovery/application_a.cpp — OfferService before StartFindService, then wait
 
 In the operational phase, application A simultaneously sends on its own skeleton event and
@@ -387,7 +387,7 @@ polls the remote proxy's event in the same loop, both heap-free:
 
 .. literalinclude:: bidirectional_discovery/application_a.cpp
    :language: cpp
-   :lines: 143-187
+   :lines: 144-188
    :caption: bidirectional_discovery/application_a.cpp — operational loop: send and receive without heap
 
 .. _chapter_13_asil_guidance:

--- a/score/mw/com/doc/tutorial/chapter_2/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_2/README.rst
@@ -109,7 +109,7 @@ you will see that we added a specific call:
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 37-37
+   :lines: 40-40
    :caption: consumer/consumer.cpp
 
 

--- a/score/mw/com/doc/tutorial/chapter_3/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_3/README.rst
@@ -142,7 +142,7 @@ of its instances by 5 seconds each:
 
 .. literalinclude:: provider/provider.cpp
    :language: cpp
-   :lines: 103-131
+   :lines: 106-134
    :caption: provider/provider.cpp
 
 
@@ -177,7 +177,7 @@ handing over the container of **all** currently matching service handles.
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 111-147
+   :lines: 116-152
    :caption: consumer/consumer.cpp
 
 
@@ -208,7 +208,7 @@ The portable way to get a representation of the instance id out of a handle is:
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 54-60
+   :lines: 53-59
    :caption: consumer/consumer.cpp
 
 
@@ -225,7 +225,7 @@ The main loop of the consumer then simply polls the `message` event of **every**
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 157-169
+   :lines: 162-174
    :caption: consumer/consumer.cpp
 
 
@@ -235,7 +235,7 @@ longer be called):
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 179-179
+   :lines: 184-184
    :caption: consumer/consumer.cpp
 
 

--- a/score/mw/com/doc/tutorial/chapter_4/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_4/README.rst
@@ -175,7 +175,7 @@ phase change is due. On each phase change it either stops or (re-)starts offerin
 
 .. literalinclude:: provider/provider.cpp
    :language: cpp
-   :lines: 107-121
+   :lines: 110-124
    :caption: provider/provider.cpp
 
 
@@ -183,7 +183,7 @@ Event updates (`SendSample()`) are only published while the service is currently
 
 .. literalinclude:: provider/provider.cpp
    :language: cpp
-   :lines: 132-133
+   :lines: 135-136
    :caption: provider/provider.cpp
 
 
@@ -209,7 +209,7 @@ capture capacity):
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 113-138
+   :lines: 112-137
    :caption: consumer/consumer.cpp
 
 
@@ -225,7 +225,7 @@ called once, with a non-empty set:
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 180-180
+   :lines: 178-178
    :caption: consumer/consumer.cpp
 
 
@@ -236,13 +236,13 @@ terminating:
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 189-192
+   :lines: 188-191
    :caption: consumer/consumer.cpp
 
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 279-282
+   :lines: 278-281
    :caption: consumer/consumer.cpp
 
 
@@ -255,7 +255,7 @@ After subscribing, proxy_1 polls the subscription state **exactly once** via `Ge
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 198-214
+   :lines: 197-213
    :caption: consumer/consumer.cpp
 
 
@@ -264,7 +264,7 @@ subscription state:
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 297-299
+   :lines: 296-298
    :caption: consumer/consumer.cpp
 
 
@@ -284,7 +284,7 @@ records the new state in an atomic and returns `true` to stay registered:
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 237-252
+   :lines: 236-251
    :caption: consumer/consumer.cpp
 
 
@@ -294,7 +294,7 @@ state returns to `kSubscribed`:
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 305-312
+   :lines: 304-311
    :caption: consumer/consumer.cpp
 
 

--- a/score/mw/com/doc/tutorial/chapter_5/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_5/README.rst
@@ -138,7 +138,7 @@ sends strictly cyclically. Instead, it draws a random delay between `kMinSendDel
 
 .. literalinclude:: provider/provider.cpp
    :language: cpp
-   :lines: 33-113
+   :lines: 33-116
    :caption: provider/provider.cpp
 
 
@@ -155,7 +155,7 @@ subscribes, the consumer registers an `EventReceiveHandler` via `SetReceiveHandl
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 130-144
+   :lines: 129-143
    :caption: consumer/consumer.cpp
 
 
@@ -165,7 +165,7 @@ sample has actually been sent by the provider.
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 160-160
+   :lines: 159-159
    :caption: consumer/consumer.cpp
 
 
@@ -176,13 +176,13 @@ signal requests the shut down. The signal handler sets a flag and notifies the c
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 35-43
+   :lines: 37-45
    :caption: consumer/consumer.cpp
 
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 181-181
+   :lines: 180-180
    :caption: consumer/consumer.cpp
 
 
@@ -194,7 +194,7 @@ handler and the receive handler is the `std::optional<HelloWorldProxy> proxy`, c
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 122-125
+   :lines: 121-124
    :caption: consumer/consumer.cpp
 
 

--- a/score/mw/com/doc/tutorial/chapter_6/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_6/README.rst
@@ -109,7 +109,7 @@ sample slot – which is exactly what we want to observe in this chapter:
 
 .. literalinclude:: provider/provider.cpp
    :language: cpp
-   :lines: 55-58
+   :lines: 58-61
    :caption: provider/provider.cpp
 
 
@@ -138,7 +138,7 @@ this chapter is more realistic:
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 130-159
+   :lines: 133-162
    :caption: consumer/consumer.cpp
 
 

--- a/score/mw/com/doc/tutorial/chapter_7/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_7/README.rst
@@ -168,7 +168,7 @@ the previous chapters (which offered an event) is that **before** the provider m
 
 .. literalinclude:: provider/provider.cpp
    :language: cpp
-   :lines: 95-95
+   :lines: 98-98
    :caption: provider/provider.cpp
 
 
@@ -183,7 +183,7 @@ random pressure between `2.0` and `2.5` bar) are randomized:
 
 .. literalinclude:: provider/provider.cpp
    :language: cpp
-   :lines: 105-110
+   :lines: 108-113
    :caption: provider/provider.cpp
 
 
@@ -199,13 +199,13 @@ handler. It then, for **each** of the four fields, registers an `EventReceiveHan
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 100-129
+   :lines: 99-128
    :caption: consumer/consumer.cpp
 
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 183-187
+   :lines: 182-186
    :caption: consumer/consumer.cpp
 
 

--- a/score/mw/com/doc/tutorial/chapter_8/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_8/README.rst
@@ -155,7 +155,7 @@ by const-reference. The handler writes the result into that out-parameter and re
 
 .. literalinclude:: provider/provider.cpp
    :language: cpp
-   :lines: 61-92
+   :lines: 64-95
    :caption: provider/provider.cpp
 
 
@@ -183,7 +183,7 @@ const-reference**. The middleware allocates the argument slot, copies the argume
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 99-108
+   :lines: 98-107
    :caption: consumer/consumer.cpp
 
 
@@ -202,7 +202,7 @@ unnecessary copies matters. For this we use the second call-operator overload, w
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 119-126
+   :lines: 118-125
    :caption: consumer/consumer.cpp
 
 

--- a/score/mw/com/doc/tutorial/chapter_9/README.rst
+++ b/score/mw/com/doc/tutorial/chapter_9/README.rst
@@ -187,7 +187,7 @@ whenever it has to adjust a value:
 
 .. literalinclude:: provider/provider.cpp
    :language: cpp
-   :lines: 133-148
+   :lines: 136-151
    :caption: provider/provider.cpp
 
 
@@ -197,7 +197,7 @@ field, the provider must supply an **initial value for each field** before offer
 
 .. literalinclude:: provider/provider.cpp
    :language: cpp
-   :lines: 153-169
+   :lines: 156-172
    :caption: provider/provider.cpp
 
 
@@ -208,7 +208,7 @@ carrying the affected tire (several warnings may be sent after a single cycle):
 
 .. literalinclude:: provider/provider.cpp
    :language: cpp
-   :lines: 201-234
+   :lines: 204-237
    :caption: provider/provider.cpp
 
 
@@ -228,7 +228,7 @@ of chapter 7:
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 242-260
+   :lines: 241-259
    :caption: consumer/consumer.cpp
 
 
@@ -236,7 +236,7 @@ The receive handler drains all new warning samples via ``GetNewSamples()`` and r
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 187-199
+   :lines: 186-198
    :caption: consumer/consumer.cpp
 
 
@@ -248,7 +248,7 @@ accepted (the provider may have clamped it):
 
 .. literalinclude:: consumer/consumer.cpp
    :language: cpp
-   :lines: 133-183
+   :lines: 132-182
    :caption: consumer/consumer.cpp
 
 


### PR DESCRIPTION
Later changes of the source-code hadn't been reflected in README.rst, thus tutorial pointing to wrong code locations. Fixed line numbers.