### PR TITLE
Refactor OnProxyMethodUnsubscribe to remove code duplication

### DIFF
--- a/score/mw/com/impl/bindings/lola/skeleton.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton.cpp
@@ -719,8 +719,9 @@ Result<void> Skeleton::OnServiceMethodsUnsubscribed(const ProxyInstanceIdentifie
     for (auto& [method_id, skeleton_method_ref] : skeleton_methods_)
     {
         const ProxyMethodInstanceIdentifier proxy_method_instance_identifier{proxy_instance_identifier, method_id};
-        // Loops over all skeleton methods for the departing proxy, not just the ones it actually subscribed
-        // to, so a missing entry is expected here and must not be asserted on.
+        // We are looping over all SkeletonMethods, not just the ones corresponding to the ProxyMethod which is
+        // unsubscribing. Therefore, it's expected that some of the calls to OnProxyMethodUnsubscribe will not
+        // unregister anything so we don't assert on the return.
         std::ignore = skeleton_method_ref.get().OnProxyMethodUnsubscribe(proxy_method_instance_identifier);
     }
 
@@ -787,7 +788,7 @@ void Skeleton::UnsubscribeMethods(const std::vector<UniqueMethodIdentifier>& met
     {
         auto& skeleton_method = skeleton_methods_.at(method_id);
         const ProxyMethodInstanceIdentifier proxy_method_instance_identifier{proxy_instance_identifier, method_id};
-        // This rolls back a just-inserted registration guard, where the entry is guaranteed to exist.
+        // A precondition of this function is that all provided method_ids were successfully registered.
         const bool element_erased = skeleton_method.get().OnProxyMethodUnsubscribe(proxy_method_instance_identifier);
         SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(element_erased);
     }

--- a/score/mw/com/impl/bindings/lola/skeleton.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton.cpp
@@ -719,7 +719,9 @@ Result<void> Skeleton::OnServiceMethodsUnsubscribed(const ProxyInstanceIdentifie
     for (auto& [method_id, skeleton_method_ref] : skeleton_methods_)
     {
         const ProxyMethodInstanceIdentifier proxy_method_instance_identifier{proxy_instance_identifier, method_id};
-        skeleton_method_ref.get().OnProxyMethodUnsubscribeFinished(proxy_method_instance_identifier);
+        // Loops over all skeleton methods for the departing proxy, not just the ones it actually subscribed
+        // to, so a missing entry is expected here and must not be asserted on.
+        std::ignore = skeleton_method_ref.get().OnProxyMethodUnsubscribe(proxy_method_instance_identifier);
     }
 
     return {};
@@ -785,7 +787,9 @@ void Skeleton::UnsubscribeMethods(const std::vector<UniqueMethodIdentifier>& met
     {
         auto& skeleton_method = skeleton_methods_.at(method_id);
         const ProxyMethodInstanceIdentifier proxy_method_instance_identifier{proxy_instance_identifier, method_id};
-        skeleton_method.get().OnProxyMethodUnsubscribe(proxy_method_instance_identifier);
+        // This rolls back a just-inserted registration guard, where the entry is guaranteed to exist.
+        const bool element_erased = skeleton_method.get().OnProxyMethodUnsubscribe(proxy_method_instance_identifier);
+        SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(element_erased);
     }
 }
 

--- a/score/mw/com/impl/bindings/lola/skeleton.h
+++ b/score/mw/com/impl/bindings/lola/skeleton.h
@@ -229,6 +229,9 @@ class Skeleton final : public SkeletonBinding
         const uid_t proxy_uid,
         const pid_t proxy_pid,
         const QualityType asil_level);
+    /// \brief Will unsubscribe each of the provided ProxyMethods from their corresponding SkeletonMethod.
+    ///
+    /// \pre All provided method_ids were successfully subscribed via SubscribeMethods.
     void UnsubscribeMethods(const std::vector<UniqueMethodIdentifier>& method_ids,
                             const ProxyInstanceIdentifier& proxy_instance_identifier);
 

--- a/score/mw/com/impl/bindings/lola/skeleton_method.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_method.cpp
@@ -117,18 +117,11 @@ Result<void> SkeletonMethod::OnProxyMethodSubscribeFinished(
     return {};
 }
 
-void SkeletonMethod::OnProxyMethodUnsubscribe(const ProxyMethodInstanceIdentifier proxy_method_instance_identifier)
+bool SkeletonMethod::OnProxyMethodUnsubscribe(const ProxyMethodInstanceIdentifier proxy_method_instance_identifier)
 {
     const std::lock_guard lock{registration_guards_mutex_};
     const auto num_elements_erased = registration_guards_.erase(proxy_method_instance_identifier);
-    SCORE_LANGUAGE_FUTURECPP_PRECONDITION_PRD(num_elements_erased != 0U);
-}
-
-void SkeletonMethod::OnProxyMethodUnsubscribeFinished(
-    const ProxyMethodInstanceIdentifier proxy_method_instance_identifier)
-{
-    const std::lock_guard lock{registration_guards_mutex_};
-    std::ignore = registration_guards_.erase(proxy_method_instance_identifier);
+    return num_elements_erased != 0U;
 }
 
 void SkeletonMethod::UnregisterMethodCallHandlers()

--- a/score/mw/com/impl/bindings/lola/skeleton_method.h
+++ b/score/mw/com/impl/bindings/lola/skeleton_method.h
@@ -57,9 +57,11 @@ class SkeletonMethod : public SkeletonMethodBinding
         pid_t proxy_pid,
         const QualityType asil_level);
 
-    void OnProxyMethodUnsubscribe(const ProxyMethodInstanceIdentifier proxy_method_instance_identifier);
-
-    void OnProxyMethodUnsubscribeFinished(const ProxyMethodInstanceIdentifier proxy_method_instance_identifier);
+    // Returns true if a registration guard was erased, false if none existed. OnServiceMethodsUnsubscribed loops
+    // over all skeleton methods for a departing proxy, not just the ones it subscribed to, so a missing entry is
+    // expected there and the result can be ignored. Rollback of a just-inserted entry guarantees existence, so the
+    // result should be asserted there.
+    bool OnProxyMethodUnsubscribe(const ProxyMethodInstanceIdentifier proxy_method_instance_identifier);
 
     bool IsRegistered() const;
 

--- a/score/mw/com/impl/bindings/lola/skeleton_method.h
+++ b/score/mw/com/impl/bindings/lola/skeleton_method.h
@@ -57,10 +57,10 @@ class SkeletonMethod : public SkeletonMethodBinding
         pid_t proxy_pid,
         const QualityType asil_level);
 
-    // Returns true if a registration guard was erased, false if none existed. OnServiceMethodsUnsubscribed loops
-    // over all skeleton methods for a departing proxy, not just the ones it subscribed to, so a missing entry is
-    // expected there and the result can be ignored. Rollback of a just-inserted entry guarantees existence, so the
-    // result should be asserted there.
+    /// \brief Unregisters the method call handler corresponding to a given ProxyMethod which was registered with
+    /// MessagePassing in OnProxyMethodSubscribeFinished.
+    ///
+    /// \return Returns true if a registration guard was erased, false if none existed.
     bool OnProxyMethodUnsubscribe(const ProxyMethodInstanceIdentifier proxy_method_instance_identifier);
 
     bool IsRegistered() const;

--- a/score/mw/com/impl/bindings/lola/skeleton_method_test.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_method_test.cpp
@@ -432,17 +432,97 @@ TEST_F(SkeletonMethodOnProxyMethodUnsubscribedFixture, CallingWillUnregisterHand
     EXPECT_TRUE(result_2.has_value());
 
     // When calling OnProxyMethodUnsubscribe with proxy_method_instance_identifier_
-    unit_->OnProxyMethodUnsubscribe(proxy_method_instance_identifier_);
+    // Then it reports that an element was erased
+    EXPECT_TRUE(unit_->OnProxyMethodUnsubscribe(proxy_method_instance_identifier_));
 }
 
-TEST_F(SkeletonMethodOnProxyMethodUnsubscribedFixture, CallingBeforeSubscribingTerminates)
+TEST_F(SkeletonMethodOnProxyMethodUnsubscribedFixture, CallingBeforeSubscribingReturnsFalse)
 {
     GivenASkeletonMethod().WithARegisteredCallback();
 
     // When calling OnProxyMethodUnsubscribe with proxy_method_instance_identifier_ which was never subscribed
-    // Then the program terminates
-    SCORE_LANGUAGE_FUTURECPP_EXPECT_CONTRACT_VIOLATED(
-        unit_->OnProxyMethodUnsubscribe(proxy_method_instance_identifier_));
+    // Then it reports that no element was erased
+    EXPECT_FALSE(unit_->OnProxyMethodUnsubscribe(proxy_method_instance_identifier_));
+}
+
+TEST_F(SkeletonMethodOnProxyMethodUnsubscribedFixture, CallingTwiceWithSameIdentifierIsANoOp)
+{
+    GivenASkeletonMethod().WithARegisteredCallback();
+
+    EXPECT_CALL(message_passing_mock_,
+                RegisterMethodCallHandler(QualityType::kASIL_QM, proxy_method_instance_identifier_, _, _));
+    EXPECT_CALL(message_passing_mock_,
+                UnregisterMethodCallHandler(QualityType::kASIL_QM, proxy_method_instance_identifier_))
+        .Times(1);  // Must fire exactly once — not on the second Unsubscribe call
+
+    // Given that OnProxyMethodSubscribeFinished is called once for proxy_method_instance_identifier_
+    const auto result = unit_->OnProxyMethodSubscribeFinished(kTypeErasedInfoWithInArgsAndReturn,
+                                                              kValidInArgStorage,
+                                                              kValidReturnStorage,
+                                                              proxy_method_instance_identifier_,
+                                                              method_call_handler_scope_,
+                                                              kAllowedProxyUid,
+                                                              kAllowedProxyPid,
+                                                              QualityType::kASIL_QM);
+    EXPECT_TRUE(result.has_value());
+
+    // and given that OnProxyMethodUnsubscribe is called once
+    EXPECT_TRUE(unit_->OnProxyMethodUnsubscribe(proxy_method_instance_identifier_));
+
+    // When calling OnProxyMethodUnsubscribe a second time with the same identifier
+    // Then the program should NOT terminate and it should report that no element was erased
+    EXPECT_FALSE(unit_->OnProxyMethodUnsubscribe(proxy_method_instance_identifier_));
+}
+
+TEST_F(SkeletonMethodOnProxyMethodUnsubscribedFixture, CallingForOneProxyDoesNotAffectOtherProxyWithSameApplicationId)
+{
+    // Two proxy instances from the SAME application (same application_id, different proxy_instance_counter)
+    const ProxyInstanceIdentifier proxy_instance_identifier_same_app{kDummyProxyInstanceCounter + 1U,
+                                                                     kDummyApplicationId};
+    const ProxyMethodInstanceIdentifier proxy_method_instance_identifier_same_app{proxy_instance_identifier_same_app,
+                                                                                  unique_method_identifier_};
+
+    GivenASkeletonMethod().WithARegisteredCallback();
+
+    EXPECT_CALL(message_passing_mock_, RegisterMethodCallHandler(kAsilLevel, proxy_method_instance_identifier_, _, _));
+    EXPECT_CALL(message_passing_mock_,
+                RegisterMethodCallHandler(kAsilLevel, proxy_method_instance_identifier_same_app, _, _));
+
+    // The first proxy's handler is removed by OnProxyMethodUnsubscribe — must not fire on destruction
+    EXPECT_CALL(message_passing_mock_, UnregisterMethodCallHandler(kAsilLevel, proxy_method_instance_identifier_))
+        .Times(1);  // fired during OnProxyMethodUnsubscribe
+    // The second proxy's handler must still be present and unregistered on destruction
+    EXPECT_CALL(message_passing_mock_,
+                UnregisterMethodCallHandler(kAsilLevel, proxy_method_instance_identifier_same_app))
+        .Times(1);  // fired on destruction
+
+    // Given both proxies from the same application subscribed
+    ASSERT_TRUE(unit_
+                    ->OnProxyMethodSubscribeFinished(kTypeErasedInfoWithNoInArgsOrReturn,
+                                                     kEmptyInArgStorage,
+                                                     kEmptyReturnStorage,
+                                                     proxy_method_instance_identifier_,
+                                                     method_call_handler_scope_,
+                                                     kAllowedProxyUid,
+                                                     kAllowedProxyPid,
+                                                     kAsilLevel)
+                    .has_value());
+    ASSERT_TRUE(unit_
+                    ->OnProxyMethodSubscribeFinished(kTypeErasedInfoWithNoInArgsOrReturn,
+                                                     kEmptyInArgStorage,
+                                                     kEmptyReturnStorage,
+                                                     proxy_method_instance_identifier_same_app,
+                                                     method_call_handler_scope_,
+                                                     kAllowedProxyUid,
+                                                     kAllowedProxyPid,
+                                                     kAsilLevel)
+                    .has_value());
+
+    // When OnProxyMethodUnsubscribe is called for only the first proxy
+    score::cpp::ignore = unit_->OnProxyMethodUnsubscribe(proxy_method_instance_identifier_);
+
+    // Then the second proxy's handler is still registered and unregistered on destruction
+    unit_.reset();
 }
 
 using SkeletonMethodCallFixture = SkeletonMethodFixture;
@@ -627,100 +707,6 @@ TEST_F(SkeletonMethodIsRegisteredFixture, IsRegisteredReturnsTrueIfRegisterHandl
 
     // Then the result should be true
     EXPECT_TRUE(is_registered);
-}
-
-using SkeletonMethodOnProxyMethodUnsubscribeFinishedFixture = SkeletonMethodFixture;
-TEST_F(SkeletonMethodOnProxyMethodUnsubscribeFinishedFixture, CallingBeforeSubscribingIsANoOp)
-{
-    GivenASkeletonMethod().WithARegisteredCallback();
-
-    // Expecting that UnregisterMethodCallHandler will never be called since nothing was subscribed
-    EXPECT_CALL(message_passing_mock_, UnregisterMethodCallHandler(_, _)).Times(0);
-
-    // When calling OnProxyMethodUnsubscribeFinished with a proxy_method_instance_identifier_ that was never subscribed
-    // Then the program should NOT terminate (unlike OnProxyMethodUnsubscribe which has a PRECONDITION check)
-    unit_->OnProxyMethodUnsubscribeFinished(proxy_method_instance_identifier_);
-}
-
-TEST_F(SkeletonMethodOnProxyMethodUnsubscribeFinishedFixture, CallingTwiceWithSameIdentifierIsANoOp)
-{
-    GivenASkeletonMethod().WithARegisteredCallback();
-
-    EXPECT_CALL(message_passing_mock_,
-                RegisterMethodCallHandler(QualityType::kASIL_QM, proxy_method_instance_identifier_, _, _));
-    EXPECT_CALL(message_passing_mock_,
-                UnregisterMethodCallHandler(QualityType::kASIL_QM, proxy_method_instance_identifier_))
-        .Times(1);  // Must fire exactly once — not on the second UnsubscribeFinished call
-
-    // Given that OnProxyMethodSubscribeFinished is called once for proxy_method_instance_identifier_
-    const auto result = unit_->OnProxyMethodSubscribeFinished(kTypeErasedInfoWithInArgsAndReturn,
-                                                              kValidInArgStorage,
-                                                              kValidReturnStorage,
-                                                              proxy_method_instance_identifier_,
-                                                              method_call_handler_scope_,
-                                                              kAllowedProxyUid,
-                                                              kAllowedProxyPid,
-                                                              QualityType::kASIL_QM);
-    EXPECT_TRUE(result.has_value());
-
-    // and given that OnProxyMethodUnsubscribeFinished is called once
-    unit_->OnProxyMethodUnsubscribeFinished(proxy_method_instance_identifier_);
-
-    // When calling OnProxyMethodUnsubscribeFinished a second time with the same identifier
-    // Then the program should NOT terminate (unlike OnProxyMethodUnsubscribe which has a PRECONDITION check)
-    unit_->OnProxyMethodUnsubscribeFinished(proxy_method_instance_identifier_);
-}
-
-TEST_F(SkeletonMethodOnProxyMethodUnsubscribeFinishedFixture,
-       CallingForOneProxyDoesNotAffectOtherProxyWithSameApplicationId)
-{
-    // Two proxy instances from the SAME application (same application_id, different proxy_instance_counter)
-    const ProxyInstanceIdentifier proxy_instance_identifier_same_app{kDummyProxyInstanceCounter + 1U,
-                                                                     kDummyApplicationId};
-    const ProxyMethodInstanceIdentifier proxy_method_instance_identifier_same_app{proxy_instance_identifier_same_app,
-                                                                                  unique_method_identifier_};
-
-    GivenASkeletonMethod().WithARegisteredCallback();
-
-    EXPECT_CALL(message_passing_mock_, RegisterMethodCallHandler(kAsilLevel, proxy_method_instance_identifier_, _, _));
-    EXPECT_CALL(message_passing_mock_,
-                RegisterMethodCallHandler(kAsilLevel, proxy_method_instance_identifier_same_app, _, _));
-
-    // The first proxy's handler is removed by OnProxyMethodUnsubscribeFinished — must not fire on destruction
-    EXPECT_CALL(message_passing_mock_, UnregisterMethodCallHandler(kAsilLevel, proxy_method_instance_identifier_))
-        .Times(1);  // fired during OnProxyMethodUnsubscribeFinished
-    // The second proxy's handler must still be present and unregistered on destruction
-    EXPECT_CALL(message_passing_mock_,
-                UnregisterMethodCallHandler(kAsilLevel, proxy_method_instance_identifier_same_app))
-        .Times(1);  // fired on destruction
-
-    // Given both proxies from the same application subscribed
-    ASSERT_TRUE(unit_
-                    ->OnProxyMethodSubscribeFinished(kTypeErasedInfoWithNoInArgsOrReturn,
-                                                     kEmptyInArgStorage,
-                                                     kEmptyReturnStorage,
-                                                     proxy_method_instance_identifier_,
-                                                     method_call_handler_scope_,
-                                                     kAllowedProxyUid,
-                                                     kAllowedProxyPid,
-                                                     kAsilLevel)
-                    .has_value());
-    ASSERT_TRUE(unit_
-                    ->OnProxyMethodSubscribeFinished(kTypeErasedInfoWithNoInArgsOrReturn,
-                                                     kEmptyInArgStorage,
-                                                     kEmptyReturnStorage,
-                                                     proxy_method_instance_identifier_same_app,
-                                                     method_call_handler_scope_,
-                                                     kAllowedProxyUid,
-                                                     kAllowedProxyPid,
-                                                     kAsilLevel)
-                    .has_value());
-
-    // When OnProxyMethodUnsubscribeFinished is called for only the first proxy
-    unit_->OnProxyMethodUnsubscribeFinished(proxy_method_instance_identifier_);
-
-    // Then the second proxy's handler is still registered and unregistered on destruction
-    unit_.reset();
 }
 
 }  // namespace

--- a/score/mw/com/impl/bindings/lola/skeleton_method_test.cpp
+++ b/score/mw/com/impl/bindings/lola/skeleton_method_test.cpp
@@ -445,12 +445,17 @@ TEST_F(SkeletonMethodOnProxyMethodUnsubscribedFixture, CallingBeforeSubscribingR
     EXPECT_FALSE(unit_->OnProxyMethodUnsubscribe(proxy_method_instance_identifier_));
 }
 
-TEST_F(SkeletonMethodOnProxyMethodUnsubscribedFixture, CallingTwiceWithSameIdentifierIsANoOp)
+TEST_F(SkeletonMethodOnProxyMethodUnsubscribedFixture, CallingASecondTimeWithSameIdentifierReturnsFalse)
 {
     GivenASkeletonMethod().WithARegisteredCallback();
 
+    // Expecting that RegisterMethodCallHandler will be called on message passing for the single call to
+    // OnProxyMethodSubscribeFinished
     EXPECT_CALL(message_passing_mock_,
                 RegisterMethodCallHandler(QualityType::kASIL_QM, proxy_method_instance_identifier_, _, _));
+
+    // And expecting that UnregisterMethodCallHandler is only called once, since the second OnProxyMethodUnsubscribe
+    // call has nothing left to unregister
     EXPECT_CALL(message_passing_mock_,
                 UnregisterMethodCallHandler(QualityType::kASIL_QM, proxy_method_instance_identifier_))
         .Times(1);  // Must fire exactly once — not on the second Unsubscribe call
@@ -474,7 +479,8 @@ TEST_F(SkeletonMethodOnProxyMethodUnsubscribedFixture, CallingTwiceWithSameIdent
     EXPECT_FALSE(unit_->OnProxyMethodUnsubscribe(proxy_method_instance_identifier_));
 }
 
-TEST_F(SkeletonMethodOnProxyMethodUnsubscribedFixture, CallingForOneProxyDoesNotAffectOtherProxyWithSameApplicationId)
+TEST_F(SkeletonMethodOnProxyMethodUnsubscribedFixture,
+       UnsubscribingOneProxyDoesNotAffectOtherProxyWithSameApplicationId)
 {
     // Two proxy instances from the SAME application (same application_id, different proxy_instance_counter)
     const ProxyInstanceIdentifier proxy_instance_identifier_same_app{kDummyProxyInstanceCounter + 1U,
@@ -484,17 +490,19 @@ TEST_F(SkeletonMethodOnProxyMethodUnsubscribedFixture, CallingForOneProxyDoesNot
 
     GivenASkeletonMethod().WithARegisteredCallback();
 
+    // Expecting that RegisterMethodCallHandler will be called on message passing for each of the two proxies when
+    // they subscribe below
     EXPECT_CALL(message_passing_mock_, RegisterMethodCallHandler(kAsilLevel, proxy_method_instance_identifier_, _, _));
     EXPECT_CALL(message_passing_mock_,
                 RegisterMethodCallHandler(kAsilLevel, proxy_method_instance_identifier_same_app, _, _));
 
-    // The first proxy's handler is removed by OnProxyMethodUnsubscribe — must not fire on destruction
+    // Expecting that the first proxy's handler is unregistered once by OnProxyMethodUnsubscribe below
     EXPECT_CALL(message_passing_mock_, UnregisterMethodCallHandler(kAsilLevel, proxy_method_instance_identifier_))
-        .Times(1);  // fired during OnProxyMethodUnsubscribe
-    // The second proxy's handler must still be present and unregistered on destruction
+        .Times(1);
+    // Expecting that the second proxy's handler is NOT unregistered as part of unsubscribing the first proxy
     EXPECT_CALL(message_passing_mock_,
                 UnregisterMethodCallHandler(kAsilLevel, proxy_method_instance_identifier_same_app))
-        .Times(1);  // fired on destruction
+        .Times(0);
 
     // Given both proxies from the same application subscribed
     ASSERT_TRUE(unit_
@@ -519,10 +527,67 @@ TEST_F(SkeletonMethodOnProxyMethodUnsubscribedFixture, CallingForOneProxyDoesNot
                     .has_value());
 
     // When OnProxyMethodUnsubscribe is called for only the first proxy
+    // Then only the first proxy's handler is unregistered, and the second proxy's handler is left untouched
+    EXPECT_TRUE(unit_->OnProxyMethodUnsubscribe(proxy_method_instance_identifier_));
+}
+
+TEST_F(SkeletonMethodOnProxyMethodUnsubscribedFixture, DestroyingUnregistersHandlerOfProxyWhichWasNeverUnsubscribed)
+{
+    // Two proxy instances from the SAME application (same application_id, different proxy_instance_counter)
+    const ProxyInstanceIdentifier proxy_instance_identifier_same_app{kDummyProxyInstanceCounter + 1U,
+                                                                     kDummyApplicationId};
+    const ProxyMethodInstanceIdentifier proxy_method_instance_identifier_same_app{proxy_instance_identifier_same_app,
+                                                                                  unique_method_identifier_};
+
+    GivenASkeletonMethod().WithARegisteredCallback();
+
+    // Expecting that RegisterMethodCallHandler will be called on message passing for each of the two proxies when
+    // they subscribe below
+    EXPECT_CALL(message_passing_mock_, RegisterMethodCallHandler(kAsilLevel, proxy_method_instance_identifier_, _, _));
+    EXPECT_CALL(message_passing_mock_,
+                RegisterMethodCallHandler(kAsilLevel, proxy_method_instance_identifier_same_app, _, _));
+
+    // Expecting that the first proxy's handler is unregistered once by OnProxyMethodUnsubscribe below
+    EXPECT_CALL(message_passing_mock_, UnregisterMethodCallHandler(kAsilLevel, proxy_method_instance_identifier_))
+        .Times(1);
+    // Expecting that the second proxy's handler, which is never explicitly unsubscribed, is unregistered once on
+    // destruction
+    bool second_proxy_handler_unregistered{false};
+    EXPECT_CALL(message_passing_mock_,
+                UnregisterMethodCallHandler(kAsilLevel, proxy_method_instance_identifier_same_app))
+        .Times(1)
+        .WillOnce(Assign(&second_proxy_handler_unregistered, true));
+
+    // Given both proxies from the same application subscribed
+    ASSERT_TRUE(unit_
+                    ->OnProxyMethodSubscribeFinished(kTypeErasedInfoWithNoInArgsOrReturn,
+                                                     kEmptyInArgStorage,
+                                                     kEmptyReturnStorage,
+                                                     proxy_method_instance_identifier_,
+                                                     method_call_handler_scope_,
+                                                     kAllowedProxyUid,
+                                                     kAllowedProxyPid,
+                                                     kAsilLevel)
+                    .has_value());
+    ASSERT_TRUE(unit_
+                    ->OnProxyMethodSubscribeFinished(kTypeErasedInfoWithNoInArgsOrReturn,
+                                                     kEmptyInArgStorage,
+                                                     kEmptyReturnStorage,
+                                                     proxy_method_instance_identifier_same_app,
+                                                     method_call_handler_scope_,
+                                                     kAllowedProxyUid,
+                                                     kAllowedProxyPid,
+                                                     kAsilLevel)
+                    .has_value());
+
+    // and given that the first proxy has already unsubscribed
     score::cpp::ignore = unit_->OnProxyMethodUnsubscribe(proxy_method_instance_identifier_);
 
-    // Then the second proxy's handler is still registered and unregistered on destruction
+    // When destroying the SkeletonMethod
     unit_.reset();
+
+    // Then the second proxy's handler, which was never explicitly unsubscribed, is unregistered on destruction
+    EXPECT_TRUE(second_proxy_handler_unregistered);
 }
 
 using SkeletonMethodCallFixture = SkeletonMethodFixture;


### PR DESCRIPTION
Refactor OnProxyMethodUnsubscribe to remove code duplication

- Merged OnProxyMethodUnsubscribe and OnProxyMethodUnsubscribeFinished into a single OnProxyMethodUnsubscribe method.
- Returns bool and assert/ignore decided at call site.
- Added doc comment and call site comments.
- Renamed test fixtures/cases to match.