### PR TITLE
safety_sentinel: Remove generic skeleton / proxy from binding

### DIFF
--- a/score/mw/com/dependability/software_architectural_design/static_design/lola_binding.puml
+++ b/score/mw/com/dependability/software_architectural_design/static_design/lola_binding.puml
@@ -32,18 +32,6 @@ package "Lola Binding" as lola_binding <<component>> {
     component "ProxyEvent" as lola_proxy_event <<unit>> 
     component "ProxyMethod" as lola_proxy_method <<unit>> 
   }
-
-  package "GenericSkeletonAndServiceElements" as lola_generic_skeleton_and_service_elements <<component>> {
-    component "GenericSkeleton" as lola_generic_skeleton <<unit>>
-    component "GenericSkeletonEvent" as lola_generic_skeleton_event <<unit>>
-    component "GenericSkeletonMethod" as lola_generic_skeleton_method <<unit>>
-  }
-
-  package "GenericProxyAndServiceElements" as lola_generic_proxy_and_service_elements <<component>> {
-    component "GenericProxy" as lola_generic_proxy <<unit>> 
-    component "GenericProxyEvent" as lola_generic_proxy_event <<unit>> 
-    component "GenericProxyMethod" as lola_generic_proxy_method <<unit>> 
-  }
 }
 
 @enduml

--- a/score/mw/com/dependability/software_architectural_design/static_design/mock_binding.puml
+++ b/score/mw/com/dependability/software_architectural_design/static_design/mock_binding.puml
@@ -25,18 +25,6 @@ package "Mock Binding" as mock_binding <<component>> {
     component "ProxyEvent" as mock_binding_proxy_event <<unit>> 
     component "ProxyMethod" as mock_binding_proxy_method <<unit>> 
   }
-
-  package "GenericSkeletonAndServiceElements" as mock_binding_generic_skeleton_and_service_elements <<component>>  {
-    component "GenericSkeleton" as mock_binding_generic_skeleton <<unit>> 
-    component "GenericSkeletonEvent" as mock_binding_generic_skeleton_event <<unit>> 
-    component "GenericSkeletonMethod" as mock_binding_generic_skeleton_method <<unit>> 
-  }
-
-  package "GenericProxyAndServiceElements" as mock_binding_generic_proxy_and_service_elements <<component>>  {
-    component "GenericProxy" as mock_binding_generic_proxy <<unit>> 
-    component "GenericProxyEvent" as mock_binding_generic_proxy_event <<unit>> 
-    component "GenericProxyMethod" as mock_binding_generic_proxy_method <<unit>> 
-  }
 }
 
 @enduml

--- a/score/mw/com/dependability/software_architectural_design/static_design/someip_binding.puml
+++ b/score/mw/com/dependability/software_architectural_design/static_design/someip_binding.puml
@@ -25,18 +25,6 @@ package "Someip Binding" as someip_binding <<component>> {
     component "ProxyEvent" as someip_proxy_event <<unit>> 
     component "ProxyMethod" as someip_proxy_method <<unit>> 
   }
-
-  package "GenericSkeletonAndServiceElements" as someip_generic_skeleton_and_service_elements <<component>>  {
-    component "GenericSkeleton" as someip_generic_skeleton <<unit>> 
-    component "GenericSkeletonEvent" as someip_generic_skeleton_event <<unit>> 
-    component "GenericSkeletonMethod" as someip_generic_skeleton_method <<unit>> 
-  }
-
-  package "GenericProxyAndServiceElements" as someip_generic_proxy_and_service_elements <<component>>  {
-    component "GenericProxy" as someip_generic_proxy <<unit>> 
-    component "GenericProxyEvent" as someip_generic_proxy_event <<unit>> 
-    component "GenericProxyMethod" as someip_generic_proxy_method <<unit>> 
-  }
 }
 
 @enduml


### PR DESCRIPTION
Since the binding level will soon be type erased, we no longer differentiate between a SkeletonEvent and GenericEvent (and same for the proxy side). Therefore, we can remove these units / components from the binding level.